### PR TITLE
Update timezone.py

### DIFF
--- a/plugins/modules/timezone.py
+++ b/plugins/modules/timezone.py
@@ -75,6 +75,7 @@ diff:
 
 EXAMPLES = r'''
 - name: Set timezone to Asia/Tokyo
+  become: true
   community.general.timezone:
     name: Asia/Tokyo
 '''


### PR DESCRIPTION
in order to set a timezone, root priviliages are needed on most distros, therefore i suggest to change an example to make it plug and play ready.

##### SUMMARY
Example should use `become: true`

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
timezone