### PR TITLE
keycloak_user_federation: add module arg to make mapper removal optout

### DIFF
--- a/changelogs/fragments/8764-keycloak_user_federation-make-mapper-removal-optout.yml
+++ b/changelogs/fragments/8764-keycloak_user_federation-make-mapper-removal-optout.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak_user_federation - add module argument allowing users to optout of the removal of unspecified mappers, e.g. to keep the keycloak default mappers (https://github.com/ansible-collections/community.general/pull/8764).

--- a/changelogs/fragments/8764-keycloak_user_federation-make-mapper-removal-optout.yml
+++ b/changelogs/fragments/8764-keycloak_user_federation-make-mapper-removal-optout.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - keycloak_user_federation - add module argument allowing users to optout of the removal of unspecified mappers, e.g. to keep the keycloak default mappers (https://github.com/ansible-collections/community.general/pull/8764).
+  - keycloak_user_federation - add module argument allowing users to optout of the removal of unspecified mappers, for example to keep the keycloak default mappers (https://github.com/ansible-collections/community.general/pull/8764).

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -918,7 +918,7 @@ def main():
             changeset['mappers'].append(new_mapper)
 
         # to keep unspecified existing mappers we add them to the desired mappers list, unless they're already present
-        if not module.params.get('remove_unspecified_mappers') and 'mappers' in before_comp:
+        if not module.params['remove_unspecified_mappers'] and 'mappers' in before_comp:
             changeset_mapper_ids = [mapper['id'] for mapper in changeset['mappers'] if 'id' in mapper]
             changeset['mappers'].extend([mapper for mapper in before_comp['mappers'] if mapper['id'] not in changeset_mapper_ids])
 
@@ -977,7 +977,7 @@ def main():
                     new_mapper['parentId'] = cid
                 updated_mappers.append(kc.create_component(new_mapper, realm))
 
-        if module.params.get('remove_unspecified_mappers'):
+        if module.params['remove_unspecified_mappers']:
             # we remove all unwanted default mappers
             # we use ids so we dont accidently remove one of the previously updated default mapper
             for default_mapper in default_mappers:

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -87,7 +87,7 @@ options:
 
     remove_unspecified_mappers:
         description:
-            - Remove mappers that are not specified in the configuration for this federation
+            - Remove mappers that are not specified in the configuration for this federation.
         type: bool
         default: true
 

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -90,6 +90,7 @@ options:
             - Remove mappers that are not specified in the configuration for this federation.
         type: bool
         default: true
+        version_added: 9.4.0
 
     config:
         description:

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -88,6 +88,7 @@ options:
     remove_unspecified_mappers:
         description:
             - Remove mappers that are not specified in the configuration for this federation.
+            - Set to V(false) to keep mappers that are not listed in O(mappers).
         type: bool
         default: true
         version_added: 9.4.0

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -85,6 +85,12 @@ options:
             - parentId
         type: str
 
+    removeUnspecifiedMappers:
+        description:
+            - Remove mappers that are not specified in the configuration for this federation
+        type: bool
+        default: true
+
     config:
         description:
             - Dict specifying the configuration options for the provider; the contents differ depending on
@@ -808,6 +814,7 @@ def main():
         provider_id=dict(type='str', aliases=['providerId']),
         provider_type=dict(type='str', aliases=['providerType'], default='org.keycloak.storage.UserStorageProvider'),
         parent_id=dict(type='str', aliases=['parentId']),
+        removeUnspecifiedMappers=dict(type='bool', default=True),
         mappers=dict(type='list', elements='dict', options=mapper_spec),
     )
 
@@ -849,7 +856,7 @@ def main():
 
     # Filter and map the parameters names that apply
     comp_params = [x for x in module.params
-                   if x not in list(keycloak_argument_spec().keys()) + ['state', 'realm', 'mappers'] and
+                   if x not in list(keycloak_argument_spec().keys()) + ['state', 'realm', 'mappers', 'removeUnspecifiedMappers'] and
                    module.params.get(x) is not None]
 
     # See if it already exists in Keycloak
@@ -910,6 +917,11 @@ def main():
                 changeset['mappers'] = list()
             changeset['mappers'].append(new_mapper)
 
+        # to keep unspecified existing mappers we add them to the desired mappers list, unless they're already present
+        if not module.params.get('removeUnspecifiedMappers') and 'mappers' in before_comp:
+            changeset_mapper_ids = [mapper['id'] for mapper in changeset['mappers'] if 'id' in mapper]
+            changeset['mappers'].extend([mapper for mapper in before_comp['mappers'] if mapper['id'] not in changeset_mapper_ids])
+
     # Prepare the desired values using the existing values (non-existence results in a dict that is save to use as a basis)
     desired_comp = before_comp.copy()
     desired_comp.update(changeset)
@@ -965,11 +977,12 @@ def main():
                     new_mapper['parentId'] = cid
                 updated_mappers.append(kc.create_component(new_mapper, realm))
 
-        # we remove all unwanted default mappers
-        # we use ids so we dont accidently remove one of the previously updated default mapper
-        for default_mapper in default_mappers:
-            if not default_mapper['id'] in [x['id'] for x in updated_mappers]:
-                kc.delete_component(default_mapper['id'], realm)
+        if module.params.get('removeUnspecifiedMappers'):
+            # we remove all unwanted default mappers
+            # we use ids so we dont accidently remove one of the previously updated default mapper
+            for default_mapper in default_mappers:
+                if not default_mapper['id'] in [x['id'] for x in updated_mappers]:
+                    kc.delete_component(default_mapper['id'], realm)
 
         after_comp['mappers'] = kc.get_components(urlencode(dict(parent=cid)), realm)
         if module._diff:

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -85,7 +85,7 @@ options:
             - parentId
         type: str
 
-    removeUnspecifiedMappers:
+    remove_unspecified_mappers:
         description:
             - Remove mappers that are not specified in the configuration for this federation
         type: bool
@@ -814,7 +814,7 @@ def main():
         provider_id=dict(type='str', aliases=['providerId']),
         provider_type=dict(type='str', aliases=['providerType'], default='org.keycloak.storage.UserStorageProvider'),
         parent_id=dict(type='str', aliases=['parentId']),
-        removeUnspecifiedMappers=dict(type='bool', default=True),
+        remove_unspecified_mappers=dict(type='bool', default=True),
         mappers=dict(type='list', elements='dict', options=mapper_spec),
     )
 
@@ -856,7 +856,7 @@ def main():
 
     # Filter and map the parameters names that apply
     comp_params = [x for x in module.params
-                   if x not in list(keycloak_argument_spec().keys()) + ['state', 'realm', 'mappers', 'removeUnspecifiedMappers'] and
+                   if x not in list(keycloak_argument_spec().keys()) + ['state', 'realm', 'mappers', 'remove_unspecified_mappers'] and
                    module.params.get(x) is not None]
 
     # See if it already exists in Keycloak
@@ -918,7 +918,7 @@ def main():
             changeset['mappers'].append(new_mapper)
 
         # to keep unspecified existing mappers we add them to the desired mappers list, unless they're already present
-        if not module.params.get('removeUnspecifiedMappers') and 'mappers' in before_comp:
+        if not module.params.get('remove_unspecified_mappers') and 'mappers' in before_comp:
             changeset_mapper_ids = [mapper['id'] for mapper in changeset['mappers'] if 'id' in mapper]
             changeset['mappers'].extend([mapper for mapper in before_comp['mappers'] if mapper['id'] not in changeset_mapper_ids])
 
@@ -977,7 +977,7 @@ def main():
                     new_mapper['parentId'] = cid
                 updated_mappers.append(kc.create_component(new_mapper, realm))
 
-        if module.params.get('removeUnspecifiedMappers'):
+        if module.params.get('remove_unspecified_mappers'):
             # we remove all unwanted default mappers
             # we use ids so we dont accidently remove one of the previously updated default mapper
             for default_mapper in default_mappers:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `keycloak_user_federation` module removes mappers that are not specified/listed in the module arguments. In order to keep the default mappers created by keycloak, they have to be specified in the module arguments. This could break something silently if keycloak changes the default mappers in the future and adds an mapper thats important. 

The argument `removeUnspecifiedMappers` added by the changes would allow users to disable or enable the removal of unspecified mappers, picking the desired behavior.

The default is to enable the removal for now. But I'm not sure whether that's the right way and need some input.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_user_federation
