### PR TITLE
udm_user, homectl: use legacycrypt on Python 3.13+

### DIFF
--- a/changelogs/fragments/8987-legacycrypt.yml
+++ b/changelogs/fragments/8987-legacycrypt.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "homectl - the module now tries to use ``legacycrypt`` on Python 3.13+ (https://github.com/ansible-collections/community.general/issues/4691, https://github.com/ansible-collections/community.general/pull/8987)."
+  - "udm_user - the module now tries to use ``legacycrypt`` on Python 3.13+ (https://github.com/ansible-collections/community.general/issues/4690, https://github.com/ansible-collections/community.general/pull/8987)."

--- a/plugins/modules/homectl.py
+++ b/plugins/modules/homectl.py
@@ -18,11 +18,11 @@ version_added: 4.4.0
 description:
     - Manages a user's home directory managed by systemd-homed.
 notes:
-    - This module does B(not) work with Python 3.13 or newer. It uses the deprecated L(crypt Python module,
-      https://docs.python.org/3.12/library/crypt.html) from the Python standard library, which was removed
-      from Python 3.13.
+    - This module requires the deprecated L(crypt Python module,
+      https://docs.python.org/3.12/library/crypt.html) library which was removed from Python 3.13.
+      For Python 3.13 or newer, you need to install L(legacycrypt, https://pypi.org/project/legacycrypt/).
 requirements:
-    - Python 3.12 or earlier
+    - legacycrypt (on Python 3.13 or newer)
 extends_documentation_fragment:
     - community.general.attributes
 attributes:
@@ -283,6 +283,17 @@ except ImportError:
 else:
     HAS_CRYPT = True
     CRYPT_IMPORT_ERROR = None
+
+try:
+    import legacycrypt
+    if not HAS_CRYPT:
+        crypt = legacycrypt
+except ImportError:
+    HAS_LEGACYCRYPT = False
+    LEGACYCRYPT_IMPORT_ERROR = traceback.format_exc()
+else:
+    HAS_LEGACYCRYPT = True
+    LEGACYCRYPT_IMPORT_ERROR = None
 
 
 class Homectl(object):
@@ -606,9 +617,9 @@ def main():
         ]
     )
 
-    if not HAS_CRYPT:
+    if not HAS_CRYPT and not HAS_LEGACYCRYPT:
         module.fail_json(
-            msg=missing_required_lib('crypt (part of Python 3.13 standard library)'),
+            msg=missing_required_lib('crypt (part of standard library up to Python 3.12) or legacycrypt (PyPI)'),
             exception=CRYPT_IMPORT_ERROR,
         )
 

--- a/plugins/modules/udm_user.py
+++ b/plugins/modules/udm_user.py
@@ -21,11 +21,11 @@ description:
        server (UCS).
        It uses the python API of the UCS to create a new object or edit it."
 notes:
-    - This module does B(not) work with Python 3.13 or newer. It uses the deprecated L(crypt Python module,
-      https://docs.python.org/3.12/library/crypt.html) from the Python standard library, which was removed
-      from Python 3.13.
+    - This module requires the deprecated L(crypt Python module,
+      https://docs.python.org/3.12/library/crypt.html) library which was removed from Python 3.13.
+      For Python 3.13 or newer, you need to install L(legacycrypt, https://pypi.org/project/legacycrypt/).
 requirements:
-    - Python 3.12 or earlier
+    - legacycrypt (on Python 3.13 or newer)
 extends_documentation_fragment:
     - community.general.attributes
 attributes:
@@ -350,6 +350,17 @@ else:
     HAS_CRYPT = True
     CRYPT_IMPORT_ERROR = None
 
+try:
+    import legacycrypt
+    if not HAS_CRYPT:
+        crypt = legacycrypt
+except ImportError:
+    HAS_LEGACYCRYPT = False
+    LEGACYCRYPT_IMPORT_ERROR = traceback.format_exc()
+else:
+    HAS_LEGACYCRYPT = True
+    LEGACYCRYPT_IMPORT_ERROR = None
+
 
 def main():
     expiry = date.strftime(date.today() + timedelta(days=365), "%Y-%m-%d")
@@ -467,10 +478,10 @@ def main():
         ])
     )
 
-    if not HAS_CRYPT:
+    if not HAS_CRYPT and not HAS_LEGACYCRYPT:
         module.fail_json(
-            msg=missing_required_lib('crypt (part of Python 3.13 standard library)'),
-            exception=CRYPT_IMPORT_ERROR,
+            msg=missing_required_lib('crypt (part of standard library up to Python 3.12) or legacycrypt (PyPI)'),
+            exception=LEGACYCRYPT_IMPORT_ERROR,
         )
 
     username = module.params['username']

--- a/tests/integration/targets/homectl/tasks/main.yml
+++ b/tests/integration/targets/homectl/tasks/main.yml
@@ -15,6 +15,11 @@
   ignore_errors: true
 
 - block:
+    - name: Install legacycrypt on Python 3.13+
+      pip:
+        name: legacycrypt
+      when: ansible_python_version is version("3.13", ">=")
+
     - name: Check and start systemd-homed service
       service:
         name: systemd-homed.service


### PR DESCRIPTION
##### SUMMARY
On Python 3.13, crypt has been removed from the standard library. There's now a [PyPI package legacycrypt](https://pypi.org/project/legacycrypt/) which contains the removed module. Use that one if available.

Ref: #4690
Ref: #4691

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
udm_user
homectl
