### PR TITLE
ipa_hostgroup: fix state params

### DIFF
--- a/changelogs/fragments/8900-ipa-hostgroup-fix-states.yml
+++ b/changelogs/fragments/8900-ipa-hostgroup-fix-states.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ipa_hostgroup - fix ``enabled `` and ``disabled`` states (https://github.com/ansible-collections/community.general/issues/8408, https://github.com/ansible-collections/community.general/pull/8900).

--- a/plugins/modules/ipa_hostgroup.py
+++ b/plugins/modules/ipa_hostgroup.py
@@ -57,13 +57,14 @@ options:
   state:
     description:
     - State to ensure.
+    - V("absent") and V("disabled") give the same results.
+    - V("present") and V("enabled") give the same results.
     default: "present"
     choices: ["absent", "disabled", "enabled", "present"]
     type: str
 extends_documentation_fragment:
   - community.general.ipa.documentation
   - community.general.attributes
-
 '''
 
 EXAMPLES = r'''
@@ -160,7 +161,7 @@ def ensure(module, client):
     module_hostgroup = get_hostgroup_dict(description=module.params['description'])
 
     changed = False
-    if state == 'present':
+    if state in ['present', 'enabled']:
         if not ipa_hostgroup:
             changed = True
             if not module.check_mode:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix state `enabled` and `disabled` params
Fixes #8408
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
`ipa_hostgroup`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
As it was mentioned in a related issue these values for `state:` are useless and because of else statement the lead to `absent` result. It is not clear if these values should be kept because they do not work as intented so maybe we should just remove or deprecate them? For now i made it so 'absent'/'disabled' and 'present'/'enabled' are the same thing
<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
# before
  - ipa_hostgroup:
      # 'present' works.
      # 'enabled' and 'disabled' behave equivalent to 'absent'
      state: 'enabled'
      name:  'testhostgroup'
      
# after
  - ipa_hostgroup:
      # 'present' is equivalent to 'enabled'
      state: enabled
      name:  'testhostgroup'
 
  - ipa_hostgroup:
      # 'absent' is equivalent to 'disabled'
      state: disabled
      name:  'testhostgroup'
```
