### PR TITLE
npm: Add force flag

### DIFF
--- a/changelogs/fragments/8885-add-force-flag-for-nmp.yml
+++ b/changelogs/fragments/8885-add-force-flag-for-nmp.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - nmp - add force parameter to allow --force (https://github.com/ansible-collections/community.general/pull/8885).
+  - npm - add ``force`` parameter to allow ``--force`` (https://github.com/ansible-collections/community.general/pull/8885).

--- a/changelogs/fragments/8885-add-force-flag-for-nmp.yml
+++ b/changelogs/fragments/8885-add-force-flag-for-nmp.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmp - add force parameter to allow --force (https://github.com/ansible-collections/community.general/pull/8885).

--- a/plugins/modules/npm.py
+++ b/plugins/modules/npm.py
@@ -96,6 +96,12 @@ options:
     type: bool
     default: false
     version_added: 2.5.0
+  force:
+    description:
+      - Use the C(--force) flag when installing.
+    type: bool
+    default: false
+    version_added: 9.5.0
 requirements:
     - npm installed in bin path (recommended /usr/local/bin)
 '''
@@ -116,6 +122,11 @@ EXAMPLES = r'''
   community.general.npm:
     name: coffee-script
     global: true
+
+- name: Force Install "coffee-script" node.js package.
+  community.general.npm:
+    name: coffee-script
+    force: true
 
 - name: Remove the globally package "coffee-script".
   community.general.npm:
@@ -167,6 +178,7 @@ class Npm(object):
         self.state = kwargs['state']
         self.no_optional = kwargs['no_optional']
         self.no_bin_links = kwargs['no_bin_links']
+        self.force = kwargs['force']
 
         if kwargs['executable']:
             self.executable = kwargs['executable'].split(' ')
@@ -191,6 +203,7 @@ class Npm(object):
                 registry=cmd_runner_fmt.as_opt_val('--registry'),
                 no_optional=cmd_runner_fmt.as_bool('--no-optional'),
                 no_bin_links=cmd_runner_fmt.as_bool('--no-bin-links'),
+                force=cmd_runner_fmt.as_bool('--force'),
             )
         )
 
@@ -289,6 +302,7 @@ def main():
         ci=dict(default=False, type='bool'),
         no_optional=dict(default=False, type='bool'),
         no_bin_links=dict(default=False, type='bool'),
+        force=dict(default=False, type='bool')
     )
     arg_spec['global'] = dict(default=False, type='bool')
     module = AnsibleModule(
@@ -318,7 +332,8 @@ def main():
               unsafe_perm=module.params['unsafe_perm'],
               state=state,
               no_optional=module.params['no_optional'],
-              no_bin_links=module.params['no_bin_links'])
+              no_bin_links=module.params['no_bin_links'],
+              force=module.params['force'])
 
     changed = False
     if module.params['ci']:

--- a/plugins/modules/npm.py
+++ b/plugins/modules/npm.py
@@ -225,7 +225,7 @@ class Npm(object):
             params['name_version'] = self.name_version if add_package_name else None
 
             with self.runner(
-                "exec_args global_ production ignore_scripts unsafe_perm name_version registry no_optional no_bin_links",
+                "exec_args global_ production ignore_scripts unsafe_perm name_version registry no_optional no_bin_links force",
                 check_rc=check_rc, cwd=cwd
             ) as ctx:
                 rc, out, err = ctx.run(**params)

--- a/plugins/modules/npm.py
+++ b/plugins/modules/npm.py
@@ -302,7 +302,7 @@ def main():
         ci=dict(default=False, type='bool'),
         no_optional=dict(default=False, type='bool'),
         no_bin_links=dict(default=False, type='bool'),
-        force=dict(default=False, type='bool')
+        force=dict(default=False, type='bool'),
     )
     arg_spec['global'] = dict(default=False, type='bool')
     module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add `--force` flag for nmp module
Fixes #8678
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
nmp

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
It seemed easy to implement without breaking backward compatibility
<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
# Now this is possible
- name: Force Install "coffee-script" node.js package.
  community.general.npm:
    name: coffee-script
    force: true
```