### PR TITLE
ipa_getkeytab: Create module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -714,7 +714,7 @@ files:
   $modules/ipa_:
     maintainers: $team_ipa
     ignore: fxfitz
-  $modules/ipa_getkeytab:
+  $modules/ipa_getkeytab.py:
     maintainers: abakanovskii
   $modules/ipa_dnsrecord.py:
     maintainers: $team_ipa jwbernin

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -714,6 +714,8 @@ files:
   $modules/ipa_:
     maintainers: $team_ipa
     ignore: fxfitz
+  $modules/ipa_getkeytab:
+    maintainers: abakanovskii
   $modules/ipa_dnsrecord.py:
     maintainers: $team_ipa jwbernin
   $modules/ipbase_info.py:

--- a/plugins/modules/ipa_getkeytab.py
+++ b/plugins/modules/ipa_getkeytab.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: ipa_getkeytab
 short_description: Manage keytab file in FreeIPA
 description:
-  - Manage keytab file with ipa-getkeytab utulity.
+  - Manage keytab file with ipa-getkeytab utility.
 author: "Alexander Bakanovskii (@abakanovskii)"
 attributes:
   check_mode:

--- a/plugins/modules/ipa_getkeytab.py
+++ b/plugins/modules/ipa_getkeytab.py
@@ -83,8 +83,7 @@ options:
   state:
     description:
       - The state of the keytab file.
-      - V(present) only check for existence of a file, so if you want to recreate keytab
-        with other parameters you should set O(force: true).
+      - V(present) only check for existence of a file, if you want to recreate keytab with other parameters you should set O(force: true).
     type: str
     default: present
     choices: ["present", "absent"]

--- a/plugins/modules/ipa_getkeytab.py
+++ b/plugins/modules/ipa_getkeytab.py
@@ -167,14 +167,14 @@ class IPAKeytab(object):
         )
 
     def _exec(self, check_rc=True):
-          params = dict(self.module.params)
+        params = dict(self.module.params)
 
-          with self.runner(
-              "retrieve_mode path ipa_server principal ldap_uri bind_dn bind_pw password ca_certificate sasl_mech encryption_types",
-              check_rc=check_rc
-          ) as ctx:
-              rc, out, err = ctx.run(**params)
-          return out
+        with self.runner(
+            "retrieve_mode path ipa_server principal ldap_uri bind_dn bind_pw password ca_certificate sasl_mech encryption_types",
+            check_rc=check_rc
+        ) as ctx:
+            rc, out, err = ctx.run(**params)
+        return out
 
 
 def main():

