### PR TITLE
flatpak: improve flatpak name parsing in `_parse_flatpak_name`

### DIFF
--- a/changelogs/fragments/8909-flatpak-improve-name-parsing.yaml
+++ b/changelogs/fragments/8909-flatpak-improve-name-parsing.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - flatpak - improve `_parse_flatpak_name` function to better validation of flatpak application IDs according to official guidelines (https://github.com/ansible-collections/community.general/pull/8909).
+  - flatpak - improve the parsing of Flatpak application IDs based on official guidelines (https://github.com/ansible-collections/community.general/pull/8909).

--- a/changelogs/fragments/8909-flatpak-improve-name-parsing.yaml
+++ b/changelogs/fragments/8909-flatpak-improve-name-parsing.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - flatpak - improve `_parse_flatpak_name` function to better validation of flatpak application IDs according to official guidelines (https://github.com/ansible-collections/community.general/pull/8909).

--- a/plugins/modules/flatpak.py
+++ b/plugins/modules/flatpak.py
@@ -329,13 +329,34 @@ def _match_flat_using_flatpak_column_feature(module, binary, parsed_name, method
             return row.split()[0]
 
 
+def _is_flatpak_id(part):
+    if not '.' in part:
+        return False
+    sections = part.split('.')
+    if len(sections) < 2:
+        return False
+    domain = sections[0]
+    if not domain.islower():
+        return False
+    for section in sections[1:]:
+        if not section.isalnum():
+            return False
+    return True
+
+
 def _parse_flatpak_name(name):
     if name.startswith('http://') or name.startswith('https://'):
         file_name = urlparse(name).path.split('/')[-1]
         file_name_without_extension = file_name.split('.')[0:-1]
         common_name = ".".join(file_name_without_extension)
     else:
-        common_name = name
+        parts = name.split('/')
+        for part in parts:
+            if _is_flatpak_id(part):
+                common_name = part
+                break
+        else:
+            common_name = name
     return common_name
 
 

--- a/plugins/modules/flatpak.py
+++ b/plugins/modules/flatpak.py
@@ -330,7 +330,7 @@ def _match_flat_using_flatpak_column_feature(module, binary, parsed_name, method
 
 
 def _is_flatpak_id(part):
-    if not '.' in part:
+    if '.' not in part:
         return False
     sections = part.split('.')
     if len(sections) < 2:

--- a/plugins/modules/flatpak.py
+++ b/plugins/modules/flatpak.py
@@ -330,6 +330,11 @@ def _match_flat_using_flatpak_column_feature(module, binary, parsed_name, method
 
 
 def _is_flatpak_id(part):
+    # For guidelines on application IDs, refer to the following resources:
+    # Flatpak:
+    # https://docs.flatpak.org/en/latest/conventions.html#application-ids
+    # Flathub:
+    # https://docs.flathub.org/docs/for-app-authors/requirements#application-id
     if '.' not in part:
         return False
     sections = part.split('.')


### PR DESCRIPTION
##### SUMMARY

This pull request updates the Flatpak name parsing functionality to handle additional valid cases for Flatpak identifiers.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

flatpak

##### ADDITIONAL INFORMATION

While trying to install `com.chatterino.chatterino` from Flathub, I encountered a problem with the multiple versions of this package available: `stable` and `nightly`. To install it properly, it has to be the full name: `app/com.chatterino.chatterino/x86_64/stable` or `com.chatterino.chatterino/x86_64/stable`. But the module doesn't handle those names very well and tries to install the package even if it's already installed, returning `changed` instead of `ok`.

```yaml
- name: Install applications from flathub
  community.general.flatpak:
    name:
      - app/com.brave.Browser
      - app/com.google.Chrome/
      - org.mozilla.firefox/
      - app/com.chatterino.chatterino/x86_64/stable
      - io.freetubeapp.FreeTube/x86_64/stable
    remote: flathub
```

All the names above are valid and return `ok` when running multiple times, with the changes.
