### PR TITLE
keycloak_user_federation: get the before mappers from `before_comp` to fix `UnboundLocalError`

### DIFF
--- a/changelogs/fragments/8831-fix-error-when-mapper-id-is-provided.yml
+++ b/changelogs/fragments/8831-fix-error-when-mapper-id-is-provided.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_user_federation - fix the `UnboundLocalError` that occurs when an id is provided for a user federation mapper (https://github.com/ansible-collections/community.general/pull/8831)

--- a/changelogs/fragments/8831-fix-error-when-mapper-id-is-provided.yml
+++ b/changelogs/fragments/8831-fix-error-when-mapper-id-is-provided.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - keycloak_user_federation - fix the `UnboundLocalError` that occurs when an id is provided for a user federation mapper (https://github.com/ansible-collections/community.general/pull/8831)
+  - keycloak_user_federation - fix the ``UnboundLocalError`` that occurs when an ID is provided for a user federation mapper (https://github.com/ansible-collections/community.general/pull/8831).

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -901,7 +901,7 @@ def main():
             if cid is None:
                 old_mapper = {}
             elif change.get('id') is not None:
-                old_mapper = next((before_mapper for before_mapper in before_mapper.get('mappers', []) if before_mapper["id"] == change['id']), None)
+                old_mapper = next((before_mapper for before_mapper in before_comp.get('mappers', []) if before_mapper["id"] == change['id']), None)
                 if old_mapper is None:
                     old_mapper = {}
             else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The module crashes if an id is provided for a mapper, see https://github.com/ansible-collections/community.general/pull/8695#issuecomment-2331251238.

The before mappers should be retrieved from the `before_comp` not `before_mapper`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
community.general.keycloak_user_federation
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. create a mapper without providing an id:
```
mappers:
  - name: "first name"
    providerId: "user-attribute-ldap-mapper"
    providerType: "org.keycloak.storage.ldap.mappers.LDAPStorageMapper"
    config:
      ldap.attribute: givenName
      read.only: true
      write.only: false
      attribute.force.default: true
      is.mandatory.in.ldap: true
      is.binary.attribute: false
      user.model.attribute: firstName
```
2. copy id from keycloak and update mapper:
```
mappers:
  - name: "first name"
    id: f2d82dec-923c-40da-a9f7-0fe83ca8c009
    providerId: "user-attribute-ldap-mapper"
    providerType: "org.keycloak.storage.ldap.mappers.LDAPStorageMapper"
    config:
      ldap.attribute: givenName
      read.only: true
      write.only: false
      attribute.force.default: true
      is.mandatory.in.ldap: true
      is.binary.attribute: false
      user.model.attribute: firstName
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
