### PR TITLE
Disk description now contains a StorageId and a RedfishURI

### DIFF
--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -866,6 +866,7 @@ class RedfishUtils(object):
                         return response
                     data = response['data']
                     controller_name = 'Controller 1'
+                    storage_id = data['Id']
                     if 'Controllers' in data:
                         controllers_uri = data['Controllers'][u'@odata.id']
 
@@ -900,6 +901,7 @@ class RedfishUtils(object):
                             data = response['data']
 
                             drive_result = {}
+                            drive_result['RedfishURI'] = data['@odata.id']
                             for property in properties:
                                 if property in data:
                                     if data[property] is not None:
@@ -911,6 +913,7 @@ class RedfishUtils(object):
                                             drive_result[property] = data[property]
                             drive_results.append(drive_result)
                     drives = {'Controller': controller_name,
+                              'StorageID': storage_id,
                               'Drives': drive_results}
                     result["entries"].append(drives)
 


### PR DESCRIPTION
##### SUMMARY

Add a `StorageID` to the drives description and a `RedfishURI` to each disk  in the redfish_facts returned by the GetDiskInventory command.

Fixes #8935


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
redfish_utils

##### ADDITIONAL INFORMATION
entries description before 
```json
{
    "Controller": "HPE Smart Array P816i-a SR Gen10",
    "Drives": [
        {
            "BlockSizeBytes": 512,
            "CapableSpeedGbs": 12,
            "CapacityBytes": 16000900661248,
            "EncryptionAbility": "None",
            "FailurePredicted": false,
            "HotspareType": "None",
            "Id": "16",
            "Identifiers": [
                {
                    "DurableName": "5000039D28430101",
                    "DurableNameFormat": "NAA"
                }
            ],
            "MediaType": "HDD",
            "Model": "MB016000JZYVQ",
            "Name": "16TB 12G SAS HDD",
            "PhysicalLocation": {
                "PartLocation": {
                    "LocationOrdinalValue": 1,
                    "LocationType": "Bay",
                    "ServiceLabel": "Slot=12:Port=1I:Box=1:Bay=1"
                }
            },
            "Protocol": "SAS",
            "Revision": "HPD4",
            "RotationSpeedRPM": 7200,
            "SerialNumber": "34K0A0LCFU8H",
            "Status": {
                "Health": "OK",
                "State": "Enabled"
            },
            "Volumes": [
                "/redfish/v1/Systems/1/Storage/DE07A000/Volumes/129"
            ]
        }
    ]
}
```

And after
```
{
    "Controller": "HPE Smart Array P816i-a SR Gen10",
    "Drives": [
        {
            "BlockSizeBytes": 512,
            "CapableSpeedGbs": 12,
            "CapacityBytes": 16000900661248,
            "EncryptionAbility": "None",
            "FailurePredicted": false,
            "HotspareType": "None",
            "Id": "16",
            "Identifiers": [
                {
                    "DurableName": "5000039D28430101",
                    "DurableNameFormat": "NAA"
                }
            ],
            "MediaType": "HDD",
            "Model": "MB016000JZYVQ",
            "Name": "16TB 12G SAS HDD",
            "PhysicalLocation": {
                "PartLocation": {
                    "LocationOrdinalValue": 1,
                    "LocationType": "Bay",
                    "ServiceLabel": "Slot=12:Port=1I:Box=1:Bay=1"
                }
            },
            "Protocol": "SAS",
            "RedfishURI": "/redfish/v1/Systems/1/Storage/DE07A000/Drives/16",
            "Revision": "HPD4",
            "RotationSpeedRPM": 7200,
            "SerialNumber": "34K0A0LCFU8H",
            "Status": {
                "Health": "OK",
                "State": "Enabled"
            },
            "Volumes": [
                "/redfish/v1/Systems/1/Storage/DE07A000/Volumes/129"
            ]
        }
    ],
    "StorageID": "DE07A000"
}
```