### PR TITLE
use dict comprehension in plugins, part 3

### DIFF
--- a/changelogs/fragments/8833-dict-comprehension.yml
+++ b/changelogs/fragments/8833-dict-comprehension.yml
@@ -1,0 +1,23 @@
+minor_changes:
+  - redis cache plugin - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - onepassword lookup plugin - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - ocapi_utils - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - redfish_utils - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - scaleway - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - alternatives - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - apache2_mod_proxy - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - consul_acl - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - imc_rest - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - keycloak_user_federation - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - pids - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - pipx - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - pipx_info - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - pkg5_publisher - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - scaleway_compute - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - scaleway_ip - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - scaleway_lb - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - scaleway_security_group - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - scaleway_user_data - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - sensu_silence - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - snmp_facts - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).
+  - sorcery - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8833).

--- a/plugins/cache/redis.py
+++ b/plugins/cache/redis.py
@@ -227,7 +227,7 @@ class CacheModule(BaseCacheModule):
 
     def copy(self):
         # TODO: there is probably a better way to do this in redis
-        ret = dict([(k, self.get(k)) for k in self.keys()])
+        ret = {k: self.get(k) for k in self.keys()}
         return ret
 
     def __getstate__(self):

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -135,7 +135,7 @@ class OnePassCLIBase(with_metaclass(abc.ABCMeta, object)):
         self._version = None
 
     def _check_required_params(self, required_params):
-        non_empty_attrs = dict((param, getattr(self, param, None)) for param in required_params if getattr(self, param, None))
+        non_empty_attrs = {param: getattr(self, param) for param in required_params if getattr(self, param, None)}
         missing = set(required_params).difference(non_empty_attrs)
         if missing:
             prefix = "Unable to sign in to 1Password. Missing required parameter"

--- a/plugins/module_utils/ocapi_utils.py
+++ b/plugins/module_utils/ocapi_utils.py
@@ -56,7 +56,7 @@ class OcapiUtils(object):
                             follow_redirects='all',
                             use_proxy=True, timeout=self.timeout)
             data = json.loads(to_native(resp.read()))
