### PR TITLE
archive - add reproducible_tar option

### DIFF
--- a/changelogs/fragments/8691-archive-add-reproducible-tar-option.yml
+++ b/changelogs/fragments/8691-archive-add-reproducible-tar-option.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - archive - add ``reproducible_tar`` option to make tar archives vary with the same input (https://github.com/ansible-collections/community.general/pull/8691).
+  - archive - add ``reproducible_tar`` option to make tar archives vary less given the same input file content (https://github.com/ansible-collections/community.general/pull/8691).

--- a/changelogs/fragments/8691-archive-add-reproducible-tar-option.yml
+++ b/changelogs/fragments/8691-archive-add-reproducible-tar-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - archive - add ``reproducible_tar`` option to make tar archives vary with the same input (https://github.com/ansible-collections/community.general/pull/8691).

--- a/plugins/modules/archive.py
+++ b/plugins/modules/archive.py
@@ -365,14 +365,14 @@ class Archive(object):
         try:
             for target in self.targets:
                 if os.path.isdir(target):
-                    paths = []
-                    for directory_path, _directory_names, file_names in os.walk(target, topdown=True):
-                        paths.append(directory_path)
-                        for file_name in file_names:
-                            paths.append(os.path.join(directory_path, file_name))
+                    for directory_path, directory_names, file_names in os.walk(target, topdown=True):
+                        for directory_name in directory_names:
+                            full_path = os.path.join(directory_path, directory_name)
+                            self.add(full_path, strip_prefix(self.root, full_path))
 
-                    for path in sorted(paths):
-                        self.add(path, strip_prefix(self.root, path))
+                        for file_name in file_names:
+                            full_path = os.path.join(directory_path, file_name)
+                            self.add(full_path, strip_prefix(self.root, full_path))
                 else:
                     self.add(target, strip_prefix(self.root, target))
         except Exception as e:

--- a/plugins/modules/archive.py
+++ b/plugins/modules/archive.py
@@ -551,10 +551,10 @@ class TGZFileWithMtime(tarfile.TarFile):
         if fileobj is None:
             fileobj = open(name, mode + "b")
 
-        # filename intentionally empty to match GNU tar
         try:
+            # filename intentionally empty to match GNU tar
             gzipfileobj = gzip.GzipFile("", mode, compresslevel, fileobj, mtime)
-        except:
+        except Exception:
             fileobj.close()
             raise
 
@@ -563,7 +563,7 @@ class TGZFileWithMtime(tarfile.TarFile):
 
         try:
             super(TGZFileWithMtime, self).__init__(mode="w", fileobj=gzipfileobj, **kwargs)
-        except:
+        except Exception:
             gzipfileobj.close()
             raise
 

--- a/plugins/modules/archive.py
+++ b/plugins/modules/archive.py
@@ -286,7 +286,7 @@ class Archive(object):
         self.format = module.params['format']
         self.must_archive = module.params['force_archive']
         self.remove = module.params['remove']
-        self.reproducible_tar = module.params["reproducible_tar"] or False
+        self.reproducible_tar = module.params["reproducible_tar"]
 
         self.changed = False
         self.destination_state = STATE_ABSENT

--- a/plugins/modules/archive.py
+++ b/plugins/modules/archive.py
@@ -569,7 +569,7 @@ class ReproducibleTGZFile(tarfile.TarFile):
             self._fileobj.close()
             raise
 
-    def close(self) -> None:
+    def close(self):
         try:
             super(ReproducibleTGZFile, self).close()
         finally:

--- a/tests/unit/plugins/modules/test_archive.py
+++ b/tests/unit/plugins/modules/test_archive.py
@@ -42,6 +42,7 @@ class TestArchive(ModuleTestCase):
                 exclusion_patterns=dict(type='list', elements='path'),
                 force_archive=dict(type='bool', default=False),
                 remove=dict(type='bool', default=False),
+                reproducible_tar=dict(type="bool", default=False),
             ),
             add_file_common_args=True,
             supports_check_mode=True,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

`archive` - add ``reproducible_tar`` option to make tar archives vary less given the same input file content

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`community.general.archive` new parameter `reproducible_archive`

##### ADDITIONAL INFORMATION

Used `diffoscope` to compare with GNU tar on an example directory

```
tar --create --file ../roles/k8s_node/files/lelastic2.tgz --gzip \
	--mtime='@0' \
	--sort=name \
	--numeric-owner --owner=0 --group=0 \
	--mode=go+u,go-w \
	--directory ../charts lelastic)
```

The most obvious remaining improvement would be to add the root directory and sort all files.

I [removed such a change here](https://github.com/ansible-collections/community.general/pull/8691/commits/b68c377470aedd08b24c4035981b45a532c14918) because it caused test failures I haven't debugged.

###### Before diffoscope

```
diffoscope ./roles/k8s_node/files/lelastic2.tgz ./roles/k8s_node/files/lelastic.tgz
--- ./roles/k8s_node/files/lelastic2.tgz
+++ ./roles/k8s_node/files/lelastic.tgz
├── filetype from file(1)
│ @@ -1 +1 @@
│ -gzip compressed data, from Unix
│ +gzip compressed data, was "lelastic.tgz", last modified: Tue Jul 30 16:09:12 2024, max compression
│   --- lelastic2.tgz-content
├── +++ lelastic.tgz-content
│ ├── file list
│ │ @@ -1,6 +1,5 @@
│ │ -drwxr-xr-x   0        0        0        0 1970-01-01 00:00:00.000000 lelastic/
│ │ --rw-r--r--   0        0        0      349 1970-01-01 00:00:00.000000 lelastic/.helmignore
│ │ --rw-r--r--   0        0        0     1158 1970-01-01 00:00:00.000000 lelastic/Chart.yaml
│ │ -drwxr-xr-x   0        0        0        0 1970-01-01 00:00:00.000000 lelastic/templates/
│ │ --rw-r--r--   0        0        0     1855 1970-01-01 00:00:00.000000 lelastic/templates/lelastic-deployment.yaml
│ │ --rw-r--r--   0        0        0     1428 1970-01-01 00:00:00.000000 lelastic/values.yaml
│ │ +drwxr-xr-x   0 gpratt     (503) staff       (20)        0 2024-07-26 19:51:37.315485 lelastic/templates/
│ │ +-rw-r--r--   0 gpratt     (503) staff       (20)     1158 2023-09-14 23:52:21.421117 lelastic/Chart.yaml
│ │ +-rw-r--r--   0 gpratt     (503) staff       (20)      349 2023-09-14 23:52:21.421037 lelastic/.helmignore
│ │ +-rw-r--r--   0 gpratt     (503) staff       (20)     1428 2023-09-14 23:52:21.421620 lelastic/values.yaml
│ │ +-rw-r--r--   0 gpratt     (503) staff       (20)     1855 2024-07-26 19:51:37.315540 lelastic/templates/lelastic-deployment.yaml
│ ├── filetype from file(1)
│ │ @@ -1 +1 @@
│ │ -POSIX tar archive (GNU)
│ │ +POSIX tar archive
```

###### After diffoscope

```
❯ diffoscope ./roles/k8s_node/files/lelastic2.tgz ./roles/k8s_node/files/lelastic.tgz 
--- ./roles/k8s_node/files/lelastic2.tgz
+++ ./roles/k8s_node/files/lelastic.tgz
├── filetype from file(1)
│ @@ -1 +1 @@
│ -gzip compressed data, from Unix
│ +gzip compressed data
│   --- lelastic2.tgz-content
├── +++ lelastic.tgz-content
│ ├── file list
│ │ @@ -1,6 +1,5 @@
│ │ -drwxr-xr-x   0        0        0        0 1970-01-01 00:00:00.000000 lelastic/
│ │ --rw-r--r--   0        0        0      349 1970-01-01 00:00:00.000000 lelastic/.helmignore
│ │ --rw-r--r--   0        0        0     1158 1970-01-01 00:00:00.000000 lelastic/Chart.yaml
│ │  drwxr-xr-x   0        0        0        0 1970-01-01 00:00:00.000000 lelastic/templates/
│ │ --rw-r--r--   0        0        0     1855 1970-01-01 00:00:00.000000 lelastic/templates/lelastic-deployment.yaml
│ │ +-rw-r--r--   0        0        0     1158 1970-01-01 00:00:00.000000 lelastic/Chart.yaml
│ │ +-rw-r--r--   0        0        0      349 1970-01-01 00:00:00.000000 lelastic/.helmignore
│ │  -rw-r--r--   0        0        0     1428 1970-01-01 00:00:00.000000 lelastic/values.yaml
│ │ +-rw-r--r--   0        0        0     1855 1970-01-01 00:00:00.000000 lelastic/templates/lelastic-deployment.yaml
│ ├── filetype from file(1)
│ │ @@ -1 +1 @@
│ │ -POSIX tar archive (GNU)
│ │ +POSIX tar archive
```
