### PR TITLE
fix(nmcli): remove bond from ip_conn_type

### DIFF
--- a/changelogs/fragments/8558-fix-bond-connection-type-options.yml
+++ b/changelogs/fragments/8558-fix-bond-connection-type-options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "nmcli - corrects underlying command formation by no longer including ``ipv4.*`` and ``ipv6.*`` settings when working with ``bond`` connection types (https://github.com/ansible-collections/community.general/issues/8558)."

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1951,7 +1951,6 @@ class Nmcli(object):
     @property
     def ip_conn_type(self):
         return self.type in (
-            'bond',
             'bridge',
             'dummy',
             'ethernet',


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Removes `bond` connection types from the `ip_conn_type` list. Currently, with `bond` connections being included in the `ip_conn_type` list, the resulting `nmcli` commands include references to `ipv4` and `ipv6` settings. These options are not available to `bond` connection types as stated by the error output in issue #8558.

Fixes #8558

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME
nmcli

##### ADDITIONAL INFORMATION

```
# before change

TASK [Setup bond interface for - internal] ***********************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Error: invalid or not allowed setting 'ipv4': 'ipv4' not among [connection, bond, 802-3-ethernet (ethernet), ethtool, bridge-port, link, match].\n", "name": "bond-internal", "rc": 2}


# after change

TASK [Setup bond interface for - internal] ***********************************************************************************
ok: [localhost]

```
