### PR TITLE
Fix new Proxmox Volume handling

### DIFF
--- a/changelogs/fragments/8646-fix-bug-in-proxmox-volumes.yml
+++ b/changelogs/fragments/8646-fix-bug-in-proxmox-volumes.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - proxmox - Removed the forced conversion of non-string values to strings to be consistent with the module documentation
-  - proxmox - Fixed an issue where the new volume handling incorrectly converted `None`-type values into `"None"` strings
-  - proxmox - Fixed an issue where volume strings where overwritten instead of appended to in the new `build_volume()` method
+  - proxmox - removed the forced conversion of non-string values to strings to be consistent with the module documentation (https://github.com/ansible-collections/community.general/pull/8646).
+  - proxmox - fixed an issue where the new volume handling incorrectly converted ``null`` values into ``"None"`` strings (https://github.com/ansible-collections/community.general/pull/8646).
+  - proxmox - fixed an issue where volume strings where overwritten instead of appended to in the new ``build_volume()`` method (https://github.com/ansible-collections/community.general/pull/8646).

--- a/changelogs/fragments/8646-fix-bug-in-proxmox-volumes.yml
+++ b/changelogs/fragments/8646-fix-bug-in-proxmox-volumes.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - proxmox - Removed the forced conversion of non-string values to strings to be consistent with the module documentation
+  - proxmox - Fixed an issue where the new volume handling incorrectly converted `None`-type values into `"None"` strings
+  - proxmox - Fixed an issue where volume strings where overwritten instead of appended to in the new `build_volume()` method

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -729,8 +729,8 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
                 [vol_string] +
                 ([] if host_path is None else [host_path]) +
                 ([] if mountpoint is None else ["mp={0}".format(mountpoint)]) +
-                ([] if options is None else [map("=".join, options.items())]) +
-                ([] if not kwargs else [map("=".join, kwargs.items())])
+                ([] if options is None else list(map("=".join, options.items()))) +
+                ([] if not kwargs else list(map("=".join, kwargs.items())))
             )
 
             return {key: vol_string}

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -729,8 +729,8 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
                 [vol_string] +
                 ([] if host_path is None else [host_path]) +
                 ([] if mountpoint is None else ["mp={0}".format(mountpoint)]) +
-                ([] if options is None else list(map("=".join, options.items()))) +
-                ([] if not kwargs else list(map("=".join, kwargs.items())))
+                ([] if options is None else ["{0}={1}".format(k, v) for k, v in options.items()]) +
+                ([] if not kwargs else ["{0}={1}".format(k, v) for k, v in kwargs.items()])
             )
 
             return {key: vol_string}

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -727,6 +727,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
 
             # 1.3 If we have a host_path, we don't have storage, a volume, or a size
             vol_string = ",".join(
+                [vol_string] +
                 ([] if host_path is None else [host_path]) +
                 ([] if mountpoint is None else ["mp={0}".format(mountpoint)]) +
                 ([] if options is None else [map("=".join, options.items())]) +

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -590,8 +590,7 @@ import time
 from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import string_types
-from ansible.module_utils.common.text.converters import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native
 
 
 from ansible_collections.community.general.plugins.module_utils.proxmox import (

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -760,9 +760,6 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
         if disk is not None:
             kwargs["disk_volume"] = parse_disk_string(disk)
         if "disk_volume" in kwargs:
-            if not all(isinstance(val, string_types) for val in kwargs["disk_volume"].values()):
-                self.module.warn("All disk_volume values must be strings. Converting non-string values to strings.")
-                kwargs["disk_volume"] = {key: to_text(val) for key, val in kwargs["disk_volume"].items()}
             disk_dict = build_volume(key="rootfs", **kwargs.pop("disk_volume"))
             kwargs.update(disk_dict)
         if memory is not None:
@@ -776,9 +773,6 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
         if "mount_volumes" in kwargs:
             mounts_list = kwargs.pop("mount_volumes")
             for mount_config in mounts_list:
-                if not all(isinstance(val, string_types) for val in mount_config.values()):
-                    self.module.warn("All mount_volumes values must be strings. Converting non-string values to strings.")
-                    mount_config = {key: to_text(val) for key, val in mount_config.items()}
                 key = mount_config.pop("id")
                 mount_dict = build_volume(key=key, **mount_config)
                 kwargs.update(mount_dict)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This fixes two issues with the [new proxmox volume handling](https://github.com/ansible-collections/community.general/pull/8542) (`disk_volume` and `mount_volumes`):

1. In the plugin, a string conversion was previously forced that clashed with the documentation and incorrectly converted `None`-type values into `"None"` strings.
2. In the `build_volume()` method of the plugin, half of the built string was accidentally discarded.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

proxmox

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Here is a sample playbook to test the validity:
```yaml
---
- name: Create LXC
  hosts: localhost
  become: false
  gather_facts: false
  vars_files:
    - proxmox_credentials.yml
  tasks:
    - name: Create LXC
      community.general.proxmox:
        api_host: "{{ api_host }}"
        api_user: "{{ api_user }}"
        api_password: "{{ api_password }}"
        # api_token_id: "{{ api_token_id }}"
        # api_token_secret: "{{ api_token_secret }}"
        node: "{{ node }}"
        hostname: test-node
        ostemplate: local:vztmpl/debian-12-standard_12.2-1_amd64.tar.zst
        disk: local-lvm:8
      register: create_res

    - name: Update LXC config [new - create volumes]
      community.general.proxmox:
        api_host: "{{ api_host }}"
        api_user: "{{ api_user }}"
        api_password: "{{ api_password }}"
        # api_token_id: "{{ api_token_id }}"
        # api_token_secret: "{{ api_token_secret }}"
        node: "{{ node }}"
        hostname: test-node
        cores: 1
        vmid: "{{ create_res.vmid }}"
        disk_volume:
          storage: local-lvm
          size: 14
        mount_volumes:
          - id: mp0
            storage: local-lvm
            size: 3
            mountpoint: /mnt/test
          - id: mp1
            host_path: /root/test
            mountpoint: /mnt/host
            options:
              backup: "0"
        update: true

    - name: Update LXC config [new - explicit volumes]
      community.general.proxmox:
        api_host: "{{ api_host }}"
        api_user: "{{ api_user }}"
        api_password: "{{ api_password }}"
        # api_token_id: "{{ api_token_id }}"
        # api_token_secret: "{{ api_token_secret }}"
        node: "{{ node }}"
        hostname: test-node
        cores: 1
        vmid: "{{ create_res.vmid }}"
        disk_volume:
          storage: local-lvm
          volume: "vm-{{ create_res.vmid }}-disk-0"
          size: 14
        mount_volumes:
          - id: mp0
            storage: local-lvm
            volume: "vm-{{ create_res.vmid }}-disk-1"
            size: 3
            mountpoint: /mnt/test
          - id: mp1
            host_path: /root/test
            mountpoint: /mnt/host
            options:
              backup: "0"
        update: true

    - name: Update LXC config [old - implicit volumes]
      community.general.proxmox:
        api_host: "{{ api_host }}"
        api_user: "{{ api_user }}"
        api_password: "{{ api_password }}"
        # api_token_id: "{{ api_token_id }}"
        # api_token_secret: "{{ api_token_secret }}"
        node: "{{ node }}"
        hostname: test-node
        cores: 1
        vmid: "{{ create_res.vmid }}"
        disk: local-lvm:14
        mounts: '{"mp0":"local-lvm:3,mp=/mnt/test","mp1":"/root/test,mp=/mnt/host,backup=0"}'
        update: true

    - name: Update LXC config [old - explicit volumes]
      community.general.proxmox:
        api_host: "{{ api_host }}"
        api_user: "{{ api_user }}"
        api_password: "{{ api_password }}"
        # api_token_id: "{{ api_token_id }}"
        # api_token_secret: "{{ api_token_secret }}"
        node: "{{ node }}"
        hostname: test-node
        cores: 1
        vmid: "{{ create_res.vmid }}"
        disk: "local-lvm:vm-{{ create_res.vmid }}-disk-0,size=14G"
        mounts: '{"mp0":"local-lvm:vm-{{ create_res.vmid }}-disk-1,size=3G,mp=/mnt/test","mp1":"/root/test,mp=/mnt/host,backup=0"}'
        update: true
```
