### PR TITLE
keycloak_clientscope: ignore ids on diff check

### DIFF
--- a/changelogs/fragments/8545-keycloak-clientscope-remove-id-on-compare.yml
+++ b/changelogs/fragments/8545-keycloak-clientscope-remove-id-on-compare.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - keycloak_clientscope - remove ids from clientscope and its protocol mappers on comparison for ansible changed check (https://github.com/ansible-collections/community.general/pull/8545).
+  - keycloak_clientscope - remove IDs from clientscope and its protocol mappers on comparison for changed check (https://github.com/ansible-collections/community.general/pull/8545).

--- a/changelogs/fragments/8545-keycloak-clientscope-remove-id-on-compare.yml
+++ b/changelogs/fragments/8545-keycloak-clientscope-remove-id-on-compare.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_clientscope - remove ids from clientscope and its protocol mappers on comparison for ansible changed check (https://github.com/ansible-collections/community.general/pull/8545).

--- a/plugins/modules/keycloak_clientscope.py
+++ b/plugins/modules/keycloak_clientscope.py
@@ -472,7 +472,9 @@ def main():
             # Process an update
 
             # no changes
-            if desired_clientscope == before_clientscope:
+            # remove ids for compare, problematic if desired has no ids set (not required),
+            # normalize for consentRequired in protocolMappers
+            if normalise_cr(desired_clientscope, remove_ids=True) == normalise_cr(before_clientscope, remove_ids=True):
                 result['changed'] = False
                 result['end_state'] = sanitize_cr(desired_clientscope)
                 result['msg'] = "No changes required to clientscope {name}.".format(name=before_clientscope['name'])


### PR DESCRIPTION
##### SUMMARY

Stumbled upon this when using an older version of the plugin.
Originally had the issue with `consentRequired` which was fixed by Merge #8496 .

If the user supplies no `id` either in the `module.params.get('id')` or in one of the `module.params.get('protocol_mappers')`, the comparison will result in a diff detected, even though all other params might be identical.

Running a task multiple times with no `id`s set (Keycloak API then creates one) will now result in no change detected, improving idempotence checks.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

commnity.general.keycloak_clientscope.py

##### ADDITIONAL INFORMATION

The check on wether the task `changed` now normalizes the dicts `desired_clientscope` and `before_clientscope` to ignore all `id` fields on all levels, as they are not required to be set if a `name` has been set instead.

This ensures that the module does not detect a change and does not call the keycloak API unnecessarily.

Before:
```python
if desired_clientscope == before_clientscope:  #...
```

After:
```python
if normalise_cr(desired_clientscope, remove_ids=True) == normalise_cr(before_clientscope, remove_ids=True):  #...
```