### PR TITLE
keycloak_group: fix subgroup creation in Keycloak ≥23

### DIFF
--- a/changelogs/fragments/8979-keycloak_group-fix-subgroups.yml
+++ b/changelogs/fragments/8979-keycloak_group-fix-subgroups.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - keycloak_group - fix crash caused in subgroup creation. The crash was caused by a missing or empty `subGroups` property in Keycloak ≥23
+  - keycloak_group - fix crash caused in subgroup creation. The crash was caused by a missing or empty ``subGroups`` property in Keycloak ≥23 (https://github.com/ansible-collections/community.general/issues/8788, https://github.com/ansible-collections/community.general/pull/8979).

--- a/changelogs/fragments/8979-keycloak_group-fix-subgroups.yml
+++ b/changelogs/fragments/8979-keycloak_group-fix-subgroups.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_group - fix crash caused in subgroup creation. The crash was caused by a missing or empty `subGroups` property in Keycloak ≥23

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1509,8 +1509,8 @@ class KeycloakAPI(object):
             else:
                 group_children_url = URL_GROUP_CHILDREN.format(url=self.baseurl, realm=realm, groupid=parent['id'])
                 group_children = json.loads(to_native(open_url(group_children_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
-                                                                timeout=self.connection_timeout,
-                                                                validate_certs=self.validate_certs).read()))
+                                                               timeout=self.connection_timeout,
+                                                               validate_certs=self.validate_certs).read()))
             subgroups = group_children
         else:
             subgroups = parent['subGroups']

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1499,6 +1499,23 @@ class KeycloakAPI(object):
             self.module.fail_json(msg="Could not fetch group %s in realm %s: %s"
                                       % (gid, realm, str(e)))
 
+    def get_subgroups(self, parent, realm="master"):
+        if 'subGroupCount' in parent:
+            # Since version 23, when GETting a group Keycloak does not
+            # return subGroups but only a subGroupCount.
+            # Children must be fetched in a second request.
+            if parent['subGroupCount'] == 0:
+                group_children = []
+            else:
+                group_children_url = URL_GROUP_CHILDREN.format(url=self.baseurl, realm=realm, groupid=parent['id'])
+                group_children = json.loads(to_native(open_url(group_children_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                                timeout=self.connection_timeout,
+                                                                validate_certs=self.validate_certs).read()))
+            subgroups = group_children
+        else:
+            subgroups = parent['subGroups']
+        return subgroups
+
     def get_group_by_name(self, name, realm="master", parents=None):
         """ Fetch a keycloak group within a realm based on its name.
 
@@ -1519,21 +1536,7 @@ class KeycloakAPI(object):
                 if not parent:
                     return None
 
-                if 'subGroupCount' in parent:
-                    # Since version 23, when GETting a group Keycloak does not
-                    # return subGroups but only a subGroupCount.
-                    # Children must be fetched in a second request.
-                    if parent['subGroupCount'] == 0:
-                        group_children = []
-                    else:
-                        group_children_url = URL_GROUP_CHILDREN.format(url=self.baseurl, realm=realm, groupid=parent['id'])
-
-                        group_children = json.loads(to_native(open_url(group_children_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
-                                                                       timeout=self.connection_timeout,
-                                                                       validate_certs=self.validate_certs).read()))
-                    all_groups = group_children
-                else:
-                    all_groups = parent['subGroups']
+                all_groups = self.get_subgroups(parent, realm)
             else:
                 all_groups = self.get_groups(realm=realm)
 
@@ -1582,7 +1585,7 @@ class KeycloakAPI(object):
             return None
 
         for p in name_chain[1:]:
-            for sg in tmp['subGroups']:
+            for sg in self.get_subgroups(tmp):
                 pv, is_id = self._get_normed_group_parent(p)
 
                 if is_id:


### PR DESCRIPTION
##### SUMMARY

In Keycloak versions 23 and later, GroupRepresentation.subGroups has been replaced by GroupRepresentation.subGroupCount and another endpoint to get subgroups.
This caused community.general.keycloak_group to fail when creating a group with a parent.
We now execute this second request if needed.

Fixes ansible-collections/community.general#8788

See https://www.keycloak.org/docs/latest/upgrading/#grouprepresentation-changes

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

keycloak_group

##### ADDITIONAL INFORMATION

Related issue : ansible-collections/community.general#8788

Tested on Keycloak versions (Docker images) :
- 17.0.0
- 21.1.2
- 22.0.5
- 23.0.4
- 23.0.7
- 24.0.5
- 25.0.6