### PR TITLE
Improve Proxmox volume handling

### DIFF
--- a/changelogs/fragments/8542-fix-proxmox-volume-handling.yml
+++ b/changelogs/fragments/8542-fix-proxmox-volume-handling.yml
@@ -1,5 +1,5 @@
 bugfixes:
-  - proxmox - fix idempotency on creation of mount volumes using Proxmox' special ``<storage>:<size>`` syntax.
+  - proxmox - fix idempotency on creation of mount volumes using Proxmox' special ``<storage>:<size>`` syntax (https://github.com/ansible-collections/community.general/issues/8407, https://github.com/ansible-collections/community.general/pull/8542).
 minor_changes:
-  - proxmox - add ``disk_volume`` and ``mount_volumes`` keys for better readability.
-  - proxmox - translate the old ``disk`` and ``mounts`` keys to the new handling internally.
+  - proxmox - add ``disk_volume`` and ``mount_volumes`` keys for better readability (https://github.com/ansible-collections/community.general/pull/8542).
+  - proxmox - translate the old ``disk`` and ``mounts`` keys to the new handling internally (https://github.com/ansible-collections/community.general/pull/8542).

--- a/changelogs/fragments/8542-fix-proxmox-volume-handling.yml
+++ b/changelogs/fragments/8542-fix-proxmox-volume-handling.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - proxmox - fix idempotency on creation of mount volumes using Proxmox' special ``<storage>:<size>`` syntax.
+minor_changes:
+  - proxmox - add ``disk_volume`` and ``mount_volumes`` keys for better readability.
+  - proxmox - translate the old ``disk`` and ``mounts`` keys to the new handling internally.

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -590,7 +590,9 @@ import time
 from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
+from ansible.module_utils.six import string_types
+from ansible.module_utils.common.text.converters import to_native, to_text
+
 
 from ansible_collections.community.general.plugins.module_utils.proxmox import (
     ansible_to_proxmox_bool, proxmox_auth_argument_spec, ProxmoxAnsible)
@@ -757,9 +759,9 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
         if disk is not None:
             kwargs["disk_volume"] = parse_disk_string(disk)
         if "disk_volume" in kwargs:
-            if not all(isinstance(val, str) for val in kwargs["disk_volume"].values()):
+            if not all(isinstance(val, string_types) for val in kwargs["disk_volume"].values()):
                 self.module.warn("All disk_volume values must be strings. Converting non-string values to strings.")
-                kwargs["disk_volume"] = {key: str(val) for key, val in kwargs["disk_volume"].items()}
+                kwargs["disk_volume"] = {key: to_text(val) for key, val in kwargs["disk_volume"].items()}
             disk_dict = build_volume(key="rootfs", **kwargs.pop("disk_volume"))
             kwargs.update(disk_dict)
         if memory is not None:
@@ -773,9 +775,9 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
         if "mount_volumes" in kwargs:
             mounts_list = kwargs.pop("mount_volumes")
             for mount_config in mounts_list:
-                if not all(isinstance(val, str) for val in mount_config.values()):
+                if not all(isinstance(val, string_types) for val in mount_config.values()):
                     self.module.warn("All mount_volumes values must be strings. Converting non-string values to strings.")
-                    mount_config = {key: str(val) for key, val in mount_config.items()}
+                    mount_config = {key: to_text(val) for key, val in mount_config.items()}
                 key = mount_config.pop("id")
                 mount_dict = build_volume(key=key, **mount_config)
                 kwargs.update(mount_dict)

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -173,7 +173,7 @@ options:
       options:
         description:
           - O(mount_volumes[].options) is a dict of extra options.
-          - The value of any given option must be a string, e.g. V("1").
+          - The value of any given option must be a string, for example V("1").
         type: dict
   ip_address:
     description:

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -6,10 +6,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import absolute_import, division, print_function
-
 __metaclass__ = type
 
-DOCUMENTATION = """
+DOCUMENTATION = '''
 ---
 module: proxmox
 short_description: Management of instances in Proxmox VE cluster
@@ -309,9 +308,9 @@ extends_documentation_fragment:
   - community.general.proxmox.documentation
   - community.general.proxmox.selection
   - community.general.attributes
-"""
+'''
 
-EXAMPLES = r"""
+EXAMPLES = r'''
 - name: Create new container with minimal options
   community.general.proxmox:
     vmid: 100
@@ -585,40 +584,31 @@ EXAMPLES = r"""
     api_password: 1q2w3e
     api_host: node1
     state: absent
-"""
+'''
 
 import re
 import time
 
+from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
+
 from ansible_collections.community.general.plugins.module_utils.proxmox import (
-    ProxmoxAnsible,
-    ansible_to_proxmox_bool,
-    proxmox_auth_argument_spec,
-)
-from ansible_collections.community.general.plugins.module_utils.version import (
-    LooseVersion,
-)
+    ansible_to_proxmox_bool, proxmox_auth_argument_spec, ProxmoxAnsible)
 
 VZ_TYPE = None
 
 
 class ProxmoxLxcAnsible(ProxmoxAnsible):
     def content_check(self, node, ostemplate, template_store):
-        return [
-            True
-            for cnt in self.proxmox_api.nodes(node)
-            .storage(template_store)
-            .content.get()
-            if cnt["volid"] == ostemplate
-        ]
+        return [True for cnt in self.proxmox_api.nodes(node).storage(template_store).content.get() if cnt['volid'] == ostemplate]
 
     def is_template_container(self, node, vmid):
         """Check if the specified container is a template."""
         proxmox_node = self.proxmox_api.nodes(node)
         config = getattr(proxmox_node, VZ_TYPE)(vmid).config.get()
-        return config.get("template", False)
+        return config.get('template', False)
 
     def update_config(self, vmid, node, disk, cpus, memory, swap, **kwargs):
         if VZ_TYPE != "lxc":
@@ -804,7 +794,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
 
         # compare the requested config against the current
         update_config = False
-        for arg, value in kwargs.items():
+        for (arg, value) in kwargs.items():
             # if the arg isn't in the current config, it needs to be updated
             if arg not in current_config:
                 update_config = True
@@ -825,20 +815,17 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
                     break
 
         if update_config:
-            getattr(proxmox_node, VZ_TYPE)(vmid).config.put(
-                vmid=vmid, node=node, **kwargs
-            )
+            getattr(proxmox_node, VZ_TYPE)(vmid).config.put(vmid=vmid, node=node, **kwargs)
         else:
-            self.module.exit_json(
-                changed=False, msg="Container config is already up to date"
-            )
+            self.module.exit_json(changed=False, msg="Container config is already up to date")
 
-    def create_instance(
-        self, vmid, node, disk, storage, cpus, memory, swap, timeout, clone, **kwargs
-    ):
+    def create_instance(self, vmid, node, disk, storage, cpus, memory, swap, timeout, clone, **kwargs):
 
         # Version limited features
-        minimum_version = {"tags": "6.1", "timezone": "6.3"}
+        minimum_version = {
+            'tags': '6.1',
+            'timezone': '6.3'
+        }
         proxmox_node = self.proxmox_api.nodes(node)
 
         # Remove all empty kwarg entries
@@ -849,47 +836,40 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
         # Fail on unsupported features
         for option, version in minimum_version.items():
             if pve_version < LooseVersion(version) and option in kwargs:
-                self.module.fail_json(
-                    changed=False,
-                    msg="Feature {option} is only supported in PVE {version}+, and you're using PVE {pve_version}".format(
-                        option=option, version=version, pve_version=pve_version
-                    ),
-                )
+                self.module.fail_json(changed=False, msg="Feature {option} is only supported in PVE {version}+, and you're using PVE {pve_version}".
+                                      format(option=option, version=version, pve_version=pve_version))
 
-        if VZ_TYPE == "lxc":
-            kwargs["cpulimit"] = cpus
-            kwargs["rootfs"] = disk
-            if "netif" in kwargs:
-                kwargs.update(kwargs["netif"])
-                del kwargs["netif"]
-            if "mounts" in kwargs:
-                kwargs.update(kwargs["mounts"])
-                del kwargs["mounts"]
-            if "pubkey" in kwargs:
-                if self.version() >= LooseVersion("4.2"):
-                    kwargs["ssh-public-keys"] = kwargs["pubkey"]
-                del kwargs["pubkey"]
+        if VZ_TYPE == 'lxc':
+            kwargs['cpulimit'] = cpus
+            kwargs['rootfs'] = disk
+            if 'netif' in kwargs:
+                kwargs.update(kwargs['netif'])
+                del kwargs['netif']
+            if 'mounts' in kwargs:
+                kwargs.update(kwargs['mounts'])
+                del kwargs['mounts']
+            if 'pubkey' in kwargs:
+                if self.version() >= LooseVersion('4.2'):
+                    kwargs['ssh-public-keys'] = kwargs['pubkey']
+                del kwargs['pubkey']
         else:
-            kwargs["cpus"] = cpus
-            kwargs["disk"] = disk
+            kwargs['cpus'] = cpus
+            kwargs['disk'] = disk
 
         # LXC tags are expected to be valid and presented as a comma/semi-colon delimited string
-        if "tags" in kwargs:
-            re_tag = re.compile(r"^[a-z0-9_][a-z0-9_\-\+\.]*$")
-            for tag in kwargs["tags"]:
+        if 'tags' in kwargs:
+            re_tag = re.compile(r'^[a-z0-9_][a-z0-9_\-\+\.]*$')
+            for tag in kwargs['tags']:
                 if not re_tag.match(tag):
-                    self.module.fail_json(msg="%s is not a valid tag" % tag)
-            kwargs["tags"] = ",".join(kwargs["tags"])
+                    self.module.fail_json(msg='%s is not a valid tag' % tag)
+            kwargs['tags'] = ",".join(kwargs['tags'])
 
-        if kwargs.get("ostype") == "auto":
-            kwargs.pop("ostype")
+        if kwargs.get('ostype') == 'auto':
+            kwargs.pop('ostype')
 
         if clone is not None:
-            if VZ_TYPE != "lxc":
-                self.module.fail_json(
-                    changed=False,
-                    msg="Clone operator is only supported for LXC enabled proxmox clusters.",
-                )
+            if VZ_TYPE != 'lxc':
+                self.module.fail_json(changed=False, msg="Clone operator is only supported for LXC enabled proxmox clusters.")
 
             clone_is_template = self.is_template_container(node, clone)
 
@@ -897,136 +877,96 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
             create_full_copy = not clone_is_template
 
             # Only accept parameters that are compatible with the clone endpoint.
-            valid_clone_parameters = ["hostname", "pool", "description"]
-            if self.module.params["storage"] is not None and clone_is_template:
+            valid_clone_parameters = ['hostname', 'pool', 'description']
+            if self.module.params['storage'] is not None and clone_is_template:
                 # Cloning a template, so create a full copy instead of a linked copy
                 create_full_copy = True
-            elif self.module.params["storage"] is None and not clone_is_template:
+            elif self.module.params['storage'] is None and not clone_is_template:
                 # Not cloning a template, but also no defined storage. This isn't possible.
-                self.module.fail_json(
-                    changed=False,
-                    msg="Cloned container is not a template, storage needs to be specified.",
-                )
+                self.module.fail_json(changed=False, msg="Cloned container is not a template, storage needs to be specified.")
 
-            if self.module.params["clone_type"] == "linked":
+            if self.module.params['clone_type'] == 'linked':
                 if not clone_is_template:
-                    self.module.fail_json(
-                        changed=False,
-                        msg="'linked' clone type is specified, but cloned container is not a template container.",
-                    )
+                    self.module.fail_json(changed=False, msg="'linked' clone type is specified, but cloned container is not a template container.")
                 # Don't need to do more, by default create_full_copy is set to false already
-            elif self.module.params["clone_type"] == "opportunistic":
+            elif self.module.params['clone_type'] == 'opportunistic':
                 if not clone_is_template:
                     # Cloned container is not a template, so we need our 'storage' parameter
-                    valid_clone_parameters.append("storage")
-            elif self.module.params["clone_type"] == "full":
+                    valid_clone_parameters.append('storage')
+            elif self.module.params['clone_type'] == 'full':
                 create_full_copy = True
-                valid_clone_parameters.append("storage")
+                valid_clone_parameters.append('storage')
 
             clone_parameters = {}
 
             if create_full_copy:
-                clone_parameters["full"] = "1"
+                clone_parameters['full'] = '1'
             else:
-                clone_parameters["full"] = "0"
+                clone_parameters['full'] = '0'
             for param in valid_clone_parameters:
                 if self.module.params[param] is not None:
                     clone_parameters[param] = self.module.params[param]
 
-            taskid = getattr(proxmox_node, VZ_TYPE)(clone).clone.post(
-                newid=vmid, **clone_parameters
-            )
+            taskid = getattr(proxmox_node, VZ_TYPE)(clone).clone.post(newid=vmid, **clone_parameters)
         else:
-            taskid = getattr(proxmox_node, VZ_TYPE).create(
-                vmid=vmid, storage=storage, memory=memory, swap=swap, **kwargs
-            )
+            taskid = getattr(proxmox_node, VZ_TYPE).create(vmid=vmid, storage=storage, memory=memory, swap=swap, **kwargs)
 
         while timeout:
             if self.api_task_ok(node, taskid):
                 return True
             timeout -= 1
             if timeout == 0:
-                self.module.fail_json(
-                    vmid=vmid,
-                    node=node,
-                    msg="Reached timeout while waiting for creating VM. Last line in task before timeout: %s"
-                    % proxmox_node.tasks(taskid).log.get()[:1],
-                )
+                self.module.fail_json(vmid=vmid, node=node, msg='Reached timeout while waiting for creating VM. Last line in task before timeout: %s' %
+                                      proxmox_node.tasks(taskid).log.get()[:1])
 
             time.sleep(1)
         return False
 
     def start_instance(self, vm, vmid, timeout):
-        taskid = getattr(self.proxmox_api.nodes(vm["node"]), VZ_TYPE)(
-            vmid
-        ).status.start.post()
+        taskid = getattr(self.proxmox_api.nodes(vm['node']), VZ_TYPE)(vmid).status.start.post()
         while timeout:
-            if self.api_task_ok(vm["node"], taskid):
+            if self.api_task_ok(vm['node'], taskid):
                 return True
             timeout -= 1
             if timeout == 0:
-                self.module.fail_json(
-                    vmid=vmid,
-                    taskid=taskid,
-                    msg="Reached timeout while waiting for starting VM. Last line in task before timeout: %s"
-                    % self.proxmox_api.nodes(vm["node"]).tasks(taskid).log.get()[:1],
-                )
+                self.module.fail_json(vmid=vmid, taskid=taskid, msg='Reached timeout while waiting for starting VM. Last line in task before timeout: %s' %
+                                      self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
 
             time.sleep(1)
         return False
 
     def stop_instance(self, vm, vmid, timeout, force):
         if force:
-            taskid = getattr(self.proxmox_api.nodes(vm["node"]), VZ_TYPE)(
-                vmid
-            ).status.shutdown.post(forceStop=1)
+            taskid = getattr(self.proxmox_api.nodes(vm['node']), VZ_TYPE)(vmid).status.shutdown.post(forceStop=1)
         else:
-            taskid = getattr(self.proxmox_api.nodes(vm["node"]), VZ_TYPE)(
-                vmid
-            ).status.shutdown.post()
+            taskid = getattr(self.proxmox_api.nodes(vm['node']), VZ_TYPE)(vmid).status.shutdown.post()
         while timeout:
-            if self.api_task_ok(vm["node"], taskid):
+            if self.api_task_ok(vm['node'], taskid):
                 return True
             timeout -= 1
             if timeout == 0:
-                self.module.fail_json(
-                    vmid=vmid,
-                    taskid=taskid,
-                    msg="Reached timeout while waiting for stopping VM. Last line in task before timeout: %s"
-                    % self.proxmox_api.nodes(vm["node"]).tasks(taskid).log.get()[:1],
-                )
+                self.module.fail_json(vmid=vmid, taskid=taskid, msg='Reached timeout while waiting for stopping VM. Last line in task before timeout: %s' %
+                                      self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
 
             time.sleep(1)
         return False
 
     def convert_to_template(self, vm, vmid, timeout, force):
-        if (
-            getattr(self.proxmox_api.nodes(vm["node"]), VZ_TYPE)(
-                vmid
-            ).status.current.get()["status"]
-            == "running"
-            and force
-        ):
+        if getattr(self.proxmox_api.nodes(vm['node']), VZ_TYPE)(vmid).status.current.get()['status'] == 'running' and force:
             self.stop_instance(vm, vmid, timeout, force)
         # not sure why, but templating a container doesn't return a taskid
-        getattr(self.proxmox_api.nodes(vm["node"]), VZ_TYPE)(vmid).template.post()
+        getattr(self.proxmox_api.nodes(vm['node']), VZ_TYPE)(vmid).template.post()
         return True
 
     def umount_instance(self, vm, vmid, timeout):
-        taskid = getattr(self.proxmox_api.nodes(vm["node"]), VZ_TYPE)(
-            vmid
-        ).status.umount.post()
+        taskid = getattr(self.proxmox_api.nodes(vm['node']), VZ_TYPE)(vmid).status.umount.post()
         while timeout:
-            if self.api_task_ok(vm["node"], taskid):
+            if self.api_task_ok(vm['node'], taskid):
                 return True
             timeout -= 1
             if timeout == 0:
-                self.module.fail_json(
-                    vmid=vmid,
-                    taskid=taskid,
-                    msg="Reached timeout while waiting for unmounting VM. Last line in task before timeout: %s"
-                    % self.proxmox_api.nodes(vm["node"]).tasks(taskid).log.get()[:1],
-                )
+                self.module.fail_json(vmid=vmid, taskid=taskid, msg='Reached timeout while waiting for unmounting VM. Last line in task before timeout: %s' %
+                                      self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
 
             time.sleep(1)
         return False
@@ -1035,13 +975,13 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
 def main():
     module_args = proxmox_auth_argument_spec()
     proxmox_args = dict(
-        vmid=dict(type="int", required=False),
+        vmid=dict(type='int', required=False),
         node=dict(),
         pool=dict(),
         password=dict(no_log=True),
         hostname=dict(),
         ostemplate=dict(),
-        disk=dict(type="str"),
+        disk=dict(type='str'),
         disk_volume=dict(
             type="dict",
             options=dict(
@@ -1061,12 +1001,12 @@ def main():
                 ("host_path", "size"),
             ],
         ),
-        cores=dict(type="int"),
-        cpus=dict(type="int"),
-        memory=dict(type="int"),
-        swap=dict(type="int"),
-        netif=dict(type="dict"),
-        mounts=dict(type="dict"),
+        cores=dict(type='int'),
+        cpus=dict(type='int'),
+        memory=dict(type='int'),
+        swap=dict(type='int'),
+        netif=dict(type='dict'),
+        mounts=dict(type='dict'),
         mount_volumes=dict(
             type="list",
             elements="dict",
@@ -1090,65 +1030,39 @@ def main():
             ],
         ),
         ip_address=dict(),
-        ostype=dict(
-            default="auto",
-            choices=[
-                "auto",
-                "debian",
-                "devuan",
-                "ubuntu",
-                "centos",
-                "fedora",
-                "opensuse",
-                "archlinux",
-                "alpine",
-                "gentoo",
-                "nixos",
-                "unmanaged",
-            ],
-        ),
-        onboot=dict(type="bool"),
-        features=dict(type="list", elements="str"),
-        startup=dict(type="list", elements="str"),
-        storage=dict(default="local"),
-        cpuunits=dict(type="int"),
+        ostype=dict(default='auto', choices=[
+            'auto', 'debian', 'devuan', 'ubuntu', 'centos', 'fedora', 'opensuse', 'archlinux', 'alpine', 'gentoo', 'nixos', 'unmanaged'
+        ]),
+        onboot=dict(type='bool'),
+        features=dict(type='list', elements='str'),
+        startup=dict(type='list', elements='str'),
+        storage=dict(default='local'),
+        cpuunits=dict(type='int'),
         nameserver=dict(),
         searchdomain=dict(),
-        timeout=dict(type="int", default=30),
-        update=dict(type="bool", default=False),
-        force=dict(type="bool", default=False),
-        purge=dict(type="bool", default=False),
-        state=dict(
-            default="present",
-            choices=[
-                "present",
-                "absent",
-                "stopped",
-                "started",
-                "restarted",
-                "template",
-            ],
-        ),
-        pubkey=dict(type="str"),
-        unprivileged=dict(type="bool", default=True),
-        description=dict(type="str"),
-        hookscript=dict(type="str"),
-        timezone=dict(type="str"),
-        clone=dict(type="int"),
-        clone_type=dict(
-            default="opportunistic", choices=["full", "linked", "opportunistic"]
-        ),
-        tags=dict(type="list", elements="str"),
+        timeout=dict(type='int', default=30),
+        update=dict(type='bool', default=False),
+        force=dict(type='bool', default=False),
+        purge=dict(type='bool', default=False),
+        state=dict(default='present', choices=['present', 'absent', 'stopped', 'started', 'restarted', 'template']),
+        pubkey=dict(type='str'),
+        unprivileged=dict(type='bool', default=True),
+        description=dict(type='str'),
+        hookscript=dict(type='str'),
+        timezone=dict(type='str'),
+        clone=dict(type='int'),
+        clone_type=dict(default='opportunistic', choices=['full', 'linked', 'opportunistic']),
+        tags=dict(type='list', elements='str')
     )
     module_args.update(proxmox_args)
 
     module = AnsibleModule(
         argument_spec=module_args,
         required_if=[
-            ("state", "present", ["node", "hostname"]),
+            ('state', 'present', ['node', 'hostname']),
             # Require one of clone, ostemplate, or update. Together with mutually_exclusive this ensures that we
             # either clone a container or create a new one from a template file.
-            ("state", "present", ("clone", "ostemplate", "update"), True),
+            ('state', 'present', ('clone', 'ostemplate', 'update'), True),
         ],
         required_together=[("api_token_id", "api_token_secret")],
         required_one_of=[("api_password", "api_token_id")],
@@ -1166,73 +1080,59 @@ def main():
     proxmox = ProxmoxLxcAnsible(module)
 
     global VZ_TYPE
-    VZ_TYPE = "openvz" if proxmox.version() < LooseVersion("4.0") else "lxc"
+    VZ_TYPE = 'openvz' if proxmox.version() < LooseVersion('4.0') else 'lxc'
 
-    state = module.params["state"]
-    vmid = module.params["vmid"]
-    node = module.params["node"]
-    disk = module.params["disk"]
-    cpus = module.params["cpus"]
-    memory = module.params["memory"]
-    swap = module.params["swap"]
-    storage = module.params["storage"]
-    hostname = module.params["hostname"]
-    if module.params["ostemplate"] is not None:
-        template_store = module.params["ostemplate"].split(":")[0]
-    timeout = module.params["timeout"]
-    clone = module.params["clone"]
+    state = module.params['state']
+    vmid = module.params['vmid']
+    node = module.params['node']
+    disk = module.params['disk']
+    cpus = module.params['cpus']
+    memory = module.params['memory']
+    swap = module.params['swap']
+    storage = module.params['storage']
+    hostname = module.params['hostname']
+    if module.params['ostemplate'] is not None:
+        template_store = module.params['ostemplate'].split(":")[0]
+    timeout = module.params['timeout']
+    clone = module.params['clone']
 
     # If vmid not set get the Next VM id from ProxmoxAPI
     # If hostname is set get the VM id from ProxmoxAPI
-    if not vmid and state == "present":
+    if not vmid and state == 'present':
         vmid = proxmox.get_nextvmid()
     elif not vmid and hostname:
         vmid = proxmox.get_vmid(hostname)
     elif not vmid:
-        module.exit_json(
-            changed=False,
-            msg="Vmid could not be fetched for the following action: %s" % state,
-        )
+        module.exit_json(changed=False, msg="Vmid could not be fetched for the following action: %s" % state)
 
     # Create a new container
-    if state == "present" and clone is None:
+    if state == 'present' and clone is None:
         try:
             if proxmox.get_vm(vmid, ignore_missing=True):
                 if module.params["update"]:
                     try:
-                        proxmox.update_config(
-                            vmid,
-                            node,
-                            disk,
-                            cpus,
-                            memory,
-                            swap,
-                            cores=module.params["cores"],
-                            hostname=module.params["hostname"],
-                            netif=module.params["netif"],
-                            disk_volume=module.params["disk_volume"],
-                            mounts=module.params["mounts"],
-                            mount_volumes=module.params["mount_volumes"],
-                            ip_address=module.params["ip_address"],
-                            onboot=ansible_to_proxmox_bool(module.params["onboot"]),
-                            cpuunits=module.params["cpuunits"],
-                            nameserver=module.params["nameserver"],
-                            searchdomain=module.params["searchdomain"],
-                            features=(
-                                ",".join(module.params["features"])
-                                if module.params["features"] is not None
-                                else None
-                            ),
-                            startup=(
-                                ",".join(module.params["startup"])
-                                if module.params["startup"] is not None
-                                else None
-                            ),
-                            description=module.params["description"],
-                            hookscript=module.params["hookscript"],
-                            timezone=module.params["timezone"],
-                            tags=module.params["tags"],
-                        )
+                        proxmox.update_config(vmid, node, disk, cpus, memory, swap,
+                                              cores=module.params["cores"],
+                                              hostname=module.params["hostname"],
+                                              netif=module.params["netif"],
+                                              disk_volume=module.params["disk_volume"],
+                                              mounts=module.params["mounts"],
+                                              mount_volumes=module.params["mount_volumes"],
+                                              ip_address=module.params["ip_address"],
+                                              onboot=ansible_to_proxmox_bool(module.params["onboot"]),
+                                              cpuunits=module.params["cpuunits"],
+                                              nameserver=module.params["nameserver"],
+                                              searchdomain=module.params["searchdomain"],
+                                              features=",".join(module.params["features"])
+                                              if module.params["features"] is not None
+                                              else None,
+                                              startup=",".join(module.params["startup"])
+                                              if module.params["startup"] is not None
+                                              else None,
+                                              description=module.params["description"],
+                                              hookscript=module.params["hookscript"],
+                                              timezone=module.params["timezone"],
+                                              tags=module.params["tags"])
                         module.exit_json(
                             changed=True,
                             vmid=vmid,
@@ -1251,315 +1151,161 @@ def main():
                         msg="VM with vmid = %s is already exists" % vmid,
                     )
             # If no vmid was passed, there cannot be another VM named 'hostname'
-            if (
-                not module.params["vmid"]
-                and proxmox.get_vmid(hostname, ignore_missing=True)
-                and not module.params["force"]
-            ):
+            if (not module.params['vmid'] and
+                    proxmox.get_vmid(hostname, ignore_missing=True) and
+                    not module.params['force']):
                 vmid = proxmox.get_vmid(hostname)
-                module.exit_json(
-                    changed=False,
-                    vmid=vmid,
-                    msg="VM with hostname %s already exists and has ID number %s"
-                    % (hostname, vmid),
-                )
+                module.exit_json(changed=False, vmid=vmid, msg="VM with hostname %s already exists and has ID number %s" % (hostname, vmid))
             elif not proxmox.get_node(node):
-                module.fail_json(
-                    vmid=vmid, msg="node '%s' not exists in cluster" % node
-                )
-            elif not proxmox.content_check(
-                node, module.params["ostemplate"], template_store
-            ):
-                module.fail_json(
-                    vmid=vmid,
-                    msg="ostemplate '%s' not exists on node %s and storage %s"
-                    % (module.params["ostemplate"], node, template_store),
-                )
+                module.fail_json(vmid=vmid, msg="node '%s' not exists in cluster" % node)
+            elif not proxmox.content_check(node, module.params['ostemplate'], template_store):
+                module.fail_json(vmid=vmid, msg="ostemplate '%s' not exists on node %s and storage %s"
+                                 % (module.params['ostemplate'], node, template_store))
         except Exception as e:
-            module.fail_json(
-                vmid=vmid,
-                msg="Pre-creation checks of {VZ_TYPE} VM {vmid} failed with exception: {e}".format(
-                    VZ_TYPE=VZ_TYPE, vmid=vmid, e=e
-                ),
-            )
+            module.fail_json(vmid=vmid, msg="Pre-creation checks of {VZ_TYPE} VM {vmid} failed with exception: {e}".format(VZ_TYPE=VZ_TYPE, vmid=vmid, e=e))
 
         try:
-            proxmox.create_instance(
-                vmid,
-                node,
-                disk,
-                storage,
-                cpus,
-                memory,
-                swap,
-                timeout,
-                clone,
-                cores=module.params["cores"],
-                pool=module.params["pool"],
-                password=module.params["password"],
-                hostname=module.params["hostname"],
-                ostemplate=module.params["ostemplate"],
-                netif=module.params["netif"],
-                disk_volume=module.params["disk_volume"],
-                mounts=module.params["mounts"],
-                mount_volumes=module.params["mount_volumes"],
-                ostype=module.params["ostype"],
-                ip_address=module.params["ip_address"],
-                onboot=ansible_to_proxmox_bool(module.params["onboot"]),
-                cpuunits=module.params["cpuunits"],
-                nameserver=module.params["nameserver"],
-                searchdomain=module.params["searchdomain"],
-                force=ansible_to_proxmox_bool(module.params["force"]),
-                pubkey=module.params["pubkey"],
-                features=(
-                    ",".join(module.params["features"])
-                    if module.params["features"] is not None
-                    else None
-                ),
-                startup=(
-                    ",".join(module.params["startup"])
-                    if module.params["startup"] is not None
-                    else None
-                ),
-                unprivileged=ansible_to_proxmox_bool(module.params["unprivileged"]),
-                description=module.params["description"],
-                hookscript=module.params["hookscript"],
-                timezone=module.params["timezone"],
-                tags=module.params["tags"],
-            )
+            proxmox.create_instance(vmid, node, disk, storage, cpus, memory, swap, timeout, clone,
+                                    cores=module.params['cores'],
+                                    pool=module.params['pool'],
+                                    password=module.params['password'],
+                                    hostname=module.params['hostname'],
+                                    ostemplate=module.params['ostemplate'],
+                                    netif=module.params['netif'],
+                                    disk_volume=module.params["disk_volume"],
+                                    mounts=module.params['mounts'],
+                                    mount_volumes=module.params["mount_volumes"],
+                                    ostype=module.params['ostype'],
+                                    ip_address=module.params['ip_address'],
+                                    onboot=ansible_to_proxmox_bool(module.params['onboot']),
+                                    cpuunits=module.params['cpuunits'],
+                                    nameserver=module.params['nameserver'],
+                                    searchdomain=module.params['searchdomain'],
+                                    force=ansible_to_proxmox_bool(module.params['force']),
+                                    pubkey=module.params['pubkey'],
+                                    features=",".join(module.params['features']) if module.params['features'] is not None else None,
+                                    startup=",".join(module.params['startup']) if module.params['startup'] is not None else None,
+                                    unprivileged=ansible_to_proxmox_bool(module.params['unprivileged']),
+                                    description=module.params['description'],
+                                    hookscript=module.params['hookscript'],
+                                    timezone=module.params['timezone'],
+                                    tags=module.params['tags'])
 
-            module.exit_json(
-                changed=True,
-                vmid=vmid,
-                msg="Deployed VM %s from template %s"
-                % (vmid, module.params["ostemplate"]),
-            )
+            module.exit_json(changed=True, vmid=vmid, msg="Deployed VM %s from template %s" % (vmid, module.params['ostemplate']))
         except Exception as e:
-            module.fail_json(
-                vmid=vmid,
-                msg="Creation of %s VM %s failed with exception: %s"
-                % (VZ_TYPE, vmid, e),
-            )
+            module.fail_json(vmid=vmid, msg="Creation of %s VM %s failed with exception: %s" % (VZ_TYPE, vmid, e))
 
     # Clone a container
-    elif state == "present" and clone is not None:
+    elif state == 'present' and clone is not None:
         try:
-            if proxmox.get_vm(vmid, ignore_missing=True) and not module.params["force"]:
-                module.exit_json(
-                    changed=False,
-                    vmid=vmid,
-                    msg="VM with vmid = %s is already exists" % vmid,
-                )
+            if proxmox.get_vm(vmid, ignore_missing=True) and not module.params['force']:
+                module.exit_json(changed=False, vmid=vmid, msg="VM with vmid = %s is already exists" % vmid)
             # If no vmid was passed, there cannot be another VM named 'hostname'
-            if (
-                not module.params["vmid"]
-                and proxmox.get_vmid(hostname, ignore_missing=True)
-                and not module.params["force"]
-            ):
+            if (not module.params['vmid'] and
+                    proxmox.get_vmid(hostname, ignore_missing=True) and
+                    not module.params['force']):
                 vmid = proxmox.get_vmid(hostname)
-                module.exit_json(
-                    changed=False,
-                    vmid=vmid,
-                    msg="VM with hostname %s already exists and has ID number %s"
-                    % (hostname, vmid),
-                )
+                module.exit_json(changed=False, vmid=vmid, msg="VM with hostname %s already exists and has ID number %s" % (hostname, vmid))
             if not proxmox.get_vm(clone, ignore_missing=True):
-                module.exit_json(
-                    changed=False,
-                    vmid=vmid,
-                    msg="Container to be cloned does not exist",
-                )
+                module.exit_json(changed=False, vmid=vmid, msg="Container to be cloned does not exist")
         except Exception as e:
-            module.fail_json(
-                vmid=vmid,
-                msg="Pre-clone checks of {VZ_TYPE} VM {vmid} failed with exception: {e}".format(
-                    VZ_TYPE=VZ_TYPE, vmid=vmid, e=e
-                ),
-            )
+            module.fail_json(vmid=vmid, msg="Pre-clone checks of {VZ_TYPE} VM {vmid} failed with exception: {e}".format(VZ_TYPE=VZ_TYPE, vmid=vmid, e=e))
 
         try:
-            proxmox.create_instance(
-                vmid, node, disk, storage, cpus, memory, swap, timeout, clone
-            )
+            proxmox.create_instance(vmid, node, disk, storage, cpus, memory, swap, timeout, clone)
 
-            module.exit_json(
-                changed=True, vmid=vmid, msg="Cloned VM %s from %s" % (vmid, clone)
-            )
+            module.exit_json(changed=True, vmid=vmid, msg="Cloned VM %s from %s" % (vmid, clone))
         except Exception as e:
-            module.fail_json(
-                vmid=vmid,
-                msg="Cloning %s VM %s failed with exception: %s" % (VZ_TYPE, vmid, e),
-            )
+            module.fail_json(vmid=vmid, msg="Cloning %s VM %s failed with exception: %s" % (VZ_TYPE, vmid, e))
 
-    elif state == "started":
+    elif state == 'started':
         try:
             vm = proxmox.get_vm(vmid)
-            if (
-                getattr(proxmox.proxmox_api.nodes(vm["node"]), VZ_TYPE)(
-                    vmid
-                ).status.current.get()["status"]
-                == "running"
-            ):
-                module.exit_json(
-                    changed=False, vmid=vmid, msg="VM %s is already running" % vmid
-                )
+            if getattr(proxmox.proxmox_api.nodes(vm['node']), VZ_TYPE)(vmid).status.current.get()['status'] == 'running':
+                module.exit_json(changed=False, vmid=vmid, msg="VM %s is already running" % vmid)
 
             if proxmox.start_instance(vm, vmid, timeout):
                 module.exit_json(changed=True, vmid=vmid, msg="VM %s started" % vmid)
         except Exception as e:
-            module.fail_json(
-                vmid=vmid, msg="starting of VM %s failed with exception: %s" % (vmid, e)
-            )
+            module.fail_json(vmid=vmid, msg="starting of VM %s failed with exception: %s" % (vmid, e))
 
-    elif state == "stopped":
+    elif state == 'stopped':
         try:
             vm = proxmox.get_vm(vmid)
 
-            if (
-                getattr(proxmox.proxmox_api.nodes(vm["node"]), VZ_TYPE)(
-                    vmid
-                ).status.current.get()["status"]
-                == "mounted"
-            ):
-                if module.params["force"]:
+            if getattr(proxmox.proxmox_api.nodes(vm['node']), VZ_TYPE)(vmid).status.current.get()['status'] == 'mounted':
+                if module.params['force']:
                     if proxmox.umount_instance(vm, vmid, timeout):
-                        module.exit_json(
-                            changed=True, vmid=vmid, msg="VM %s is shutting down" % vmid
-                        )
+                        module.exit_json(changed=True, vmid=vmid, msg="VM %s is shutting down" % vmid)
                 else:
-                    module.exit_json(
-                        changed=False,
-                        vmid=vmid,
-                        msg=(
-                            "VM %s is already shutdown, but mounted. You can use force option to umount it."
-                        )
-                        % vmid,
-                    )
+                    module.exit_json(changed=False, vmid=vmid,
+                                     msg=("VM %s is already shutdown, but mounted. You can use force option to umount it.") % vmid)
 
-            if (
-                getattr(proxmox.proxmox_api.nodes(vm["node"]), VZ_TYPE)(
-                    vmid
-                ).status.current.get()["status"]
-                == "stopped"
-            ):
-                module.exit_json(
-                    changed=False, vmid=vmid, msg="VM %s is already shutdown" % vmid
-                )
+            if getattr(proxmox.proxmox_api.nodes(vm['node']), VZ_TYPE)(vmid).status.current.get()['status'] == 'stopped':
+                module.exit_json(changed=False, vmid=vmid, msg="VM %s is already shutdown" % vmid)
 
-            if proxmox.stop_instance(vm, vmid, timeout, force=module.params["force"]):
-                module.exit_json(
-                    changed=True, vmid=vmid, msg="VM %s is shutting down" % vmid
-                )
+            if proxmox.stop_instance(vm, vmid, timeout, force=module.params['force']):
+                module.exit_json(changed=True, vmid=vmid, msg="VM %s is shutting down" % vmid)
         except Exception as e:
-            module.fail_json(
-                vmid=vmid, msg="stopping of VM %s failed with exception: %s" % (vmid, e)
-            )
+            module.fail_json(vmid=vmid, msg="stopping of VM %s failed with exception: %s" % (vmid, e))
 
-    elif state == "template":
+    elif state == 'template':
         try:
             vm = proxmox.get_vm(vmid)
 
-            proxmox.convert_to_template(vm, vmid, timeout, force=module.params["force"])
+            proxmox.convert_to_template(vm, vmid, timeout, force=module.params['force'])
             module.exit_json(changed=True, msg="VM %s is converted to template" % vmid)
         except Exception as e:
-            module.fail_json(
-                vmid=vmid,
-                msg="conversion of VM %s to template failed with exception: %s"
-                % (vmid, e),
-            )
+            module.fail_json(vmid=vmid, msg="conversion of VM %s to template failed with exception: %s" % (vmid, e))
 
-    elif state == "restarted":
+    elif state == 'restarted':
         try:
             vm = proxmox.get_vm(vmid)
 
-            vm_status = getattr(proxmox.proxmox_api.nodes(vm["node"]), VZ_TYPE)(
-                vmid
-            ).status.current.get()["status"]
-            if vm_status in ["stopped", "mounted"]:
-                module.exit_json(
-                    changed=False, vmid=vmid, msg="VM %s is not running" % vmid
-                )
+            vm_status = getattr(proxmox.proxmox_api.nodes(vm['node']), VZ_TYPE)(vmid).status.current.get()['status']
+            if vm_status in ['stopped', 'mounted']:
+                module.exit_json(changed=False, vmid=vmid, msg="VM %s is not running" % vmid)
 
-            if proxmox.stop_instance(
-                vm, vmid, timeout, force=module.params["force"]
-            ) and proxmox.start_instance(vm, vmid, timeout):
-                module.exit_json(
-                    changed=True, vmid=vmid, msg="VM %s is restarted" % vmid
-                )
+            if (proxmox.stop_instance(vm, vmid, timeout, force=module.params['force']) and
+                    proxmox.start_instance(vm, vmid, timeout)):
+                module.exit_json(changed=True, vmid=vmid, msg="VM %s is restarted" % vmid)
         except Exception as e:
-            module.fail_json(
-                vmid=vmid,
-                msg="restarting of VM %s failed with exception: %s" % (vmid, e),
-            )
+            module.fail_json(vmid=vmid, msg="restarting of VM %s failed with exception: %s" % (vmid, e))
 
-    elif state == "absent":
+    elif state == 'absent':
         if not vmid:
-            module.exit_json(
-                changed=False,
-                vmid=vmid,
-                msg="VM with hostname = %s is already absent" % hostname,
-            )
+            module.exit_json(changed=False, vmid=vmid, msg='VM with hostname = %s is already absent' % hostname)
         try:
             vm = proxmox.get_vm(vmid, ignore_missing=True)
             if not vm:
-                module.exit_json(
-                    changed=False, vmid=vmid, msg="VM %s does not exist" % vmid
-                )
+                module.exit_json(changed=False, vmid=vmid, msg="VM %s does not exist" % vmid)
 
-            vm_status = getattr(proxmox.proxmox_api.nodes(vm["node"]), VZ_TYPE)(
-                vmid
-            ).status.current.get()["status"]
-            if vm_status == "running":
-                module.exit_json(
-                    changed=False,
-                    vmid=vmid,
-                    msg="VM %s is running. Stop it before deletion." % vmid,
-                )
+            vm_status = getattr(proxmox.proxmox_api.nodes(vm['node']), VZ_TYPE)(vmid).status.current.get()['status']
+            if vm_status == 'running':
+                module.exit_json(changed=False, vmid=vmid, msg="VM %s is running. Stop it before deletion." % vmid)
 
-            if vm_status == "mounted":
-                module.exit_json(
-                    changed=False,
-                    vmid=vmid,
-                    msg="VM %s is mounted. Stop it with force option before deletion."
-                    % vmid,
-                )
+            if vm_status == 'mounted':
+                module.exit_json(changed=False, vmid=vmid, msg="VM %s is mounted. Stop it with force option before deletion." % vmid)
 
             delete_params = {}
 
-            if module.params["purge"]:
-                delete_params["purge"] = 1
+            if module.params['purge']:
+                delete_params['purge'] = 1
 
-            taskid = getattr(proxmox.proxmox_api.nodes(vm["node"]), VZ_TYPE).delete(
-                vmid, **delete_params
-            )
+            taskid = getattr(proxmox.proxmox_api.nodes(vm['node']), VZ_TYPE).delete(vmid, **delete_params)
 
             while timeout:
-                if proxmox.api_task_ok(vm["node"], taskid):
-                    module.exit_json(
-                        changed=True,
-                        vmid=vmid,
-                        taskid=taskid,
-                        msg="VM %s removed" % vmid,
-                    )
+                if proxmox.api_task_ok(vm['node'], taskid):
+                    module.exit_json(changed=True, vmid=vmid, taskid=taskid, msg="VM %s removed" % vmid)
                 timeout -= 1
                 if timeout == 0:
-                    module.fail_json(
-                        vmid=vmid,
-                        taskid=taskid,
-                        msg="Reached timeout while waiting for removing VM. Last line in task before timeout: %s"
-                        % proxmox.proxmox_api.nodes(vm["node"])
-                        .tasks(taskid)
-                        .log.get()[:1],
-                    )
+                    module.fail_json(vmid=vmid, taskid=taskid, msg='Reached timeout while waiting for removing VM. Last line in task before timeout: %s'
+                                     % proxmox.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
 
                 time.sleep(1)
         except Exception as e:
-            module.fail_json(
-                vmid=vmid,
-                msg="deletion of VM %s failed with exception: %s"
-                % (vmid, to_native(e)),
-            )
+            module.fail_json(vmid=vmid, msg="deletion of VM %s failed with exception: %s" % (vmid, to_native(e)))
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -693,7 +693,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
             size=None,
             mountpoint=None,
             options=None,
-            **kwargs,
+            **kwargs
         ):
             if size is not None and isinstance(size, str):
                 size = size.strip("G")

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -85,7 +85,7 @@ options:
       options:
         description:
           - O(disk_volume.options) is a dict of extra options.
-          - The value of any given option must be a string, e.g. V("1").
+          - The value of any given option must be a string, for example V("1").
         type: dict
   cores:
     description:

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -764,8 +764,8 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
             kwargs["disk_volume"] = parse_disk_string(disk)
         if "disk_volume" in kwargs:
             if not all(isinstance(val, str) for val in kwargs["disk_volume"].values()):
-              self.module.warn("All disk_volume values must be strings. Converting non-string values to strings.")
-              kwargs["disk_volume"] = {key: str(val) for key, val in kwargs["disk_volume"].items()}
+                self.module.warn("All disk_volume values must be strings. Converting non-string values to strings.")
+                kwargs["disk_volume"] = {key: str(val) for key, val in kwargs["disk_volume"].items()}
             disk_dict = build_volume(key="rootfs", **kwargs.pop("disk_volume"))
             kwargs.update(disk_dict)
         if memory is not None:
@@ -780,8 +780,8 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
             mounts_list = kwargs.pop("mount_volumes")
             for mount_config in mounts_list:
                 if not all(isinstance(val, str) for val in mount_config.values()):
-                  self.module.warn("All mount_volumes values must be strings. Converting non-string values to strings.")
-                  mount_config = {key: str(val) for key, val in mount_config.items()}
+                    self.module.warn("All mount_volumes values must be strings. Converting non-string values to strings.")
+                    mount_config = {key: str(val) for key, val in mount_config.items()}
                 key = mount_config.pop("id")
                 mount_dict = build_volume(key=key, **mount_config)
                 kwargs.update(mount_dict)

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -61,30 +61,30 @@ options:
     suboptions:
       storage:
         description:
-          - O(storage) is the storage identifier of the storage to use for the C(rootfs).
+          - O(disk_volume.storage) is the storage identifier of the storage to use for the C(rootfs).
           - Mutually exclusive with O(disk_volume.host_path).
         type: str
       volume:
         description:
-          - O(volume) is the name of an existing volume.
+          - O(disk_volume.volume) is the name of an existing volume.
           - If not defined, the module will check if one exists. If not, a new volume will be created.
           - If defined, the volume must exist under that name.
           - Required only if O(disk_volume.storage) is defined and mutually exclusive with O(disk_volume.host_path).
         type: str
       size:
         description:
-          - O(size) is the size of the storage to use.
+          - O(disk_volume.size) is the size of the storage to use.
           - The size is given in GB.
           - Required only if O(disk_volume.storage) is defined and mutually exclusive with O(disk_volume.host_path).
         type: int
       host_path:
         description:
-          - O(host_path) defines a bind or device path on the PVE host to use for the C(rootfs).
+          - O(disk_volume.host_path) defines a bind or device path on the PVE host to use for the C(rootfs).
           - Mutually exclusive with O(disk_volume.storage), O(disk_volume.volume), and O(disk_volume.size).
         type: path
       options:
         description:
-          - O(options) is a list of extra options.
+          - O(disk_volume.options) is a list of extra options.
           - The options are given as key-value pairs such as C([ro=0, acl=1]).
         type: list
         elements: str
@@ -140,40 +140,40 @@ options:
     suboptions:
       id:
         description:
-          - O(id) is the identifier of the mount point written as C(mp[n])
+          - O(mount_volumes.id) is the identifier of the mount point written as C(mp[n])
         type: str
         required: true
       storage:
         description:
-          - O(storage) is the storage identifier of the storage to use.
-          - Mutually exclusive with O(mount_volumes.[].host_path).
+          - O(mount_volumes.storage) is the storage identifier of the storage to use.
+          - Mutually exclusive with O(mount_volumes.host_path).
         type: str
       volume:
         description:
-          - O(volume) is the name of an existing volume.
+          - O(mount_volumes.volume) is the name of an existing volume.
           - If not defined, the module will check if one exists. If not, a new volume will be created.
           - If defined, the volume must exist under that name.
-          - Required only if O(storage) is defined and mutually exclusive with O(mount_volumes.[].host_path).
+          - Required only if O(mount_volumes.storage) is defined and mutually exclusive with O(mount_volumes.host_path).
         type: str
       size:
         description:
-          - O(size) is the size of the storage to use.
+          - O(mount_volumes.size) is the size of the storage to use.
           - The size is given in GB.
-          - Required only if O(mount_volumes.[].storage) is defined and mutually exclusive with O(mount_volumes.[].host_path).
+          - Required only if O(mount_volumes.storage) is defined and mutually exclusive with O(mount_volumes.host_path).
         type: int
       host_path:
         description:
-          - O(host_path) defines a bind or device path on the PVE host to use for the C(rootfs).
-          - Mutually exclusive with O(mount_volumes.[].storage), O(mount_volumes.[].volume), and O(mount_volumes.[].size).
+          - O(mount_volumes.host_path) defines a bind or device path on the PVE host to use for the C(rootfs).
+          - Mutually exclusive with O(mount_volumes.storage), O(mount_volumes.volume), and O(mount_volumes.size).
         type: path
       mountpoint:
         description:
-          - O(mountpoint) is the mount point of the volume.
+          - O(mount_volumes.mountpoint) is the mount point of the volume.
         type: path
         required: true
       options:
         description:
-          - O(options) is a list of extra options.
+          - O(mount_volumes.options) is a list of extra options.
           - The options are given as key-value pairs such as C([ro=1, backup=1]).
         type: list
         elements: str

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -140,40 +140,40 @@ options:
     suboptions:
       id:
         description:
-          - O(mount_volumes.id) is the identifier of the mount point written as C(mp[n])
+          - O(mount_volumes[].id) is the identifier of the mount point written as C(mp[n])
         type: str
         required: true
       storage:
         description:
-          - O(mount_volumes.storage) is the storage identifier of the storage to use.
-          - Mutually exclusive with O(mount_volumes.host_path).
+          - O(mount_volumes[].storage) is the storage identifier of the storage to use.
+          - Mutually exclusive with O(mount_volumes[].host_path).
         type: str
       volume:
         description:
-          - O(mount_volumes.volume) is the name of an existing volume.
+          - O(mount_volumes[].volume) is the name of an existing volume.
           - If not defined, the module will check if one exists. If not, a new volume will be created.
           - If defined, the volume must exist under that name.
-          - Required only if O(mount_volumes.storage) is defined and mutually exclusive with O(mount_volumes.host_path).
+          - Required only if O(mount_volumes[].storage) is defined and mutually exclusive with O(mount_volumes[].host_path).
         type: str
       size:
         description:
-          - O(mount_volumes.size) is the size of the storage to use.
+          - O(mount_volumes[].size) is the size of the storage to use.
           - The size is given in GB.
-          - Required only if O(mount_volumes.storage) is defined and mutually exclusive with O(mount_volumes.host_path).
+          - Required only if O(mount_volumes[].storage) is defined and mutually exclusive with O(mount_volumes[].host_path).
         type: int
       host_path:
         description:
-          - O(mount_volumes.host_path) defines a bind or device path on the PVE host to use for the C(rootfs).
-          - Mutually exclusive with O(mount_volumes.storage), O(mount_volumes.volume), and O(mount_volumes.size).
+          - O(mount_volumes[].host_path) defines a bind or device path on the PVE host to use for the C(rootfs).
+          - Mutually exclusive with O(mount_volumes[].storage), O(mount_volumes[].volume), and O(mount_volumes[].size).
         type: path
       mountpoint:
         description:
-          - O(mount_volumes.mountpoint) is the mount point of the volume.
+          - O(mount_volumes[].mountpoint) is the mount point of the volume.
         type: path
         required: true
       options:
         description:
-          - O(mount_volumes.options) is a list of extra options.
+          - O(mount_volumes[].options) is a list of extra options.
           - The options are given as key-value pairs such as C([ro=1, backup=1]).
         type: list
         elements: str

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -84,10 +84,9 @@ options:
         type: path
       options:
         description:
-          - O(disk_volume.options) is a list of extra options.
-          - The options are given as key-value pairs such as C([ro=0, acl=1]).
-        type: list
-        elements: str
+          - O(disk_volume.options) is a dict of extra options.
+          - The value of any given option must be a string, e.g. V("1").
+        type: dict
   cores:
     description:
       - Specify number of cores per socket.
@@ -173,10 +172,9 @@ options:
         required: true
       options:
         description:
-          - O(mount_volumes[].options) is a list of extra options.
-          - The options are given as key-value pairs such as C([ro=1, backup=1]).
-        type: list
-        elements: str
+          - O(mount_volumes[].options) is a dict of extra options.
+          - The value of any given option must be a string, e.g. V("1").
+        type: dict
   ip_address:
     description:
       - specifies the address the container will be assigned
@@ -734,7 +732,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
                 vol_string += ",mp={mountpoint}".format(mountpoint=mountpoint)
             if options is not None:
                 vol_string += ","
-                vol_string += ",".join(options)
+                vol_string += ",".join(map("=".join, options.items()))
             if kwargs:
                 vol_string += ","
                 vol_string += ",".join(map("=".join, kwargs.items()))
@@ -989,7 +987,7 @@ def main():
                 volume=dict(type="str"),
                 size=dict(type="int"),
                 host_path=dict(type="path"),
-                options=dict(type="list", elements="str"),
+                options=dict(type="dict"),
             ),
             required_together=[("storage", "size")],
             required_by={
@@ -1017,7 +1015,7 @@ def main():
                 size=dict(type="int"),
                 host_path=dict(type="path"),
                 mountpoint=dict(type="path", required=True),
-                options=dict(type="list", elements="str"),
+                options=dict(type="dict"),
             ),
             required_together=[("storage", "size")],
             required_by={

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -724,18 +724,12 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
                     vol_string = "{storage}:{size}".format(storage=storage, size=size)
 
             # 1.3 If we have a host_path, we don't have storage, a volume, or a size
-            if host_path is not None:
-                vol_string = host_path
-
-            # 2. Build valid string
-            if mountpoint is not None:
-                vol_string += ",mp={mountpoint}".format(mountpoint=mountpoint)
-            if options is not None:
-                vol_string += ","
-                vol_string += ",".join(map("=".join, options.items()))
-            if kwargs:
-                vol_string += ","
-                vol_string += ",".join(map("=".join, kwargs.items()))
+            vol_string = ",".join(
+                ([] if host_path is None else [host_path]) +
+                ([] if mountpoint is None else ["mp={0}".format(mountpoint)]) +
+                ([] if options is None else [map("=".join, options.items())]) +
+                ([] if not kwargs else [map("=".join, kwargs.items())])
+            )
 
             return {key: vol_string}
 

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -139,7 +139,7 @@ options:
     suboptions:
       id:
         description:
-          - O(mount_volumes[].id) is the identifier of the mount point written as C(mp[n])
+          - O(mount_volumes[].id) is the identifier of the mount point written as C(mp[n]).
         type: str
         required: true
       storage:
@@ -185,7 +185,7 @@ options:
     type: bool
   storage:
     description:
-      - Target storage
+      - Target storage.
       - This Option is mutually exclusive with O(disk) and O(disk_volume).
     type: str
     default: 'local'

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -50,40 +50,42 @@ options:
         comma-delimited list C([volume=]<volume> [,acl=<1|0>] [,mountoptions=<opt[;opt...]>] [,quota=<1|0>]
         [,replicate=<1|0>] [,ro=<1|0>] [,shared=<1|0>] [,size=<DiskSize>])."
       - See U(https://pve.proxmox.com/wiki/Linux_Container) for a full description.
-      - Should not be used in conjunction with O(storage).
+      - This option is mutually exclusive with O(storage) and O(disk_volume).
     type: str
   disk_volume:
     description:
       - Specify a hash/dictionary of the C(rootfs) disk.
       - See U(https://pve.proxmox.com/wiki/Linux_Container#pct_mount_points) for a full description.
+      - This option is mutually exclusive with O(storage) and O(disk).
     type: dict
+    version_added: 9.2.0
     suboptions:
       storage:
         description:
-          - V(storage) is the storage identifier of the storage to use for the C(rootfs).
-          - Mutually exclusive with V(host_path).
+          - O(storage) is the storage identifier of the storage to use for the C(rootfs).
+          - Mutually exclusive with O(disk_volume.host_path).
         type: str
       volume:
         description:
-          - V(volume) is the name of an existing volume.
+          - O(volume) is the name of an existing volume.
           - If not defined, the module will check if one exists. If not, a new volume will be created.
           - If defined, the volume must exist under that name.
-          - Required only if V(storage) is defined and mutually exclusive with V(host_path).
+          - Required only if O(disk_volume.storage) is defined and mutually exclusive with O(disk_volume.host_path).
         type: str
       size:
         description:
-          - V(size) is the size of the storage to use.
+          - O(size) is the size of the storage to use.
           - The size is given in GB.
-          - Required only if V(storage) is defined and mutually exclusive with V(host_path).
+          - Required only if O(disk_volume.storage) is defined and mutually exclusive with O(disk_volume.host_path).
         type: int
       host_path:
         description:
-          - V(host_path) defines a bind or device path on the PVE host to use for the C(rootfs).
-          - Mutually exclusive with V(storage), V(volume), and V(size).
+          - O(host_path) defines a bind or device path on the PVE host to use for the C(rootfs).
+          - Mutually exclusive with O(disk_volume.storage), O(disk_volume.volume), and O(disk_volume.size).
         type: path
       options:
         description:
-          - V(options) is a list of extra options.
+          - O(options) is a list of extra options.
           - The options are given as key-value pairs such as C([ro=0, acl=1]).
         type: list
         elements: str
@@ -125,51 +127,54 @@ options:
     version_added: 8.5.0
   mounts:
     description:
-      - specifies additional mounts (separate disks) for the container. As a hash/dictionary defining mount points as strings.
+      - Specifies additional mounts (separate disks) for the container. As a hash/dictionary defining mount points as strings.
+      - This Option is mutually exclusive with O(mount_volumes).
     type: dict
   mount_volumes:
     description:
       - Specify additional mounts (separate disks) for the container. As a hash/dictionary defining mount points.
       - See U(https://pve.proxmox.com/wiki/Linux_Container#pct_mount_points) for a full description.
+      - This Option is mutually exclusive with O(mounts).
     type: list
     elements: dict
+    version_added: 9.2.0
     suboptions:
       id:
         description:
-          - V(id) is the identifier of the mount point written as C(mp[n])
+          - O(id) is the identifier of the mount point written as C(mp[n])
         type: str
         required: true
       storage:
         description:
-          - V(storage) is the storage identifier of the storage to use.
-          - Mutually exclusive with V(host_path).
+          - O(storage) is the storage identifier of the storage to use.
+          - Mutually exclusive with O(mount_volumes.[].host_path).
         type: str
       volume:
         description:
-          - V(volume) is the name of an existing volume.
+          - O(volume) is the name of an existing volume.
           - If not defined, the module will check if one exists. If not, a new volume will be created.
           - If defined, the volume must exist under that name.
-          - Required only if V(storage) is defined and mutually exclusive with V(host_path).
+          - Required only if O(storage) is defined and mutually exclusive with O(mount_volumes.[].host_path).
         type: str
       size:
         description:
-          - V(size) is the size of the storage to use.
+          - O(size) is the size of the storage to use.
           - The size is given in GB.
-          - Required only if V(storage) is defined and mutually exclusive with V(host_path).
+          - Required only if O(mount_volumes.[].storage) is defined and mutually exclusive with O(mount_volumes.[].host_path).
         type: int
       host_path:
         description:
-          - V(host_path) defines a bind or device path on the PVE host to use for the C(rootfs).
-          - Mutually exclusive with V(storage), V(volume), and V(size).
+          - O(host_path) defines a bind or device path on the PVE host to use for the C(rootfs).
+          - Mutually exclusive with O(mount_volumes.[].storage), O(mount_volumes.[].volume), and O(mount_volumes.[].size).
         type: path
       mountpoint:
         description:
-          - V(mountpoint) is the mount point of the volume.
+          - O(mountpoint) is the mount point of the volume.
         type: path
         required: true
       options:
         description:
-          - V(options) is a list of extra options.
+          - O(options) is a list of extra options.
           - The options are given as key-value pairs such as C([ro=1, backup=1]).
         type: list
         elements: str
@@ -183,8 +188,8 @@ options:
     type: bool
   storage:
     description:
-      - target storage
-      - Should not be used in conjunction with O(disk).
+      - Target storage
+      - This Option is mutually exclusive with O(disk) and O(disk_volume).
     type: str
     default: 'local'
   ostype:

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -763,6 +763,9 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
         if disk is not None:
             kwargs["disk_volume"] = parse_disk_string(disk)
         if "disk_volume" in kwargs:
+            if not all(isinstance(val, str) for val in kwargs["disk_volume"].values()):
+              self.module.warn("All disk_volume values must be strings. Converting non-string values to strings.")
+              kwargs["disk_volume"] = {key: str(val) for key, val in kwargs["disk_volume"].items()}
             disk_dict = build_volume(key="rootfs", **kwargs.pop("disk_volume"))
             kwargs.update(disk_dict)
         if memory is not None:
@@ -776,6 +779,9 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
         if "mount_volumes" in kwargs:
             mounts_list = kwargs.pop("mount_volumes")
             for mount_config in mounts_list:
+                if not all(isinstance(val, str) for val in mount_config.values()):
+                  self.module.warn("All mount_volumes values must be strings. Converting non-string values to strings.")
+                  mount_config = {key: str(val) for key, val in mount_config.items()}
                 key = mount_config.pop("id")
                 mount_dict = build_volume(key=key, **mount_config)
                 kwargs.update(mount_dict)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #8407

Makes the creation of new volumes idempotent and adds new keys with better readability.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
proxmox

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Here is a sample playbook to test the new features/bug fixes:

```yaml
---
- name: Create LXC
  hosts: localhost
  become: false
  gather_facts: false
  vars_files:
    - proxmox_credentials.yml
  tasks:
    - name: Create LXC
      community.general.proxmox:
        api_host: "{{ api_host }}"
        api_user: "{{ api_user }}"
        api_password: "{{ api_password }}"
        # api_token_id: "{{ api_token_id }}"
        # api_token_secret: "{{ api_token_secret }}"
        node: "{{ node }}"
        hostname: test-node
        ostemplate: local:vztmpl/debian-12-standard_12.2-1_amd64.tar.zst
        disk: local-lvm:8
      register: create_res

    - name: Update LXC config [new - create volumes]
      community.general.proxmox:
        api_host: "{{ api_host }}"
        api_user: "{{ api_user }}"
        api_password: "{{ api_password }}"
        # api_token_id: "{{ api_token_id }}"
        # api_token_secret: "{{ api_token_secret }}"
        node: "{{ node }}"
        hostname: test-node
        cores: 1
        vmid: "{{ create_res.vmid }}"
        disk_volume:
          storage: local-lvm
          size: 14
        mount_volumes:
          - id: mp0
            storage: local-lvm
            size: 3
            mountpoint: /mnt/test
          - id: mp1
            host_path: /root/test
            mountpoint: /mnt/host
            options:
              backup: "0"
        update: true

    - name: Update LXC config [new - explicit volumes]
      community.general.proxmox:
        api_host: "{{ api_host }}"
        api_user: "{{ api_user }}"
        api_password: "{{ api_password }}"
        # api_token_id: "{{ api_token_id }}"
        # api_token_secret: "{{ api_token_secret }}"
        node: "{{ node }}"
        hostname: test-node
        cores: 1
        vmid: "{{ create_res.vmid }}"
        disk_volume:
          storage: local-lvm
          volume: "vm-{{ create_res.vmid }}-disk-0"
          size: 14
        mount_volumes:
          - id: mp0
            storage: local-lvm
            volume: "vm-{{ create_res.vmid }}-disk-1"
            size: 3
            mountpoint: /mnt/test
          - id: mp1
            host_path: /root/test
            mountpoint: /mnt/host
            options:
              backup: "0"
        update: true

    - name: Update LXC config [old - implicit volumes]
      community.general.proxmox:
        api_host: "{{ api_host }}"
        api_user: "{{ api_user }}"
        api_password: "{{ api_password }}"
        # api_token_id: "{{ api_token_id }}"
        # api_token_secret: "{{ api_token_secret }}"
        node: "{{ node }}"
        hostname: test-node
        cores: 1
        vmid: "{{ create_res.vmid }}"
        disk: local-lvm:14
        mounts: '{"mp0":"local-lvm:3,mp=/mnt/test","mp1":"/root/test,mp=/mnt/host,backup=0"}'
        update: true

    - name: Update LXC config [old - explicit volumes]
      community.general.proxmox:
        api_host: "{{ api_host }}"
        api_user: "{{ api_user }}"
        api_password: "{{ api_password }}"
        # api_token_id: "{{ api_token_id }}"
        # api_token_secret: "{{ api_token_secret }}"
        node: "{{ node }}"
        hostname: test-node
        cores: 1
        vmid: "{{ create_res.vmid }}"
        disk: "local-lvm:vm-{{ create_res.vmid }}-disk-0,size=14G"
        mounts: '{"mp0":"local-lvm:vm-{{ create_res.vmid }}-disk-1,size=3G,mp=/mnt/test","mp1":"/root/test,mp=/mnt/host,backup=0"}'
        update: true
```

Note: To test bind mounting, we actually need to use the `root@pam` user with its password. Even a token owned by that user will not work due to missing permissions.

Output:
```
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [Create LXC] *******************************************************************************************************************************************************************

TASK [Create LXC] *******************************************************************************************************************************************************************
ok: [localhost]

TASK [Update LXC config [new - create volumes]] *************************************************************************************************************************************
changed: [localhost]

TASK [Update LXC config [new - explicit volumes]] ***********************************************************************************************************************************
ok: [localhost]

TASK [Update LXC config [old - implicit volumes]] ***********************************************************************************************************************************
ok: [localhost]

TASK [Update LXC config [old - explicit volumes]] ***********************************************************************************************************************************
ok: [localhost]

PLAY RECAP **************************************************************************************************************************************************************************
localhost                  : ok=5    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0  
```