### PR TITLE
opennebula inventory: add VM ID and VM host to data

### DIFF
--- a/changelogs/fragments/8532-expand-opennuebula-inventory-data.yml
+++ b/changelogs/fragments/8532-expand-opennuebula-inventory-data.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - opennebula.py - add VM `id`` and VM `host` to inventory host data (https://github.com/ansible-collections/community.general/pull/8532).

--- a/changelogs/fragments/8532-expand-opennuebula-inventory-data.yml
+++ b/changelogs/fragments/8532-expand-opennuebula-inventory-data.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - opennebula.py - add VM `id`` and VM `host` to inventory host data (https://github.com/ansible-collections/community.general/pull/8532).
+  - opennebula.py - add VM ``id`` and VM ``host`` to inventory host data (https://github.com/ansible-collections/community.general/pull/8532).

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -97,6 +97,7 @@ except ImportError:
 from ansible.errors import AnsibleError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 from ansible.module_utils.common.text.converters import to_native
+from ansible.module_utils.common._collections_compat import Sequence
 
 from ansible_collections.community.general.plugins.plugin_utils.unsafe import make_unsafe
 
@@ -200,10 +201,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
             server['name'] = vm.NAME
             server['id'] = vm.ID
-            if hasattr(vm.HISTORY_RECORDS, 'HISTORY'):
-                if isinstance(vm.HISTORY_RECORDS.HISTORY, list) and len(vm.HISTORY_RECORDS.HISTORY) > 0:
-                    if hasattr(vm.HISTORY_RECORDS.HISTORY[-1], 'HOSTNAME'):
-                        server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
+            if isinstance(vm.HISTORY_RECORDS.HISTORY, Sequence) and len(vm.HISTORY_RECORDS.HISTORY) > 0:
+                if hasattr(vm.HISTORY_RECORDS.HISTORY[-1], 'HOSTNAME'):
+                    server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
             server['LABELS'] = labels
             server['v4_first_ip'] = self._get_vm_ipv4(vm)
             server['v6_first_ip'] = self._get_vm_ipv6(vm)

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -97,7 +97,6 @@ except ImportError:
 from ansible.errors import AnsibleError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 from ansible.module_utils.common.text.converters import to_native
-from ansible.module_utils.common._collections_compat import Sequence
 
 from ansible_collections.community.general.plugins.plugin_utils.unsafe import make_unsafe
 
@@ -202,9 +201,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             server['name'] = vm.NAME
             server['id'] = vm.ID
             if hasattr(vm.HISTORY_RECORDS, 'HISTORY'):
-                if isinstance(vm.HISTORY_RECORDS.HISTORY, Sequence) and len(vm.HISTORY_RECORDS.HISTORY) > 0:
-                    if hasattr(vm.HISTORY_RECORDS.HISTORY[-1], 'HOSTNAME'):
-                        server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
+                server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
             server['LABELS'] = labels
             server['v4_first_ip'] = self._get_vm_ipv4(vm)
             server['v6_first_ip'] = self._get_vm_ipv6(vm)

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -201,9 +201,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
             server['name'] = vm.NAME
             server['id'] = vm.ID
-            if isinstance(vm.HISTORY_RECORDS.HISTORY, Sequence) and len(vm.HISTORY_RECORDS.HISTORY) > 0:
-                if hasattr(vm.HISTORY_RECORDS.HISTORY[-1], 'HOSTNAME'):
-                    server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
+            if vm.HISTORY_RECORDS.HISTORY:
+                if isinstance(vm.HISTORY_RECORDS.HISTORY, Sequence) and len(vm.HISTORY_RECORDS.HISTORY) > 0:
+                    if hasattr(vm.HISTORY_RECORDS.HISTORY[-1], 'HOSTNAME'):
+                        server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
             server['LABELS'] = labels
             server['v4_first_ip'] = self._get_vm_ipv4(vm)
             server['v6_first_ip'] = self._get_vm_ipv6(vm)

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -176,44 +176,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         return vm_pool
 
-    def _get_host_pool_info(self):
-        auth = self._get_connection_info()
-
-        if not (auth.username and auth.password):
-            raise AnsibleError('API Credentials missing. Check OpenNebula inventory file.')
-        else:
-            one_client = pyone.OneServer(auth.url, session=auth.username + ':' + auth.password)
-
-        # get hosts (underlying hardware hosts)
-        try:
-            host_pool_info = one_client.hostpool.info()
-        except Exception as e:
-            raise AnsibleError("Something happened during XML-RPC call: {e}".format(e=to_native(e)))
-
-        return host_pool_info
-
-    def _get_vm_to_host_map(self, host_pool_info):
-        vm_to_host_map = {}
-
-        # Iterate over the hosts
-        for host in host_pool_info.HOST:
-            host_name = host.NAME
-
-            # Some hosts might not have VMs, so we need to check for VMS attribute
-            if hasattr(host, 'VMS') and hasattr(host.VMS, 'ID'):
-                # VMS.ID could be a single ID or a list of IDs
-                if isinstance(host.VMS.ID, list):
-                    for vm_id in host.VMS.ID:
-                        vm_to_host_map[vm_id] = host_name
-                else:
-                    vm_to_host_map[host.VMS.ID] = host_name
-
-        return vm_to_host_map
-
     def _retrieve_servers(self, label_filter=None):
         vm_pool = self._get_vm_pool()
-        host_pool_info = self._get_host_pool_info()
-        vm_to_host_map = self._get_vm_to_host_map(host_pool_info)
 
         result = []
 
@@ -236,7 +200,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
             server['name'] = vm.NAME
             server['id'] = vm.ID
-            server['host'] = vm_to_host_map.get(vm.ID, "VM ID not found")
+            server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
             server['LABELS'] = labels
             server['v4_first_ip'] = self._get_vm_ipv4(vm)
             server['v6_first_ip'] = self._get_vm_ipv6(vm)

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -200,9 +200,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
             server['name'] = vm.NAME
             server['id'] = vm.ID
-            if 'HISTORY' in vm.HISTORY_RECORDS:
-                if vm.HISTORY_RECORDS['HISTORY']:
-                    server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
+            if hasattr(vm.HISTORY_RECORDS, 'HISTORY'):
+                if vm.HISTORY_RECORDS.HISTORY:
+                    if isinstance(vm.HISTORY_RECORDS.HISTORY, list) and len(vm.HISTORY_RECORDS.HISTORY) > 0:
+                        if hasattr(vm.HISTORY_RECORDS.HISTORY[-1], 'HOSTNAME'):
+                            server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
             server['LABELS'] = labels
             server['v4_first_ip'] = self._get_vm_ipv4(vm)
             server['v6_first_ip'] = self._get_vm_ipv6(vm)

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -202,9 +202,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             server['name'] = vm.NAME
             server['id'] = vm.ID
             if hasattr(vm.HISTORY_RECORDS, 'HISTORY'):
-                    if isinstance(vm.HISTORY_RECORDS.HISTORY, Sequence) and len(vm.HISTORY_RECORDS.HISTORY) > 0:
-                        if hasattr(vm.HISTORY_RECORDS.HISTORY[-1], 'HOSTNAME'):
-                            server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
+                if isinstance(vm.HISTORY_RECORDS.HISTORY, Sequence) and len(vm.HISTORY_RECORDS.HISTORY) > 0:
+                    if hasattr(vm.HISTORY_RECORDS.HISTORY[-1], 'HOSTNAME'):
+                        server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
             server['LABELS'] = labels
             server['v4_first_ip'] = self._get_vm_ipv4(vm)
             server['v6_first_ip'] = self._get_vm_ipv6(vm)

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -201,10 +201,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             server['name'] = vm.NAME
             server['id'] = vm.ID
             if hasattr(vm.HISTORY_RECORDS, 'HISTORY'):
-                if vm.HISTORY_RECORDS.HISTORY:
-                    if isinstance(vm.HISTORY_RECORDS.HISTORY, list) and len(vm.HISTORY_RECORDS.HISTORY) > 0:
-                        if hasattr(vm.HISTORY_RECORDS.HISTORY[-1], 'HOSTNAME'):
-                            server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
+                if isinstance(vm.HISTORY_RECORDS.HISTORY, list) and len(vm.HISTORY_RECORDS.HISTORY) > 0:
+                    if hasattr(vm.HISTORY_RECORDS.HISTORY[-1], 'HOSTNAME'):
+                        server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
             server['LABELS'] = labels
             server['v4_first_ip'] = self._get_vm_ipv4(vm)
             server['v6_first_ip'] = self._get_vm_ipv6(vm)

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -200,8 +200,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
             server['name'] = vm.NAME
             server['id'] = vm.ID
-            if vm.HISTORY_RECORDS.HISTORY:
-                server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
+            if 'HISTORY' in vm.HISTORY_RECORDS:
+                if vm.HISTORY_RECORDS['HISTORY']:
+                    server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
             server['LABELS'] = labels
             server['v4_first_ip'] = self._get_vm_ipv4(vm)
             server['v6_first_ip'] = self._get_vm_ipv6(vm)

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -201,10 +201,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
             server['name'] = vm.NAME
             server['id'] = vm.ID
-            if vm.HISTORY_RECORDS.HISTORY:
-                if isinstance(vm.HISTORY_RECORDS.HISTORY, Sequence) and len(vm.HISTORY_RECORDS.HISTORY) > 0:
-                    if hasattr(vm.HISTORY_RECORDS.HISTORY[-1], 'HOSTNAME'):
-                        server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
+            if hasattr(vm.HISTORY_RECORDS, 'HISTORY'):
+                    if isinstance(vm.HISTORY_RECORDS.HISTORY, Sequence) and len(vm.HISTORY_RECORDS.HISTORY) > 0:
+                        if hasattr(vm.HISTORY_RECORDS.HISTORY[-1], 'HOSTNAME'):
+                            server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
             server['LABELS'] = labels
             server['v4_first_ip'] = self._get_vm_ipv4(vm)
             server['v6_first_ip'] = self._get_vm_ipv6(vm)

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -176,8 +176,44 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         return vm_pool
 
+    def _get_host_pool_info(self):
+        auth = self._get_connection_info()
+
+        if not (auth.username and auth.password):
+            raise AnsibleError('API Credentials missing. Check OpenNebula inventory file.')
+        else:
+            one_client = pyone.OneServer(auth.url, session=auth.username + ':' + auth.password)
+
+        # get hosts (underlying hardware hosts)
+        try:
+            host_pool_info = one_client.hostpool.info()
+        except Exception as e:
+            raise AnsibleError("Something happened during XML-RPC call: {e}".format(e=to_native(e)))
+
+        return host_pool_info
+
+    def _get_vm_to_host_map(self, host_pool_info):
+        vm_to_host_map = {}
+
+        # Iterate over the hosts
+        for host in host_pool_info.HOST:
+            host_name = host.NAME
+
+            # Some hosts might not have VMs, so we need to check for VMS attribute
+            if hasattr(host, 'VMS') and hasattr(host.VMS, 'ID'):
+                # VMS.ID could be a single ID or a list of IDs
+                if isinstance(host.VMS.ID, list):
+                    for vm_id in host.VMS.ID:
+                        vm_to_host_map[vm_id] = host_name
+                else:
+                    vm_to_host_map[host.VMS.ID] = host_name
+
+        return vm_to_host_map
+
     def _retrieve_servers(self, label_filter=None):
         vm_pool = self._get_vm_pool()
+        host_pool_info = self._get_host_pool_info()
+        vm_to_host_map = self._get_vm_to_host_map(host_pool_info)
 
         result = []
 
@@ -199,6 +235,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                     continue
 
             server['name'] = vm.NAME
+            server['id'] = vm.ID
+            server['host'] = vm_to_host_map.get(vm.ID, "VM ID not found")
             server['LABELS'] = labels
             server['v4_first_ip'] = self._get_vm_ipv4(vm)
             server['v6_first_ip'] = self._get_vm_ipv6(vm)

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -200,7 +200,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
             server['name'] = vm.NAME
             server['id'] = vm.ID
-            if vm.HISTORY_RECORDS.HISTORY[-1]:
+            if vm.HISTORY_RECORDS.HISTORY:
                 server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
             server['LABELS'] = labels
             server['v4_first_ip'] = self._get_vm_ipv4(vm)

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -200,7 +200,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
             server['name'] = vm.NAME
             server['id'] = vm.ID
-            server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
+            if vm.HISTORY_RECORDS.HISTORY[-1]:
+                server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
             server['LABELS'] = labels
             server['v4_first_ip'] = self._get_vm_ipv4(vm)
             server['v6_first_ip'] = self._get_vm_ipv6(vm)

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -200,7 +200,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
             server['name'] = vm.NAME
             server['id'] = vm.ID
-            if hasattr(vm.HISTORY_RECORDS, 'HISTORY'):
+            if hasattr(vm.HISTORY_RECORDS, 'HISTORY') and vm.HISTORY_RECORDS.HISTORY:
                 server['host'] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
             server['LABELS'] = labels
             server['v4_first_ip'] = self._get_vm_ipv4(vm)

--- a/tests/unit/plugins/inventory/test_opennebula.py
+++ b/tests/unit/plugins/inventory/test_opennebula.py
@@ -58,7 +58,7 @@ def get_vm_pool():
         'ETIME': 0,
         'GID': 132,
         'GNAME': 'CSApparelVDC',
-        'HISTORY_RECORDS': OrderedDict({
+        'HISTORY_RECORDS': list [
             'HISTORY': OrderedDict({
                 'OID': '42',
                 'SEQ': '384',
@@ -69,8 +69,8 @@ def get_vm_pool():
                 'VM_MAD': 'kvm',
                 'TM_MAD': '3par',
                 'ACTION': '0'
-            })
-        }),
+            }),
+        ],
         'ID': 7157,
         'LAST_POLL': 1632762935,
         'LCM_STATE': 3,
