### PR TITLE
Move ansible-core 2.15 tests to EOL tests

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -112,19 +112,6 @@ stages:
             - test: 2
             - test: 3
             - test: 4
-  - stage: Sanity_2_15
-    displayName: Sanity 2.15
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Test {0}
-          testFormat: 2.15/sanity/{0}
-          targets:
-            - test: 1
-            - test: 2
-            - test: 3
-            - test: 4
 ### Units
   - stage: Units_devel
     displayName: Units devel
@@ -175,17 +162,6 @@ stages:
             - test: 2.7
             - test: 3.6
             - test: "3.11"
-  - stage: Units_2_15
-    displayName: Units 2.15
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.15/units/{0}/1
-          targets:
-            - test: 3.5
-            - test: "3.10"
 
 ## Remote
   - stage: Remote_devel_extra_vms
@@ -270,30 +246,10 @@ stages:
               test: rhel/9.2
             - name: RHEL 8.8
               test: rhel/8.8
-            # - name: FreeBSD 13.2
-            #   test: freebsd/13.2
-          groups:
-            - 1
-            - 2
-            - 3
-  - stage: Remote_2_15
-    displayName: Remote 2.15
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.15/{0}
-          targets:
-            - name: RHEL 9.1
-              test: rhel/9.1
-            - name: RHEL 8.7
-              test: rhel/8.7
             - name: RHEL 7.9
               test: rhel/7.9
-            # - name: FreeBSD 13.1
-            #   test: freebsd/13.1
-            # - name: FreeBSD 12.4
-            #   test: freebsd/12.4
+            # - name: FreeBSD 13.2
+            #   test: freebsd/13.2
           groups:
             - 1
             - 2
@@ -366,20 +322,6 @@ stages:
               test: opensuse15
             - name: Alpine 3
               test: alpine3
-          groups:
-            - 1
-            - 2
-            - 3
-  - stage: Docker_2_15
-    displayName: Docker 2.15
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.15/linux/{0}
-          targets:
-            - name: Fedora 37
-              test: fedora37
             - name: CentOS 7
               test: centos7
           groups:
@@ -455,16 +397,6 @@ stages:
 #            - test: '2.7'
 #            - test: '3.6'
 #            - test: '3.11'
-#  - stage: Generic_2_15
-#    displayName: Generic 2.15
-#    dependsOn: []
-#    jobs:
-#      - template: templates/matrix.yml
-#        parameters:
-#          nameFormat: Python {0}
-#          testFormat: 2.15/generic/{0}/1
-#          targets:
-#            - test: '3.9'
 
   - stage: Summary
     condition: succeededOrFailed()
@@ -473,29 +405,24 @@ stages:
       - Sanity_2_18
       - Sanity_2_17
       - Sanity_2_16
-      - Sanity_2_15
       - Units_devel
       - Units_2_18
       - Units_2_17
       - Units_2_16
-      - Units_2_15
       - Remote_devel_extra_vms
       - Remote_devel
       - Remote_2_18
       - Remote_2_17
       - Remote_2_16
-      - Remote_2_15
       - Docker_devel
       - Docker_2_18
       - Docker_2_17
       - Docker_2_16
-      - Docker_2_15
       - Docker_community_devel
 # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
 #      - Generic_devel
 #      - Generic_2_18
 #      - Generic_2_17
 #      - Generic_2_16
-#      - Generic_2_15
     jobs:
       - template: templates/coverage.yml

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -31,6 +31,7 @@ jobs:
         ansible:
           - '2.13'
           - '2.14'
+          - '2.15'
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will
@@ -76,6 +77,10 @@ jobs:
             python: '3.8'
           - ansible: '2.14'
             python: '3.9'
+          - ansible: '2.15'
+            python: '3.5'
+          - ansible: '2.15'
+            python: '3.10'
 
     steps:
       - name: >-
@@ -166,15 +171,31 @@ jobs:
             docker: alpine3
             python: ''
             target: azp/posix/3/
+          # 2.15
+          - ansible: '2.15'
+            docker: fedora37
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.15'
+            docker: fedora37
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.15'
+            docker: fedora37
+            python: ''
+            target: azp/posix/3/
           # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
           # - ansible: '2.13'
           #   docker: default
           #   python: '3.9'
           #   target: azp/generic/1/
-          # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
           # - ansible: '2.14'
           #   docker: default
           #   python: '3.10'
+          #   target: azp/generic/1/
+          # - ansible: '2.15'
+          #   docker: default
+          #   python: '3.9'
           #   target: azp/generic/1/
 
     steps:


### PR DESCRIPTION
##### SUMMARY
2.15 is only EOL in November, but I want to remove 2.13 and 2.14 from CI, which would leave the EOL tests empty :)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
