### PR TITLE
pkgng - add option use_globs (default=true)

### DIFF
--- a/changelogs/fragments/8632-pkgng-add-option-use_globs.yml
+++ b/changelogs/fragments/8632-pkgng-add-option-use_globs.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - pkgng - add option use_globs (default=true) to optionally disable glob patterns (https://github.com/ansible-collections/community.general/issues/8632).

--- a/changelogs/fragments/8632-pkgng-add-option-use_globs.yml
+++ b/changelogs/fragments/8632-pkgng-add-option-use_globs.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - pkgng - add option use_globs (default=true) to optionally disable glob patterns (https://github.com/ansible-collections/community.general/issues/8632).
+  - pkgng - add option ``use_globs`` (default ``true``) to optionally disable glob patterns (https://github.com/ansible-collections/community.general/issues/8632, https://github.com/ansible-collections/community.general/pull/8633).

--- a/plugins/modules/pkgng.py
+++ b/plugins/modules/pkgng.py
@@ -100,6 +100,13 @@ options:
         type: bool
         default: false
         version_added: 1.3.0
+    use_globs:
+        description:
+            - Treat the package names as shell glob patterns.
+        required: false
+        type: bool
+        default: true
+        version_added: 9.2.0
 author: "bleader (@bleader)"
 notes:
   - When using pkgsite, be careful that already in cache packages won't be downloaded again.
@@ -137,6 +144,13 @@ EXAMPLES = '''
   community.general.pkgng:
     name: "*"
     state: latest
+
+# "use_globs" support added in 9.2.0
+- name: Upgrade foo/bar
+  community.general.pkgng:
+    name: foo/bar
+    state: latest
+    use_globs: false
 '''
 
 
@@ -147,7 +161,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 def query_package(module, run_pkgng, name):
 
-    rc, out, err = run_pkgng('info', '-g', '-e', name)
+    rc, out, err = run_pkgng('info', '-e', name)
 
     return rc == 0
 
@@ -157,7 +171,7 @@ def query_update(module, run_pkgng, name):
     # Check to see if a package upgrade is available.
     # rc = 0, no updates available or package not installed
     # rc = 1, updates available
-    rc, out, err = run_pkgng('upgrade', '-g', '-n', name)
+    rc, out, err = run_pkgng('upgrade', '-n', name)
 
     return rc == 1
 
@@ -260,7 +274,7 @@ def install_packages(module, run_pkgng, packages, cached, state):
             action_count[action] += len(package_list)
             continue
 
-        pkgng_args = [action, '-g', '-U', '-y'] + package_list
+        pkgng_args = [action, '-U', '-y'] + package_list
         rc, out, err = run_pkgng(*pkgng_args)
         stdout += out
         stderr += err
@@ -290,7 +304,7 @@ def install_packages(module, run_pkgng, packages, cached, state):
 
 
 def annotation_query(module, run_pkgng, package, tag):
-    rc, out, err = run_pkgng('info', '-g', '-A', package)
+    rc, out, err = run_pkgng('info', '-A', package)
     match = re.search(r'^\s*(?P<tag>%s)\s*:\s*(?P<value>\w+)' % tag, out, flags=re.MULTILINE)
     if match:
         return match.group('value')
@@ -425,7 +439,8 @@ def main():
             rootdir=dict(required=False, type='path'),
             chroot=dict(required=False, type='path'),
             jail=dict(required=False, type='str'),
-            autoremove=dict(default=False, type='bool')),
+            autoremove=dict(default=False, type='bool'),
+            use_globs=dict(default=True, required=False, type='bool')),
         supports_check_mode=True,
         mutually_exclusive=[["rootdir", "chroot", "jail"]])
 
@@ -465,6 +480,9 @@ def main():
 
     def run_pkgng(action, *args, **kwargs):
         cmd = [pkgng_path, dir_arg, action]
+
+        if p["use_globs"] and  action in ('info', 'install', 'upgrade',) :
+            args = ('-g',) + args
 
         pkgng_env = {'BATCH': 'yes'}
 

