### PR TITLE
Namespace the passwordstore lockfile

### DIFF
--- a/changelogs/fragments/8689-passwordstore-lock-naming.yml
+++ b/changelogs/fragments/8689-passwordstore-lock-naming.yml
@@ -1,2 +1,2 @@
-minor_change:
+minor_changes:
   - passwordstore - add the current user to the lockfile file name to address issues on multi-user systems (https://github.com/ansible-collections/community.general/pull/8689).

--- a/changelogs/fragments/8689-passwordstore-lock-naming.yml
+++ b/changelogs/fragments/8689-passwordstore-lock-naming.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - passwordstore - add the current user to the lockfile file name to address issues on multi-user systems (https://github.com/ansible-collections/community.general/pull/8689).
+  - passwordstore lookup plugin - add the current user to the lockfile file name to address issues on multi-user systems (https://github.com/ansible-collections/community.general/pull/8689).

--- a/changelogs/fragments/8689-passwordstore-lock-naming.yml
+++ b/changelogs/fragments/8689-passwordstore-lock-naming.yml
@@ -1,0 +1,2 @@
+minor_change:
+  - passwordstore - add the current user to the lockfile file name to address issues on multi-user systems (https://github.com/ansible-collections/community.general/pull/8689).

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -469,7 +469,8 @@ class LookupModule(LookupBase):
     def opt_lock(self, type):
         if self.get_option('lock') == type:
             tmpdir = os.environ.get('TMPDIR', '/tmp')
-            lockfile = os.path.join(tmpdir, '.passwordstore.lock')
+            user = os.environ.get('USER')
+            lockfile = os.path.join(tmpdir, '.{}.passwordstore.lock'.format(user))
             with FileLock().lock_file(lockfile, tmpdir, self.lock_timeout):
                 self.locked = type
                 yield

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -470,7 +470,7 @@ class LookupModule(LookupBase):
         if self.get_option('lock') == type:
             tmpdir = os.environ.get('TMPDIR', '/tmp')
             user = os.environ.get('USER')
-            lockfile = os.path.join(tmpdir, '.{}.passwordstore.lock'.format(user))
+            lockfile = os.path.join(tmpdir, '.{0}.passwordstore.lock'.format(user))
             with FileLock().lock_file(lockfile, tmpdir, self.lock_timeout):
                 self.locked = type
                 yield


### PR DESCRIPTION
##### SUMMARY
When passwordstore needs to grab a lock, it creates a statically named file (within /tmp, typically). It also leaves that lock file around after it is done with it. This is unfortunate as there might be more than one user using the passwordstore functionality on a single machine, even if they aren't using it contemporaneously. Prepend the username to the filename so that the lock file is unique per user.

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
passwordstore

##### ADDITIONAL INFORMATION

1.  run a playbook that will lookup from a passwordstore
2. login as another user
3. run the same or another playbook that will lookup from a passwordstore
4. it errors out because the lockfile exists and cannot be removed (due to not being the owner of the file)