@@ -116,7 +116,7 @@ def get_vm_pool():
         'ETIME': 0,
         'GID': 0,
         'GNAME': 'oneadmin',
-        'HISTORY_RECORDS': {},
+        'HISTORY_RECORDS': [],
         'ID': 327,
         'LAST_POLL': 1632763543,
         'LCM_STATE': 3,
@@ -179,7 +179,7 @@ def get_vm_pool():
         'ETIME': 0,
         'GID': 0,
         'GNAME': 'oneadmin',
-        'HISTORY_RECORDS': {},
+        'HISTORY_RECORDS': [],
         'ID': 107,
         'LAST_POLL': 1632764186,
         'LCM_STATE': 3,

--- a/tests/unit/plugins/inventory/test_opennebula.py
+++ b/tests/unit/plugins/inventory/test_opennebula.py
@@ -21,6 +21,23 @@ from ansible_collections.community.general.plugins.inventory.opennebula import I
 from ansible_collections.community.general.tests.unit.compat.mock import create_autospec
 
 
+class HistoryEntry(object):
+    def __init__(self):
+        self.SEQ = '384'
+        self.HOSTNAME = 'sam-691-sam'
+        self.HID = '10'
+        self.CID = '0'
+        self.DS_ID = '100'
+        self.VM_MAD = 'kvm'
+        self.TM_MAD = '3par'
+        self.ACTION = '0'
+
+
+class HistoryRecords(object):
+    def __init__(self):
+        self.HISTORY = [HistoryEntry()]
+
+
 @pytest.fixture
 def inventory():
     r = InventoryModule()
