### PR TITLE
keycloak_userprofile: fix empty response by removing `parent` filter when fetching userprofile component

### DIFF
--- a/changelogs/fragments/8923-keycloak_userprofile-fix-empty-response-when-fetching-userprofile.yml
+++ b/changelogs/fragments/8923-keycloak_userprofile-fix-empty-response-when-fetching-userprofile.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - keycloak_userprofile - fix empty response when fetching userprofile component by removing `parent=parent_id` filter (https://github.com/ansible-collections/community.general/pull/8923).
+  - keycloak_userprofile - fix empty response when fetching userprofile component by removing ``parent=parent_id`` filter (https://github.com/ansible-collections/community.general/pull/8923).

--- a/changelogs/fragments/8923-keycloak_userprofile-fix-empty-response-when-fetching-userprofile.yml
+++ b/changelogs/fragments/8923-keycloak_userprofile-fix-empty-response-when-fetching-userprofile.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_userprofile - fix empty response when fetching userprofile component by removing `parent=parent_id` filter (https://github.com/ansible-collections/community.general/pull/8923).

--- a/plugins/modules/keycloak_userprofile.py
+++ b/plugins/modules/keycloak_userprofile.py
@@ -641,7 +641,7 @@ def main():
     changeset_copy = deepcopy(changeset)
 
     # Get a list of all Keycloak components that are of userprofile provider type.
-    realm_userprofiles = kc.get_components(urlencode(dict(type=provider_type, parent=parent_id)), parent_id)
+    realm_userprofiles = kc.get_components(urlencode(dict(type=provider_type)), parent_id)
 
     # If this component is present get its userprofile ID. Confusingly the userprofile ID is
     # also known as the Provider ID.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The module filters the components by `parent=parent_id` (and `type`). The same variable `parent_id` is also used as the `realm` argument for the `get_components` call. 

https://github.com/ansible-collections/community.general/blob/89ad40db4181d88dd4c8e7d68237f7a4a7e61bb4/plugins/modules/keycloak_userprofile.py#L644

https://github.com/ansible-collections/community.general/blob/89ad40db4181d88dd4c8e7d68237f7a4a7e61bb4/plugins/module_utils/identity/keycloak/keycloak.py#L2612

The `parent` filter expects the ID of the parent realm (usually a uuid) whereas the `realm` argument requires the name of a realm ('master' for example). So unless the ID and the name of realm are identical the returned list is empty.

```
--- before
+++ after
@@ -1 +1,9 @@
-{}
+{
+    "config": {
+        "kc.user.profile.config": [
+            "{\"attributes\": [{\"name\": \"username\", \"displayName\": \"${username}\", \"validations\": {\"length\": {\"min\": 3, \"max\": 255}, \"username-prohibited-characters\": {}, \"up-username-not-idn-homograph\": {}}, \"annotations\": {}, \"permissions\": {\"view\": [\"********\", \"user\"], \"edit\": []}, \"multivalued\": false}, {\"name\": \"email\", \"displayName\": \"${email}\", \"validations\": {\"email\": {}, \"length\": {\"max\": 255}}, \"annotations\": {}
[...]
```

Since the components are already filtered by realm with `realm=parent_id`, i think the filter `parent=parent_id` can be removed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. create a realm
2. run module normally (keycloak seems to return an empty list if the default profile has not been updated, creating a user profile should work)
3. rerun in check or normal mode -> should always show empty before dict and update not working
