### PR TITLE
#8572 - Updated docs to include pip >= 20.3b1 requirement

### DIFF
--- a/plugins/modules/pip_package_info.py
+++ b/plugins/modules/pip_package_info.py
@@ -27,6 +27,7 @@ options:
     type: list
     elements: path
 requirements:
+  - pip >= 20.3b1 (necessary for the --format option)
   - The requested pip executables must be installed on the target.
 author:
   - Matthew Jones (@matburt)

--- a/plugins/modules/pip_package_info.py
+++ b/plugins/modules/pip_package_info.py
@@ -27,7 +27,7 @@ options:
     type: list
     elements: path
 requirements:
-  - pip >= 20.3b1 (necessary for the --format option)
+  - pip >= 20.3b1 (necessary for the C(--format) option)
   - The requested pip executables must be installed on the target.
 author:
   - Matthew Jones (@matburt)


### PR DESCRIPTION
##### SUMMARY

Fixes #8572 (include pip >= 20.3b1 requirement in docs)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
pip_package_info

##### ADDITIONAL INFORMATION
See #8572 for the problem