### PR TITLE
keycloak_userprofile: improve diff by deserializing fetched `kc.user.profile.config` and serializing it before sending

### DIFF
--- a/changelogs/fragments/8940-keycloak_userprofile-improve-diff.yml
+++ b/changelogs/fragments/8940-keycloak_userprofile-improve-diff.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_userprofile - improve diff by deserializing the fetched ``kc.user.profile.config`` and serialize it only when sending back (https://github.com/ansible-collections/community.general/pull/8940).

--- a/plugins/modules/keycloak_userprofile.py
+++ b/plugins/modules/keycloak_userprofile.py
@@ -612,9 +612,7 @@ def main():
                                         attribute['validations']['person-name-prohibited-characters'] = (
                                             attribute['validations'].pop('personNameProhibitedCharacters')
                                         )
-                        # special JSON parsing for kc_user_profile_config
-                        value = json.dumps(kc_user_profile_config[0])
-                        changeset[camel(component_param)][config_param].append(value)
+                        changeset[camel(component_param)][config_param].append(kc_user_profile_config[0])
                 # usual camelCase parameters
                 else:
                     changeset[camel(component_param)][camel(config_param)] = []
@@ -662,6 +660,10 @@ def main():
             changeset['id'] = userprofile_id
             changeset_copy['id'] = userprofile_id
 
+            # keycloak returns kc.user.profile.config as a single JSON formatted string, so we have to deserialize it
+            if 'config' in userprofile and 'kc.user.profile.config' in userprofile['config']:
+                userprofile['config']['kc.user.profile.config'][0] = json.loads(userprofile['config']['kc.user.profile.config'][0])
+
             # Compare top-level parameters
             for param, value in changeset.items():
                 before_realm_userprofile[param] = userprofile[param]
@@ -680,6 +682,10 @@ def main():
     # Check all the possible states of the resource and do what is needed to
     # converge current state with desired state (create, update or delete
     # the userprofile).
+
+    # keycloak expects kc.user.profile.config as a single JSON formatted string, so we have to serialize it
+    if 'config' in changeset and 'kc.user.profile.config' in changeset['config']:
+        changeset['config']['kc.user.profile.config'][0] = json.dumps(changeset['config']['kc.user.profile.config'][0])
     if userprofile_id and state == 'present':
         if result['changed']:
             if module._diff:

--- a/tests/unit/plugins/modules/test_keycloak_userprofile.py
+++ b/tests/unit/plugins/modules/test_keycloak_userprofile.py
@@ -17,6 +17,8 @@ from ansible_collections.community.general.plugins.modules import keycloak_userp
 
 from itertools import count
 
+from json import dumps
+
 from ansible.module_utils.six import StringIO
 
 
@@ -509,7 +511,7 @@ class TestKeycloakUserprofile(ModuleTestCase):
                     "providerType": "org.keycloak.userprofile.UserProfileProvider",
                     "config": {
                         "kc.user.profile.config": [
-                            {
+                            dumps({
                                 "attributes": [
                                     {
                                         "name": "username",
@@ -625,7 +627,7 @@ class TestKeycloakUserprofile(ModuleTestCase):
                                         "displayDescription": "Attributes, which refer to user metadata",
                                     }
                                 ],
-                            }
+                            })
                         ]
                     }
                 }
@@ -714,7 +716,7 @@ class TestKeycloakUserprofile(ModuleTestCase):
                     "providerType": "org.keycloak.userprofile.UserProfileProvider",
                     "config": {
                         "kc.user.profile.config": [
-                            {
+                            dumps({
                                 "attributes": [
                                     {
                                         "name": "username",
@@ -830,7 +832,7 @@ class TestKeycloakUserprofile(ModuleTestCase):
                                         "displayDescription": "Attributes, which refer to user metadata",
                                     }
                                 ],
-                            }
+                            })
                         ]
                     }
                 }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Keycloak returns a single JSON formatted string for the `kc.user.profile.config` which cant be diffed properly.
```
--- before
+++ after
@@ -1,7 +1,7 @@
 {
     "config": {
         "kc.user.profile.config": [
-            "{\"attributes\": [{\"name\": \"username\", \"displayName\": \"${username}\", \"validations\": {\"length\": {\"min\": 3, \"max\": 255}, \"username-prohibited-characters\": {}, \"up-username-not-idn-homograph\": {}}, \"annotations\": {}, \"permissions\": {\"view\": [\"********\", \"user\"], \"edit\": []}, \"multivalued\": false}, {\"name\": \"email\", \"displayName\": \"${email}\", \"validations\": {\"email\": {}, \"length\": {\"max\": 255}}, \"annotations\": {}, \"required\": {\"roles\": [\"user\"]}, \"permissions\": {\"view\": [\"********\", \"user\"], \"edit\": []}, \"multivalued\": false}], \"groups\": []}"
+            "{\"attributes\": [{\"name\": \"username\", \"displayName\": \"${username}\", \"validations\": {\"length\": {\"min\": 3, \"max\": 255}, \"username-prohibited-characters\": {}, \"up-username-not-idn-homograph\": {}}, \"annotations\": {}, \"permissions\": {\"view\": [\"********\", \"user\"], \"edit\": []}, \"multivalued\": false}, {\"name\": \"email\", \"displayName\": \"${email}\", \"validations\": {\"email\": {}, \"length\": {\"max\": 255}}, \"annotations\": {}, \"required\": {\"roles\": [\"user\"]}, \"permissions\": {\"view\": [\"********\", \"user\"], \"edit\": []}, \"multivalued\": false}], \"groups\": [{\"name\": \"user-metadata\", \"displayHeader\": \"User metadata\", \"displayDescription\": \"Attributes, which refer to user metadata\"}]}"
         ]
     },
     "id": "fd55b673-e34a-44b6-96f3-11531bead097",

changed: [kc1]
```

Deserializing the string after fetching the userprofile component and serializing only when sending it back to the Keycloak API would allow a finer grained diff.

```
--- before
+++ after
@@ -49,7 +49,13 @@
                         }
                     }
                 ],
-                "groups": []
+                "groups": [
+                    {
+                        "displayDescription": "Attributes, which refer to user metadata",
+                        "displayHeader": "User metadata",
+                        "name": "user-metadata"
+                    }
+                ]
             }
         ]
     },

changed: [kc1]
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_userprofile

