### PR TITLE
keycloak_user_federation: remove `lastSync` param from kc API responses

### DIFF
--- a/changelogs/fragments/8812-keycloak-user-federation-remove-lastSync-param-from-kc-responses.yml
+++ b/changelogs/fragments/8812-keycloak-user-federation-remove-lastSync-param-from-kc-responses.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_user_federation - remove ``lastSync`` parameter from Keycloak responses to minimize diff/changes (https://github.com/ansible-collections/community.general/pull/8812).

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -1052,7 +1052,8 @@ def main():
 
             after_comp = kc.get_component(cid, realm)
             after_comp['mappers'] = sorted(kc.get_components(urlencode(dict(parent=cid)), realm), key=lambda x: x.get('name') or '')
-            after_comp_sanitized = sanitize(normalize_kc_comp(after_comp))
+            normalize_kc_comp(after_comp)
+            after_comp_sanitized = sanitize(after_comp)
             before_comp_sanitized = sanitize(before_comp)
             result['end_state'] = after_comp_sanitized
             if module._diff:

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -731,6 +731,7 @@ def normalize_kc_comp(comp):
         # kc stores a timestamp of the last sync in `lastSync` to time the periodic sync, it is removed to minimize diff/changes
         comp['config'].pop('lastSync', None)
 
+
 def sanitize(comp):
     compcopy = deepcopy(comp)
     if 'config' in compcopy:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Keycloak stores a timestamp of the last ldap sync in the parameter `lastSync`. Once the parameter is set after a sync (periodic or manual), the module always detects a change and shows a diff similar to the one below.

```
--- before
+++ after
@@ -18,7 +18,6 @@
         "kerberosRealm": "EXAMPLE.NET",
         "keyTab": "/mnt/ad2",
         "krbPrincipalAttribute": "test",
-        "lastSync": "1724663435",
         "pagination": "false",
         "priority": "0",
         "rdnLDAPAttribute": "sAMAccountName",

changed: [kc1]
```

The parameter seems to be used to time the periodic syncs, so i don't think changing it is good idea. The API does allow changing it though. But I did not find a way to view or change the parameter in the web GUI.

It looks like the parameter is only used by kc internally, so it should be safe to ignore it and remove it entirely from all API responses. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes [5842](https://github.com/ansible-collections/community.general/issues/5842)
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
community.general.keycloak_user_federation

