### PR TITLE
Get interfaces for Proxmox LXC containers

### DIFF
--- a/changelogs/fragments/8713-proxmox_lxc_interfaces.yml
+++ b/changelogs/fragments/8713-proxmox_lxc_interfaces.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox - Add new fact for lxc interface details (https://github.com/ansible-collections/community.general/pull/8713)

--- a/changelogs/fragments/8713-proxmox_lxc_interfaces.yml
+++ b/changelogs/fragments/8713-proxmox_lxc_interfaces.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox - Add new fact for lxc interface details (https://github.com/ansible-collections/community.general/pull/8713)
+  - proxmox inventory plugin - add new fact for LXC interface details (https://github.com/ansible-collections/community.general/pull/8713).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -363,32 +363,26 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 return None
 
     def _get_lxc_interfaces(self, properties, node, vmid):
-        try:
-            ret = self._get_json("%s/api2/json/nodes/%s/lxc/%s/interfaces" % (self.proxmox_url, node, vmid))
-        except Exception:
+        if not properties[self._fact('status')] == 'running':
             return
 
-        if not ret:
-            return
+        ret = self._get_json("%s/api2/json/nodes/%s/lxc/%s/interfaces" % (self.proxmox_url, node, vmid))
 
         result = []
 
-        try:
-            for iface in ret:
-                result_iface = {
-                    'name': iface['name'],
-                    'hwaddr': iface['hwaddr']
-                }
+        for iface in ret:
+            result_iface = {
+                'name': iface['name'],
+                'hwaddr': iface['hwaddr']
+            }
 
-                if 'inet' in iface:
-                    result_iface['inet'] = iface['inet']
+            if 'inet' in iface:
+                result_iface['inet'] = iface['inet']
 
-                if 'inet6' in iface:
-                    result_iface['inet6'] = iface['inet6']
+            if 'inet6' in iface:
+                result_iface['inet6'] = iface['inet6']
 
-                result.append(result_iface)
-        except Exception:
-            return
+            result.append(result_iface)
 
         properties[self._fact('lxc_interfaces')] = result
 

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -365,7 +365,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _get_lxc_interfaces(self, properties, node, vmid):
         try:
             ret = self._get_json("%s/api2/json/nodes/%s/lxc/%s/interfaces" % (self.proxmox_url, node, vmid))
-        except:
+        except Exception:
             return
 
         if not ret:
@@ -387,7 +387,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     result_iface['inet6'] = iface['inet6']
 
                 result.append(result_iface)
-        except:
+        except Exception:
             return
 
         properties[self._fact('lxc_interfaces')] = result

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -366,7 +366,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not properties[self._fact('status')] == 'running':
             return
 
-        ret = self._get_json("%s/api2/json/nodes/%s/lxc/%s/interfaces" % (self.proxmox_url, node, vmid))
+        ret = self._get_json("%s/api2/json/nodes/%s/lxc/%s/interfaces" % (self.proxmox_url, node, vmid), ignore_errors=[501])
+        if not ret:
+            return
 
         result = []
 

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -365,7 +365,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _get_lxc_interfaces(self, properties, node, vmid):
         status_key = self._fact('status')
 
-        if not status_key in properties or not properties[status_key] == 'running':
+        if status_key not in properties or not properties[status_key] == 'running':
             return
 
         ret = self._get_json("%s/api2/json/nodes/%s/lxc/%s/interfaces" % (self.proxmox_url, node, vmid), ignore_errors=[501])

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -363,7 +363,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 return None
 
     def _get_lxc_interfaces(self, properties, node, vmid):
-        if not properties[self._fact('status')] == 'running':
+        status_key = self._fact('status')
+
+        if not status_key in properties or not properties[status_key] == 'running':
             return
 
         ret = self._get_json("%s/api2/json/nodes/%s/lxc/%s/interfaces" % (self.proxmox_url, node, vmid), ignore_errors=[501])

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -37,7 +37,7 @@ def get_auth():
 
 # NOTE: when updating/adding replies to this function,
 # be sure to only add only the _contents_ of the 'data' dict in the API reply
-def get_json(url):
+def get_json(url, ignore_errors=None):
     if url == "https://localhost:8006/api2/json/nodes":
         # _get_nodes
         return [{"type": "node",


### PR DESCRIPTION
##### SUMMARY
- Add fact for [proxmox lxc interfaces](https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/lxc/{vmid}/interfaces)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
proxmox

##### ADDITIONAL INFORMATION
Useful for setting the ansible_host variable for lxc containers interfaces using dhcp.

Fact example:
```json
"proxmox_lxc_interfaces": [
    {
        "hwaddr": "00:00:00:00:00:00",
        "inet": "127.0.0.1/8",
        "inet6": "::1/128",
        "name": "lo"
    },
    {
        "hwaddr": "00:00:5e:00:53:a1",
        "inet": "192.0.2.12/24",
        "inet6": "2001:db8:3c4d:0015:0000:0000:1a2f:1a2b/48",
        "name": "eth0"
    }
]
```