### PR TITLE
use dict comprehension in plugins, part 4

### DIFF
--- a/changelogs/fragments/8858-dict-comprehension.yml
+++ b/changelogs/fragments/8858-dict-comprehension.yml
@@ -1,0 +1,11 @@
+minor_changes:
+  - scaleway_container - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8858).
+  - scaleway_container_info - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8858).
+  - scaleway_container_namespace - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8858).
+  - scaleway_container_namespace_info - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8858).
+  - scaleway_container_registry - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8858).
+  - scaleway_container_registry_info - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8858).
+  - scaleway_function - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8858).
+  - scaleway_function_info - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8858).
+  - scaleway_function_namespace - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8858).
+  - scaleway_function_namespace_info - replace Python 2.6 construct with dict comprehensions (https://github.com/ansible-collections/community.general/pull/8858).

--- a/plugins/modules/scaleway_container.py
+++ b/plugins/modules/scaleway_container.py
@@ -260,8 +260,7 @@ def absent_strategy(api, wished_cn):
     changed = False
 
     cn_list = api.fetch_all_resources("containers")
-    cn_lookup = dict((cn["name"], cn)
-                     for cn in cn_list)
+    cn_lookup = {cn["name"]: cn for cn in cn_list}
 
     if wished_cn["name"] not in cn_lookup:
         return changed, {}
@@ -285,8 +284,7 @@ def present_strategy(api, wished_cn):
     changed = False
 
     cn_list = api.fetch_all_resources("containers")
-    cn_lookup = dict((cn["name"], cn)
-                     for cn in cn_list)
+    cn_lookup = {cn["name"]: cn for cn in cn_list}
 
     payload_cn = payload_from_wished_cn(wished_cn)
 

--- a/plugins/modules/scaleway_container_info.py
+++ b/plugins/modules/scaleway_container_info.py
@@ -97,8 +97,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 def info_strategy(api, wished_cn):
     cn_list = api.fetch_all_resources("containers")
-    cn_lookup = dict((fn["name"], fn)
-                     for fn in cn_list)
+    cn_lookup = {cn["name"]: cn for cn in cn_list}
 
     if wished_cn["name"] not in cn_lookup:
         msg = "Error during container lookup: Unable to find container named '%s' in namespace '%s'" % (wished_cn["name"],

--- a/plugins/modules/scaleway_container_namespace.py
+++ b/plugins/modules/scaleway_container_namespace.py
@@ -167,8 +167,7 @@ def absent_strategy(api, wished_cn):
     changed = False
 
     cn_list = api.fetch_all_resources("namespaces")
-    cn_lookup = dict((cn["name"], cn)
-                     for cn in cn_list)
+    cn_lookup = {cn["name"]: cn for cn in cn_list}
 
     if wished_cn["name"] not in cn_lookup:
         return changed, {}
@@ -192,8 +191,7 @@ def present_strategy(api, wished_cn):
     changed = False
 
     cn_list = api.fetch_all_resources("namespaces")
-    cn_lookup = dict((cn["name"], cn)
-                     for cn in cn_list)
+    cn_lookup = {cn["name"]: cn for cn in cn_list}
 
     payload_cn = payload_from_wished_cn(wished_cn)
 

--- a/plugins/modules/scaleway_container_namespace_info.py
+++ b/plugins/modules/scaleway_container_namespace_info.py
@@ -88,8 +88,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 def info_strategy(api, wished_cn):
     cn_list = api.fetch_all_resources("namespaces")
-    cn_lookup = dict((fn["name"], fn)
-                     for fn in cn_list)
+    cn_lookup = {cn["name"]: cn for cn in cn_list}
 
     if wished_cn["name"] not in cn_lookup:
         msg = "Error during container namespace lookup: Unable to find container namespace named '%s' in project '%s'" % (wished_cn["name"],

--- a/plugins/modules/scaleway_container_registry.py
+++ b/plugins/modules/scaleway_container_registry.py
@@ -150,8 +150,7 @@ def absent_strategy(api, wished_cr):
     changed = False
 
     cr_list = api.fetch_all_resources("namespaces")
-    cr_lookup = dict((cr["name"], cr)
-                     for cr in cr_list)
+    cr_lookup = {cr["name"]: cr for cr in cr_list}
 
     if wished_cr["name"] not in cr_lookup:
         return changed, {}
@@ -175,8 +174,7 @@ def present_strategy(api, wished_cr):
     changed = False
 
     cr_list = api.fetch_all_resources("namespaces")
-    cr_lookup = dict((cr["name"], cr)
-                     for cr in cr_list)
+    cr_lookup = {cr["name"]: cr for cr in cr_list}
 
     payload_cr = payload_from_wished_cr(wished_cr)
 

--- a/plugins/modules/scaleway_container_registry_info.py
+++ b/plugins/modules/scaleway_container_registry_info.py
@@ -87,8 +87,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 def info_strategy(api, wished_cn):
     cn_list = api.fetch_all_resources("namespaces")
-    cn_lookup = dict((fn["name"], fn)
-                     for fn in cn_list)
+    cn_lookup = {cn["name"]: cn for cn in cn_list}
 
     if wished_cn["name"] not in cn_lookup:
         msg = "Error during container registries lookup: Unable to find container registry named '%s' in project '%s'" % (wished_cn["name"],

--- a/plugins/modules/scaleway_function.py
+++ b/plugins/modules/scaleway_function.py
@@ -245,8 +245,7 @@ def absent_strategy(api, wished_fn):
     changed = False
 
     fn_list = api.fetch_all_resources("functions")
-    fn_lookup = dict((fn["name"], fn)
-                     for fn in fn_list)
+    fn_lookup = {fn["name"]: fn for fn in fn_list}
 
     if wished_fn["name"] not in fn_lookup:
         return changed, {}
@@ -270,8 +269,7 @@ def present_strategy(api, wished_fn):
     changed = False
 
     fn_list = api.fetch_all_resources("functions")
-    fn_lookup = dict((fn["name"], fn)
-                     for fn in fn_list)
+    fn_lookup = {fn["name"]: fn for fn in fn_list}
 
     payload_fn = payload_from_wished_fn(wished_fn)
 

--- a/plugins/modules/scaleway_function_info.py
+++ b/plugins/modules/scaleway_function_info.py
@@ -96,8 +96,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 def info_strategy(api, wished_fn):
     fn_list = api.fetch_all_resources("functions")
-    fn_lookup = dict((fn["name"], fn)
-                     for fn in fn_list)
+    fn_lookup = {fn["name"]: fn for fn in fn_list}
 
     if wished_fn["name"] not in fn_lookup:
         msg = "Error during function lookup: Unable to find function named '%s' in namespace '%s'" % (wished_fn["name"],

--- a/plugins/modules/scaleway_function_namespace.py
+++ b/plugins/modules/scaleway_function_namespace.py
@@ -168,8 +168,7 @@ def absent_strategy(api, wished_fn):
     changed = False
 
     fn_list = api.fetch_all_resources("namespaces")
-    fn_lookup = dict((fn["name"], fn)
-                     for fn in fn_list)
+    fn_lookup = {fn["name"]: fn for fn in fn_list}
 
     if wished_fn["name"] not in fn_lookup:
         return changed, {}
@@ -193,8 +192,7 @@ def present_strategy(api, wished_fn):
     changed = False
 
     fn_list = api.fetch_all_resources("namespaces")
-    fn_lookup = dict((fn["name"], fn)
-                     for fn in fn_list)
+    fn_lookup = {fn["name"]: fn for fn in fn_list}
 
     payload_fn = payload_from_wished_fn(wished_fn)
 

--- a/plugins/modules/scaleway_function_namespace_info.py
+++ b/plugins/modules/scaleway_function_namespace_info.py
@@ -88,8 +88,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 def info_strategy(api, wished_fn):
     fn_list = api.fetch_all_resources("namespaces")
-    fn_lookup = dict((fn["name"], fn)
-                     for fn in fn_list)
+    fn_lookup = {fn["name"]: fn for fn in fn_list}
 
     if wished_fn["name"] not in fn_lookup:
         msg = "Error during function namespace lookup: Unable to find function namespace named '%s' in project '%s'" % (wished_fn["name"],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Another PR to mass-replace the construct `dict((k, v) for k, v in d if condition)` with dict comprehensions: `{k: v for k, v in d if condition}`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/modules/scaleway_container.py
plugins/modules/scaleway_container_info.py
plugins/modules/scaleway_container_namespace.py
plugins/modules/scaleway_container_namespace_info.py
plugins/modules/scaleway_container_registry.py
plugins/modules/scaleway_container_registry_info.py
plugins/modules/scaleway_function.py
plugins/modules/scaleway_function_info.py
plugins/modules/scaleway_function_namespace.py
plugins/modules/scaleway_function_namespace_info.py
