### PR TITLE
gitlab_project: sort parameters in order to avoid futur merge conflicts

### DIFF
--- a/changelogs/fragments/8759-gitlab_project-sort-params.yml
+++ b/changelogs/fragments/8759-gitlab_project-sort-params.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - gitlab_project - sorted parameters in order to avoid future merge conflicts (https://github.com/ansible-collections/community.general/pull/8759).

--- a/plugins/modules/gitlab_project.py
+++ b/plugins/modules/gitlab_project.py
@@ -34,160 +34,17 @@ attributes:
     support: none
 
 options:
-  group:
-    description:
-      - Id or the full path of the group of which this projects belongs to.
-    type: str
-  name:
-    description:
-      - The name of the project.
-    required: true
-    type: str
-  path:
-    description:
-      - The path of the project you want to create, this will be server_url/<group>/path.
-      - If not supplied, name will be used.
-    type: str
-  description:
-    description:
-      - An description for the project.
-    type: str
-  initialize_with_readme:
-    description:
-      - Will initialize the project with a default C(README.md).
-      - Is only used when the project is created, and ignored otherwise.
-    type: bool
-    default: false
-    version_added: "4.0.0"
-  issues_enabled:
-    description:
-      - Whether you want to create issues or not.
-      - Possible values are true and false.
-    type: bool
-    default: true
-  merge_requests_enabled:
-    description:
-      - If merge requests can be made or not.
-      - Possible values are true and false.
-    type: bool
-    default: true
-  wiki_enabled:
-    description:
-      - If an wiki for this project should be available or not.
-    type: bool
-    default: true
-  snippets_enabled:
-    description:
-      - If creating snippets should be available or not.
-    type: bool
-    default: true
-  visibility:
-    description:
-      - V(private) Project access must be granted explicitly for each user.
-      - V(internal) The project can be cloned by any logged in user.
-      - V(public) The project can be cloned without any authentication.
-    default: private
-    type: str
-    choices: ["private", "internal", "public"]
-    aliases:
-      - visibility_level
-  import_url:
-    description:
-      - Git repository which will be imported into gitlab.
-      - GitLab server needs read access to this git repository.
-    required: false
-    type: str
-  state:
-    description:
-      - Create or delete project.
-      - Possible values are present and absent.
-    default: present
-    type: str
-    choices: ["present", "absent"]
-  merge_method:
-    description:
-      - What requirements are placed upon merges.
-      - Possible values are V(merge), V(rebase_merge) merge commit with semi-linear history, V(ff) fast-forward merges only.
-    type: str
-    choices: ["ff", "merge", "rebase_merge"]
-    default: merge
-    version_added: "1.0.0"
-  lfs_enabled:
-    description:
-      - Enable Git large file systems to manages large files such
-        as audio, video, and graphics files.
-    type: bool
-    required: false
-    default: false
-    version_added: "2.0.0"
-  username:
-    description:
-      - Used to create a personal project under a user's name.
-    type: str
-    version_added: "3.3.0"
   allow_merge_on_skipped_pipeline:
     description:
       - Allow merge when skipped pipelines exist.
     type: bool
     version_added: "3.4.0"
-  only_allow_merge_if_all_discussions_are_resolved:
-    description:
-      - All discussions on a merge request (MR) have to be resolved.
-    type: bool
-    version_added: "3.4.0"
-  only_allow_merge_if_pipeline_succeeds:
-    description:
-      - Only allow merges if pipeline succeeded.
-    type: bool
-    version_added: "3.4.0"
-  packages_enabled:
-    description:
-      - Enable GitLab package repository.
-    type: bool
-    version_added: "3.4.0"
-  remove_source_branch_after_merge:
-    description:
-      - Remove the source branch after merge.
-    type: bool
-    version_added: "3.4.0"
-  squash_option:
-    description:
-      - Squash commits when merging.
-    type: str
-    choices: ["never", "always", "default_off", "default_on"]
-    version_added: "3.4.0"
-  ci_config_path:
-    description:
-      - Custom path to the CI configuration file for this project.
-    type: str
-    version_added: "3.7.0"
-  shared_runners_enabled:
-    description:
-      - Enable shared runners for this project.
-    type: bool
-    version_added: "3.7.0"
   avatar_path:
     description:
       - Absolute path image to configure avatar. File size should not exceed 200 kb.
       - This option is only used on creation, not for updates.
     type: path
     version_added: "4.2.0"
-  default_branch:
-    description:
-      - The default branch name for this project.
-      - For project creation, this option requires O(initialize_with_readme=true).
-      - For project update, the branch must exist.
-      - Supports project's default branch update since community.general 8.0.0.
-    type: str
-    version_added: "4.2.0"
-  repository_access_level:
-    description:
-      - V(private) means that accessing repository is allowed only to project members.
-      - V(disabled) means that accessing repository is disabled.
-      - V(enabled) means that accessing repository is enabled.
-    type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "9.3.0"
   builds_access_level:
     description:
       - V(private) means that repository CI/CD is allowed only to project members.
@@ -196,77 +53,11 @@ options:
     type: str
     choices: ["private", "disabled", "enabled"]
     version_added: "6.2.0"
-  forking_access_level:
+  ci_config_path:
     description:
-      - V(private) means that repository forks is allowed only to project members.
-      - V(disabled) means that repository forks are disabled.
-      - V(enabled) means that repository forks are enabled.
+      - Custom path to the CI configuration file for this project.
     type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "6.2.0"
-  container_registry_access_level:
-    description:
-      - V(private) means that container registry is allowed only to project members.
-      - V(disabled) means that container registry is disabled.
-      - V(enabled) means that container registry is enabled.
-    type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "6.2.0"
-  releases_access_level:
-    description:
-      - V(private) means that accessing release is allowed only to project members.
-      - V(disabled) means that accessing release is disabled.
-      - V(enabled) means that accessing release is enabled.
-    type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "6.4.0"
-  environments_access_level:
-    description:
-      - V(private) means that deployment to environment is allowed only to project members.
-      - V(disabled) means that deployment to environment is disabled.
-      - V(enabled) means that deployment to environment is enabled.
-    type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "6.4.0"
-  feature_flags_access_level:
-    description:
-      - V(private) means that feature rollout is allowed only to project members.
-      - V(disabled) means that feature rollout is disabled.
-      - V(enabled) means that feature rollout is enabled.
-    type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "6.4.0"
-  infrastructure_access_level:
-    description:
-      - V(private) means that configuring infrastructure is allowed only to project members.
-      - V(disabled) means that configuring infrastructure is disabled.
-      - V(enabled) means that configuring infrastructure is enabled.
-    type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "6.4.0"
-  monitor_access_level:
-    description:
-      - V(private) means that monitoring health is allowed only to project members.
-      - V(disabled) means that monitoring health is disabled.
-      - V(enabled) means that monitoring health is enabled.
-    type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "6.4.0"
-  security_and_compliance_access_level:
-    description:
-      - V(private) means that accessing security and complicance tab is allowed only to project members.
-      - V(disabled) means that accessing security and complicance tab is disabled.
-      - V(enabled) means that accessing security and complicance tab is enabled.
-    type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "6.4.0"
-  topics:
-    description:
-      - A topic or list of topics to be assigned to a project.
-      - It is compatible with old GitLab server releases (versions before 14, correspond to C(tag_list)).
-    type: list
-    elements: str
-    version_added: "6.6.0"
+    version_added: "3.7.0"
   container_expiration_policy:
     description:
       - Project cleanup policy for its container registry.
@@ -302,19 +93,103 @@ options:
           - Keep tags matching this regular expression.
         type: str
     version_added: "9.3.0"
-  pages_access_level:
+  container_registry_access_level:
     description:
-      - V(private) means that accessing pages tab is allowed only to project members.
-      - V(disabled) means that accessing pages tab is disabled.
-      - V(enabled) means that accessing pages tab is enabled.
+      - V(private) means that container registry is allowed only to project members.
+      - V(disabled) means that container registry is disabled.
+      - V(enabled) means that container registry is enabled.
     type: str
     choices: ["private", "disabled", "enabled"]
-    version_added: "9.3.0"
-  service_desk_enabled:
+    version_added: "6.2.0"
+  default_branch:
     description:
-      - Enable Service Desk.
+      - The default branch name for this project.
+      - For project creation, this option requires O(initialize_with_readme=true).
+      - For project update, the branch must exist.
+      - Supports project's default branch update since community.general 8.0.0.
+    type: str
+    version_added: "4.2.0"
+  description:
+    description:
+      - An description for the project.
+    type: str
+  environments_access_level:
+    description:
+      - V(private) means that deployment to environment is allowed only to project members.
+      - V(disabled) means that deployment to environment is disabled.
+      - V(enabled) means that deployment to environment is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  feature_flags_access_level:
+    description:
+      - V(private) means that feature rollout is allowed only to project members.
+      - V(disabled) means that feature rollout is disabled.
+      - V(enabled) means that feature rollout is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  forking_access_level:
+    description:
+      - V(private) means that repository forks is allowed only to project members.
+      - V(disabled) means that repository forks are disabled.
+      - V(enabled) means that repository forks are enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.2.0"
+  group:
+    description:
+      - Id or the full path of the group of which this projects belongs to.
+    type: str
+  import_url:
+    description:
+      - Git repository which will be imported into gitlab.
+      - GitLab server needs read access to this git repository.
+    required: false
+    type: str
+  infrastructure_access_level:
+    description:
+      - V(private) means that configuring infrastructure is allowed only to project members.
+      - V(disabled) means that configuring infrastructure is disabled.
+      - V(enabled) means that configuring infrastructure is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  initialize_with_readme:
+    description:
+      - Will initialize the project with a default C(README.md).
+      - Is only used when the project is created, and ignored otherwise.
     type: bool
-    version_added: "9.3.0"
+    default: false
+    version_added: "4.0.0"
+  issues_enabled:
+    description:
+      - Whether you want to create issues or not.
+      - Possible values are true and false.
+    type: bool
+    default: true
+  lfs_enabled:
+    description:
+      - Enable Git large file systems to manages large files such
+        as audio, video, and graphics files.
+    type: bool
+    required: false
+    default: false
+    version_added: "2.0.0"
+  merge_method:
+    description:
+      - What requirements are placed upon merges.
+      - Possible values are V(merge), V(rebase_merge) merge commit with semi-linear history, V(ff) fast-forward merges only.
+    type: str
+    choices: ["ff", "merge", "rebase_merge"]
+    default: merge
+    version_added: "1.0.0"
+  merge_requests_enabled:
+    description:
+      - If merge requests can be made or not.
+      - Possible values are true and false.
+    type: bool
+    default: true
   model_registry_access_level:
     description:
       - V(private) means that accessing model registry tab is allowed only to project members.
@@ -323,6 +198,131 @@ options:
     type: str
     choices: ["private", "disabled", "enabled"]
     version_added: "9.3.0"
+  monitor_access_level:
+    description:
+      - V(private) means that monitoring health is allowed only to project members.
+      - V(disabled) means that monitoring health is disabled.
+      - V(enabled) means that monitoring health is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  name:
+    description:
+      - The name of the project.
+    required: true
+    type: str
+  only_allow_merge_if_all_discussions_are_resolved:
+    description:
+      - All discussions on a merge request (MR) have to be resolved.
+    type: bool
+    version_added: "3.4.0"
+  only_allow_merge_if_pipeline_succeeds:
+    description:
+      - Only allow merges if pipeline succeeded.
+    type: bool
+    version_added: "3.4.0"
+  packages_enabled:
+    description:
+      - Enable GitLab package repository.
+    type: bool
+    version_added: "3.4.0"
+  pages_access_level:
+    description:
+      - V(private) means that accessing pages tab is allowed only to project members.
+      - V(disabled) means that accessing pages tab is disabled.
+      - V(enabled) means that accessing pages tab is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "9.3.0"
+  path:
+    description:
+      - The path of the project you want to create, this will be server_url/<group>/path.
+      - If not supplied, name will be used.
+    type: str
+  releases_access_level:
+    description:
+      - V(private) means that accessing release is allowed only to project members.
+      - V(disabled) means that accessing release is disabled.
+      - V(enabled) means that accessing release is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  remove_source_branch_after_merge:
+    description:
+      - Remove the source branch after merge.
+    type: bool
+    version_added: "3.4.0"
+  repository_access_level:
+    description:
+      - V(private) means that accessing repository is allowed only to project members.
+      - V(disabled) means that accessing repository is disabled.
+      - V(enabled) means that accessing repository is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "9.3.0"
+  security_and_compliance_access_level:
+    description:
+      - V(private) means that accessing security and complicance tab is allowed only to project members.
+      - V(disabled) means that accessing security and complicance tab is disabled.
+      - V(enabled) means that accessing security and complicance tab is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  service_desk_enabled:
+    description:
+      - Enable Service Desk.
+    type: bool
+    version_added: "9.3.0"
+  shared_runners_enabled:
+    description:
+      - Enable shared runners for this project.
+    type: bool
+    version_added: "3.7.0"
+  snippets_enabled:
+    description:
+      - If creating snippets should be available or not.
+    type: bool
+    default: true
+  squash_option:
+    description:
+      - Squash commits when merging.
+    type: str
+    choices: ["never", "always", "default_off", "default_on"]
+    version_added: "3.4.0"
+  state:
+    description:
+      - Create or delete project.
+      - Possible values are present and absent.
+    default: present
+    type: str
+    choices: ["present", "absent"]
+  topics:
+    description:
+      - A topic or list of topics to be assigned to a project.
+      - It is compatible with old GitLab server releases (versions before 14, correspond to C(tag_list)).
+    type: list
+    elements: str
+    version_added: "6.6.0"
+  username:
+    description:
+      - Used to create a personal project under a user's name.
+    type: str
+    version_added: "3.3.0"
+  visibility:
+    description:
+      - V(private) Project access must be granted explicitly for each user.
+      - V(internal) The project can be cloned by any logged in user.
+      - V(public) The project can be cloned without any authentication.
+    default: private
+    type: str
+    choices: ["private", "internal", "public"]
+    aliases:
+      - visibility_level
+  wiki_enabled:
+    description:
+      - If an wiki for this project should be available or not.
+    type: bool
+    default: true
 '''
 
 EXAMPLES = r'''
@@ -422,37 +422,37 @@ class GitLabProject(object):
     def create_or_update_project(self, module, project_name, namespace, options):
         changed = False
         project_options = {
-            'name': project_name,
-            'description': options['description'],
-            'issues_enabled': options['issues_enabled'],
-            'merge_requests_enabled': options['merge_requests_enabled'],
-            'merge_method': options['merge_method'],
-            'wiki_enabled': options['wiki_enabled'],
-            'snippets_enabled': options['snippets_enabled'],
-            'visibility': options['visibility'],
-            'lfs_enabled': options['lfs_enabled'],
             'allow_merge_on_skipped_pipeline': options['allow_merge_on_skipped_pipeline'],
+            'builds_access_level': options['builds_access_level'],
+            'ci_config_path': options['ci_config_path'],
+            'container_expiration_policy': options['container_expiration_policy'],
+            'container_registry_access_level': options['container_registry_access_level'],
+            'description': options['description'],
+            'environments_access_level': options['environments_access_level'],
+            'feature_flags_access_level': options['feature_flags_access_level'],
+            'forking_access_level': options['forking_access_level'],
+            'infrastructure_access_level': options['infrastructure_access_level'],
+            'issues_enabled': options['issues_enabled'],
+            'lfs_enabled': options['lfs_enabled'],
+            'merge_method': options['merge_method'],
+            'merge_requests_enabled': options['merge_requests_enabled'],
+            'model_registry_access_level': options['model_registry_access_level'],
+            'monitor_access_level': options['monitor_access_level'],
+            'name': project_name,
             'only_allow_merge_if_all_discussions_are_resolved': options['only_allow_merge_if_all_discussions_are_resolved'],
             'only_allow_merge_if_pipeline_succeeds': options['only_allow_merge_if_pipeline_succeeds'],
             'packages_enabled': options['packages_enabled'],
-            'remove_source_branch_after_merge': options['remove_source_branch_after_merge'],
-            'squash_option': options['squash_option'],
-            'ci_config_path': options['ci_config_path'],
-            'shared_runners_enabled': options['shared_runners_enabled'],
-            'repository_access_level': options['repository_access_level'],
-            'builds_access_level': options['builds_access_level'],
-            'forking_access_level': options['forking_access_level'],
-            'container_registry_access_level': options['container_registry_access_level'],
-            'releases_access_level': options['releases_access_level'],
-            'environments_access_level': options['environments_access_level'],
-            'feature_flags_access_level': options['feature_flags_access_level'],
-            'infrastructure_access_level': options['infrastructure_access_level'],
-            'monitor_access_level': options['monitor_access_level'],
-            'security_and_compliance_access_level': options['security_and_compliance_access_level'],
-            'container_expiration_policy': options['container_expiration_policy'],
             'pages_access_level': options['pages_access_level'],
+            'releases_access_level': options['releases_access_level'],
+            'remove_source_branch_after_merge': options['remove_source_branch_after_merge'],
+            'repository_access_level': options['repository_access_level'],
+            'security_and_compliance_access_level': options['security_and_compliance_access_level'],
             'service_desk_enabled': options['service_desk_enabled'],
-            'model_registry_access_level': options['model_registry_access_level'],
+            'shared_runners_enabled': options['shared_runners_enabled'],
+            'snippets_enabled': options['snippets_enabled'],
+            'squash_option': options['squash_option'],
+            'visibility': options['visibility'],
+            'wiki_enabled': options['wiki_enabled'],
         }
 
         # topics was introduced on gitlab >=14 and replace tag_list. We get current gitlab version
@@ -465,7 +465,7 @@ class GitLabProject(object):
         # Because we have already call userExists in main()
         if self.project_object is None:
             if options['default_branch'] and not options['initialize_with_readme']:
-                module.fail_json(msg="Param default_branch need param initialize_with_readme set to true")
+                module.fail_json(msg="Param default_branch needs param initialize_with_readme set to true")
             project_options.update({
                 'path': options['path'],
                 'import_url': options['import_url'],
@@ -499,7 +499,7 @@ class GitLabProject(object):
             try:
                 project.save()
             except Exception as e:
-                self._module.fail_json(msg="Failed update project: %s " % e)
+                self._module.fail_json(msg="Failed to update project: %s " % e)
             return True
         return False
 
@@ -583,42 +583,10 @@ def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(auth_argument_spec())
     argument_spec.update(dict(
-        group=dict(type='str'),
-        name=dict(type='str', required=True),
-        path=dict(type='str'),
-        description=dict(type='str'),
-        initialize_with_readme=dict(type='bool', default=False),
-        default_branch=dict(type='str'),
-        issues_enabled=dict(type='bool', default=True),
-        merge_requests_enabled=dict(type='bool', default=True),
-        merge_method=dict(type='str', default='merge', choices=["merge", "rebase_merge", "ff"]),
-        wiki_enabled=dict(type='bool', default=True),
-        snippets_enabled=dict(default=True, type='bool'),
-        visibility=dict(type='str', default="private", choices=["internal", "private", "public"], aliases=["visibility_level"]),
-        import_url=dict(type='str'),
-        state=dict(type='str', default="present", choices=["absent", "present"]),
-        lfs_enabled=dict(default=False, type='bool'),
-        username=dict(type='str'),
         allow_merge_on_skipped_pipeline=dict(type='bool'),
-        only_allow_merge_if_all_discussions_are_resolved=dict(type='bool'),
-        only_allow_merge_if_pipeline_succeeds=dict(type='bool'),
-        packages_enabled=dict(type='bool'),
-        remove_source_branch_after_merge=dict(type='bool'),
-        squash_option=dict(type='str', choices=['never', 'always', 'default_off', 'default_on']),
-        ci_config_path=dict(type='str'),
-        shared_runners_enabled=dict(type='bool'),
         avatar_path=dict(type='path'),
-        repository_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
         builds_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        forking_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        container_registry_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        releases_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        environments_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        feature_flags_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        infrastructure_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        monitor_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        security_and_compliance_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        topics=dict(type='list', elements='str'),
+        ci_config_path=dict(type='str'),
         container_expiration_policy=dict(type='dict', default=None, options=dict(
             cadence=dict(type='str', choices=["1d", "7d", "14d", "1month", "3month"]),
             enabled=dict(type='bool'),
@@ -627,9 +595,41 @@ def main():
             name_regex=dict(type='str'),
             name_regex_keep=dict(type='str'),
         )),
-        pages_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        service_desk_enabled=dict(type='bool'),
+        container_registry_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        default_branch=dict(type='str'),
+        description=dict(type='str'),
+        environments_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        feature_flags_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        forking_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        group=dict(type='str'),
+        import_url=dict(type='str'),
+        infrastructure_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        initialize_with_readme=dict(type='bool', default=False),
+        issues_enabled=dict(type='bool', default=True),
+        lfs_enabled=dict(default=False, type='bool'),
+        merge_method=dict(type='str', default='merge', choices=["merge", "rebase_merge", "ff"]),
+        merge_requests_enabled=dict(type='bool', default=True),
         model_registry_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        monitor_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        name=dict(type='str', required=True),
+        only_allow_merge_if_all_discussions_are_resolved=dict(type='bool'),
+        only_allow_merge_if_pipeline_succeeds=dict(type='bool'),
+        packages_enabled=dict(type='bool'),
+        pages_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        path=dict(type='str'),
+        releases_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        remove_source_branch_after_merge=dict(type='bool'),
+        repository_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        security_and_compliance_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        service_desk_enabled=dict(type='bool'),
+        shared_runners_enabled=dict(type='bool'),
+        snippets_enabled=dict(default=True, type='bool'),
+        squash_option=dict(type='str', choices=['never', 'always', 'default_off', 'default_on']),
+        state=dict(type='str', default="present", choices=["absent", "present"]),
+        topics=dict(type='list', elements='str'),
+        username=dict(type='str'),
+        visibility=dict(type='str', default="private", choices=["internal", "private", "public"], aliases=["visibility_level"]),
+        wiki_enabled=dict(type='bool', default=True),
     ))
 
     module = AnsibleModule(
@@ -654,46 +654,46 @@ def main():
     # check prerequisites and connect to gitlab server
     gitlab_instance = gitlab_authentication(module)
 
+    allow_merge_on_skipped_pipeline = module.params['allow_merge_on_skipped_pipeline']
+    avatar_path = module.params['avatar_path']
+    builds_access_level = module.params['builds_access_level']
+    ci_config_path = module.params['ci_config_path']
+    container_expiration_policy = module.params['container_expiration_policy']
+    container_registry_access_level = module.params['container_registry_access_level']
+    default_branch = module.params['default_branch']
+    environments_access_level = module.params['environments_access_level']
+    feature_flags_access_level = module.params['feature_flags_access_level']
+    forking_access_level = module.params['forking_access_level']
     group_identifier = module.params['group']
-    project_name = module.params['name']
-    project_path = module.params['path']
-    project_description = module.params['description']
+    import_url = module.params['import_url']
+    infrastructure_access_level = module.params['infrastructure_access_level']
     initialize_with_readme = module.params['initialize_with_readme']
     issues_enabled = module.params['issues_enabled']
-    merge_requests_enabled = module.params['merge_requests_enabled']
-    merge_method = module.params['merge_method']
-    wiki_enabled = module.params['wiki_enabled']
-    snippets_enabled = module.params['snippets_enabled']
-    visibility = module.params['visibility']
-    import_url = module.params['import_url']
-    state = module.params['state']
     lfs_enabled = module.params['lfs_enabled']
-    username = module.params['username']
-    allow_merge_on_skipped_pipeline = module.params['allow_merge_on_skipped_pipeline']
+    merge_method = module.params['merge_method']
+    merge_requests_enabled = module.params['merge_requests_enabled']
+    model_registry_access_level = module.params['model_registry_access_level']
+    monitor_access_level = module.params['monitor_access_level']
     only_allow_merge_if_all_discussions_are_resolved = module.params['only_allow_merge_if_all_discussions_are_resolved']
     only_allow_merge_if_pipeline_succeeds = module.params['only_allow_merge_if_pipeline_succeeds']
     packages_enabled = module.params['packages_enabled']
-    remove_source_branch_after_merge = module.params['remove_source_branch_after_merge']
-    squash_option = module.params['squash_option']
-    ci_config_path = module.params['ci_config_path']
-    shared_runners_enabled = module.params['shared_runners_enabled']
-    avatar_path = module.params['avatar_path']
-    default_branch = module.params['default_branch']
-    repository_access_level = module.params['repository_access_level']
-    builds_access_level = module.params['builds_access_level']
-    forking_access_level = module.params['forking_access_level']
-    container_registry_access_level = module.params['container_registry_access_level']
-    releases_access_level = module.params['releases_access_level']
-    environments_access_level = module.params['environments_access_level']
-    feature_flags_access_level = module.params['feature_flags_access_level']
-    infrastructure_access_level = module.params['infrastructure_access_level']
-    monitor_access_level = module.params['monitor_access_level']
-    security_and_compliance_access_level = module.params['security_and_compliance_access_level']
-    topics = module.params['topics']
-    container_expiration_policy = module.params['container_expiration_policy']
     pages_access_level = module.params['pages_access_level']
+    project_description = module.params['description']
+    project_name = module.params['name']
+    project_path = module.params['path']
+    releases_access_level = module.params['releases_access_level']
+    remove_source_branch_after_merge = module.params['remove_source_branch_after_merge']
+    repository_access_level = module.params['repository_access_level']
+    security_and_compliance_access_level = module.params['security_and_compliance_access_level']
     service_desk_enabled = module.params['service_desk_enabled']
-    model_registry_access_level = module.params['model_registry_access_level']
+    shared_runners_enabled = module.params['shared_runners_enabled']
+    snippets_enabled = module.params['snippets_enabled']
+    squash_option = module.params['squash_option']
+    state = module.params['state']
+    topics = module.params['topics']
+    username = module.params['username']
+    visibility = module.params['visibility']
+    wiki_enabled = module.params['wiki_enabled']
 
     # Set project_path to project_name if it is empty.
     if project_path is None:
@@ -737,42 +737,42 @@ def main():
     if state == 'present':
 
         if gitlab_project.create_or_update_project(module, project_name, namespace, {
-            "path": project_path,
-            "description": project_description,
-            "initialize_with_readme": initialize_with_readme,
-            "default_branch": default_branch,
-            "issues_enabled": issues_enabled,
-            "merge_requests_enabled": merge_requests_enabled,
-            "merge_method": merge_method,
-            "wiki_enabled": wiki_enabled,
-            "snippets_enabled": snippets_enabled,
-            "visibility": visibility,
-            "import_url": import_url,
-            "lfs_enabled": lfs_enabled,
             "allow_merge_on_skipped_pipeline": allow_merge_on_skipped_pipeline,
+            "avatar_path": avatar_path,
+            "builds_access_level": builds_access_level,
+            "ci_config_path": ci_config_path,
+            "container_expiration_policy": container_expiration_policy,
+            "container_registry_access_level": container_registry_access_level,
+            "default_branch": default_branch,
+            "description": project_description,
+            "environments_access_level": environments_access_level,
+            "feature_flags_access_level": feature_flags_access_level,
+            "forking_access_level": forking_access_level,
+            "import_url": import_url,
+            "infrastructure_access_level": infrastructure_access_level,
+            "initialize_with_readme": initialize_with_readme,
+            "issues_enabled": issues_enabled,
+            "lfs_enabled": lfs_enabled,
+            "merge_method": merge_method,
+            "merge_requests_enabled": merge_requests_enabled,
+            "model_registry_access_level": model_registry_access_level,
+            "monitor_access_level": monitor_access_level,
             "only_allow_merge_if_all_discussions_are_resolved": only_allow_merge_if_all_discussions_are_resolved,
             "only_allow_merge_if_pipeline_succeeds": only_allow_merge_if_pipeline_succeeds,
             "packages_enabled": packages_enabled,
-            "remove_source_branch_after_merge": remove_source_branch_after_merge,
-            "squash_option": squash_option,
-            "ci_config_path": ci_config_path,
-            "shared_runners_enabled": shared_runners_enabled,
-            "avatar_path": avatar_path,
-            "repository_access_level": repository_access_level,
-            "builds_access_level": builds_access_level,
-            "forking_access_level": forking_access_level,
-            "container_registry_access_level": container_registry_access_level,
-            "releases_access_level": releases_access_level,
-            "environments_access_level": environments_access_level,
-            "feature_flags_access_level": feature_flags_access_level,
-            "infrastructure_access_level": infrastructure_access_level,
-            "monitor_access_level": monitor_access_level,
-            "security_and_compliance_access_level": security_and_compliance_access_level,
-            "topics": topics,
-            "container_expiration_policy": container_expiration_policy,
             "pages_access_level": pages_access_level,
+            "path": project_path,
+            "releases_access_level": releases_access_level,
+            "remove_source_branch_after_merge": remove_source_branch_after_merge,
+            "repository_access_level": repository_access_level,
+            "security_and_compliance_access_level": security_and_compliance_access_level,
             "service_desk_enabled": service_desk_enabled,
-            "model_registry_access_level": model_registry_access_level,
+            "shared_runners_enabled": shared_runners_enabled,
+            "snippets_enabled": snippets_enabled,
+            "squash_option": squash_option,
+            "topics": topics,
+            "visibility": visibility,
+            "wiki_enabled": wiki_enabled,
         }):
 
             module.exit_json(changed=True, msg="Successfully created or updated the project %s" % project_name, project=gitlab_project.project_object._attrs)


### PR DESCRIPTION
##### SUMMARY

As briefly evoked on [this comment](https://github.com/ansible-collections/community.general/pull/8688#issuecomment-2282866565), sorting the params can avoid future conflicts if two users add new GitLab parameters.

##### ISSUE TYPE
- Refactoring Pull Request

##### COMPONENT NAME

- gitlab_project

##### ADDITIONAL INFORMATION

Since I'm currently working on a [GitLab playbook](https://gitlab.com/cappysan/ansible/gitlab) that uses a copy of this plugin (to avoid having to wait for new releases), I have a stake in this MR as I'll be contributing back all additions I make.


