### PR TITLE
keycloak_user_federation: sort desired and after mappers by name

### DIFF
--- a/changelogs/fragments/8761-keycloak_user_federation-sort-desired-and-after-mappers-by-name.yml
+++ b/changelogs/fragments/8761-keycloak_user_federation-sort-desired-and-after-mappers-by-name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_user_federation - sort desired and after mapper list by name (analog to before mapper list) to minimize diff and make change detection more accurate (https://github.com/ansible-collections/community.general/pull/8761).

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -909,8 +909,7 @@ def main():
             if changeset.get('mappers') is None:
                 changeset['mappers'] = list()
             changeset['mappers'].append(new_mapper)
-
-    changeset['mappers'] = sorted(changeset['mappers'], key=lambda x: x.get('name'))
+        changeset['mappers'] = sorted(changeset['mappers'], key=lambda x: x.get('name'))
 
     # Prepare the desired values using the existing values (non-existence results in a dict that is save to use as a basis)
     desired_comp = before_comp.copy()

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -868,7 +868,7 @@ def main():
 
     # if user federation exists, get associated mappers
     if cid is not None and before_comp:
-        before_comp['mappers'] = sorted(kc.get_components(urlencode(dict(parent=cid)), realm), key=lambda x: x.get('name'))
+        before_comp['mappers'] = sorted(kc.get_components(urlencode(dict(parent=cid)), realm), key=lambda x: x.get('name') or '')
 
     # Build a proposed changeset from parameters given to this module
     changeset = {}
@@ -909,7 +909,7 @@ def main():
             if changeset.get('mappers') is None:
                 changeset['mappers'] = list()
             changeset['mappers'].append(new_mapper)
-        changeset['mappers'] = sorted(changeset['mappers'], key=lambda x: x.get('name'))
+        changeset['mappers'] = sorted(changeset['mappers'], key=lambda x: x.get('name') or '')
 
     # Prepare the desired values using the existing values (non-existence results in a dict that is save to use as a basis)
     desired_comp = before_comp.copy()
@@ -1019,7 +1019,7 @@ def main():
                     kc.create_component(mapper, realm)
 
             after_comp = kc.get_component(cid, realm)
-            after_comp['mappers'] = sorted(kc.get_components(urlencode(dict(parent=cid)), realm), key=lambda x: x.get('name'))
+            after_comp['mappers'] = sorted(kc.get_components(urlencode(dict(parent=cid)), realm), key=lambda x: x.get('name') or '')
             after_comp_sanitized = sanitize(after_comp)
             before_comp_sanitized = sanitize(before_comp)
             result['end_state'] = after_comp_sanitized

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -910,6 +910,8 @@ def main():
                 changeset['mappers'] = list()
             changeset['mappers'].append(new_mapper)
 
+    changeset['mappers'] = sorted(changeset['mappers'], key=lambda x: x.get('name'))
+
     # Prepare the desired values using the existing values (non-existence results in a dict that is save to use as a basis)
     desired_comp = before_comp.copy()
     desired_comp.update(changeset)

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -1020,7 +1020,7 @@ def main():
                     kc.create_component(mapper, realm)
 
             after_comp = kc.get_component(cid, realm)
-            after_comp['mappers'] = kc.get_components(urlencode(dict(parent=cid)), realm)
+            after_comp['mappers'] = sorted(kc.get_components(urlencode(dict(parent=cid)), realm), key=lambda x: x.get('name'))
             after_comp_sanitized = sanitize(after_comp)
             before_comp_sanitized = sanitize(before_comp)
             result['end_state'] = after_comp_sanitized


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The module inconsistently sorts the mappers.

The module sorts the mappers fetched for the before state by name. The desired mappers and the mappers fetched after an update are not sorted. When comparing the desired mappers with the before mappers, changes are detected even if the mappers in both lists are the same except for the order. When diffing before with after mappers, differences are shown when the mappers are the same except for the order. 

The changes add sorting by name for the desired mappers and the mappers fetched after an update, analog to the existing sorting for the before mappers. This minimizes the diff and makes the change detection more accurate.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_user_federation
