### PR TITLE
keycloak_client add option to support client-x509 authentication

### DIFF
--- a/changelogs/fragments/8973-keycloak_client-add-x509-auth.yml
+++ b/changelogs/fragments/8973-keycloak_client-add-x509-auth.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak_client - Add ``client-x509`` choise to ``client_authenticator_type`` (https://github.com/ansible-collections/community.general/pull/8973).

--- a/changelogs/fragments/8973-keycloak_client-add-x509-auth.yml
+++ b/changelogs/fragments/8973-keycloak_client-add-x509-auth.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - keycloak_client - Add ``client-x509`` choise to ``client_authenticator_type`` (https://github.com/ansible-collections/community.general/pull/8973).
+  - keycloak_client - add ``client-x509`` choice to ``client_authenticator_type`` (https://github.com/ansible-collections/community.general/pull/8973).

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -582,6 +582,14 @@ options:
                     - For OpenID-Connect clients, client certificate for validating JWT issued by
                       client and signed by its key, base64-encoded.
 
+            x509.subjectdn:
+                description:
+                    - For OpenID-Connect clients, subject which will be used to authenticate the client.
+
+            x509.allow.regex.pattern.comparison:
+                description:
+                    - For OpenID-Connect clients, boolean specifying whether to allow C(x509.subjectdn) as regular expression.
+
 extends_documentation_fragment:
     - community.general.keycloak
     - community.general.attributes

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -108,13 +108,14 @@ options:
 
     client_authenticator_type:
         description:
-            - How do clients authenticate with the auth server? Either V(client-secret) or
-              V(client-jwt) can be chosen. When using V(client-secret), the module parameter
-              O(secret) can set it, while for V(client-jwt), you can use the keys C(use.jwks.url),
+            - How do clients authenticate with the auth server? Either V(client-secret),
+              V(client-jwt) or V(client-x509) can be chosen. When using V(client-secret), the module parameter
+              O(secret) can set it, for V(client-jwt), you can use the keys C(use.jwks.url),
               C(jwks.url), and C(jwt.credential.certificate) in the O(attributes) module parameter
-              to configure its behavior.
+              to configure its behavior. For V(client-x509) you can use the keys C(x509.allow.regex.pattern.comparison) 
+              and C(x509.subjectdn) in the O(attributes) module parameter.
             - This is 'clientAuthenticatorType' in the Keycloak REST API.
-        choices: ['client-secret', 'client-jwt']
+        choices: ['client-secret', 'client-jwt', 'client-x509']
         aliases:
             - clientAuthenticatorType
         type: str
@@ -913,7 +914,7 @@ def main():
         base_url=dict(type='str', aliases=['baseUrl']),
         surrogate_auth_required=dict(type='bool', aliases=['surrogateAuthRequired']),
         enabled=dict(type='bool'),
-        client_authenticator_type=dict(type='str', choices=['client-secret', 'client-jwt'], aliases=['clientAuthenticatorType']),
+        client_authenticator_type=dict(type='str', choices=['client-secret', 'client-jwt', 'client-x509'], aliases=['clientAuthenticatorType']),
         secret=dict(type='str', no_log=True),
         registration_access_token=dict(type='str', aliases=['registrationAccessToken'], no_log=True),
         default_roles=dict(type='list', elements='str', aliases=['defaultRoles']),

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -534,7 +534,6 @@ options:
                 description:
                     - SAML Redirect Binding URL for the client's assertion consumer service (login responses).
 
-
             saml_force_name_id_format:
                 description:
                     - For SAML clients, Boolean specifying whether to ignore requested NameID subject format and using the configured one instead.
@@ -585,10 +584,14 @@ options:
             x509.subjectdn:
                 description:
                     - For OpenID-Connect clients, subject which will be used to authenticate the client.
+                type: str
+                version_added: 9.5.0
 
             x509.allow.regex.pattern.comparison:
                 description:
                     - For OpenID-Connect clients, boolean specifying whether to allow C(x509.subjectdn) as regular expression.
+                type: bool
+                version_added: 9.5.0
 
 extends_documentation_fragment:
     - community.general.keycloak

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -112,7 +112,7 @@ options:
               V(client-jwt) or V(client-x509) can be chosen. When using V(client-secret), the module parameter
               O(secret) can set it, for V(client-jwt), you can use the keys C(use.jwks.url),
               C(jwks.url), and C(jwt.credential.certificate) in the O(attributes) module parameter
-              to configure its behavior. For V(client-x509) you can use the keys C(x509.allow.regex.pattern.comparison) 
+              to configure its behavior. For V(client-x509) you can use the keys C(x509.allow.regex.pattern.comparison)
               and C(x509.subjectdn) in the O(attributes) module parameter to configure which certificate(s) to accept.
             - This is 'clientAuthenticatorType' in the Keycloak REST API.
         choices: ['client-secret', 'client-jwt', 'client-x509']

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -633,6 +633,22 @@ EXAMPLES = '''
   delegate_to: localhost
 
 
+- name: Create or update a Keycloak client (minimal example), with x509 authentication
+  community.general.keycloak_client:
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://auth.example.com/auth
+    auth_realm: master
+    auth_username: USERNAME
+    auth_password: PASSWORD
+    realm: master
+    state: present
+    client_id: test
+    client_authenticator_type: client-x509
+    attributes:
+      x509.subjectdn: "CN=client"
+      x509.allow.regex.pattern.comparison: false
+
+
 - name: Create or update a Keycloak client (with all the bells and whistles)
   community.general.keycloak_client:
     auth_client_id: admin-cli

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -113,7 +113,7 @@ options:
               O(secret) can set it, for V(client-jwt), you can use the keys C(use.jwks.url),
               C(jwks.url), and C(jwt.credential.certificate) in the O(attributes) module parameter
               to configure its behavior. For V(client-x509) you can use the keys C(x509.allow.regex.pattern.comparison) 
-              and C(x509.subjectdn) in the O(attributes) module parameter.
+              and C(x509.subjectdn) in the O(attributes) module parameter to configure which certificate(s) to accept.
             - This is 'clientAuthenticatorType' in the Keycloak REST API.
         choices: ['client-secret', 'client-jwt', 'client-x509']
         aliases:

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -109,7 +109,7 @@ options:
     client_authenticator_type:
         description:
             - How do clients authenticate with the auth server? Either V(client-secret),
-              V(client-jwt) or V(client-x509) can be chosen. When using V(client-secret), the module parameter
+              V(client-jwt), or V(client-x509) can be chosen. When using V(client-secret), the module parameter
               O(secret) can set it, for V(client-jwt), you can use the keys C(use.jwks.url),
               C(jwks.url), and C(jwt.credential.certificate) in the O(attributes) module parameter
               to configure its behavior. For V(client-x509) you can use the keys C(x509.allow.regex.pattern.comparison)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
keycloak_client is missing support for x509 client authentication,   
this PR updates `client_authenticator_type` with the choice `client-x509`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
modules/keycloak_client

##### ADDITIONAL INFORMATION
Below is steps to test the result with this PR applied.
```
cat ~/keycloak/certs/start.sh  
export KEYCLOAK_ADMIN=admin
export KEYCLOAK_ADMIN_PASSWORD=admin


cd /opt/keycloak
bin/kc.sh start-dev --https-certificate-key-file=/certs/certificate.key --https-certificate-file=/certs/certificate.crt --https-trust-store-file=/certs/truststore.jks --https-trust-store-password=password --https-client-auth=request --log-level=trace
```
Start Keycloak
`docker run --rm -it -p 8080:8080 -p 8443:8443 -v ~/keycloak/certs:/certs --entrypoint=/bin/bash keycloak/keycloak:25.0 bash /certs/start.sh`

Apply config
```
ansible-playbook ....
```
Verify 
```
$ curl --cacert ~/keycloak/certs/ca.crt --cert ~/keycloak/certs/certificate.crt --key ~/keycloak/certs/certificate.key https://127.0.0.1:8443/realms/test/protocol/openid-connect/token --data "client_id=test&username=testuser&password=testuser&grant_type=password" -k -v
```