--- a/plugins/modules/ipa_getkeytab.py
+++ b/plugins/modules/ipa_getkeytab.py
@@ -1,0 +1,257 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024 Alexander Bakanovskii <skottttt228@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: ipa_getkeytab
+short_description: Manage keytab file in FreeIPA
+description:
+    - Manage keytab file with ipa-getkeytab utulity.
+author: "Alexander Bakanovskii (@abakanovskii)"
+attributes:
+    check_mode:
+        support: full
+    diff_mode:
+        support: none
+options:
+    path:
+        description:
+            - The base path where to put generated keytab file.
+        type: path
+        aliases: ["keytab"]
+        required: true
+    principal:
+        description:
+            - The non-realm part of the full principal name.
+        type: str
+        required: true
+    ipa_server:
+        description:
+            - The IPA server to retrieve the keytab from (FQDN).
+        type: str
+        aliases: ["server"]
+    ldap_uri:
+        description:
+            - LDAP URI. If V(ldap://) is specified, STARTTLS is initiated by default. 
+            - Can not be used with the O(ipa_server) option.
+        type: str
+    bind_dn:
+        description:
+            - The LDAP DN to bind as when retrieving a keytab without Kerberos credentials. 
+            - Generally used with the O(bind_pw) option.
+        type: str
+    bind_pw:
+        description:
+            - The LDAP password to use when not binding with Kerberos.
+        type: str
+        required: true
+    password:
+        description:
+            - Use this password for the key instead of one randomly generated.
+        type: str
+    ca_certificate:
+        description:
+            - The path to the IPA CA certificate used to validate LDAPS/STARTTLS connections.
+        type: path
+        aliases: ["ca_cert"]
+    sasl_mech:
+        description:
+            - SASL mechanism to use if O(bind_dn) and O(bind_pw) are not specified.
+        choices: ["GSSAPI", "EXTERNAL"]
+        type: str
+        aliases: ["ca_cert"]
+    retrieve_mode:
+        description:
+            - Retrieve an existing key from the server instead of generating a new one.
+            - This is incompatible with the O(password), and will work only against a IPA server more recent than version 3.3. 
+            - The user requesting the keytab must have access to the keys for this operation to succeed.
+            - Be aware that if set V(true), a new keytab will be generated. 
+            - This invalidates all previously retrieved keytabs for this service principal.
+        type: bool
+    encryption_types:
+        description:
+            - The list of encryption types to use to generate keys. 
+            - M(ipa_getkeytab) will use local client defaults if not provided. 
+            - Valid values depend on the Kerberos library version and configuration.
+        type: str
+    state:
+        description:
+            - The state of the keytab file.
+            - V(present) only check for existence of a file, so if you want to recreate keytab
+              with other parameters you should set O(force: true).
+        type: str
+        default: present
+        choices: ["present", "absent"]
+    force:
+        description:
+            - Force recreation if exists already.
+        type: bool
+requirements:
+    - freeipa-client
+    - Managed host is FreeIPA client
+extends_documentation_fragment:
+    - community.general.attributes
+    - community.general.ipa.documentation
+'''
+
+EXAMPLES = r'''
+- name: Get kerberos ticket
+  ansible.builtin.shell: kinit admin
+  args:
+    stdin: "{{ aldpro_admin_password }}"
+  changed_when: true
+
+- name: Create keytab
+  community.general.ipa_getkeytab:
+    path: /etc/ipa/test.keytab
+    principal: HTTP/freeipa-dc02.ipa.test
+    ipa_server: freeipa-dc01.ipa.test
+
+- name: Retrieve already existing keytab
+  community.general.ipa_getkeytab:
+    path: /etc/ipa/test.keytab
+    principal: HTTP/freeipa-dc02.ipa.test
+    ipa_server: freeipa-dc01.ipa.test
+    retrieve_mode: true
+
+- name: Force keytab recreation
+  community.general.ipa_getkeytab:
+    path: /etc/ipa/test.keytab
+    principal: HTTP/freeipa-dc02.ipa.test
+    ipa_server: freeipa-dc01.ipa.test
+    force: true
+'''
+
+import os
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.general.plugins.module_utils.cmd_runner import CmdRunner, cmd_runner_fmt
+
+
+class IPAKeytab(object):
+    def __init__(self, module, **kwargs):
+        self.module = module
+        self.path = kwargs['path']
+        self.state = kwargs['state']
+        self.principal = kwargs['principal']
+        self.ipa_server = kwargs['ipa_server']
+        self.ldap_uri = kwargs['ldap_uri']
+        self.bind_dn = kwargs['bind_dn']
+        self.bind_pw = kwargs['bind_pw']
+        self.password = kwargs['password']
+        self.ca_certificate = kwargs['ca_certificate']
+        self.sasl_mech = kwargs['sasl_mech']
+        self.retrieve_mode = kwargs['retrieve_mode']
+        self.encryption_types = kwargs['encryption_types']
+
+        self.executable = [module.get_bin_path('ipa-getkeytab', True)]
+        self.runner = CmdRunner(
+            module,
+            command=self.executable,
+            arg_formats=dict(
+                retrieve_mode=cmd_runner_fmt.as_bool('--retrieve'),
+                path=cmd_runner_fmt.as_opt_val('--keytab'),
+                ipa_server=cmd_runner_fmt.as_opt_val('--server'),
+                principal=cmd_runner_fmt.as_opt_val('--principal'),
+                ldap_uri=cmd_runner_fmt.as_opt_val('--ldapuri'),
+                bind_dn=cmd_runner_fmt.as_opt_val('--binddn'),
+                bind_pw=cmd_runner_fmt.as_opt_val('--bindpw'),
+                password=cmd_runner_fmt.as_opt_val('--password'),
+                ca_certificate=cmd_runner_fmt.as_opt_val('--cacert'),
+                sasl_mech=cmd_runner_fmt.as_opt_val('--mech'),
+                encryption_types=cmd_runner_fmt.as_opt_val('--enctypes'),
+            )
+        )
+
+    def _exec(self, run_in_check_mode=False, check_rc=True):
+        if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
+            params = dict(self.module.params)
+
+            with self.runner(
+                "retrieve_mode path ipa_server principal ldap_uri bind_dn bind_pw password ca_certificate sasl_mech encryption_types",
+                check_rc=check_rc
+            ) as ctx:
+                rc, out, err = ctx.run(**params)
+            return out
+
+        return ''
+
+
+def main():
+    arg_spec = dict(
+        path=dict(type='path', required=True, aliases=["keytab"]),
+        state=dict(default='present', choices=['present', 'absent']),
+        principal=dict(type='str', required=True),
+        ipa_server=dict(type='str'),
+        ldap_uri=dict(type='path'),
+        bind_dn=dict(type='str'),
+        bind_pw=dict(type='str'),
+        password=dict(type='str', no_log=True),
+        ca_certificate=dict(type='path'),
+        sasl_mech=dict(type='str', choices=["GSSAPI", "EXTERNAL"]),
+        retrieve_mode=dict(type='bool'),
+        encryption_types=dict(type='str'),
+        force=dict(type='bool'),
+    )
+    module = AnsibleModule(
+        argument_spec=arg_spec,
+        mutually_exclusive=[('ipa_server', 'ldap_uri'), ('retrieve_mode', 'password')],
+        supports_check_mode=True,
+    )
+
+    path = module.params['path']
+    state = module.params['state']
+    force = module.params['force']
+
+    keytab = IPAKeytab(module,
+              path=path,
+              state=state,
+              principal=module.params['principal'],
+              ipa_server=module.params['ipa_server'],
+              ldap_uri=module.params['ldap_uri'],
+              bind_dn=module.params['bind_dn'],
+              bind_pw=module.params['bind_pw'],
+              password=module.params['password'],
+              ca_certificate=module.params['ca_certificate'],
+              sasl_mech=module.params['sasl_mech'],
+              retrieve_mode=module.params['retrieve_mode'],
+              encryption_types=module.params['encryption_types'],
+              )
+
+    changed = False
+    if state == 'present':
+        if os.path.exists(path):
+            if force and not module.check_mode:
+                try:
+                    os.remove(path)
+                except OSError as e:
+                    module.fail_json(msg="Error deleting: %s - %s." % (e.filename, e.strerror))
+                keytab._exec()
+                changed = True
+            if force and module.check_mode:
+                changed = True
+        else:
+            changed = True
+            keytab._exec()
+
+    if state == 'absent':
+        if os.path.exists(path):
+            changed = True
+            if not module.check_mode:
+                try:
+                    os.remove(path)
+                except OSError as e:
+                    module.fail_json(msg="Error deleting: %s - %s." % (e.filename, e.strerror))
+
+    module.exit_json(changed=changed)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/ipa_getkeytab.py
+++ b/plugins/modules/ipa_getkeytab.py
@@ -51,7 +51,6 @@ options:
     description:
       - The LDAP password to use when not binding with Kerberos.
     type: str
-    required: true
   password:
     description:
       - Use this password for the key instead of one randomly generated.
@@ -77,13 +76,13 @@ options:
   encryption_types:
     description:
       - The list of encryption types to use to generate keys.
-      - M(ipa_getkeytab) will use local client defaults if not provided.
+      - It will use local client defaults if not provided.
       - Valid values depend on the Kerberos library version and configuration.
     type: str
   state:
     description:
       - The state of the keytab file.
-      - V(present) only check for existence of a file, if you want to recreate keytab with other parameters you should set O(force: true).
+      - V(present) only check for existence of a file, if you want to recreate keytab with other parameters you should set O(force=true).
     type: str
     default: present
     choices: ["present", "absent"]
@@ -187,7 +186,7 @@ def main():
         state=dict(default='present', choices=['present', 'absent']),
         principal=dict(type='str', required=True),
         ipa_server=dict(type='str', aliases=["server"]),
-        ldap_uri=dict(type='path'),
+        ldap_uri=dict(type='str'),
         bind_dn=dict(type='str'),
         bind_pw=dict(type='str'),
         password=dict(type='str', no_log=True),

--- a/plugins/modules/ipa_getkeytab.py
+++ b/plugins/modules/ipa_getkeytab.py
@@ -96,7 +96,6 @@ requirements:
   - Managed host is FreeIPA client
 extends_documentation_fragment:
   - community.general.attributes
-  - community.general.ipa.documentation
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/ipa_getkeytab.py
+++ b/plugins/modules/ipa_getkeytab.py
@@ -166,18 +166,15 @@ class IPAKeytab(object):
             )
         )
 
-    def _exec(self, run_in_check_mode=False, check_rc=True):
-        if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
-            params = dict(self.module.params)
+    def _exec(self, check_rc=True):
+          params = dict(self.module.params)
 
-            with self.runner(
-                "retrieve_mode path ipa_server principal ldap_uri bind_dn bind_pw password ca_certificate sasl_mech encryption_types",
-                check_rc=check_rc
-            ) as ctx:
-                rc, out, err = ctx.run(**params)
-            return out
-
-        return ''
+          with self.runner(
+              "retrieve_mode path ipa_server principal ldap_uri bind_dn bind_pw password ca_certificate sasl_mech encryption_types",
+              check_rc=check_rc
+          ) as ctx:
+              rc, out, err = ctx.run(**params)
+          return out
 
 
 def main():

--- a/plugins/modules/ipa_getkeytab.py
+++ b/plugins/modules/ipa_getkeytab.py
@@ -147,10 +147,9 @@ class IPAKeytab(object):
         self.retrieve_mode = kwargs['retrieve_mode']
         self.encryption_types = kwargs['encryption_types']
 
-        self.executable = [module.get_bin_path('ipa-getkeytab', True)]
         self.runner = CmdRunner(
             module,
-            command=self.executable,
+            command='ipa-getkeytab',
             arg_formats=dict(
                 retrieve_mode=cmd_runner_fmt.as_bool('--retrieve'),
                 path=cmd_runner_fmt.as_opt_val('--keytab'),
@@ -167,13 +166,11 @@ class IPAKeytab(object):
         )
 
     def _exec(self, check_rc=True):
-        params = dict(self.module.params)
-
         with self.runner(
             "retrieve_mode path ipa_server principal ldap_uri bind_dn bind_pw password ca_certificate sasl_mech encryption_types",
             check_rc=check_rc
         ) as ctx:
-            rc, out, err = ctx.run(**params)
+            rc, out, err = ctx.run()
         return out
 
 

--- a/plugins/modules/ipa_getkeytab.py
+++ b/plugins/modules/ipa_getkeytab.py
@@ -39,12 +39,12 @@ options:
         aliases: ["server"]
     ldap_uri:
         description:
-            - LDAP URI. If V(ldap://) is specified, STARTTLS is initiated by default. 
+            - LDAP URI. If V(ldap://) is specified, STARTTLS is initiated by default.
             - Can not be used with the O(ipa_server) option.
         type: str
     bind_dn:
         description:
-            - The LDAP DN to bind as when retrieving a keytab without Kerberos credentials. 
+            - The LDAP DN to bind as when retrieving a keytab without Kerberos credentials.
             - Generally used with the O(bind_pw) option.
         type: str
     bind_pw:
@@ -69,15 +69,15 @@ options:
     retrieve_mode:
         description:
             - Retrieve an existing key from the server instead of generating a new one.
-            - This is incompatible with the O(password), and will work only against a IPA server more recent than version 3.3. 
+            - This is incompatible with the O(password), and will work only against a IPA server more recent than version 3.3.
             - The user requesting the keytab must have access to the keys for this operation to succeed.
-            - Be aware that if set V(true), a new keytab will be generated. 
+            - Be aware that if set V(true), a new keytab will be generated.
             - This invalidates all previously retrieved keytabs for this service principal.
         type: bool
     encryption_types:
         description:
-            - The list of encryption types to use to generate keys. 
-            - M(ipa_getkeytab) will use local client defaults if not provided. 
+            - The list of encryption types to use to generate keys.
+            - M(ipa_getkeytab) will use local client defaults if not provided.
             - Valid values depend on the Kerberos library version and configuration.
         type: str
     state:
@@ -210,19 +210,19 @@ def main():
     force = module.params['force']
 
     keytab = IPAKeytab(module,
-              path=path,
-              state=state,
-              principal=module.params['principal'],
-              ipa_server=module.params['ipa_server'],
-              ldap_uri=module.params['ldap_uri'],
-              bind_dn=module.params['bind_dn'],
-              bind_pw=module.params['bind_pw'],
-              password=module.params['password'],
-              ca_certificate=module.params['ca_certificate'],
-              sasl_mech=module.params['sasl_mech'],
-              retrieve_mode=module.params['retrieve_mode'],
-              encryption_types=module.params['encryption_types'],
-              )
+                       path=path,
+                       state=state,
+                       principal=module.params['principal'],
+                       ipa_server=module.params['ipa_server'],
+                       ldap_uri=module.params['ldap_uri'],
+                       bind_dn=module.params['bind_dn'],
+                       bind_pw=module.params['bind_pw'],
+                       password=module.params['password'],
+                       ca_certificate=module.params['ca_certificate'],
+                       sasl_mech=module.params['sasl_mech'],
+                       retrieve_mode=module.params['retrieve_mode'],
+                       encryption_types=module.params['encryption_types'],
+                      )
 
     changed = False
     if state == 'present':

--- a/plugins/modules/ipa_getkeytab.py
+++ b/plugins/modules/ipa_getkeytab.py
@@ -13,91 +13,91 @@ DOCUMENTATION = r'''
 module: ipa_getkeytab
 short_description: Manage keytab file in FreeIPA
 description:
-    - Manage keytab file with ipa-getkeytab utulity.
+  - Manage keytab file with ipa-getkeytab utulity.
 author: "Alexander Bakanovskii (@abakanovskii)"
 attributes:
-    check_mode:
-        support: full
-    diff_mode:
-        support: none
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
 options:
-    path:
-        description:
-            - The base path where to put generated keytab file.
-        type: path
-        aliases: ["keytab"]
-        required: true
-    principal:
-        description:
-            - The non-realm part of the full principal name.
-        type: str
-        required: true
-    ipa_server:
-        description:
-            - The IPA server to retrieve the keytab from (FQDN).
-        type: str
-        aliases: ["server"]
-    ldap_uri:
-        description:
-            - LDAP URI. If V(ldap://) is specified, STARTTLS is initiated by default.
-            - Can not be used with the O(ipa_server) option.
-        type: str
-    bind_dn:
-        description:
-            - The LDAP DN to bind as when retrieving a keytab without Kerberos credentials.
-            - Generally used with the O(bind_pw) option.
-        type: str
-    bind_pw:
-        description:
-            - The LDAP password to use when not binding with Kerberos.
-        type: str
-        required: true
-    password:
-        description:
-            - Use this password for the key instead of one randomly generated.
-        type: str
-    ca_certificate:
-        description:
-            - The path to the IPA CA certificate used to validate LDAPS/STARTTLS connections.
-        type: path
-        aliases: ["ca_cert"]
-    sasl_mech:
-        description:
-            - SASL mechanism to use if O(bind_dn) and O(bind_pw) are not specified.
-        choices: ["GSSAPI", "EXTERNAL"]
-        type: str
-    retrieve_mode:
-        description:
-            - Retrieve an existing key from the server instead of generating a new one.
-            - This is incompatible with the O(password), and will work only against a IPA server more recent than version 3.3.
-            - The user requesting the keytab must have access to the keys for this operation to succeed.
-            - Be aware that if set V(true), a new keytab will be generated.
-            - This invalidates all previously retrieved keytabs for this service principal.
-        type: bool
-    encryption_types:
-        description:
-            - The list of encryption types to use to generate keys.
-            - M(ipa_getkeytab) will use local client defaults if not provided.
-            - Valid values depend on the Kerberos library version and configuration.
-        type: str
-    state:
-        description:
-            - The state of the keytab file.
-            - V(present) only check for existence of a file, so if you want to recreate keytab
-              with other parameters you should set O(force: true).
-        type: str
-        default: present
-        choices: ["present", "absent"]
-    force:
-        description:
-            - Force recreation if exists already.
-        type: bool
+  path:
+    description:
+      - The base path where to put generated keytab file.
+    type: path
+    aliases: ["keytab"]
+    required: true
+  principal:
+    description:
+      - The non-realm part of the full principal name.
+    type: str
+    required: true
+  ipa_server:
+    description:
+      - The IPA server to retrieve the keytab from (FQDN).
+    type: str
+    aliases: ["server"]
+  ldap_uri:
+    description:
+      - LDAP URI. If V(ldap://) is specified, STARTTLS is initiated by default.
+      - Can not be used with the O(ipa_server) option.
+    type: str
+  bind_dn:
+    description:
+      - The LDAP DN to bind as when retrieving a keytab without Kerberos credentials.
+      - Generally used with the O(bind_pw) option.
+    type: str
+  bind_pw:
+    description:
+      - The LDAP password to use when not binding with Kerberos.
+    type: str
+    required: true
+  password:
+    description:
+      - Use this password for the key instead of one randomly generated.
+    type: str
+  ca_certificate:
+    description:
+      - The path to the IPA CA certificate used to validate LDAPS/STARTTLS connections.
+    type: path
+    aliases: ["ca_cert"]
+  sasl_mech:
+    description:
+      - SASL mechanism to use if O(bind_dn) and O(bind_pw) are not specified.
+    choices: ["GSSAPI", "EXTERNAL"]
+    type: str
+  retrieve_mode:
+    description:
+      - Retrieve an existing key from the server instead of generating a new one.
+      - This is incompatible with the O(password), and will work only against a IPA server more recent than version 3.3.
+      - The user requesting the keytab must have access to the keys for this operation to succeed.
+      - Be aware that if set V(true), a new keytab will be generated.
+      - This invalidates all previously retrieved keytabs for this service principal.
+    type: bool
+  encryption_types:
+    description:
+      - The list of encryption types to use to generate keys.
+      - M(ipa_getkeytab) will use local client defaults if not provided.
+      - Valid values depend on the Kerberos library version and configuration.
+    type: str
+  state:
+    description:
+      - The state of the keytab file.
+      - V(present) only check for existence of a file, so if you want to recreate keytab
+        with other parameters you should set O(force: true).
+    type: str
+    default: present
+    choices: ["present", "absent"]
+  force:
+    description:
+      - Force recreation if exists already.
+    type: bool
 requirements:
-    - freeipa-client
-    - Managed host is FreeIPA client
+  - freeipa-client
+  - Managed host is FreeIPA client
 extends_documentation_fragment:
-    - community.general.attributes
-    - community.general.ipa.documentation
+  - community.general.attributes
+  - community.general.ipa.documentation
 '''
 
 EXAMPLES = r'''
@@ -222,7 +222,7 @@ def main():
                        sasl_mech=module.params['sasl_mech'],
                        retrieve_mode=module.params['retrieve_mode'],
                        encryption_types=module.params['encryption_types'],
-                      )
+                       )
 
     changed = False
     if state == 'present':

--- a/plugins/modules/ipa_getkeytab.py
+++ b/plugins/modules/ipa_getkeytab.py
@@ -15,6 +15,7 @@ short_description: Manage keytab file in FreeIPA
 version_added: 9.5.0
 description:
   - Manage keytab file with C(ipa-getkeytab) utility.
+  - See U(https://manpages.ubuntu.com/manpages/jammy/man1/ipa-getkeytab.1.html) for reference.
 author: "Alexander Bakanovskii (@abakanovskii)"
 attributes:
   check_mode:

--- a/plugins/modules/ipa_getkeytab.py
+++ b/plugins/modules/ipa_getkeytab.py
@@ -66,7 +66,6 @@ options:
             - SASL mechanism to use if O(bind_dn) and O(bind_pw) are not specified.
         choices: ["GSSAPI", "EXTERNAL"]
         type: str
-        aliases: ["ca_cert"]
     retrieve_mode:
         description:
             - Retrieve an existing key from the server instead of generating a new one.
@@ -189,12 +188,12 @@ def main():
         path=dict(type='path', required=True, aliases=["keytab"]),
         state=dict(default='present', choices=['present', 'absent']),
         principal=dict(type='str', required=True),
-        ipa_server=dict(type='str'),
+        ipa_server=dict(type='str', aliases=["server"]),
         ldap_uri=dict(type='path'),
         bind_dn=dict(type='str'),
         bind_pw=dict(type='str'),
         password=dict(type='str', no_log=True),
-        ca_certificate=dict(type='path'),
+        ca_certificate=dict(type='path', aliases=["ca_cert"]),
         sasl_mech=dict(type='str', choices=["GSSAPI", "EXTERNAL"]),
         retrieve_mode=dict(type='bool'),
         encryption_types=dict(type='str'),

--- a/tests/unit/plugins/modules/test_ipa_getkeytab.py
+++ b/tests/unit/plugins/modules/test_ipa_getkeytab.py
@@ -37,7 +37,7 @@ class IPAKeytabModuleTestCase(ModuleTestCase):
         set_module_args({
             'path': '/tmp/test.keytab',
             'principal': 'HTTP/freeipa-dc02.ipa.test',
-            'ipa_server': 'freeipa-dc01.ipa.test',
+            'ipa_host': 'freeipa-dc01.ipa.test',
             'state': 'present'
         })
 

--- a/tests/unit/plugins/modules/test_ipa_getkeytab.py
+++ b/tests/unit/plugins/modules/test_ipa_getkeytab.py
@@ -33,7 +33,7 @@ class IPAKeytabModuleTestCase(ModuleTestCase):
             self.module.main()
         return exc.exception.args[0]
 
-    def test_present_missing(self):
+    def test_present(self):
         set_module_args({
             'path': '/tmp/test.keytab',
             'principal': 'HTTP/freeipa-dc02.ipa.test',
@@ -54,19 +54,7 @@ class IPAKeytabModuleTestCase(ModuleTestCase):
                   '--server', 'freeipa-dc01.ipa.test',
                   '--principal', 'HTTP/freeipa-dc02.ipa.test'
                   ],
-                 check_rc=False
+                 check_rc=False,
+                 environ_update={'LC_ALL': 'C', 'LANGUAGE': 'C'}
                  ),
         ])
