### PR TITLE
keycloak_user_federation: set `krbPrincipalAttribute` to `''` if unset in kc responses

### DIFF
--- a/changelogs/fragments/8785-keycloak_user_federation-set-krbPrincipalAttribute-to-empty-string-if-missing.yaml
+++ b/changelogs/fragments/8785-keycloak_user_federation-set-krbPrincipalAttribute-to-empty-string-if-missing.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_user_federation - minimize change detection by setting krbPrincipalAttribute to '' in keycloak responses if missing (https://github.com/ansible-collections/community.general/pull/8785).

--- a/changelogs/fragments/8785-keycloak_user_federation-set-krbPrincipalAttribute-to-empty-string-if-missing.yaml
+++ b/changelogs/fragments/8785-keycloak_user_federation-set-krbPrincipalAttribute-to-empty-string-if-missing.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - keycloak_user_federation - minimize change detection by setting krbPrincipalAttribute to '' in keycloak responses if missing (https://github.com/ansible-collections/community.general/pull/8785).
+  - keycloak_user_federation - minimize change detection by setting ``krbPrincipalAttribute`` to ``''`` in Keycloak responses if missing (https://github.com/ansible-collections/community.general/pull/8785).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Issue: 
The `keycloak_user_federation` module always detects a change in check mode if the parameter `krbPrincipalAttribute` is set to `''`. The empty string is a valid value: https://github.com/ansible-collections/community.general/blob/96d5e6e50e972ae1bfc61cf1fb71c0738230c213/plugins/modules/keycloak_user_federation.py#L354
Keycloak completely removes the parameter `krbPrincipalAttribute` if it is set to `''`. So subsequent check runs always detect a change. In a normal run the module would always make an update (its the same change check), but compare the before and after responses afterwards, in both of which the parameter is not present. In the check diff this is already fixed by setting `''` in the sanitize function if the parameter is not present (see [8320](https://github.com/ansible-collections/community.general/pull/8320)).


Proposed solution:
Normalize the keycloak responses (before and after) by setting `krbPrincipalAttribute = ''` if the parameter is not present in the response.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_user_federation

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. set `krbPrincipalAttribute = ''` for the module
2. do a normal module run to set the parameter
3. subsequent check runs always detect a change
