### PR TITLE
pipx: remove unused param from the runner ctx.run() call

### DIFF
--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -308,7 +308,7 @@ class PipX(StateModuleHelper):
     def state_install_all(self):
         self.changed = True
         with self.runner('state global index_url force python system_site_packages editable pip_args spec_metadata', check_mode_skip=True) as ctx:
-            ctx.run(name_source=[self.vars.name, self.vars.source])
+            ctx.run()
             self._capture_results(ctx)
 
     def state_upgrade(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove unused param from the `CmdRunner` context run. It is guaranteed to be unused because the param `name_source` is not used in the context, as defined in the previous line. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
pipx