-
-    def test_absent(self):
-        set_module_args({
-            'path': '/tmp/test.keytab',
-            'state': 'absent'
-        })
-
-        self.module_main_command.side_effect = []
-
-        result = self.module_main(AnsibleExitJson)
-
-        self.assertTrue(result['changed'])
-        self.module_main_command.assert_has_calls([])

--- a/tests/unit/plugins/modules/test_ipa_getkeytab.py
+++ b/tests/unit/plugins/modules/test_ipa_getkeytab.py
@@ -1,0 +1,66 @@
+#
+# Copyright (c) 2021, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.community.general.tests.unit.compat.mock import call, patch
+from ansible_collections.community.general.plugins.modules import ipa_getkeytab
+from ansible_collections.community.general.tests.unit.plugins.modules.utils import AnsibleExitJson, ModuleTestCase, set_module_args
+
+
+class IPAKeytabModuleTestCase(ModuleTestCase):
+    module = ipa_getkeytab
+
+    def setUp(self):
+        super(IPAKeytabModuleTestCase, self).setUp()
+        ansible_module_path = "ansible_collections.community.general.plugins.modules.ipa_getkeytab.AnsibleModule"
+        self.mock_run_command = patch('%s.run_command' % ansible_module_path)
+        self.module_main_command = self.mock_run_command.start()
+        self.mock_get_bin_path = patch('%s.get_bin_path' % ansible_module_path)
+        self.get_bin_path = self.mock_get_bin_path.start()
+        self.get_bin_path.return_value = '/testbin/ipa_getkeytab'
+
+    def tearDown(self):
+        self.mock_run_command.stop()
+        self.mock_get_bin_path.stop()
+        super(IPAKeytabModuleTestCase, self).tearDown()
+
+    def module_main(self, exit_exc):
+        with self.assertRaises(exit_exc) as exc:
+            self.module.main()
+        return exc.exception.args[0]
+
+    def test_present_missing(self):
+        set_module_args({
+            'path': '/tmp/test.keytab',
+            'principal': 'HTTP/freeipa-dc02.ipa.test',
+            'ipa_server': 'freeipa-dc01.ipa.test',
+            'state': 'present'
+        })
+
+        self.module_main_command.side_effect = [
+            (0, '{}', ''),
+        ]
+
+        result = self.module_main(AnsibleExitJson)
+
+        self.assertTrue(result['changed'])
+        self.module_main_command.assert_has_calls([
+            call(['/testbin/ipa_getkeytab', '--keytab', '/tmp/test.keytab', '--server', 'freeipa-dc01.ipa.test', '--principal', 'HTTP/freeipa-dc02.ipa.test'], check_rc=False),
+        ])
+
+    def test_absent(self):
+        set_module_args({
+            'path': '/tmp/test.keytab',
+            'state': 'absent'
+        })
+
+        self.module_main_command.side_effect = []
+
+        result = self.module_main(AnsibleExitJson)
+
+        self.assertTrue(result['changed'])
+        self.module_main_command.assert_has_calls([])

