### PR TITLE
one_service: fix recreation

### DIFF
--- a/changelogs/fragments/8887-fix-one_service-unique.yml
+++ b/changelogs/fragments/8887-fix-one_service-unique.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - one_service - fix service creation after it was deleted with ``unique`` parameter (https://github.com/ansible-collections/community.general/pull/8887).

--- a/changelogs/fragments/8887-fix-one_service-unique.yml
+++ b/changelogs/fragments/8887-fix-one_service-unique.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - one_service - fix service creation after it was deleted with ``unique`` parameter (https://github.com/ansible-collections/community.general/pull/8887).
+  - one_service - fix service creation after it was deleted with ``unique`` parameter (https://github.com/ansible-collections/community.general/issues/3137, https://github.com/ansible-collections/community.general/pull/8887).

--- a/plugins/modules/one_service.py
+++ b/plugins/modules/one_service.py
@@ -291,7 +291,6 @@ def get_service(module, auth, pred):
                 found = found + 1
                 found_service = service
                 service_name = service["NAME"]
-
     # fail if there are more services with same name
     if found > 1:
         module.fail_json(msg="There are multiple services with a name: '" +
@@ -522,7 +521,7 @@ def create_service_and_operation(module, auth, template_id, service_name, owner_
     if unique:
         service = get_service_by_name(module, auth, service_name)
 
-    if not service:
+    if not service or service["TEMPLATE"]["BODY"]["state"] == "DONE":
         if not module.check_mode:
             service = create_service(module, auth, template_id, service_name, custom_attrs, unique, wait, wait_timeout)
         changed = True
@@ -637,7 +636,6 @@ def get_service_id_by_name(module, auth, service_name):
 
 
 def get_connection_info(module):
-
     url = module.params.get('api_url')
     username = module.params.get('api_username')
     password = module.params.get('api_password')

--- a/plugins/modules/one_service.py
+++ b/plugins/modules/one_service.py
@@ -291,6 +291,7 @@ def get_service(module, auth, pred):
                 found = found + 1
                 found_service = service
                 service_name = service["NAME"]
+
     # fail if there are more services with same name
     if found > 1:
         module.fail_json(msg="There are multiple services with a name: '" +


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
After some investigation i concluded that the problem described in the related issue can be fixed by changing one if-statement 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #3137
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
one_service

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I also deleted a space between a function and a body because in all other functions there is no
<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
# Now this should work as intented
- name: Instantiating OpenNebula service
  ansible.community.one_service:
    template_id: "{{ one_template_id }}"
    service_name: "{{ deployment_name }}"
    unique: true
    wait: true
```
