### PR TITLE
proxmox inventory: fixing possible concatenation error

### DIFF
--- a/changelogs/fragments/8794-Fixing-possible-concatination-error.yaml
+++ b/changelogs/fragments/8794-Fixing-possible-concatination-error.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - community.general.proxmox inventory - Fixed a possible error on concatenating responses from proxmox. In case an API call unexpectedly returned an empty result, the inventory failed with a fatal error. Added check for empty response.

--- a/changelogs/fragments/8794-Fixing-possible-concatination-error.yaml
+++ b/changelogs/fragments/8794-Fixing-possible-concatination-error.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - community.general.proxmox inventory - Fixed a possible error on concatenating responses from proxmox. In case an API call unexpectedly returned an empty result, the inventory failed with a fatal error. Added check for empty response.
+  - proxmox inventory plugin - fixed a possible error on concatenating responses from proxmox. In case an API call unexpectedly returned an empty result, the inventory failed with a fatal error. Added check for empty response (https://github.com/ansible-collections/community.general/issues/8798, https://github.com/ansible-collections/community.general/pull/8794).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -329,8 +329,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     data = json['data']
                     break
                 else:
-                    # /hosts 's 'results' is a list of all hosts, returned is paginated
-                    data = data + json['data']
+                    if json['data']:
+                        # /hosts 's 'results' is a list of all hosts, returned is paginated
+                        data = data + json['data']
                     break
 
             self._cache[self.cache_key][url] = data


### PR DESCRIPTION
##### SUMMARY

When starting to use the proxmox inventory plugin with my 4 node setup, the plugin failed creating the inventory from the proxmox api. Some debugging led to the changed area, where it may happen that API calls return an empty result, leading to `json["data"]` being `None` and the list concatenation failing. 

Fixes https://github.com/ansible-collections/community.general/issues/8798

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
inventory: community.general.proxmox

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
