### PR TITLE
CI: Replace FreeBSD 14.0 with 14.1; add 14.0 for stable-2.17

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -194,8 +194,8 @@ stages:
               test: macos/14.3
             - name: RHEL 9.4
               test: rhel/9.4
-            - name: FreeBSD 14.0
-              test: freebsd/14.0
+            - name: FreeBSD 14.1
+              test: freebsd/14.1
           groups:
             - 1
             - 2
@@ -212,6 +212,8 @@ stages:
               test: freebsd/13.3
             - name: RHEL 9.3
               test: rhel/9.3
+            - name: FreeBSD 14.0
+              test: freebsd/14.0
           groups:
             - 1
             - 2

--- a/tests/integration/targets/filter_jc/aliases
+++ b/tests/integration/targets/filter_jc/aliases
@@ -6,3 +6,4 @@ azp/posix/2
 skip/python2.7  # jc only supports python3.x
 skip/freebsd13.3  # FIXME - ruyaml compilation fails
 skip/freebsd14.0  # FIXME - ruyaml compilation fails
+skip/freebsd14.1  # FIXME - ruyaml compilation fails

--- a/tests/integration/targets/iso_extract/aliases
+++ b/tests/integration/targets/iso_extract/aliases
@@ -16,3 +16,4 @@ skip/freebsd12.4  # FIXME
 skip/freebsd13.2  # FIXME
 skip/freebsd13.3  # FIXME
 skip/freebsd14.0  # FIXME
+skip/freebsd14.1  # FIXME

--- a/tests/integration/targets/pkgng/tasks/freebsd.yml
+++ b/tests/integration/targets/pkgng/tasks/freebsd.yml
@@ -521,12 +521,15 @@
   # NOTE: FreeBSD 14.0 fails to update the package catalogue for unknown reasons (someone with FreeBSD
   #       knowledge has to take a look)
   #
+  # NOTE: FreeBSD 14.1 fails to update the package catalogue for unknown reasons (someone with FreeBSD
+  #       knowledge has to take a look)
+  #
   # See also
   # https://github.com/ansible-collections/community.general/issues/5795
   when: >-
     (ansible_distribution_version is version('12.01', '>=') and ansible_distribution_version is version('12.3', '<'))
     or (ansible_distribution_version is version('13.4', '>=') and ansible_distribution_version is version('14.0', '<'))
-    or ansible_distribution_version is version('14.1', '>=')
+    or ansible_distribution_version is version('14.2', '>=')
   block:
     - name: Setup testjail
       include_tasks: setup-testjail.yml


### PR DESCRIPTION
##### SUMMARY
Ref: https://forum.ansible.com/t/ansible-test-devel-freebsd-14-0-remote-replaced-with-freebsd-14-1/6714

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
