### PR TITLE
User federation cleaner diff

### DIFF
--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -347,6 +347,7 @@ options:
                       to the first part of his Kerberos principal. For instance, for principal C(john@KEYCLOAK.ORG),
                       it will assume that LDAP username is V(john).
                 type: str
+                default: 'userPrincipalName'
                 version_added: 8.1.0
 
             serverPrincipal:
@@ -712,6 +713,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from copy import deepcopy
 
+
 def set_mapper_defaults(mapper):
     '''
     Set explicit default values expected by the kc API for the different mapper types.
@@ -722,8 +724,9 @@ def set_mapper_defaults(mapper):
     if mapper.get('providerId') == 'msad-user-account-control-mapper':
         if not mapper.get('config'):
             mapper['config'] = {}
-        if not 'always.read.enabled.value.from.ldap' in mapper['config']:
+        if 'always.read.enabled.value.from.ldap' not in mapper['config']:
             mapper['config']['always.read.enabled.value.from.ldap'] = True
+
 
 def sanitize(comp):
     compcopy = deepcopy(comp)
@@ -786,7 +789,8 @@ def main():
         readTimeout=dict(type='int'),
         searchScope=dict(type='str', choices=['1', '2'], default='1'),
         serverPrincipal=dict(type='str'),
-        # When creating a user federation with this parameter not present or set to '', this parameter is set explicitly to the default value 'userPrincipalName' by kc
+        # When creating a user federation with this parameter not present or set to '',
+        # this parameter is set explicitly to the default value 'userPrincipalName' by kc,
         # even if kerbereos authentication is disabled.
         # To get krbPrincipalAttribute = '' (and the optional behavior described in the GUI) explicitly set it to '', and run the module twice:
         # once to create the federation with the default value and then to update it to the desired '' value.
@@ -1027,7 +1031,6 @@ def main():
             if module._diff:
                 result['diff'] = dict(before=before_comp_sanitized, after=after_comp_sanitized)
             result['changed'] = before_comp_sanitized != after_comp_sanitized
-
 
             result['msg'] = "User federation {id} has been updated".format(id=cid)
             module.exit_json(**result)

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -1020,8 +1020,7 @@ def main():
                         mapper['parentId'] = desired_comp['id']
                     mapper = kc.create_component(mapper, realm)
 
-            after_comp['mappers'] = kc.get_components(urlencode(dict(parent=cid, name=mapper['name'])), realm)
-            before_comp['mappers'] = updated_mappers
+            after_comp['mappers'] = kc.get_components(urlencode(dict(parent=cid)), realm)
             after_comp_sanitized = sanitize(after_comp)
             before_comp_sanitized = sanitize(before_comp)
             result['end_state'] = after_comp_sanitized

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -927,10 +927,10 @@ def main():
                     old_mapper = {}
             new_mapper = old_mapper.copy()
             new_mapper.update(change)
-            if new_mapper != old_mapper:
-                if changeset.get('mappers') is None:
-                    changeset['mappers'] = list()
-                changeset['mappers'].append(new_mapper)
+            # changeset includes all desired mappers: unchanged, modified and newly created
+            if changeset.get('mappers') is None:
+                changeset['mappers'] = list()
+            changeset['mappers'].append(new_mapper)
 
     # Prepare the desired values using the existing values (non-existence results in a dict that is save to use as a basis)
     desired_comp = before_comp.copy()

--- a/tests/unit/plugins/modules/test_keycloak_user_federation.py
+++ b/tests/unit/plugins/modules/test_keycloak_user_federation.py
@@ -228,7 +228,9 @@ class TestKeycloakUserFederation(ModuleTestCase):
                     }
                 }
             ],
+            [],
             []
+
         ]
         return_value_component_get = [
             {
@@ -281,7 +283,7 @@ class TestKeycloakUserFederation(ModuleTestCase):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
-        self.assertEqual(len(mock_get_components.mock_calls), 2)
+        self.assertEqual(len(mock_get_components.mock_calls), 3)
         self.assertEqual(len(mock_get_component.mock_calls), 1)
         self.assertEqual(len(mock_create_component.mock_calls), 0)
         self.assertEqual(len(mock_update_component.mock_calls), 1)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Six smaller changes to improve the change detection and make the diff cleaner and more precise.

- set the default value of the ```krbPrincipalAttribute``` parameter to ```userPrincipalName``` to match the KC API behavior
- explicitly set the default parameter ```always.read.enabled.value.from.ldap' = True``` for the mapper ```msad-user-account-control-mapper``` to match KC API behavior (this happens even if kereberos authentication is disabled)
- the changeset now also includes unchanged mappers, not only those that will be modified or newly created, to improve the diff; e.g. when changes are necessary, in check mode diffing before with desired (after updating it with the changeset) would wrongly show, that the unchanged mappers should/will be removed
- sorting the mapper in sanitize function; the order is not really relevant and not used in the code, the API also seems to have a different random order for every user federation; to get a more correct diff we order the mappers of both states by name 
- in update code path always make an update and send the desired user federation config (except for check mod); this way we can always update the ```bindCredential``` parameter and still overwrite/ignore it when evaluating changed and diffing (for secrets the KC API always returns ```**********```, so comparing before with desired states always leads to changed = True)
- in update code path, fetch mapper data again after update for comparison with before state

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Should partially fix [7169](https://github.com/ansible-collections/community.general/issues/7169) (for the mapper removal i will make another PR) and make [8604](https://github.com/ansible-collections/community.general/pull/8604) obsolete.

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_user_federation