### PR TITLE
redfish mod utils: remove required image_url for Virtual Media

### DIFF
--- a/changelogs/fragments/8765-redfish-remove-required-image_url-for-virtual-media.yml
+++ b/changelogs/fragments/8765-redfish-remove-required-image_url-for-virtual-media.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_utils - Make `image_url` an optional parameter for virtual media eject (https://github.com/ansible-collections/community.general/issues/3042, https://github.com/ansible-collections/community.general/pull/8765).

--- a/changelogs/fragments/8765-redfish-remove-required-image_url-for-virtual-media.yml
+++ b/changelogs/fragments/8765-redfish-remove-required-image_url-for-virtual-media.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redfish_utils - Make `image_url` an optional parameter for virtual media eject (https://github.com/ansible-collections/community.general/issues/3042, https://github.com/ansible-collections/community.general/pull/8765).
+  - redfish_command - Make ``image_url`` an optional parameter for virtual media eject (https://github.com/ansible-collections/community.general/issues/3042, https://github.com/ansible-collections/community.general/pull/8765).

--- a/changelogs/fragments/8765-redfish-remove-required-image_url-for-virtual-media.yml
+++ b/changelogs/fragments/8765-redfish-remove-required-image_url-for-virtual-media.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redfish_command - Make ``image_url`` an optional parameter for virtual media eject (https://github.com/ansible-collections/community.general/issues/3042, https://github.com/ansible-collections/community.general/pull/8765).
+  - redfish_command - make ``image_url`` an optional parameter for virtual media eject (https://github.com/ansible-collections/community.general/issues/3042, https://github.com/ansible-collections/community.general/pull/8765).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->
Removes the required `image_url` for Redfish Eject Virtual media.
Resolves #3042


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

If `image_url` isn't provided, all virtual media is ejected. If there is no virtual media to eject the play returns  `okay=true` and `changed=false`.

If `image_url` is provided the URL will be removed from all virtual media where it's mounted. If the image can't be found the play errors.

The following tests were run against an OpenBMC module:
| Image | image_url | Result | 
|--- | --- |--- | 
| mounted | null | OK, Changed | 
| mounted | valid |  OK, Changed | 
| mounted | invalid | Not OK | 
| unmounted | null | OK, Unchanged | 
| unmounted | not null | OK, Unchanged | 