--- a/tests/unit/plugins/modules/test_ipa_getkeytab.py
+++ b/tests/unit/plugins/modules/test_ipa_getkeytab.py
@@ -49,11 +49,11 @@ class IPAKeytabModuleTestCase(ModuleTestCase):
 
         self.assertTrue(result['changed'])
         self.module_main_command.assert_has_calls([
-            call(['/testbin/ipa_getkeytab', 
-                  '--keytab', '/tmp/test.keytab', 
-                  '--server', 'freeipa-dc01.ipa.test', 
+            call(['/testbin/ipa_getkeytab',
+                  '--keytab', '/tmp/test.keytab',
+                  '--server', 'freeipa-dc01.ipa.test',
                   '--principal', 'HTTP/freeipa-dc02.ipa.test'
-                  ], 
+                  ],
                  check_rc=False
                  ),
         ])

--- a/tests/unit/plugins/modules/test_ipa_getkeytab.py
+++ b/tests/unit/plugins/modules/test_ipa_getkeytab.py
@@ -54,7 +54,7 @@ class IPAKeytabModuleTestCase(ModuleTestCase):
                   '--server', 'freeipa-dc01.ipa.test',
                   '--principal', 'HTTP/freeipa-dc02.ipa.test'
                   ],
-                 check_rc=False,
+                 check_rc=True,
                  environ_update={'LC_ALL': 'C', 'LANGUAGE': 'C'}
                  ),
         ])

