### PR TITLE
Add missing krbPrincipalAttribute to the config_spec

### DIFF
--- a/changelogs/fragments/8604-add-missing-krbprincipalattribute-to-the-config_spec.yml
+++ b/changelogs/fragments/8604-add-missing-krbprincipalattribute-to-the-config_spec.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak_user_federation - Add missing krbPrincipalAttribute to the config_spec(https://github.com/ansible-collections/community.general/pull/8604)

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -765,6 +765,7 @@ def main():
         evictionMinute=dict(type='str'),
         fullSyncPeriod=dict(type='int', default=-1),
         importEnabled=dict(type='bool', default=True),
+        krbPrincipalAttribute=dict(type='str'),
         kerberosRealm=dict(type='str'),
         keyTab=dict(type='str', no_log=False),
         maxLifespan=dict(type='int'),


### PR DESCRIPTION
##### SUMMARY
Add missing krbPrincipalAttribute to the config specification

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION
Without this attribute, the module will always return "CHANGED"