### PR TITLE
homebrew_cask: fix upgrade_all changed when nothing upgraded

### DIFF
--- a/changelogs/fragments/8708-homebrew_cask-fix-upgrade-all.yml
+++ b/changelogs/fragments/8708-homebrew_cask-fix-upgrade-all.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - homebrew_cask - fix ``upgrade_all`` returns ``changed`` when nothing upgraded (https://github.com/ansible-collections/community.general/issues/8707).
+  - homebrew_cask - fix ``upgrade_all`` returns ``changed`` when nothing upgraded (https://github.com/ansible-collections/community.general/issues/8707, https://github.com/ansible-collections/community.general/pull/8708).

--- a/changelogs/fragments/8708-homebrew_cask-fix-upgrade-all.yml
+++ b/changelogs/fragments/8708-homebrew_cask-fix-upgrade-all.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - homebrew_cask - fix ``upgrade_all`` returns ``changed`` when nothing upgraded (https://github.com/ansible-collections/community.general/issues/8707).

--- a/plugins/modules/homebrew_cask.py
+++ b/plugins/modules/homebrew_cask.py
@@ -535,7 +535,7 @@ class HomebrewCask(object):
 
         if rc == 0:
             # 'brew upgrade --cask' does not output anything if no casks are upgraded
-            if not out:
+            if not out.strip():
                 self.message = 'Homebrew casks already upgraded.'
 
             # handle legacy 'brew cask upgrade'

--- a/plugins/modules/homebrew_cask.py
+++ b/plugins/modules/homebrew_cask.py
@@ -534,7 +534,12 @@ class HomebrewCask(object):
             rc, out, err = self.module.run_command(cmd)
 
         if rc == 0:
-            if re.search(r'==> No Casks to upgrade', out.strip(), re.IGNORECASE):
+            # 'brew upgrade --cask' does not output anything if no casks are upgraded
+            if not out:
+                self.message = 'Homebrew casks already upgraded.'
+
+            # handle legacy 'brew cask upgrade'
+            elif re.search(r'==> No Casks to upgrade', out.strip(), re.IGNORECASE):
                 self.message = 'Homebrew casks already upgraded.'
 
             else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes bug with homebrew_cask upgrade_all where the module always returns 'changed' due to change in output behavior of the `brew` command.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #8707 
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
homebrew_cask

