### PR TITLE
(doc) random_string lookup: fix examples

### DIFF
--- a/plugins/lookup/random_string.py
+++ b/plugins/lookup/random_string.py
@@ -104,37 +104,37 @@ EXAMPLES = r"""
 - name: Generate random string
   ansible.builtin.debug:
     var: lookup('community.general.random_string')
-  # Example result: ['DeadBeeF']
+  # Example result: 'DeadBeeF'
 
 - name: Generate random string with length 12
   ansible.builtin.debug:
     var: lookup('community.general.random_string', length=12)
-  # Example result: ['Uan0hUiX5kVG']
+  # Example result: 'Uan0hUiX5kVG'
 
 - name: Generate base64 encoded random string
   ansible.builtin.debug:
     var: lookup('community.general.random_string', base64=True)
-  # Example result: ['NHZ6eWN5Qk0=']
+  # Example result: 'NHZ6eWN5Qk0='
 
 - name: Generate a random string with 1 lower, 1 upper, 1 number and 1 special char (at least)
   ansible.builtin.debug:
     var: lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1)
-  # Example result: ['&Qw2|E[-']
+  # Example result: '&Qw2|E[-'
 
 - name: Generate a random string with all lower case characters
-  debug:
+  ansible.builtin.debug:
     var: query('community.general.random_string', upper=false, numbers=false, special=false)
   # Example result: ['exolxzyz']
 
 - name: Generate random hexadecimal string
-  debug:
+  ansible.builtin.debug:
     var: query('community.general.random_string', upper=false, lower=false, override_special=hex_chars, numbers=false)
   vars:
     hex_chars: '0123456789ABCDEF'
   # Example result: ['D2A40737']
 
 - name: Generate random hexadecimal string with override_all
-  debug:
+  ansible.builtin.debug:
     var: query('community.general.random_string', override_all=hex_chars)
   vars:
     hex_chars: '0123456789ABCDEF'


### PR DESCRIPTION
##### SUMMARY

[The doc for random_string lookup](https://docs.ansible.com/ansible/latest/collections/community/general/random_string_lookup.html) include examples with `lookup` and `query`. While `lookup` returns a string and `query` returns an array of one element, the examples say that both calls return an array.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

random_string lookup

##### ADDITIONAL INFORMATION

I've also replaced `debug` calls by `ansible.builtin.debug` (in this example, both forms where used).

Sample playbook file :

```
- hosts: localhost
  gather_facts: no
  tasks:
  - name: Generate random string
    ansible.builtin.debug:
      var: lookup('community.general.random_string')

  - name: Generate random string with length 12
    ansible.builtin.debug:
      var: lookup('community.general.random_string', length=12)

  - name: Generate base64 encoded random string
    ansible.builtin.debug:
      var: lookup('community.general.random_string', base64=True)

  - name: Generate a random string with 1 lower, 1 upper, 1 number and 1 special char (at least)
    ansible.builtin.debug:
      var: lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1)

  - name: Generate a random string with all lower case characters
    debug:
      var: query('community.general.random_string', upper=false, numbers=false, special=false)

  - name: Generate random hexadecimal string
    debug:
      var: query('community.general.random_string', upper=false, lower=false, override_special=hex_chars, numbers=false)
    vars:
      hex_chars: '0123456789ABCDEF'

  - name: Generate random hexadecimal string with override_all
    debug:
       var: query('community.general.random_string', override_all=hex_chars)
    vars:
       hex_chars: '0123456789ABCDEF'
```
Results I got :

```
PLAY [localhost] ***********************************************************************************************************************************

TASK [Generate random string] **********************************************************************************************************************
ok: [localhost] => {
    "lookup('community.general.random_string')": "zfb^GVrD"
}

TASK [Generate random string with length 12] *******************************************************************************************************
ok: [localhost] => {
    "lookup('community.general.random_string', length=12)": "Znks;pp-lQWd"
}

TASK [Generate base64 encoded random string] *******************************************************************************************************
ok: [localhost] => {
    "lookup('community.general.random_string', base64=True)": "XXRKR3NZcDk="
}

TASK [Generate a random string with 1 lower, 1 upper, 1 number and 1 special char (at least)] ******************************************************
ok: [localhost] => {
    "lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1)": "#9qv;JoB"
}

TASK [Generate a random string with all lower case characters] *************************************************************************************
ok: [localhost] => {
    "query('community.general.random_string', upper=false, numbers=false, special=false)": [
        "jkwdqnuu"
    ]
}

TASK [Generate random hexadecimal string] **********************************************************************************************************
ok: [localhost] => {
    "query('community.general.random_string', upper=false, lower=false, override_special=hex_chars, numbers=false)": [
        "759BBEC6"
    ]
}

TASK [Generate random hexadecimal string with override_all] ****************************************************************************************
ok: [localhost] => {
    "query('community.general.random_string', override_all=hex_chars)": [
        "B7768D21"
    ]
}

PLAY RECAP *****************************************************************************************************************************************
localhost                  : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```