### PR TITLE
Fix gitlab_project container_expiration_policy for project create

### DIFF
--- a/changelogs/fragments/8790-gitlab_project-fix-cleanup-policy-on-project-create.yml
+++ b/changelogs/fragments/8790-gitlab_project-fix-cleanup-policy-on-project-create.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - gitlab_project - fix crash caused by old gitlab projects not having a container_expiration_policy attribute.
+  - gitlab_project - fix container_expiration_policy not being applied when creating a new project.

--- a/changelogs/fragments/8790-gitlab_project-fix-cleanup-policy-on-project-create.yml
+++ b/changelogs/fragments/8790-gitlab_project-fix-cleanup-policy-on-project-create.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - gitlab_project - fix crash caused by old gitlab projects not having a ``container_expiration_policy`` attribute (https://github.com/ansible-collections/community.general/pull/8790).
+  - gitlab_project - fix crash caused by old Gitlab projects not having a ``container_expiration_policy`` attribute (https://github.com/ansible-collections/community.general/pull/8790).
   - gitlab_project - fix ``container_expiration_policy`` not being applied when creating a new project (https://github.com/ansible-collections/community.general/pull/8790).

--- a/changelogs/fragments/8790-gitlab_project-fix-cleanup-policy-on-project-create.yml
+++ b/changelogs/fragments/8790-gitlab_project-fix-cleanup-policy-on-project-create.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - gitlab_project - fix crash caused by old gitlab projects not having a container_expiration_policy attribute.
-  - gitlab_project - fix container_expiration_policy not being applied when creating a new project.
+  - gitlab_project - fix crash caused by old gitlab projects not having a ``container_expiration_policy`` attribute (https://github.com/ansible-collections/community.general/pull/8790).
+  - gitlab_project - fix ``container_expiration_policy`` not being applied when creating a new project (https://github.com/ansible-collections/community.general/pull/8790).

--- a/plugins/modules/gitlab_project.py
+++ b/plugins/modules/gitlab_project.py
@@ -512,7 +512,8 @@ class GitLabProject(object):
             return True
 
         arguments['namespace_id'] = namespace.id
-        arguments['container_expiration_policy_attributes'] = arguments['container_expiration_policy']
+        if 'container_expiration_policy' in arguments:
+            arguments['container_expiration_policy_attributes'] = arguments['container_expiration_policy']
         try:
             project = self._gitlab.projects.create(arguments)
         except (gitlab.exceptions.GitlabCreateError) as e:

--- a/plugins/modules/gitlab_project.py
+++ b/plugins/modules/gitlab_project.py
@@ -512,6 +512,7 @@ class GitLabProject(object):
             return True
 
         arguments['namespace_id'] = namespace.id
+        arguments['container_expiration_policy_attributes'] = arguments['container_expiration_policy']
         try:
             project = self._gitlab.projects.create(arguments)
         except (gitlab.exceptions.GitlabCreateError) as e:
@@ -539,9 +540,9 @@ class GitLabProject(object):
 
         for arg_key, arg_value in arguments.items():
             if arguments[arg_key] is not None:
-                if getattr(project, arg_key) != arguments[arg_key]:
+                if getattr(project, arg_key, None) != arguments[arg_key]:
                     if arg_key == 'container_expiration_policy':
-                        old_val = getattr(project, arg_key)
+                        old_val = getattr(project, arg_key, {})
                         final_val = {key: value for key, value in arg_value.items() if value is not None}
 
                         if final_val.get('older_than') == '0d':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix behaviour for attribute container_expiration_policy in two scenarios.
1. Creating a new project - was using incorrect attribute name for writing
2. Updating an old project - some projects created with older versions of gitlab don't have the attribute by default which causes a AttributeError crash when trying to read it with getattr

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
gitlab_project

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
