### PR TITLE
Adding parameter to prefix option with spaces for ini_file

### DIFF
--- a/changelogs/fragments/8639-ini_file-add-option_prefix-spaces.yml
+++ b/changelogs/fragments/8639-ini_file-add-option_prefix-spaces.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ini_file - add option_prefix_spaces parameter to prefix option with a number of spaces defined by parameter

--- a/changelogs/fragments/8639-ini_file-add-option_prefix-spaces.yml
+++ b/changelogs/fragments/8639-ini_file-add-option_prefix-spaces.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ini_file - add option_prefix_spaces parameter to prefix option with a number of spaces defined by parameter
+  - ini_file - add ```option_prefix_spaces``` option to prefix option names with a number of spaces defined by this option (https://github.com/ansible-collections/community.general/pull/8639).

--- a/plugins/modules/ini_file.py
+++ b/plugins/modules/ini_file.py
@@ -155,10 +155,11 @@ options:
     version_added: 7.1.0
   option_prefix_spaces:
     description:
-    - This flag indicates that the option should start with spaces.
+    - The number of spaces to insert before every option name.
+    - By default (value V(0)), no spaces are inserted before the option name.
     type: int
     default: 0
-    version_added: 8.0.0
+    version_added: 9.3.0
 notes:
    - While it is possible to add an O(option) without specifying a O(value), this makes no sense.
    - As of community.general 3.2.0, UTF-8 BOM markers are discarded when reading files.
@@ -263,9 +264,10 @@ EXAMPLES = r'''
     value: xxxxxxxxxxxxxxxxxxxx
     mode: '0600'
     state: present
+
 - name: Update the option and indent with spaces
   community.general.ini_file:
-    path: /etc/influxdb/config.toml
+    path: /etc/influxdb/config.ini
     section: default
     option: url
     value: http://localhost:8086
@@ -618,7 +620,7 @@ def main():
             modify_inactive_option=dict(type='bool', default=True),
             create=dict(type='bool', default=True),
             follow=dict(type='bool', default=False),
-            option_prefix_spaces=dict(type='int', default=0)
+            option_prefix_spaces=dict(type='int', default=0),
         ),
         mutually_exclusive=[
             ['value', 'values']

--- a/tests/integration/targets/ini_file/tasks/main.yml
+++ b/tests/integration/targets/ini_file/tasks/main.yml
@@ -52,3 +52,6 @@
 
     - name: include tasks to test section_has_values
       include_tasks: tests/08-section.yml
+
+    - name: include tasks to test optional spaces at beginning of option lines
+      include_tasks: tests/09-option_prefix_spaces.yml

--- a/tests/integration/targets/ini_file/tasks/tests/09-option_prefix_spaces.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/09-option_prefix_spaces.yml
@@ -1,0 +1,108 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+## testing support for optional spaces at beginning of option lines
+
+- name: Test-options_start_spaces 1 - update option with prefix spaces - create test file
+  ansible.builtin.copy:  # noqa risky-file-permissions
+    dest: "{{ output_file }}"
+    content: |
+      [foo]
+      ; bar=baz
+
+- name: Test-options_start_spaces 1 - update option with prefix spaces - set new value
+  community.general.ini_file:  # noqa risky-file-permissions
+    path: "{{ output_file }}"
+    section: 'foo'
+    option: bar
+    value: frelt
+    option_prefix_spaces: 2
+  register: result
+
+- name: Test-options_start_spaces 1 - update option with prefix spaces - read content from output file
+  ansible.builtin.slurp:
+    src: "{{ output_file }}"
+  register: output_content
+
+- name: Test-options_start_spaces 1 - update option with prefix spaces - verify results
+  vars:
+    actual_content: "{{ output_content.content | b64decode }}"
+    expected_content: |
+      [foo]
+        bar = frelt
+  ansible.builtin.assert:
+    that:
+      - actual_content == expected_content
+      - result is changed
+      - result.msg == 'option changed'
+
+- name: Test-options_start_spaces 2 - set same value with prefix spaces - create test file
+  ansible.builtin.copy:  # noqa risky-file-permissions
+    dest: "{{ output_file }}"
+    content: |
+      [foo]
+        bar = baz
+
+- name: Test-options_start_spaces 2 - set same value with prefix spaces - set same value
+  community.general.ini_file:  # noqa risky-file-permissions
+    path: "{{ output_file }}"
+    section: 'foo'
+    option: bar
+    value: baz
+    option_prefix_spaces: 2
+  register: result
+
+- name: Test-options_start_spaces 2 - set same value with prefix spaces - read content from output file
+  ansible.builtin.slurp:
+    src: "{{ output_file }}"
+  register: output_content
+
+- name: Test-options_start_spaces 2 - set same value with prefix spaces - verify results
+  vars:
+    actual_content: "{{ output_content.content | b64decode }}"
+    expected_content: |
+      [foo]
+        bar = baz
+  ansible.builtin.assert:
+    that:
+      - actual_content == expected_content
+      - result is not changed
+      - result.msg == 'OK'
+
+- name: Test-options_start_spaces 3 - set new value in new sectio with prefix spaces - create test file
+  ansible.builtin.copy:  # noqa risky-file-permissions
+    dest: "{{ output_file }}"
+    content: |
+      [foo]
+        bar = baz
+
+- name: Test-options_start_spaces 3 - set new value in new sectio with prefix spaces - set same value
+  community.general.ini_file:  # noqa risky-file-permissions
+    path: "{{ output_file }}"
+    section: 'boo'
+    option: url
+    value: daz
+    option_prefix_spaces: 2
+  register: result
+
+- name: Test-options_start_spaces 3 - set new value in new sectio with prefix spaces - read content from output file
+  ansible.builtin.slurp:
+    src: "{{ output_file }}"
+  register: output_content
+
+- name: Test-options_start_spaces 3 - set new value in new sectio with prefix spaces - verify results
+  vars:
+    actual_content: "{{ output_content.content | b64decode }}"
+    expected_content: |
+      [foo]
+        bar = baz
+
+      [boo]
+        url = daz
+  ansible.builtin.assert:
+    that:
+      - actual_content == expected_content
+      - result is changed
+      - result.msg == 'section and option added'

--- a/tests/integration/targets/ini_file/tasks/tests/09-option_prefix_spaces.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/09-option_prefix_spaces.yml
@@ -98,7 +98,6 @@
     expected_content: |
       [foo]
         bar = baz
-
       [boo]
         url = daz
   ansible.builtin.assert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add parameter to prefix option with spaces when formatting the options in a section.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This is useful for formatting some INI files. The use case here was specifically around the updating some options/values in an InfluxDB config file. This is usually in an users directory. (/home/user/.influxdbv2/configs)

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
ini_file module - new parameter ```option_prefix_spaces```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
With an existing InfluxDB configs file of the following:
```yaml
[default]
  url = "http://localhost:8086"
  token = "someSuperSecretTokenThatIsLong"
  org = "myorg"
```
Using the below task:
```yaml
- name: Update url in InfluxDB user config
  community.general.ini_file:
    path: /home/user/.influxdbv2/configs
    section: default
    option: url
    value: https://localhost:8086
```
produces the following in the configs file:
```yaml
[default]
url = "https://localhost:8086"
token = "someSuperSecretTokenThatIsLong"
org = "myorg"
```
While this seems okay, the next time that the ```influx``` or ```influxd``` commands are used, it reformats the file the to the format that it expects. Running ansible again tries to change the file as it notices that the current content is different than what the expected content will be after running the task

Adding the new ini_file parameter allows the change to be applied once and not affect now the influx/influxd commands formats the file.