--- a/tests/unit/plugins/modules/test_ipa_getkeytab.py
+++ b/tests/unit/plugins/modules/test_ipa_getkeytab.py
@@ -49,7 +49,13 @@ class IPAKeytabModuleTestCase(ModuleTestCase):
 
         self.assertTrue(result['changed'])
         self.module_main_command.assert_has_calls([
-            call(['/testbin/ipa_getkeytab', '--keytab', '/tmp/test.keytab', '--server', 'freeipa-dc01.ipa.test', '--principal', 'HTTP/freeipa-dc02.ipa.test'], check_rc=False),
+            call(['/testbin/ipa_getkeytab', 
+                  '--keytab', '/tmp/test.keytab', 
+                  '--server', 'freeipa-dc01.ipa.test', 
+                  '--principal', 'HTTP/freeipa-dc02.ipa.test'
+                  ], 
+                 check_rc=False
+                 ),
         ])
 
     def test_absent(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`ipa_getkeytab` as a fancy wrapper around `ipa-getkeytab` command
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- New Module/Plugin Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
`ipa_getkeytab`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Pretty much a simple wrapper around a `ipa-getkeytab` using `cmd_runner`
I tested this module by my hands and it seems to work as intended
I don't know how to write unit tests because for integration test I would need FreeIPA server and client installed so i wrote something up using `test_npm` as a source
<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
# Before this module you would have to do something like this
    - name: Create keytab
      ansible.builtin.shell: ipa-getkeytab -s <ipa_server> -p <some_principal> -k <some_path>

# Now you can do this like this
    - name: Create keytab
      community.general.ipa_getkeytab:
        path: <some_path>
        principal: <some_principal>
        ipa_server:  <ipa_server>
```
