### PR TITLE
passwordstore: Support subkey creation and update

### DIFF
--- a/changelogs/fragments/8952-password-store-lookup-create-subkey-support.yml
+++ b/changelogs/fragments/8952-password-store-lookup-create-subkey-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - passwordstore lookup plugin - add subkey creation/update support (https://github.com/ansible-collections/community.general/pull/8952).


### PR DESCRIPTION
##### SUMMARY

passwordstore lookup - Add the ability to create and update subkeys in password files.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

passwordstore lookup

##### ADDITIONAL INFORMATION

Here some command lines to  illustrate the feature:

```
# Create a new 'foo' subkey, in an new password store file (in this case, main password is empty)
❯ ansible -m debug -i localhost, -a "msg={{ lookup('community.general.passwordstore', 'example/test', create=true, subkey='foo') }}" localhost
localhost | SUCCESS => {
    "msg": "u6V31gj3d0i3lLbO"
}
# Replace the 'foo' subkey and keep a backup trace in the password file
❯ ansible -m debug -i localhost, -a "msg={{ lookup('community.general.passwordstore', 'example/test', create=true, subkey='foo', overwrite=true, backup=true) }}
" localhost
localhost | SUCCESS => {
    "msg": "8jRMhmn9bE-Ra:Yh"
}
# Replace the main password
❯ ansible -m debug -i localhost, -a "msg={{ lookup('community.general.passwordstore', 'example/test', create=true, overwrite=true) }}" localhost
localhost | SUCCESS => {
    "msg": "Mjol:uhPxIiGcchM"
}
# Display the content of the password file
❯ pass example/test 
Mjol:uhPxIiGcchM

foo: 8jRMhmn9bE-Ra:Yh
lookup_pass: First generated by ansible on 01/10/2024 11:37:25
lookup_pass: old subkey password foo was u6V31gj3d0i3lLbO (Updated on 01/10/2024 11:38:03)

```
