### PR TITLE
redfish_utils: Let @Redfish.OperationApplyTime be optional

### DIFF
--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1888,7 +1888,7 @@ class RedfishUtils(object):
         update_uri = data['MultipartHttpPushUri']
 
         # Assemble the JSON payload portion of the request
-        payload = {"@Redfish.OperationApplyTime": "Immediate"}
+        payload = {}
         if targets:
             payload["Targets"] = targets
         if apply_time:

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1863,6 +1863,7 @@ class RedfishUtils(object):
         targets = update_opts.get('update_targets')
         apply_time = update_opts.get('update_apply_time')
         oem_params = update_opts.get('update_oem_params')
+        image_type = update_opts.get('update_image_type')
 
         # Ensure the image file is provided
         if not image_file:
@@ -1899,6 +1900,9 @@ class RedfishUtils(object):
             'UpdateParameters': {'content': json.dumps(payload), 'mime_type': 'application/json'},
             'UpdateFile': {'filename': image_file, 'content': image_payload, 'mime_type': 'application/octet-stream'}
         }
+        if image_type:
+            payload = {'ImageType': image_type}
+            multipart_payload["OemParameters"] = {'content': json.dumps(payload), 'mime_type': 'application/json'}
         response = self.post_request(self.root_uri + update_uri, multipart_payload, multipart=True)
         if response['ret'] is False:
             return response

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -161,6 +161,12 @@ options:
       - Filename, with optional path, of the image for the update.
     type: path
     version_added: '7.1.0'
+  update_image_type:
+    required: false
+    description:
+      - The image type to be set in OemParameters for the update.
+    type: str
+    version_added: '9.4.0'
   update_protocol:
     required: false
     description:
@@ -626,6 +632,7 @@ EXAMPLES = '''
       password: "{{ password }}"
       timeout: 600
       update_image_file: ~/images/myupdate.img
+      update_image_type: BMC
 
   - name: Multipart HTTP push with additional options; timeout is 600 seconds
       to allow for a large image transfer
@@ -848,6 +855,7 @@ def main():
             resource_id=dict(),
             update_image_uri=dict(),
             update_image_file=dict(type='path'),
+            update_image_type=dict(),
             update_protocol=dict(),
             update_targets=dict(type='list', elements='str', default=[]),
             update_oem_params=dict(type='dict'),
@@ -923,6 +931,7 @@ def main():
     update_opts = {
         'update_image_uri': module.params['update_image_uri'],
         'update_image_file': module.params['update_image_file'],
+        'update_image_type': module.params['update_image_type'],
         'update_protocol': module.params['update_protocol'],
         'update_targets': module.params['update_targets'],
         'update_creds': module.params['update_creds'],


### PR DESCRIPTION
As the doc states, this is not a required option. AMI BMC will complain since it's not supported. So don't add this option unless it's explicitly specified by update_apply_time.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/module_utils/redfish_utils.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
