### PR TITLE
nmcli: conn_reload param and up/down states

### DIFF
--- a/changelogs/fragments/8897-nmcli-add-reload-and-up-down.yml
+++ b/changelogs/fragments/8897-nmcli-add-reload-and-up-down.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - nmcli - add ``conn_enable`` param to reload connection (https://github.com/ansible-collections/community.general/issues/3752, https://github.com/ansible-collections/community.general/issues/8704, https://github.com/ansible-collections/community.general/pull/8897).
+  - nmcli - add ``state=up`` and ``state=down`` to enable/disable connections (https://github.com/ansible-collections/community.general/issues/3752, https://github.com/ansible-collections/community.general/issues/8704, https://github.com/ansible-collections/community.general/issues/7152, https://github.com/ansible-collections/community.general/pull/8897).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -35,8 +35,7 @@ options:
         description:
             - Whether the device should exist or not, taking action if the state is different from what is stated.
             - Using O(state=present) to create connection will automatically bring connection up.
-            - Using O(state=up) and O(state=down) will not modify connection with other parameters.
-            - O(state=up) and O(state=down) have been introduced in community.general 9.5.0.
+            - Using O(state=up) and O(state=down) will not modify connection with other parameters. These states have been added in community.general 9.5.0.
         type: str
         required: true
         choices: [ absent, present, up, down ]

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -2463,7 +2463,7 @@ def main():
         argument_spec=dict(
             ignore_unsupported_suboptions=dict(type='bool', default=False),
             autoconnect=dict(type='bool', default=True),
-            state=dict(type='str', required=True, choices=['absent', 'present']),
+            state=dict(type='str', required=True, choices=['absent', 'present', 'up', 'down']),
             conn_name=dict(type='str', required=True),
             conn_reload=dict(type='bool', required=False, default=False),
             master=dict(type='str'),

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -36,6 +36,7 @@ options:
             - Whether the device should exist or not, taking action if the state is different from what is stated.
             - Using O(state=present) to create connection will automatically bring connection up.
             - Using O(state=up) and O(state=down) will not modify connection with other parameters.
+            - O(state=up) and O(state=down) have been introduced in community.general 9.5.0.
         type: str
         required: true
         choices: [ absent, present, up, down ]
@@ -56,6 +57,7 @@ options:
         type: bool
         required: false
         default: false
+        version_added: 9.5.0
     ifname:
         description:
             - The interface to bind the connection to.
@@ -2465,7 +2467,7 @@ def main():
             autoconnect=dict(type='bool', default=True),
             state=dict(type='str', required=True, choices=['absent', 'present', 'up', 'down']),
             conn_name=dict(type='str', required=True),
-            conn_reload=dict(type='bool', required=False, default=False),
+            conn_reload=dict(type='bool', default=False),
             master=dict(type='str'),
             slave_type=dict(type='str', choices=['bond', 'bridge', 'team', 'ovs-port']),
             ifname=dict(type='str'),

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -34,9 +34,11 @@ options:
     state:
         description:
             - Whether the device should exist or not, taking action if the state is different from what is stated.
+            - Using O(state=present) to create connection will automatically bring connection up.
+            - Using O(state=up) and O(state=down) will not modify connection with other parameters.
         type: str
         required: true
-        choices: [ absent, present ]
+        choices: [ absent, present, up, down ]
     autoconnect:
         description:
             - Whether the connection should start on boot.
@@ -48,6 +50,12 @@ options:
             - The name used to call the connection. Pattern is <type>[-<ifname>][-<num>].
         type: str
         required: true
+    conn_reload:
+        description:
+            - Whether the connection should be reloaded if it was modified.
+        type: bool
+        required: false
+        default: false
     ifname:
         description:
             - The interface to bind the connection to.
@@ -1309,6 +1317,25 @@ EXAMPLES = r'''
       type: ethernet
       state: present
 
+  - name: Change the property of a setting e.g. MTU and reload connection
+    community.general.nmcli:
+      conn_name: my-eth1
+      mtu: 1500
+      type: ethernet
+      state: present
+      conn_reload: true
+
+  - name: Disable connection
+    community.general.nmcli:
+      conn_name: my-eth1
+      state: down
+
+  - name: Reload and enable connection
+    community.general.nmcli:
+      conn_name: my-eth1
+      state: up
+      reload: true
+
   - name: Add second ip4 address
     community.general.nmcli:
       conn_name: my-eth1
@@ -1581,6 +1608,7 @@ class Nmcli(object):
         self.ignore_unsupported_suboptions = module.params['ignore_unsupported_suboptions']
         self.autoconnect = module.params['autoconnect']
         self.conn_name = module.params['conn_name']
+        self.conn_reload = module.params['conn_reload']
         self.slave_type = module.params['slave_type']
         self.master = module.params['master']
         self.ifname = module.params['ifname']
@@ -2165,6 +2193,10 @@ class Nmcli(object):
         cmd = [self.nmcli_bin, 'con', 'up', self.conn_name]
         return self.execute_command(cmd)
 
+    def reload_connection(self):
+        cmd = [self.nmcli_bin, 'con', 'reload']
+        return self.execute_command(cmd)
+
     def connection_update(self, nmcli_command):
         if nmcli_command == 'create':
             cmd = [self.nmcli_bin, 'con', 'add', 'type']
@@ -2433,6 +2465,7 @@ def main():
             autoconnect=dict(type='bool', default=True),
             state=dict(type='str', required=True, choices=['absent', 'present']),
             conn_name=dict(type='str', required=True),
+            conn_reload=dict(type='bool', required=False, default=False),
             master=dict(type='str'),
             slave_type=dict(type='str', choices=['bond', 'bridge', 'team', 'ovs-port']),
             ifname=dict(type='str'),
@@ -2639,6 +2672,8 @@ def main():
                     if module.check_mode:
                         module.exit_json(changed=True, **result)
                     (rc, out, err) = nmcli.modify_connection()
+                    if nmcli.conn_reload:
+                        (rc, out, err) = nmcli.reload_connection()
                 else:
                     result['Exists'] = 'Connections already exist and no changes made'
                     if module.check_mode:
@@ -2650,6 +2685,27 @@ def main():
                 (rc, out, err) = nmcli.create_connection()
             if rc is not None and rc != 0:
                 module.fail_json(name=nmcli.conn_name, msg=err, rc=rc)
+
+        elif nmcli.state == 'up':
+            if nmcli.connection_exists():
+                if module.check_mode:
+                    module.exit_json(changed=True)
+                if nmcli.conn_reload:
+                    (rc, out, err) = nmcli.reload_connection()
+                (rc, out, err) = nmcli.up_connection()
+                if rc != 0:
+                    module.fail_json(name=('No Connection named %s exists' % nmcli.conn_name), msg=err, rc=rc)
+
+        elif nmcli.state == 'down':
+            if nmcli.connection_exists():
+                if module.check_mode:
+                    module.exit_json(changed=True)
+                if nmcli.conn_reload:
+                    (rc, out, err) = nmcli.reload_connection()
+                (rc, out, err) = nmcli.down_connection()
+                if rc != 0:
+                    module.fail_json(name=('No Connection named %s exists' % nmcli.conn_name), msg=err, rc=rc)
+
     except NmcliModuleError as e:
         module.fail_json(name=nmcli.conn_name, msg=str(e))
 

--- a/tests/unit/plugins/modules/test_nmcli.py
+++ b/tests/unit/plugins/modules/test_nmcli.py
@@ -4251,6 +4251,7 @@ def test_bond_connection_unchanged(mocked_generic_connection_diff_check, capfd):
             autoconnect=dict(type='bool', default=True),
             state=dict(type='str', required=True, choices=['absent', 'present']),
             conn_name=dict(type='str', required=True),
+            conn_reload=dict(type='bool', required=False, default=False),
             master=dict(type='str'),
             slave_type=dict(type=str, choices=['bond', 'bridge', 'team']),
             ifname=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add `conn_reload` option to perform `nmcli connection reload` if set to true
Add `up` and `down` states to perform `nmcli up`/`nmcli down` commands
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #3752
Fixes #8704
Fixes #7152
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
`nmcli`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I am not completely sure how to make applying changes correctly as there is no distinct difference between 4 different variants in a related issue (see https://github.com/ansible-collections/community.general/issues/3752#issuecomment-1714459183) so if you have some ideas I would be glad to get comments from you :)

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
# Changing with reloading afterwards
  - name: Change the property of a setting e.g. MTU and reload connection
    community.general.nmcli:
      conn_name: my-eth1
      mtu: 1500
      type: ethernet
      state: present
      conn_reload: true

# Simply disabling connection
  - name: Disable connection
    community.general.nmcli:
      conn_name: my-eth1
      state: down

# Reload and then enable connection
  - name: Reload and enable connection
    community.general.nmcli:
      conn_name: my-eth1
      state: up
      reload: true
```
