### PR TITLE
Update keycloak_realm, add organizations_enabled

### DIFF
--- a/changelogs/fragments/9027-support-organizations-in-keycloak-realm.yml
+++ b/changelogs/fragments/9027-support-organizations-in-keycloak-realm.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - keycloak_realm - add boolean toggle to configure organization support for a given keycloak realm (https://github.com/ansible-collections/community.general/issues/9027).
+  - keycloak_realm - add boolean toggle to configure organization support for a given keycloak realm (https://github.com/ansible-collections/community.general/issues/9027, https://github.com/ansible-collections/community.general/pull/8927/).

--- a/changelogs/fragments/9027-support-organizations-in-keycloak-realm.yml
+++ b/changelogs/fragments/9027-support-organizations-in-keycloak-realm.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak_realm - add boolean toggle to configure organization support for a given keycloak realm (https://github.com/ansible-collections/community.general/issues/9027).

--- a/plugins/modules/keycloak_realm.py
+++ b/plugins/modules/keycloak_realm.py
@@ -390,7 +390,7 @@ options:
         aliases:
             - organizationsEnabled
         type: bool
-        version_added: 9.5.0
+        version_added: 9.6.0
     permanent_lockout:
         description:
             - The realm permanent lockout.

--- a/plugins/modules/keycloak_realm.py
+++ b/plugins/modules/keycloak_realm.py
@@ -384,6 +384,12 @@ options:
         aliases:
             - passwordPolicy
         type: str
+    organizations_enabled:
+        description:
+            - Enables support for experimental organization feature.
+        aliases:
+            - organizationsEnabled
+        type: bool
     permanent_lockout:
         description:
             - The realm permanent lockout.
@@ -686,6 +692,7 @@ def main():
         otp_policy_type=dict(type='str', aliases=['otpPolicyType']),
         otp_supported_applications=dict(type='list', elements='str', aliases=['otpSupportedApplications']),
         password_policy=dict(type='str', aliases=['passwordPolicy'], no_log=False),
+        organizations_enabled=dict(type='bool', aliases=['organizationsEnabled']),
         permanent_lockout=dict(type='bool', aliases=['permanentLockout']),
         quick_login_check_milli_seconds=dict(type='int', aliases=['quickLoginCheckMilliSeconds']),
         refresh_token_max_reuse=dict(type='int', aliases=['refreshTokenMaxReuse'], no_log=False),

--- a/plugins/modules/keycloak_realm.py
+++ b/plugins/modules/keycloak_realm.py
@@ -390,6 +390,7 @@ options:
         aliases:
             - organizationsEnabled
         type: bool
+        version_added: 9.5.0
     permanent_lockout:
         description:
             - The realm permanent lockout.

--- a/plugins/modules/keycloak_realm.py
+++ b/plugins/modules/keycloak_realm.py
@@ -390,7 +390,7 @@ options:
         aliases:
             - organizationsEnabled
         type: bool
-        version_added: 9.6.0
+        version_added: 10.0.0
     permanent_lockout:
         description:
             - The realm permanent lockout.


### PR DESCRIPTION
##### SUMMARY
Add boolean parameter to enable organizations (still an experimental keycloak feature) feature toggling for keycloak
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.general.keycloak_realm

