### PR TITLE
open_iscsi: Make targets optional for a portal login

### DIFF
--- a/changelogs/fragments/8719-openiscsi-add-multiple-targets.yaml
+++ b/changelogs/fragments/8719-openiscsi-add-multiple-targets.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - open_iscsi - Allow login to a portal with multiple targets without specifying any of them (https://github.com/ansible-collections/community.general/pull/8719)
+  - open_iscsi - allow login to a portal with multiple targets without specifying any of them (https://github.com/ansible-collections/community.general/pull/8719).

--- a/changelogs/fragments/8719-openiscsi-add-multiple-targets.yaml
+++ b/changelogs/fragments/8719-openiscsi-add-multiple-targets.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - open_iscsi - Allow login to a portal with multiple targets without specifying any of them (https://github.com/ansible-collections/community.general/pull/8719)

--- a/plugins/modules/open_iscsi.py
+++ b/plugins/modules/open_iscsi.py
@@ -342,8 +342,7 @@ def main():
         required_if=[
             ('discover', True, ['portal']),
             ('auto_node_startup', True, ['target']),
-            ('auto_portal_startup', True, ['target'])
-            ],
+            ('auto_portal_startup', True, ['target'])],
         supports_check_mode=True,
     )
 

--- a/plugins/modules/open_iscsi.py
+++ b/plugins/modules/open_iscsi.py
@@ -256,6 +256,7 @@ def target_login(module, target, check_rc, portal=None, port=None):
     rc, out, err = module.run_command(cmd, check_rc=check_rc)
     return rc
 
+
 def target_logout(module, target):
     cmd = [iscsiadm_cmd, '--mode', 'node', '--targetname', target, '--logout']
     module.run_command(cmd, check_rc=True)
@@ -416,7 +417,7 @@ def main():
                 else:
                     target_logout(module, target)
                 # Check if there are multiple targets on a single portal and
-                # do not mark the task changed if host could not login to one of them 
+                # do not mark the task changed if host could not login to one of them
                 if len(nodes) > 1 and login_result == 24:
                     result['changed'] |= False
                     result['connection_changed'] = False
@@ -424,8 +425,8 @@ def main():
                     result['changed'] |= True
                     result['connection_changed'] = True
             else:
-                    result['changed'] |= True
-                    result['connection_changed'] = True
+                result['changed'] |= True
+                result['connection_changed'] = True
 
     if automatic is not None:
         isauto = target_isauto(module, target)

--- a/plugins/modules/open_iscsi.py
+++ b/plugins/modules/open_iscsi.py
@@ -372,6 +372,7 @@ def main():
 
     # return json dict
     result = {'changed': False}
+    login_to_all_nodes = False
     check_rc = True
 
     if discover:
@@ -391,6 +392,7 @@ def main():
             if len(nodes) > 1:
                 # Disable strict return code checking if there are multiple targets
                 # That will allow to skip target where we have no rights to login
+                login_to_all_nodes = True
                 check_rc = False
         else:
             # check given target is in cache
@@ -406,8 +408,7 @@ def main():
         result['nodes'] = nodes
 
     if login is not None:
-        # If check_rc=False we will try to login to all available target nodes
-        if not check_rc:
+        if login_to_all_nodes:
             result['devicenodes'] = []
             for index_target in nodes:
                 loggedon = target_loggedon(module, index_target, portal, port)
@@ -454,7 +455,7 @@ def main():
                 result['changed'] |= True
                 result['connection_changed'] = True
 
-    if automatic is not None and check_rc:
+    if automatic is not None and not login_to_all_nodes:
         isauto = target_isauto(module, target)
         if (automatic and isauto) or (not automatic and not isauto):
             result['changed'] |= False
@@ -470,7 +471,7 @@ def main():
             result['changed'] |= True
             result['automatic_changed'] = True
 
-    if automatic_portal is not None and check_rc:
+    if automatic_portal is not None and not login_to_all_nodes:
         isauto = target_isauto(module, target, portal, port)
         if (automatic_portal and isauto) or (not automatic_portal and not isauto):
             result['changed'] |= False

--- a/plugins/modules/open_iscsi.py
+++ b/plugins/modules/open_iscsi.py
@@ -226,7 +226,7 @@ def target_loggedon(module, target, portal=None, port=None):
         module.fail_json(cmd=cmd, rc=rc, msg=err)
 
 
-def target_login(module, target, portal=None, port=None, check_rc=True):
+def target_login(module, target, check_rc, portal=None, port=None):
     node_auth = module.params['node_auth']
     node_user = module.params['node_user']
     node_pass = module.params['node_pass']
@@ -368,6 +368,7 @@ def main():
 
     # return json dict
     result = {'changed': False}
+    check_rc = True
 
     if discover:
         if check:
@@ -408,7 +409,7 @@ def main():
                     result['devicenodes'] += target_device_node(target)
             elif not check:
                 if login:
-                    target_login(module, target, portal, port, check_rc)
+                    target_login(module, target, check_rc, portal, port)
                     # give udev some time
                     time.sleep(1)
                     result['devicenodes'] += target_device_node(target)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- open_iscsi now can login to a portal with multiple targets available
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
open_iscsi
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION
There was no option to login into multiple targets (luns) of a portal
Also as there no longer need to warn about this problem, i deleted a note not to confuse anyone with a wrong information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
# Before
# NOTE: Only works if exactly one target is exported to the initiator
- name: Discover targets on portal and login to the one available
  community.general.open_iscsi:
    portal: '{{ iscsi_target }}'
    login: true
    discover: true
    
# Now
- name: Discover targets on portal and login to the one available
  community.general.open_iscsi:
    portal: '{{ iscsi_target }}'
    login: true
    discover: true
```
