### PR TITLE
one_host: Fix ID logic

### DIFF
--- a/changelogs/fragments/8907-fix-one-host-id.yml
+++ b/changelogs/fragments/8907-fix-one-host-id.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - one_host - fix if statements for cases when ID=0 (https://github.com/ansible-collections/community.general/issues/1199, https://github.com/ansible-collections/community.general/pull/8907).
+  - one_host - fix if statements for cases when ``ID=0`` (https://github.com/ansible-collections/community.general/issues/1199, https://github.com/ansible-collections/community.general/pull/8907).

--- a/changelogs/fragments/8907-fix-one-host-id.yml
+++ b/changelogs/fragments/8907-fix-one-host-id.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - one_host - fix if statements for cases when ID=0 (https://github.com/ansible-collections/community.general/issues/1199, https://github.com/ansible-collections/community.general/pull/8907).

--- a/plugins/modules/one_host.py
+++ b/plugins/modules/one_host.py
@@ -156,14 +156,15 @@ class HostModule(OpenNebulaModule):
         Returns: True on success, fails otherwise.
 
         """
-        allocate_results = self.one.host.allocate(self.get_parameter('name'),
-                                                  self.get_parameter('vmm_mad_name'),
-                                                  self.get_parameter('im_mad_name'),
-                                                  self.get_parameter('cluster_id'))
-        if allocate_results or allocate_results == 0:
+        try:
+            self.one.host.allocate(self.get_parameter('name'),
+                                   self.get_parameter('vmm_mad_name'),
+                                   self.get_parameter('im_mad_name'),
+                                   self.get_parameter('cluster_id'))
             self.result['changed'] = True
-        else:
-            self.fail(msg="could not allocate host")
+        except Exception as e:
+            self.fail(msg="Could not allocate host, ERROR: " + str(e))
+
         return True
 
     def wait_for_host_state(self, host, target_states):

--- a/plugins/modules/one_host.py
+++ b/plugins/modules/one_host.py
@@ -225,12 +225,12 @@ class HostModule(OpenNebulaModule):
                 self.fail(msg='absent host cannot be put in disabled state')
             elif current_state in [HOST_STATES.MONITORED, HOST_STATES.OFFLINE]:
                 # returns host ID integer
-                status_results = one.host.status(host.ID, HOST_STATUS.DISABLED)
-                if status_results or status_results == 0:
-                    self.wait_for_host_state(host, [HOST_STATES.DISABLED])
+                try:
+                    one.host.status(host.ID, HOST_STATUS.DISABLED)
                     result['changed'] = True
-                else:
-                    self.fail(msg="could not disable host")
+                except Exception as e:
+                    self.fail(msg="Could not disable host, ERROR: " + str(e))
+                self.wait_for_host_state(host, [HOST_STATES.DISABLED])
             elif current_state in [HOST_STATES.DISABLED]:
                 pass
             else:
@@ -241,12 +241,12 @@ class HostModule(OpenNebulaModule):
                 self.fail(msg='absent host cannot be placed in offline state')
             elif current_state in [HOST_STATES.MONITORED, HOST_STATES.DISABLED]:
                 # returns host ID integer
-                status_results = one.host.status(host.ID, HOST_STATUS.OFFLINE)
-                if status_results or status_results == 0:
-                    self.wait_for_host_state(host, [HOST_STATES.OFFLINE])
+                try:
+                    one.host.status(host.ID, HOST_STATUS.OFFLINE)
                     result['changed'] = True
-                else:
-                    self.fail(msg="could not set host offline")
+                except Exception as e:
+                    self.fail(msg="Could not set host offline, ERROR: " + str(e))
+                self.wait_for_host_state(host, [HOST_STATES.OFFLINE])
             elif current_state in [HOST_STATES.OFFLINE]:
                 pass
             else:
@@ -255,11 +255,11 @@ class HostModule(OpenNebulaModule):
         elif desired_state == 'absent':
             if current_state != HOST_ABSENT:
                 # returns host ID integer
-                delete_results = one.host.delete(host.ID)
-                if delete_results or delete_results == 0:
+                try:
+                    one.host.delete(host.ID)
                     result['changed'] = True
-                else:
-                    self.fail(msg="could not delete host from cluster")
+                except Exception as e:
+                    self.fail(msg="Could not delete host from cluster, ERROR: " + str(e))
 
         # if we reach this point we can assume that the host was taken to the desired state
 
@@ -278,20 +278,20 @@ class HostModule(OpenNebulaModule):
                 # setup the root element so that pyone will generate XML instead of attribute vector
                 desired_template_changes = {"TEMPLATE": desired_template_changes}
                 # merge the template, returns host ID integer
-                update_results = one.host.update(host.ID, desired_template_changes, 1)
-                if update_results or update_results == 0:
+                try:
+                    one.host.update(host.ID, desired_template_changes, 1)
                     result['changed'] = True
-                else:
-                    self.fail(msg="failed to update the host template")
+                except Exception as e:
+                    self.fail(msg="Failed to update the host template, ERROR: " + str(e))
 
             # the cluster
             if host.CLUSTER_ID != self.get_parameter('cluster_id'):
                 # returns cluster id in int
-                cluster_results = one.cluster.addhost(self.get_parameter('cluster_id'), host.ID)
-                if cluster_results and cluster_results == 0:
+                try:
+                    one.cluster.addhost(self.get_parameter('cluster_id'), host.ID)
                     result['changed'] = True
-                else:
-                    self.fail(msg="failed to update the host cluster")
+                except Exception as e:
+                    self.fail(msg="Failed to update the host cluster, ERROR: " + str(e))
 
         # return
         self.exit()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix if statements when ID equals to 0
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1199
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
`one_host`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
So I tested all of the `one.` commands and It seem to be returning ID (integer) of created/updated host or cluster
So using simple `if some_variable:` will not work if ID=0 because bool(0) = False and since and since OpenNebula starts ID counter from zero thats a big problem 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
# Now this works if ID is 0
    - name: Add host to OpenNebula
      community.general.one_host:
        api_url: "{{ one_api_url }}"
        api_username: "{{ one_api_username }}"
        api_password: "{{ one_api_password }}"
        name: "{{ one_host }}"
        im_mad_name: kvm
        vmm_mad_name: kvm
        template:
          TYPE: "testing"
        state: present
```
