### PR TITLE
keycloak_realm: fix change detection in check mode by normalizing realms beforehand

### DIFF
--- a/changelogs/fragments/8877-keycloak_realm-sort-lists-before-change-detection.yaml
+++ b/changelogs/fragments/8877-keycloak_realm-sort-lists-before-change-detection.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_realm - fix change detection in check mode by sorting the lists in the realms beforehand (https://github.com/ansible-collections/community.general/pull/8877).

--- a/plugins/modules/keycloak_realm.py
+++ b/plugins/modules/keycloak_realm.py
@@ -803,7 +803,7 @@ def main():
                 if module._diff:
                     result['diff'] = dict(before=sanitize_cr(before_norm),
                                           after=sanitize_cr(desired_norm))
-                result['changed'] = (before_realm != desired_realm)
+                result['changed'] = (before_norm != desired_norm)
 
                 module.exit_json(**result)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The lists `enabledEventTypes`, `otpSupportedApplications` and `supportedLocales` are sorted (in the normalize function) for the diff but not when comparing realms for the `changed` parameter. So the module always detects a change in check mode but shows an empty diff:
```
TASK [kc1 - realm-1 - Update Keycloak realm] ************************************************************************************************************************************************************************
changed: [kc1]
```
To minimize the changes, the lists should be sorted before comparing the realms as well.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_realm
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. create minimal realm:
```
- name: Create or update Keycloak realm (minimal example)
  community.general.keycloak_realm:
    auth_client_id: admin-cli
    auth_keycloak_url: ...
    auth_realm: master
    auth_username: ...
    auth_password: ...
    id: realm-1
    realm: realm-1
    state: present
    enabledEventTypes:
    - AUTHREQID_TO_TOKEN
    - AUTHREQID_TO_TOKEN_ERROR
    - CLIENT_DELETE
    - CLIENT_DELETE_ERROR
```
2. subsequent check runs always detect a change but show an empty diff