### PR TITLE
cloudflare_dns: Update SRV record handling for Cloudflare API changes

### DIFF
--- a/changelogs/fragments/8679-fix-cloudflare-srv.yml
+++ b/changelogs/fragments/8679-fix-cloudflare-srv.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cloudflare_dns - fix changing Cloudflare SRV records (https://github.com/ansible-collections/community.general/issues/8679, https://github.com/ansible-collections/community.general/pull/8948).

--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -716,12 +716,14 @@ class CloudflareAPI(object):
                 "port": params['port'],
                 "weight": params['weight'],
                 "priority": params['priority'],
-                "name": params['record'],
-                "proto": params['proto'],
-                "service": params['service']
             }
 
-            new_record = {"type": params['type'], "ttl": params['ttl'], 'data': srv_data}
+            new_record = {
+                "type": params['type'],
+                "name": params['service'] + '.' + params['proto'] + '.' + params['record'],
+                "ttl": params['ttl'],
+                'data': srv_data,
+            }
             search_value = str(params['weight']) + '\t' + str(params['port']) + '\t' + params['value']
             search_record = params['service'] + '.' + params['proto'] + '.' + params['record']
 


### PR DESCRIPTION
##### SUMMARY
Brings SRV API up to date with the changes from here: https://developers.cloudflare.com/fundamentals/api/reference/deprecations/#2024-05-31

Fixes #8679

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudflare_dns

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Create an SRV record _foo._tcp.example.net
  community.general.cloudflare_dns:
    domain: example.net
    service: foo
    proto: tcp
    port: 3500
    priority: 10
    weight: 20
    type: SRV
    value: fooserver.example.net
```