--- a/plugins/modules/pkgng.py
+++ b/plugins/modules/pkgng.py
@@ -145,7 +145,6 @@ EXAMPLES = '''
     name: "*"
     state: latest
 
-# "use_globs" support added in 9.2.0
 - name: Upgrade foo/bar
   community.general.pkgng:
     name: foo/bar

--- a/plugins/modules/pkgng.py
+++ b/plugins/modules/pkgng.py
@@ -106,7 +106,7 @@ options:
         required: false
         type: bool
         default: true
-        version_added: 9.2.0
+        version_added: 9.3.0
 author: "bleader (@bleader)"
 notes:
   - When using pkgsite, be careful that already in cache packages won't be downloaded again.

--- a/plugins/modules/pkgng.py
+++ b/plugins/modules/pkgng.py
@@ -481,7 +481,7 @@ def main():
     def run_pkgng(action, *args, **kwargs):
         cmd = [pkgng_path, dir_arg, action]
 
-        if p["use_globs"] and  action in ('info', 'install', 'upgrade',) :
+        if p["use_globs"] and action in ('info', 'install', 'upgrade',):
             args = ('-g',) + args
 
         pkgng_env = {'BATCH': 'yes'}

--- a/plugins/modules/pkgng.py
+++ b/plugins/modules/pkgng.py
@@ -440,7 +440,8 @@ def main():
             chroot=dict(required=False, type='path'),
             jail=dict(required=False, type='str'),
             autoremove=dict(default=False, type='bool'),
-            use_globs=dict(default=True, required=False, type='bool')),
+            use_globs=dict(default=True, required=False, type='bool'),
+        ),
         supports_check_mode=True,
         mutually_exclusive=[["rootdir", "chroot", "jail"]])
 

--- a/tests/integration/targets/pkgng/tasks/install_single_package.yml
+++ b/tests/integration/targets/pkgng/tasks/install_single_package.yml
@@ -66,4 +66,4 @@
       - not pkgng_install_idempotent_cached.stdout is match("Updating \w+ repository catalogue\.\.\.")
       - pkgng_install_stat_after.stat.exists
       - pkgng_install_stat_after.stat.executable
-      - not pkgng_upgrade_orig_noglobs.changed
+      - pkgng_upgrade_orig_noglobs is not changed

--- a/tests/integration/targets/pkgng/tasks/install_single_package.yml
+++ b/tests/integration/targets/pkgng/tasks/install_single_package.yml
@@ -40,6 +40,16 @@
     get_mime: false
   register: pkgng_install_stat_after
 
+- name: Upgrade package (orig, no globs)
+  pkgng:
+    name: '{{ pkgng_test_pkg_category }}/{{ pkgng_test_pkg_name }}'
+    state: latest
+    use_globs: false
+    jail: '{{ pkgng_test_jail | default(omit) }}'
+    chroot: '{{ pkgng_test_chroot | default(omit) }}'
+    rootdir: '{{ pkgng_test_rootdir | default(omit) }}'
+  register: pkgng_upgrade_orig_noglobs
+
 - name: Remove test package (if requested)
   pkgng:
     <<: *pkgng_install_params
@@ -56,3 +66,4 @@
       - not pkgng_install_idempotent_cached.stdout is match("Updating \w+ repository catalogue\.\.\.")
       - pkgng_install_stat_after.stat.exists
       - pkgng_install_stat_after.stat.executable
+      - not pkgng_upgrade_orig_noglobs.changed


### PR DESCRIPTION
##### SUMMARY

Implement feature request  #8632

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

community.general.pkgng

##### ADDITIONAL INFORMATION

* Add option

```yaml
+    use_globs:
+        description:
+            - Treat the package names as shell glob patterns.
+        required: false
+        type: bool
+        default: true
+        version_added: 9.2.0
```

* Remove all hard coded options *-g*, e.g.

```python
-    rc, out, err = run_pkgng('info', '-g', '-e', name)
+    rc, out, err = run_pkgng('info', '-e', name)
```

* Apply the option -g conditionally

```python
     def run_pkgng(action, *args, **kwargs):
         cmd = [pkgng_path, dir_arg, action]

+        if p["use_globs"] and action in ('info', 'install', 'upgrade',):
+            args = ('-g',) + args
```

* Add example. This allows the upgrade packages by pkg-origin (foo/bar). See https://man.freebsd.org/cgi/man.cgi?query=pkg-upgrade

```yaml
+- name: Upgrade foo/bar
+  community.general.pkgng:
+    name: foo/bar
+    state: latest
+    use_globs: false
```
