### PR TITLE
cmd_runner: Add data option

### DIFF
--- a/changelogs/fragments/8951-cmdrunner-add-data-option.yml
+++ b/changelogs/fragments/8951-cmdrunner-add-data-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cmd_runner - add ``data`` option (https://github.com/ansible-collections/community.general/pull/8951).

--- a/plugins/module_utils/cmd_runner.py
+++ b/plugins/module_utils/cmd_runner.py
@@ -225,7 +225,7 @@ class CmdRunner(object):
         return tuple(order) if is_sequence(order) else tuple(order.split())
 
     def __init__(self, module, command, arg_formats=None, default_args_order=(),
-                 check_rc=False, force_lang="C", path_prefix=None, environ_update=None):
+                 check_rc=False, force_lang="C", path_prefix=None, environ_update=None, data=None):
         self.module = module
         self.command = _ensure_list(command)
         self.default_args_order = self._prepare_args_order(default_args_order)
@@ -248,6 +248,7 @@ class CmdRunner(object):
         if environ_update is None:
             environ_update = {}
         self.environ_update = environ_update
+        self.data = data
 
         _cmd = self.command[0]
         self.command[0] = _cmd if (os.path.isabs(_cmd) or '/' in _cmd) else module.get_bin_path(_cmd, opt_dirs=path_prefix, required=True)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add data option https://docs.ansible.com/ansible/latest/reference_appendices/module_utils.html
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
`cmd_runner`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
It would be useful to have that option as I'm currently working on a module to perform `kinit/kdestroy/klist` and there are no option to pass principal password other than from stdin
<!--- Paste verbatim command output below, e.g. before and after your change -->

