### PR TITLE
gitlab_project: Add some missing params

### DIFF
--- a/changelogs/fragments/8688-gitlab_project-add-new-params.yml
+++ b/changelogs/fragments/8688-gitlab_project-add-new-params.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - gitlab_project - add option ``pages_access_level`` to disable project pages (https://github.com/ansible-collections/community.general/pull/8688).
+  - gitlab_project - add option ``service_desk_enabled`` to disable service desk (https://github.com/ansible-collections/community.general/pull/8688).
+  - gitlab_project - add option ``model_registry_access_level`` to disable model registry (https://github.com/ansible-collections/community.general/pull/8688).

--- a/plugins/modules/gitlab_project.py
+++ b/plugins/modules/gitlab_project.py
@@ -302,6 +302,27 @@ options:
           - Keep tags matching this regular expression.
         type: str
     version_added: "9.3.0"
+  pages_access_level:
+    description:
+      - V(private) means that accessing pages tab is allowed only to project members.
+      - V(disabled) means that accessing pages tab is disabled.
+      - V(enabled) means that accessing pages tab is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "9.3.0"
+  service_desk_enabled:
+    description:
+      - Enable Service Desk.
+    type: bool
+    version_added: "9.3.0"
+  model_registry_access_level:
+    description:
+      - V(private) means that accessing model registry tab is allowed only to project members.
+      - V(disabled) means that accessing model registry tab is disabled.
+      - V(enabled) means that accessing model registry tab is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "9.3.0"
 '''
 
 EXAMPLES = r'''
@@ -429,6 +450,9 @@ class GitLabProject(object):
             'monitor_access_level': options['monitor_access_level'],
             'security_and_compliance_access_level': options['security_and_compliance_access_level'],
             'container_expiration_policy': options['container_expiration_policy'],
+            'pages_access_level': options['pages_access_level'],
+            'service_desk_enabled': options['service_desk_enabled'],
+            'model_registry_access_level': options['model_registry_access_level'],
         }
 
         # topics was introduced on gitlab >=14 and replace tag_list. We get current gitlab version
@@ -603,6 +627,9 @@ def main():
             name_regex=dict(type='str'),
             name_regex_keep=dict(type='str'),
         )),
+        pages_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        service_desk_enabled=dict(type='bool'),
+        model_registry_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
     ))
 
     module = AnsibleModule(
@@ -664,6 +691,9 @@ def main():
     security_and_compliance_access_level = module.params['security_and_compliance_access_level']
     topics = module.params['topics']
     container_expiration_policy = module.params['container_expiration_policy']
+    pages_access_level = module.params['pages_access_level']
+    service_desk_enabled = module.params['service_desk_enabled']
+    model_registry_access_level = module.params['model_registry_access_level']
 
     # Set project_path to project_name if it is empty.
     if project_path is None:
@@ -702,7 +732,7 @@ def main():
         if project_exists:
             gitlab_project.delete_project()
             module.exit_json(changed=True, msg="Successfully deleted project %s" % project_name)
-        module.exit_json(changed=False, msg="Project deleted or does not exists")
+        module.exit_json(changed=False, msg="Project deleted or does not exist")
 
     if state == 'present':
 
@@ -740,6 +770,9 @@ def main():
             "security_and_compliance_access_level": security_and_compliance_access_level,
             "topics": topics,
             "container_expiration_policy": container_expiration_policy,
+            "pages_access_level": pages_access_level,
+            "service_desk_enabled": service_desk_enabled,
+            "model_registry_access_level": model_registry_access_level,
         }):
 
             module.exit_json(changed=True, msg="Successfully created or updated the project %s" % project_name, project=gitlab_project.project_object._attrs)


### PR DESCRIPTION
##### SUMMARY

gitlab_project:

- add option ``pages_access_level``
- add option ``service_desk_enabled``
- add option ``model_registry_access_level``

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

gitlab_project

##### ADDITIONAL INFORMATION

Might require rebasing with https://github.com/ansible-collections/community.general/pull/8674