@@ -58,21 +75,7 @@ def get_vm_pool():
         'ETIME': 0,
         'GID': 132,
         'GNAME': 'CSApparelVDC',
-        'HISTORY_RECORDS': [
-            {
-                'HISTORY': OrderedDict({
-                    'OID': '42',
-                    'SEQ': '384',
-                    'HOSTNAME': 'sam-691-sam',
-                    'HID': '10',
-                    'CID': '0',
-                    'DS_ID': '100',
-                    'VM_MAD': 'kvm',
-                    'TM_MAD': '3par',
-                    'ACTION': '0'
-                }),
-            }
-        ],
+        'HISTORY_RECORDS': HistoryRecords(),
         'ID': 7157,
         'LAST_POLL': 1632762935,
         'LCM_STATE': 3,

--- a/tests/unit/plugins/inventory/test_opennebula.py
+++ b/tests/unit/plugins/inventory/test_opennebula.py
@@ -58,7 +58,19 @@ def get_vm_pool():
         'ETIME': 0,
         'GID': 132,
         'GNAME': 'CSApparelVDC',
-        'HISTORY_RECORDS': {},
+        'HISTORY_RECORDS': OrderedDict({
+            'HISTORY': OrderedDict({
+                'OID': '42',
+                'SEQ': '384',
+                'HOSTNAME': 'sam-691-sam',
+                'HID': '10',
+                'CID': '0',
+                'DS_ID': '100',
+                'VM_MAD': 'kvm',
+                'TM_MAD': '3par',
+                'ACTION': '0'
+            })
+        }),
         'ID': 7157,
         'LAST_POLL': 1632762935,
         'LCM_STATE': 3,