-            headers = dict((k.lower(), v) for (k, v) in resp.info().items())
+            headers = {k.lower(): v for (k, v) in resp.info().items()}
         except HTTPError as e:
             return {'ret': False,
                     'msg': "HTTP Error %s on GET request to '%s'"
@@ -86,7 +86,7 @@ class OcapiUtils(object):
                 data = json.loads(to_native(resp.read()))
             else:
                 data = ""
-            headers = dict((k.lower(), v) for (k, v) in resp.info().items())
+            headers = {k.lower(): v for (k, v) in resp.info().items()}
         except HTTPError as e:
             return {'ret': False,
                     'msg': "HTTP Error %s on DELETE request to '%s'"
@@ -113,7 +113,7 @@ class OcapiUtils(object):
                             force_basic_auth=basic_auth, validate_certs=False,
                             follow_redirects='all',
                             use_proxy=True, timeout=self.timeout)
-            headers = dict((k.lower(), v) for (k, v) in resp.info().items())
+            headers = {k.lower(): v for (k, v) in resp.info().items()}
         except HTTPError as e:
             return {'ret': False,
                     'msg': "HTTP Error %s on PUT request to '%s'"
@@ -144,7 +144,7 @@ class OcapiUtils(object):
                             force_basic_auth=basic_auth, validate_certs=False,
                             follow_redirects='all',
                             use_proxy=True, timeout=self.timeout if timeout is None else timeout)
-            headers = dict((k.lower(), v) for (k, v) in resp.info().items())
+            headers = {k.lower(): v for (k, v) in resp.info().items()}
         except HTTPError as e:
             return {'ret': False,
                     'msg': "HTTP Error %s on POST request to '%s'"

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -151,7 +151,7 @@ class RedfishUtils(object):
                             force_basic_auth=basic_auth, validate_certs=False,
                             follow_redirects='all',
                             use_proxy=True, timeout=timeout, ciphers=self.ciphers)
-            headers = dict((k.lower(), v) for (k, v) in resp.info().items())
+            headers = {k.lower(): v for (k, v) in resp.info().items()}
             try:
                 if headers.get('content-encoding') == 'gzip' and LooseVersion(ansible_version) < LooseVersion('2.14'):
                     # Older versions of Ansible do not automatically decompress the data
@@ -206,7 +206,7 @@ class RedfishUtils(object):
             except Exception as e:
                 # No response data; this is okay in many cases
                 data = None
-            headers = dict((k.lower(), v) for (k, v) in resp.info().items())
+            headers = {k.lower(): v for (k, v) in resp.info().items()}
         except HTTPError as e:
             msg = self._get_extended_message(e)
             return {'ret': False,
@@ -610,8 +610,7 @@ class RedfishUtils(object):
                 data = response['data']
                 if 'Parameters' in data:
                     params = data['Parameters']
-                    ai = dict((p['Name'], p)
-                              for p in params if 'Name' in p)
+                    ai = {p['Name']: p for p in params if 'Name' in p}
         if not ai:
             ai = {
                 k[:-24]: {'AllowableValues': v}

--- a/plugins/module_utils/scaleway.py
+++ b/plugins/module_utils/scaleway.py
@@ -140,7 +140,7 @@ def resource_attributes_should_be_changed(target, wished, verifiable_mutable_att
             diff[attr] = wished[attr]
 
     if diff:
-        return dict((attr, wished[attr]) for attr in mutable_attributes)
+        return {attr: wished[attr] for attr in mutable_attributes}
     else:
         return diff
 

--- a/plugins/modules/alternatives.py
+++ b/plugins/modules/alternatives.py
@@ -344,7 +344,7 @@ class AlternativesModule(object):
 
         subcmd_path_map = dict(subcmd_path_link_regex.findall(display_output))
         if not subcmd_path_map and self.subcommands:
-            subcmd_path_map = dict((s['name'], s['link']) for s in self.subcommands)
+            subcmd_path_map = {s['name']: s['link'] for s in self.subcommands}
 
         for path, prio, subcmd in alternative_regex.findall(display_output):
             self.current_alternatives[path] = dict(

--- a/plugins/modules/apache2_mod_proxy.py
+++ b/plugins/modules/apache2_mod_proxy.py
@@ -277,7 +277,7 @@ class BalancerMember(object):
                 for valuesset in subsoup[1::1]:
                     if re.search(pattern=self.host, string=str(valuesset)):
                         values = valuesset.findAll('td')
-                        return dict((keys[x].string, values[x].string) for x in range(0, len(keys)))
+                        return {keys[x].string: values[x].string for x in range(0, len(keys))}
 
     def get_member_status(self):
         """ Returns a dictionary of a balancer member's status attributes."""

--- a/plugins/modules/consul_acl.py
+++ b/plugins/modules/consul_acl.py
@@ -273,8 +273,8 @@ def set_acl(consul_client, configuration):
     :return: the output of setting the ACL
     """
     acls_as_json = decode_acls_as_json(consul_client.acl.list())
-    existing_acls_mapped_by_name = dict((acl.name, acl) for acl in acls_as_json if acl.name is not None)
-    existing_acls_mapped_by_token = dict((acl.token, acl) for acl in acls_as_json)
+    existing_acls_mapped_by_name = {acl.name: acl for acl in acls_as_json if acl.name is not None}
+    existing_acls_mapped_by_token = {acl.token: acl for acl in acls_as_json}
     if None in existing_acls_mapped_by_token:
         raise AssertionError("expecting ACL list to be associated to a token: %s" %
                              existing_acls_mapped_by_token[None])

--- a/plugins/modules/imc_rest.py
+++ b/plugins/modules/imc_rest.py
@@ -323,8 +323,7 @@ def merge(one, two):
     ''' Merge two complex nested datastructures into one'''
     if isinstance(one, dict) and isinstance(two, dict):
         copy = dict(one)
-        # copy.update({key: merge(one.get(key, None), two[key]) for key in two})
-        copy.update(dict((key, merge(one.get(key, None), two[key])) for key in two))
+        copy.update({key: merge(one.get(key, None), two[key]) for key in two})
         return copy
 
     elif isinstance(one, list) and isinstance(two, list):

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -856,8 +856,11 @@ def main():
     if mappers is not None:
         for mapper in mappers:
             if mapper.get('config') is not None:
-                mapper['config'] = dict((k, [str(v).lower() if not isinstance(v, str) else v])
-                                        for k, v in mapper['config'].items() if mapper['config'][k] is not None)
+                mapper['config'] = {
+                    k: [str(v).lower() if not isinstance(v, str) else v]
+                    for k, v in mapper['config'].items()
+                    if mapper['config'][k] is not None
+                }
 
     # Filter and map the parameters names that apply
     comp_params = [x for x in module.params

--- a/plugins/modules/pids.py
+++ b/plugins/modules/pids.py
@@ -111,7 +111,7 @@ class PSAdapter(object):
                 attributes['cmdline'] and compare_lower(attributes['cmdline'][0], name))
 
     def _get_proc_attributes(self, proc, *attributes):
-        return dict((attribute, self._get_attribute_from_proc(proc, attribute)) for attribute in attributes)
+        return {attribute: self._get_attribute_from_proc(proc, attribute) for attribute in attributes}
 
     @staticmethod
     @abc.abstractmethod

--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -249,9 +249,7 @@ class PipX(StateModuleHelper):
             for venv_name, venv in raw_data['venvs'].items():
                 results[venv_name] = {
                     'version': venv['metadata']['main_package']['package_version'],
-                    'injected': dict(
-                        (k, v['package_version']) for k, v in venv['metadata']['injected_packages'].items()
-                    ),
+                    'injected': {k: v['package_version'] for k, v in venv['metadata']['injected_packages'].items()},
                 }
             return results
 

--- a/plugins/modules/pipx_info.py
+++ b/plugins/modules/pipx_info.py
@@ -196,9 +196,7 @@ class PipXInfo(ModuleHelper):
                     'version': venv['metadata']['main_package']['package_version']
                 }
                 if self.vars.include_injected:
-                    entry['injected'] = dict(
-                        (k, v['package_version']) for k, v in venv['metadata']['injected_packages'].items()
-                    )
+                    entry['injected'] = {k: v['package_version'] for k, v in venv['metadata']['injected_packages'].items()}
                 if self.vars.include_deps:
                     entry['dependencies'] = list(venv['metadata']['main_package']['app_paths_of_dependencies'])
                 results.append(entry)

--- a/plugins/modules/pkg5_publisher.py
+++ b/plugins/modules/pkg5_publisher.py
@@ -183,9 +183,7 @@ def get_publishers(module):
         name = values['publisher']
 
         if name not in publishers:
-            publishers[name] = dict(
-                (k, values[k]) for k in ['sticky', 'enabled']
-            )
+            publishers[name] = {k: values[k] for k in ['sticky', 'enabled']}
             publishers[name]['origin'] = []
             publishers[name]['mirror'] = []
 

--- a/plugins/modules/scaleway_compute.py
+++ b/plugins/modules/scaleway_compute.py
@@ -586,9 +586,11 @@ def server_attributes_should_be_changed(compute_api, target_server, wished_serve
     compute_api.module.debug("Checking if server attributes should be changed")
     compute_api.module.debug("Current Server: %s" % target_server)
     compute_api.module.debug("Wished Server: %s" % wished_server)
-    debug_dict = dict((x, (target_server[x], wished_server[x]))
-                      for x in PATCH_MUTABLE_SERVER_ATTRIBUTES
-                      if x in target_server and x in wished_server)
+    debug_dict = {
+        x: (target_server[x], wished_server[x])
+        for x in PATCH_MUTABLE_SERVER_ATTRIBUTES
+        if x in target_server and x in wished_server
+    }
     compute_api.module.debug("Debug dict %s" % debug_dict)
     try:
         for key in PATCH_MUTABLE_SERVER_ATTRIBUTES:
@@ -614,7 +616,7 @@ def server_change_attributes(compute_api, target_server, wished_server):
             # When you are working with dict, only ID matter as we ask user to put only the resource ID in the playbook
             if isinstance(target_server[key], dict) and "id" in target_server[key] and wished_server[key]:
                 # Setting all key to current value except ID
-                key_dict = dict((x, target_server[key][x]) for x in target_server[key].keys() if x != "id")
+                key_dict = {x: target_server[key][x] for x in target_server[key].keys() if x != "id"}
                 # Setting ID to the user specified ID
                 key_dict["id"] = wished_server[key]
                 patch_payload[key] = key_dict

--- a/plugins/modules/scaleway_ip.py
+++ b/plugins/modules/scaleway_ip.py
@@ -145,11 +145,11 @@ def ip_attributes_should_be_changed(api, target_ip, wished_ip):
 
 
 def payload_from_wished_ip(wished_ip):
-    return dict(
-        (k, v)
+    return {
+        k: v
         for k, v in wished_ip.items()
         if k != 'id' and v is not None
-    )
+    }
 
 
 def present_strategy(api, wished_ip):
@@ -161,8 +161,7 @@ def present_strategy(api, wished_ip):
             response.status_code, response.json['message']))
 
     ips_list = response.json["ips"]
-    ip_lookup = dict((ip["id"], ip)
-                     for ip in ips_list)
+    ip_lookup = {ip["id"]: ip for ip in ips_list}
 
     if wished_ip["id"] not in ip_lookup.keys():
         changed = True
@@ -212,8 +211,7 @@ def absent_strategy(api, wished_ip):
         api.module.fail_json(msg='Error getting IPs [{0}: {1}]'.format(
             status_code, response.json['message']))
 
-    ip_lookup = dict((ip["id"], ip)
-                     for ip in ips_list)
+    ip_lookup = {ip["id"]: ip for ip in ips_list}
     if wished_ip["id"] not in ip_lookup.keys():
         return changed, {}
 

--- a/plugins/modules/scaleway_lb.py
+++ b/plugins/modules/scaleway_lb.py
@@ -224,10 +224,10 @@ def wait_to_complete_state_transition(api, lb, force_wait=False):
 
 
 def lb_attributes_should_be_changed(target_lb, wished_lb):
-    diff = dict((attr, wished_lb[attr]) for attr in MUTABLE_ATTRIBUTES if target_lb[attr] != wished_lb[attr])
+    diff = {attr: wished_lb[attr] for attr in MUTABLE_ATTRIBUTES if target_lb[attr] != wished_lb[attr]}
 
     if diff:
-        return dict((attr, wished_lb[attr]) for attr in MUTABLE_ATTRIBUTES)
+        return {attr: wished_lb[attr] for attr in MUTABLE_ATTRIBUTES}
     else:
         return diff
 
@@ -241,8 +241,7 @@ def present_strategy(api, wished_lb):
             response.status_code, response.json['message']))
 
     lbs_list = response.json["lbs"]
-    lb_lookup = dict((lb["name"], lb)
-                     for lb in lbs_list)
+    lb_lookup = {lb["name"]: lb for lb in lbs_list}
 
     if wished_lb["name"] not in lb_lookup.keys():
         changed = True
@@ -298,8 +297,7 @@ def absent_strategy(api, wished_lb):
         api.module.fail_json(msg='Error getting load-balancers [{0}: {1}]'.format(
             status_code, response.json['message']))
 
-    lb_lookup = dict((lb["name"], lb)
-                     for lb in lbs_list)
+    lb_lookup = {lb["name"]: lb for lb in lbs_list}
     if wished_lb["name"] not in lb_lookup.keys():
         return changed, {}
 

--- a/plugins/modules/scaleway_security_group.py
+++ b/plugins/modules/scaleway_security_group.py
@@ -149,8 +149,7 @@ def present_strategy(api, security_group):
     if not response.ok:
         api.module.fail_json(msg='Error getting security groups "%s": "%s" (%s)' % (response.info['msg'], response.json['message'], response.json))
 
-    security_group_lookup = dict((sg['name'], sg)
-                                 for sg in response.json['security_groups'])
+    security_group_lookup = {sg['name']: sg for sg in response.json['security_groups']}
 
     if security_group['name'] not in security_group_lookup.keys():
         ret['changed'] = True
@@ -181,8 +180,7 @@ def absent_strategy(api, security_group):
     if not response.ok:
         api.module.fail_json(msg='Error getting security groups "%s": "%s" (%s)' % (response.info['msg'], response.json['message'], response.json))
 
-    security_group_lookup = dict((sg['name'], sg)
-                                 for sg in response.json['security_groups'])
+    security_group_lookup = {sg['name']: sg for sg in response.json['security_groups']}
     if security_group['name'] not in security_group_lookup.keys():
         return ret
 

--- a/plugins/modules/scaleway_user_data.py
+++ b/plugins/modules/scaleway_user_data.py
@@ -129,10 +129,10 @@ def core(module):
         compute_api.module.fail_json(msg=msg)
 
     present_user_data_keys = user_data_list.json["user_data"]
-    present_user_data = dict(
-        (key, get_user_data(compute_api=compute_api, server_id=server_id, key=key))
+    present_user_data = {
+        key: get_user_data(compute_api=compute_api, server_id=server_id, key=key)
         for key in present_user_data_keys
-    )
+    }
 
     if present_user_data == user_data:
         module.exit_json(changed=changed, msg=user_data_list.json)

--- a/plugins/modules/sensu_silence.py
+++ b/plugins/modules/sensu_silence.py
@@ -149,7 +149,7 @@ def clear(module, url, check, subscription):
     # Test if silence exists before clearing
     (rc, out, changed) = query(module, url, check, subscription)
 
-    d = dict((i['subscription'], i['check']) for i in out)
+    d = {i['subscription']: i['check'] for i in out}
     subscription_exists = subscription in d
     if check and subscription_exists:
         exists = (check == d[subscription])

--- a/plugins/modules/snmp_facts.py
+++ b/plugins/modules/snmp_facts.py
@@ -300,7 +300,11 @@ def main():
     deps.validate(module)
 
     cmdGen = cmdgen.CommandGenerator()
-    transport_opts = dict((k, m_args[k]) for k in ('timeout', 'retries') if m_args[k] is not None)
+    transport_opts = {
+        k: m_args[k]
+        for k in ('timeout', 'retries')
+        if m_args[k] is not None
+    }
 
     # Verify that we receive a community when using snmp v2
     if m_args['version'] in ("v2", "v2c"):

--- a/plugins/modules/sorcery.py
+++ b/plugins/modules/sorcery.py
@@ -280,7 +280,7 @@ def codex_list(module, skip_new=False):
 
     # return only specified grimoires unless requested to skip new
     if params['repository'] and not skip_new:
-        codex = dict((x, codex.get(x, NA)) for x in params['name'])
+        codex = {x: codex.get(x, NA) for x in params['name']}
 
     if not codex:
         module.fail_json(msg="no grimoires to operate on; add at least one")

--- a/tests/unit/plugins/module_utils/test_cmd_runner.py
+++ b/tests/unit/plugins/module_utils/test_cmd_runner.py
@@ -359,7 +359,7 @@ def test_runner_context(runner_input, cmd_execution, expected):
     )
 
     def _assert_run_info(actual, expected):
-        reduced = dict((k, actual[k]) for k in expected.keys())
+        reduced = {k: actual[k] for k in expected.keys()}
         assert reduced == expected, "{0}".format(reduced)
 
     def _assert_run(runner_input, cmd_execution, expected, ctx, results):

--- a/tests/unit/plugins/module_utils/test_python_runner.py
+++ b/tests/unit/plugins/module_utils/test_python_runner.py
@@ -189,9 +189,11 @@ def test_runner_context(runner_input, cmd_execution, expected):
     def _extract_path(run_info):
         path = run_info.get("environ_update", {}).get("PATH")
         if path is not None:
-            run_info["environ_update"] = dict((k, v)
-                                              for k, v in run_info["environ_update"].items()
-                                              if k != "PATH")
+            run_info["environ_update"] = {
+                k: v
+                for k, v in run_info["environ_update"].items()
+                if k != "PATH"
+            }
         return run_info, path
 
     def _assert_run_info_env_path(actual, expected):
@@ -199,7 +201,7 @@ def test_runner_context(runner_input, cmd_execution, expected):
         assert expected in actual2, "Missing expected path {0} in output PATH: {1}".format(expected, actual)
 
     def _assert_run_info(actual, expected):
-        reduced = dict((k, actual[k]) for k in expected.keys())
+        reduced = {k: actual[k] for k in expected.keys()}
         reduced, act_path = _extract_path(reduced)
         expected, exp_path = _extract_path(expected)
         if exp_path is not None:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Another PR to mass-replace the construct `dict((k, v) for k, v in d if condition)` with dict comprehensions: `{k: v for k, v in d if condition}`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/cache/redis.py
plugins/lookup/onepassword.py
plugins/module_utils/ocapi_utils.py
plugins/module_utils/redfish_utils.py
plugins/module_utils/scaleway.py
plugins/modules/alternatives.py
plugins/modules/apache2_mod_proxy.py
plugins/modules/consul_acl.py
plugins/modules/imc_rest.py
plugins/modules/keycloak_user_federation.py
plugins/modules/pids.py
plugins/modules/pipx.py
plugins/modules/pipx_info.py
plugins/modules/pkg5_publisher.py
plugins/modules/scaleway_compute.py
plugins/modules/scaleway_ip.py
plugins/modules/scaleway_lb.py
plugins/modules/scaleway_security_group.py
plugins/modules/scaleway_user_data.py
plugins/modules/sensu_silence.py
plugins/modules/snmp_facts.py
plugins/modules/sorcery.py
tests/unit/plugins/module_utils/test_cmd_runner.py
tests/unit/plugins/module_utils/test_python_runner.py
