### PR TITLE
Remove 'CapacityBytes' from list of required parameters

### DIFF
--- a/changelogs/fragments/8956-remove-capacitybytes-from-the-required-parameters_list.yml
+++ b/changelogs/fragments/8956-remove-capacitybytes-from-the-required-parameters_list.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_confg - remove ``CapacityBytes`` from required paramaters of the CreateVolume command (https://github.com/ansible-collections/community.general/pull/8956).

--- a/changelogs/fragments/8956-remove-capacitybytes-from-the-required-parameters_list.yml
+++ b/changelogs/fragments/8956-remove-capacitybytes-from-the-required-parameters_list.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redfish_confg - remove ``CapacityBytes`` from required paramaters of the CreateVolume command (https://github.com/ansible-collections/community.general/pull/8956).
+  - redfish_confg - remove ``CapacityBytes`` from required paramaters of the ``CreateVolume`` command (https://github.com/ansible-collections/community.general/pull/8956).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -3774,8 +3774,8 @@ class RedfishUtils(object):
                 'msg': "Provided Storage Subsystem ID %s does not exist on the server" % storage_subsystem_id}
 
         # Validate input parameters
-        required_parameters = ['RAIDType', 'Drives', 'CapacityBytes']
-        allowed_parameters = ['DisplayName', 'InitializeMethod', 'MediaSpanCount',
+        required_parameters = ['RAIDType', 'Drives' ]
+        allowed_parameters = ['CapacityBytes', 'DisplayName', 'InitializeMethod', 'MediaSpanCount',
                               'Name', 'ReadCachePolicy', 'StripSizeBytes', 'VolumeUsage', 'WriteCachePolicy']
 
         for parameter in required_parameters:

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -3774,7 +3774,7 @@ class RedfishUtils(object):
                 'msg': "Provided Storage Subsystem ID %s does not exist on the server" % storage_subsystem_id}
 
         # Validate input parameters
-        required_parameters = ['RAIDType', 'Drives' ]
+        required_parameters = ['RAIDType', 'Drives']
         allowed_parameters = ['CapacityBytes', 'DisplayName', 'InitializeMethod', 'MediaSpanCount',
                               'Name', 'ReadCachePolicy', 'StripSizeBytes', 'VolumeUsage', 'WriteCachePolicy']
 

--- a/plugins/modules/redfish_config.py
+++ b/plugins/modules/redfish_config.py
@@ -164,9 +164,9 @@ options:
     required: false
     description:
       - Setting dict of volume to be created.
-      - If CapacityBytes key is not specified in this dictionnary, the size of 
-        the volume will be determined by the redfish service and will depend 
-        on the service's design (possibly not the maximum available size).
+      - If CapacityBytes key is not specified in this dictionary, the size of
+        the volume will be determined by the Redfish service. It's possible the
+        size will not be the maximum available size.
     type: dict
     default: {}
     version_added: '7.5.0'

--- a/plugins/modules/redfish_config.py
+++ b/plugins/modules/redfish_config.py
@@ -164,6 +164,9 @@ options:
     required: false
     description:
       - Setting dict of volume to be created.
+      - If CapacityBytes key is not specified in this dictionnary, the size of 
+        the volume will be determined by the redfish service and will depend 
+        on the service's design (possibly not the maximum available size).
     type: dict
     default: {}
     version_added: '7.5.0'

--- a/plugins/modules/redfish_config.py
+++ b/plugins/modules/redfish_config.py
@@ -164,8 +164,8 @@ options:
     required: false
     description:
       - Setting dict of volume to be created.
-      - If CapacityBytes key is not specified in this dictionary, the size of
-        the volume will be determined by the Redfish service. It's possible the
+      - If C(CapacityBytes) key is not specified in this dictionary, the size of
+        the volume will be determined by the Redfish service. It is possible the
         size will not be the maximum available size.
     type: dict
     default: {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Make `CapacityBytes` an allowed parameter and not a required one.

Fixes #8955 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
redfish_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