--- a/tests/unit/plugins/inventory/test_opennebula.py
+++ b/tests/unit/plugins/inventory/test_opennebula.py
@@ -58,18 +58,20 @@ def get_vm_pool():
         'ETIME': 0,
         'GID': 132,
         'GNAME': 'CSApparelVDC',
-        'HISTORY_RECORDS': list [
-            'HISTORY': OrderedDict({
-                'OID': '42',
-                'SEQ': '384',
-                'HOSTNAME': 'sam-691-sam',
-                'HID': '10',
-                'CID': '0',
-                'DS_ID': '100',
-                'VM_MAD': 'kvm',
-                'TM_MAD': '3par',
-                'ACTION': '0'
-            }),
+        'HISTORY_RECORDS': [
+            {
+                'HISTORY': OrderedDict({
+                    'OID': '42',
+                    'SEQ': '384',
+                    'HOSTNAME': 'sam-691-sam',
+                    'HID': '10',
+                    'CID': '0',
+                    'DS_ID': '100',
+                    'VM_MAD': 'kvm',
+                    'TM_MAD': '3par',
+                    'ACTION': '0'
+                }),
+            }
         ],
         'ID': 7157,
         'LAST_POLL': 1632762935,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions --> To enable greater use of the inventory, add the ID of the VM, and the hostname of the host the VM is running on to the inventory output

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. --> opennebula.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here --> <!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
                "host": "foo23.host",
                "id": 1234,
```