### PR TITLE
fix(opentelemetry): adjust default value for `store_spans_in_file` causing traces to be produced to a file named `None`

### DIFF
--- a/changelogs/fragments/8741-fix-opentelemetry-callback.yml
+++ b/changelogs/fragments/8741-fix-opentelemetry-callback.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - opentelemetry - fix default value for `store_spans_in_file` causing traces to be produced to a file named `None`
+  - opentelemetry callback plugin - fix default value for ``store_spans_in_file`` causing traces to be produced to a file named ``None`` (https://github.com/ansible-collections/community.general/issues/8566, https://github.com/ansible-collections/community.general/pull/8741).

--- a/changelogs/fragments/8741-fix-opentelemetry-callback.yml
+++ b/changelogs/fragments/8741-fix-opentelemetry-callback.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - opentelemetry - fix default value for `store_spans_in_file` causing traces to be produced to a file named `None`

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -85,7 +85,6 @@ DOCUMENTATION = '''
             key: disable_attributes_in_logs
         version_added: 7.1.0
       store_spans_in_file:
-        default:
         type: str
         description:
           -  It stores the exported spans in the given file

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -85,7 +85,7 @@ DOCUMENTATION = '''
             key: disable_attributes_in_logs
         version_added: 7.1.0
       store_spans_in_file:
-        default: None
+        default:
         type: str
         description:
           -  It stores the exported spans in the given file


### PR DESCRIPTION
##### SUMMARY

The commit 5f481939d introduced `store_spans_in_file` with the default
value `None` as a string. This causes the value of `store_spans_in_file`
to be a not empty string, value=None as a string and not a null value.
The rest of the code check if the store_spans_in_file is not null which
squeezes the rest of the code. The following commit set the default
value as an empty string.

Fixes (hopefully) #8566

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.general.opentelemetry

##### ADDITIONAL INFORMATION

I've used the same reproducer as #8321 with `git bisect`
```
5f481939d4558e1ae61459cee2a4aecb2f8a7207 is the first bad commit
commit 5f481939d4558e1ae61459cee2a4aecb2f8a7207 (HEAD)
Author: Victor Martinez <victormartinezrubio@gmail.com>
Date:   Sun May 19 20:48:49 2024 +0200

    feat(opentelemetry): support flag to export spans in a given file (#8363)

    * opentelemetry: support flag to create output file

    this is only to help with adding unit tests

    * refactor and rename

    * changelog

    * rename

    * fix linting

 changelogs/fragments/8363-opentelemetry-export-to-a-file.yml |  2 ++
 plugins/callback/opentelemetry.py                            | 48 ++++++++++++++++++++++++++++++++++++++++--------
 2 files changed, 42 insertions(+), 8 deletions(-)
 create mode 100644 changelogs/fragments/8363-opentelemetry-export-to-a-file.yml
```
