### PR TITLE
keycloak_user_federation: fix key error when removing mappers in update

### DIFF
--- a/changelogs/fragments/8762-keycloac_user_federation-fix-key-error-when-updating.yml
+++ b/changelogs/fragments/8762-keycloac_user_federation-fix-key-error-when-updating.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_user_federation - fix key error when removing mappers during an update and new mappers are specified in the module args (https://github.com/ansible-collections/community.general/pull/8762)

--- a/changelogs/fragments/8762-keycloac_user_federation-fix-key-error-when-updating.yml
+++ b/changelogs/fragments/8762-keycloac_user_federation-fix-key-error-when-updating.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - keycloak_user_federation - fix key error when removing mappers during an update and new mappers are specified in the module args (https://github.com/ansible-collections/community.general/pull/8762)
+  - keycloak_user_federation - fix key error when removing mappers during an update and new mappers are specified in the module args (https://github.com/ansible-collections/community.general/pull/8762).

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -1004,7 +1004,7 @@ def main():
 
             for before_mapper in before_comp.get('mappers', []):
                 # remove unwanted existing mappers that will not be updated
-                if not before_mapper['id'] in [x['id'] for x in desired_mappers]:
+                if not before_mapper['id'] in [x['id'] for x in desired_mappers if 'id' in x]:
                     kc.delete_component(before_mapper['id'], realm)
 
             for mapper in desired_mappers:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The module throws a key error in update code path if there is a new mapper specified in the module arguments. 

The desired mapper list https://github.com/ansible-collections/community.general/blob/34519a5ecbac2c7a29486584f2d9ca9fd7b71eb0/plugins/modules/keycloak_user_federation.py#L1007 contains the existing mappers we want to keep, the existing ones that will be updated and the mappers that will be newly created. Since we want to remove unwanted *existing* mappers, we can exclude the new mappers that dont have an id yet when checking if we want to keep an existing mapper.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes key error when updating and a new mapper is specified in the module arguments.
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_user_federation
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Add a new mapper to the module arguments before running a user federation update.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
The full traceback is:
Traceback (most recent call last):
  File "/home/gruenbauer/.ansible/tmp/ansible-tmp-1723626012.332673-85886-4585327035734/AnsiballZ_keycloak_user_federation.py", line 107, in <module>
    _ansiballz_main()
  File "/home/gruenbauer/.ansible/tmp/ansible-tmp-1723626012.332673-85886-4585327035734/AnsiballZ_keycloak_user_federation.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/gruenbauer/.ansible/tmp/ansible-tmp-1723626012.332673-85886-4585327035734/AnsiballZ_keycloak_user_federation.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.community.general.plugins.modules.keycloak_user_federation', init_globals=dict(_module_fqn='ansible_collections.community.general.plugins.modules.keycloak_user_federation', _modlib_path=modlib_path),
  File "<frozen runpy>", line 226, in run_module
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "/tmp/ansible_community.general.keycloak_user_federation_payload_y_yq1nli/ansible_community.general.keycloak_user_federation_payload.zip/ansible_collections/community/general/plugins/modules/keycloak_user_federation.py", line 1052, in <module>
  File "/tmp/ansible_community.general.keycloak_user_federation_payload_y_yq1nli/ansible_community.general.keycloak_user_federation_payload.zip/ansible_collections/community/general/plugins/modules/keycloak_user_federation.py", line 1007, in main
KeyError: 'id'
fatal: [kc1]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/home/gruenbauer/.ansible/tmp/ansible-tmp-1723626012.332673-85886-4585327035734/AnsiballZ_keycloak_user_federation.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/gruenbauer/.ansible/tmp/ansible-tmp-1723626012.332673-85886-4585327035734/AnsiballZ_keycloak_user_federation.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/gruenbauer/.ansible/tmp/ansible-tmp-1723626012.332673-85886-4585327035734/AnsiballZ_keycloak_user_federation.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.general.plugins.modules.keycloak_user_federation', init_globals=dict(_module_fqn='ansible_collections.community.general.plugins.modules.keycloak_user_federation', _modlib_path=modlib_path),\n  File \"<frozen runpy>\", line 226, in run_module\n  File \"<frozen runpy>\", line 98, in _run_module_code\n  File \"<frozen runpy>\", line 88, in _run_code\n  File \"/tmp/ansible_community.general.keycloak_user_federation_payload_y_yq1nli/ansible_community.general.keycloak_user_federation_payload.zip/ansible_collections/community/general/plugins/modules/keycloak_user_federation.py\", line 1052, in <module>\n  File \"/tmp/ansible_community.general.keycloak_user_federation_payload_y_yq1nli/ansible_community.general.keycloak_user_federation_payload.zip/ansible_collections/community/general/plugins/modules/keycloak_user_federation.py\", line 1007, in main\nKeyError: 'id'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```

