### PR TITLE
Fix gitlab access token crash in check mode for new tokens

### DIFF
--- a/changelogs/fragments/8796-gitlab-access-token-check-mode.yml
+++ b/changelogs/fragments/8796-gitlab-access-token-check-mode.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - gitlab_group_access_token - fix crash in check mode caused by attempted access to a newly created access token (https://github.com/ansible-collections/community.general/pull/8796).
+  - gitlab_project_access_token - fix crash in check mode caused by attempted access to a newly created access token (https://github.com/ansible-collections/community.general/pull/8796).

--- a/plugins/modules/gitlab_group_access_token.py
+++ b/plugins/modules/gitlab_group_access_token.py
@@ -313,7 +313,10 @@ def main():
                     module.exit_json(changed=True, msg="Successfully recreated access token", access_token=gitlab_access_token.access_token_object._attrs)
         else:
             gitlab_access_token.create_access_token(group, {'name': name, 'scopes': scopes, 'access_level': access_level, 'expires_at': expires_at})
-            module.exit_json(changed=True, msg="Successfully created access token", access_token=gitlab_access_token.access_token_object._attrs)
+            if module.check_mode:
+                module.exit_json(changed=True, msg="Successfully created access token", access_token={})
+            else:
+                module.exit_json(changed=True, msg="Successfully created access token", access_token=gitlab_access_token.access_token_object._attrs)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/gitlab_project_access_token.py
+++ b/plugins/modules/gitlab_project_access_token.py
@@ -311,7 +311,10 @@ def main():
                     module.exit_json(changed=True, msg="Successfully recreated access token", access_token=gitlab_access_token.access_token_object._attrs)
         else:
             gitlab_access_token.create_access_token(project, {'name': name, 'scopes': scopes, 'access_level': access_level, 'expires_at': expires_at})
-            module.exit_json(changed=True, msg="Successfully created access token", access_token=gitlab_access_token.access_token_object._attrs)
+            if module.check_mode:
+                module.exit_json(changed=True, msg="Successfully created access token", access_token={})
+            else:
+                module.exit_json(changed=True, msg="Successfully created access token", access_token=gitlab_access_token.access_token_object._attrs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The modules attempt to return newly created access token. In check mode if an access token with the same name did not exists beforehand, accessing _attrs would crash.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
gitlab_project_access_token
gitlab_group_access_token

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
