### PR TITLE
dig lookup: Allow to pass port for DNS lookup

### DIFF
--- a/changelogs/fragments/8966-dig-add-port-option.yml
+++ b/changelogs/fragments/8966-dig-add-port-option.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - dig lookup plugin - add ``port`` option to specify DNS server port (https://github.com/ansible-collections/community.general/pull/8966).
+...

--- a/plugins/lookup/dig.py
+++ b/plugins/lookup/dig.py
@@ -75,6 +75,11 @@ DOCUMENTATION = '''
         default: false
         type: bool
         version_added: 7.5.0
+      port:
+        description: Use port as target port when looking up DNS records.
+        default: 53
+        type: int
+        version_added: 9.5.0
     notes:
       - ALL is not a record per-se, merely the listed fields are available for any record results you retrieve in the form of a dictionary.
       - While the 'dig' lookup plugin supports anything which dnspython supports out of the box, only a subset can be converted into a dictionary.
@@ -336,6 +341,7 @@ class LookupModule(LookupBase):
         fail_on_error = self.get_option('fail_on_error')
         real_empty = self.get_option('real_empty')
         tcp = self.get_option('tcp')
+        port = self.get_option('port')
         try:
             rdclass = dns.rdataclass.from_text(self.get_option('class'))
         except Exception as e:
@@ -396,6 +402,8 @@ class LookupModule(LookupBase):
 
         # print "--- domain = {0} qtype={1} rdclass={2}".format(domain, qtype, rdclass)
 
+        if port:
+            myres.port = port
         if len(nameservers) > 0:
             myres.nameservers = nameservers
 


### PR DESCRIPTION
##### SUMMARY
Add new option `port` to the `dig` lookup module to specify which port is to be used for DNS query.
This is necessary for setups in which a (custom/internal) DNS server listens on a non-default port.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`dig`

##### ADDITIONAL INFORMATION
dnspython accepts a port as part of the nameserver and not, like the other optioins that are currently present in the `dig` module, to be passed to the `query` function.

Currently, the nameservers are passed as strings which leads dnspython to create Nameserver objects out of them using the port that is currently set in the Resolver instance. That creation of Nameserver objects is done right when the `nameservers` property is set.
If a port is to be set by us, the `port` attribute of the Resolver needs to be set before the nameservers are passed to the Resolver so when the nameservers are passed, that new port is used to create the Nameserver objects.
Therefore, the assignment of the `nameservers` property of the Resolver is moved after the argument processing so the `port` attribute is (if it's given) definitely set before the `nameservers` property.