### PR TITLE
Add includepkgs functionality to copr module

### DIFF
--- a/plugins/modules/copr.py
+++ b/plugins/modules/copr.py
@@ -255,6 +255,8 @@ class CoprModule(object):
         """
         if not repo_content:
             repo_content = self._download_repo_info()
+        if self.ansible_module.params.get("includepkgs"): # Add includepkg options
+            repo_content +=  f"\nincludepkgs={self.ansible_module.params['includepkgs']}\n"
         if self._compare_repo_content(repo_filename_path, repo_content):
             return False
         if not self.check_mode:
@@ -470,6 +472,7 @@ def run_module():
         name=dict(type="str", required=True),
         state=dict(type="str", choices=["enabled", "disabled", "absent"], default="enabled"),
         chroot=dict(type="str"),
+        includepkgs=dict(type='str', required=False),
     )
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
     params = module.params


### PR DESCRIPTION
**SUMMARY**

A new includepkgs parameter has been added to the copr module, allowing users to specify which packages to fetch from a COPR repository. This enhancement addresses the issue where users only want to install specific packages without inadvertently pulling in other packages from the repository. The includepkgs option is added to the repository configuration and persists across Ansible runs, ensuring that the repository remains consistent with the user’s desired package selection.

**Fixes**
 #8738
**ISSUE TYPE**

    Feature Pull Request

**COMPONENT NAME**

copr

**ADDITIONAL INFORMATION**

The new includepkgs parameter allows users to limit the scope of packages fetched from a COPR repository. This feature is particularly useful for users who need to manage their package installations tightly and avoid any unexpected changes from updates to the repository. The implementation includes appending the includepkgs option to the repository file and ensuring that it is not overwritten by subsequent Ansible runs.

```
- name: Add and limit packages from a COPR repository
  community.general.copr:
    name: ufven/epel9-extras
    state: enabled
    chroot: epel-9-x86_64
    includepkgs: "shorewall*"

```