### PR TITLE
CmdRunner: missing parameter for get_best_parsable_locale()

### DIFF
--- a/changelogs/fragments/8929-cmd_runner-bugfix.yml
+++ b/changelogs/fragments/8929-cmd_runner-bugfix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cmd_runner module utils - call to ``get_best_parsable_locales()`` was missing parameter (https://github.com/ansible-collections/community.general/pull/8929).

--- a/plugins/module_utils/cmd_runner.py
+++ b/plugins/module_utils/cmd_runner.py
@@ -239,7 +239,7 @@ class CmdRunner(object):
         self.check_rc = check_rc
         if force_lang == "auto":
             try:
-                self.force_lang = get_best_parsable_locale()
+                self.force_lang = get_best_parsable_locale(module)
             except RuntimeWarning:
                 self.force_lang = "C"
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Function call was missing a parameter

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/module_utils/cmd_runner.py