### PR TITLE
fix(modules/gitlab_runners): pass paused to gitlab

### DIFF
--- a/changelogs/fragments/8648-fix-gitlab-runner-paused.yaml
+++ b/changelogs/fragments/8648-fix-gitlab-runner-paused.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "gitlab_runner - fix ``paused`` parameter being ignored (https://github.com/ansible-collections/community.general/pull/8648)."


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The paused module parameter needs to passed to the create_or_update method to work.

As of now (gitlab 17.1.0) `active: False` is still working. But the gitlab_runner module silently ignored `paused: True` and always responded with `No need to update the runner ...` if a runner was updated with a changed paused attribute. Creating a runner with `paused: True` also did not create a runner in paused state.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
gitlab_runner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
* Create a runner with `paused: True` has the runner not paused in gitlab after creation

Or
* Create a runner
* Updated the runner with `paused: True` states: `No need to update the runner ...`
* The runner is not paused in gitlab

Info @wt-io-it