### PR TITLE
Re-enable iptables_state tests on Ubuntu 22.04 VM

### DIFF
--- a/tests/integration/targets/iptables_state/aliases
+++ b/tests/integration/targets/iptables_state/aliases
@@ -11,5 +11,4 @@ skip/osx                # no iptables/netfilter (Linux specific)
 skip/macos              # no iptables/netfilter (Linux specific)
 skip/aix                # no iptables/netfilter (Linux specific)
 
-skip/ubuntu22.04  # TODO there's a problem here!
 skip/rhel10.0     # TODO there's a problem here!

--- a/tests/integration/targets/iptables_state/tasks/tests/10-rollback.yml
+++ b/tests/integration/targets/iptables_state/tasks/tests/10-rollback.yml
@@ -70,6 +70,10 @@
         ansible_timeout: "{{ max_delay | default(300) }}"
 
   rescue:
+    - name: Show result
+      debug:
+        var: iptables_state
+
     - name: "explain expected failure"
       assert:
         that:
@@ -140,6 +144,10 @@
       poll: 0
 
   rescue:
+    - name: Show result
+      debug:
+        var: iptables_state
+
     - name: "explain expected failure"
       assert:
         that:
@@ -174,6 +182,10 @@
         ansible_timeout: "{{ max_delay | default(300) }}"
 
   rescue:
+    - name: Show result
+      debug:
+        var: iptables_state
+
     - name: "explain expected failure"
       assert:
         that:


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/ansible-collections/community.general/pull/8537#issuecomment-2176976559

##### ISSUE TYPE
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME
iptables_state
