### PR TITLE
dig lookup plugin: Fix using only last nameserver specified

### DIFF
--- a/changelogs/fragments/8970-fix-dig-multi-nameservers.yml
+++ b/changelogs/fragments/8970-fix-dig-multi-nameservers.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dig lookup plugin - fix using only the last nameserver specified (https://github.com/ansible-collections/community.general/pull/8970).

--- a/plugins/lookup/dig.py
+++ b/plugins/lookup/dig.py
@@ -330,6 +330,7 @@ class LookupModule(LookupBase):
         myres.use_edns(0, ednsflags=dns.flags.DO, payload=edns_size)
 
         domains = []
+        nameservers = []
         qtype = self.get_option('qtype')
         flat = self.get_option('flat')
         fail_on_error = self.get_option('fail_on_error')
@@ -345,7 +346,6 @@ class LookupModule(LookupBase):
             if t.startswith('@'):       # e.g. "@10.0.1.2,192.0.2.1" is ok.
                 nsset = t[1:].split(',')
                 for ns in nsset:
-                    nameservers = []
                     # Check if we have a valid IP address. If so, use that, otherwise
                     # try to resolve name to address using system's resolver. If that
                     # fails we bail out.
@@ -358,7 +358,6 @@ class LookupModule(LookupBase):
                             nameservers.append(nsaddr)
                         except Exception as e:
                             raise AnsibleError("dns lookup NS: %s" % to_native(e))
-                    myres.nameservers = nameservers
                 continue
             if '=' in t:
                 try:
@@ -396,6 +395,9 @@ class LookupModule(LookupBase):
                 domains.append(t)
 
         # print "--- domain = {0} qtype={1} rdclass={2}".format(domain, qtype, rdclass)
+
+        if len(nameservers) > 0:
+            myres.nameservers = nameservers
 
         if qtype.upper() == 'PTR':
             reversed_domains = []


### PR DESCRIPTION
##### SUMMARY
Currently, when specifying multiple nameservers, only the very last one is actually used. Fix that by collecting all specified nameservers and passing them to the Resolver after the argument processing is done.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`dig`

##### ADDITIONAL INFORMATION
Currently, when specifying multiple nameservers either using multiple `@ns.example.com` arguments or by specifying multiple nameservers in a single argument (`@ns1.example.com,ns2.example.com`), due to a bug only the very last nameserver that is specified is actually used.
This is because for every iteration of the `for ns in nsset` loop, the local list of nameservers is cleared and after adding the currently processed nameserver entry, the whole `nameservers` list of the Resolver instance is overridden with that new list with just one element. And as far as I can see, when setting that `nameserver` property, the dnspython library actually overrides the existing list and doesn't do some trickery to append the new nameservers or something like that.

Therefore, the assignment of the `nameservers` property of the Resolver is moved after the argument processing so all nameservers are added and then collectively written to the `nameservers` property of the Resolver.