### PR TITLE
merge_variables: correct misleading short description

### DIFF
--- a/plugins/lookup/merge_variables.py
+++ b/plugins/lookup/merge_variables.py
@@ -12,7 +12,7 @@ DOCUMENTATION = """
       - Mark Ettema (@m-a-r-k-e)
       - Alexander Petrenz (@alpex8)
     name: merge_variables
-    short_description: merge variables with a certain suffix
+    short_description: merge variables whose names match a given pattern
     description:
         - This lookup returns the merged result of all variables in scope that match the given prefixes, suffixes, or
           regular expressions, optionally.


### PR DESCRIPTION
##### SUMMARY
The short description makes it sound like the plugin would only support matching a given suffix, while the actual description clarifies the actual matching capabilities (suffix, prefix or regular expression).

Update the short description accordingly.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
merge_variables

##### ADDITIONAL INFORMATION
