### PR TITLE
redfish_config new bool parameter to automatically delete 'None' type volumes.

### DIFF
--- a/changelogs/fragments/8990.yml
+++ b/changelogs/fragments/8990.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - redfish_config - add parameter ``storage_none_volume_deletion`` to 
+    ``CreateVolume`` command in order to control the automatic deletion of non-RAID volumes (https://github.com/ansible-collections/community.general/pull/8990).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -3742,7 +3742,7 @@ class RedfishUtils(object):
         return {'ret': True, 'changed': True,
                 'msg': "The following volumes were deleted: %s" % str(volume_ids)}
 
-    def create_volume(self, volume_details, storage_subsystem_id, storage_none_volume_deletion):
+    def create_volume(self, volume_details, storage_subsystem_id, storage_none_volume_deletion=False):
         # Find the Storage resource from the requested ComputerSystem resource
         response = self.get_request(self.root_uri + self.systems_uri)
         if response['ret'] is False:

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -3742,7 +3742,7 @@ class RedfishUtils(object):
         return {'ret': True, 'changed': True,
                 'msg': "The following volumes were deleted: %s" % str(volume_ids)}
 
-    def create_volume(self, volume_details, storage_subsystem_id):
+    def create_volume(self, volume_details, storage_subsystem_id, storage_none_volume_deletion):
         # Find the Storage resource from the requested ComputerSystem resource
         response = self.get_request(self.root_uri + self.systems_uri)
         if response['ret'] is False:
@@ -3794,22 +3794,23 @@ class RedfishUtils(object):
         data = response['data']
 
         # Deleting any volumes of RAIDType None present on the Storage Subsystem
-        response = self.get_request(self.root_uri + data['Volumes']['@odata.id'])
-        if response['ret'] is False:
-            return response
-        volume_data = response['data']
+        if storage_none_volume_deletion:
+            response = self.get_request(self.root_uri + data['Volumes']['@odata.id'])
+            if response['ret'] is False:
+                return response
+            volume_data = response['data']
 
-        if "Members" in volume_data:
-            for member in volume_data["Members"]:
-                response = self.get_request(self.root_uri + member['@odata.id'])
-                if response['ret'] is False:
-                    return response
-                member_data = response['data']
-
-                if member_data["RAIDType"] == "None":
-                    response = self.delete_request(self.root_uri + member['@odata.id'])
+            if "Members" in volume_data:
+                for member in volume_data["Members"]:
+                    response = self.get_request(self.root_uri + member['@odata.id'])
                     if response['ret'] is False:
                         return response
+                    member_data = response['data']
+
+                    if member_data["RAIDType"] == "None":
+                        response = self.delete_request(self.root_uri + member['@odata.id'])
+                        if response['ret'] is False:
+                            return response
 
         # Construct payload and issue POST command to create volume
         volume_details["Links"] = {}

--- a/plugins/modules/redfish_config.py
+++ b/plugins/modules/redfish_config.py
@@ -148,7 +148,7 @@ options:
   storage_none_volume_deletion:
     required: false
     description:
-      - Should redfish_config erase 'None' type volumes ?
+      - Indicates if all non-RAID volumes are automatically deleted prior to creating the new volume
     type: bool
     default: false
     version_added: '9.5.0'

--- a/plugins/modules/redfish_config.py
+++ b/plugins/modules/redfish_config.py
@@ -415,6 +415,7 @@ def main():
             hostinterface_id=dict(),
             sessions_config=dict(type='dict', default={}),
             storage_subsystem_id=dict(type='str', default=''),
+            storage_none_volume_deletion=dict(type='bool', default=False),
             volume_ids=dict(type='list', default=[], elements='str'),
             secure_boot_enable=dict(type='bool', default=True),
             volume_details=dict(type='dict', default={}),
@@ -481,6 +482,7 @@ def main():
     # Volume creation options
     volume_details = module.params['volume_details']
     storage_subsystem_id = module.params['storage_subsystem_id']
+    storage_none_volume_deletion = module.params['storage_none_volume_deletion']
 
     # ciphers
     ciphers = module.params['ciphers']
@@ -524,7 +526,7 @@ def main():
             elif command == "DeleteVolumes":
                 result = rf_utils.delete_volumes(storage_subsystem_id, volume_ids)
             elif command == "CreateVolume":
-                result = rf_utils.create_volume(volume_details, storage_subsystem_id)
+                result = rf_utils.create_volume(volume_details, storage_subsystem_id, storage_none_volume_deletion)
 
     elif category == "Manager":
         # execute only if we find a Manager service resource

--- a/plugins/modules/redfish_config.py
+++ b/plugins/modules/redfish_config.py
@@ -148,7 +148,7 @@ options:
   storage_none_volume_deletion:
     required: false
     description:
-      - Indicates if all non-RAID volumes are automatically deleted prior to creating the new volume
+      - Indicates if all non-RAID volumes are automatically deleted prior to creating the new volume.
     type: bool
     default: false
     version_added: '9.5.0'

--- a/plugins/modules/redfish_config.py
+++ b/plugins/modules/redfish_config.py
@@ -145,6 +145,13 @@ options:
     type: str
     default: ''
     version_added: '7.3.0'
+  storage_none_volume_deletion:
+    required: false
+    description:
+      - Should redfish_config erase 'None' type volumes ?
+    type: bool
+    default: false
+    version_added: '9.5.0'
   volume_ids:
     required: false
     description:


### PR DESCRIPTION
##### SUMMARY

Fixes #8962

redfish_config will no longer delete 'None' type volumes by default when trying to create a new volume.
User will now have to ask for this automatic deletion with the 'storage_none_volume_deletion' boolean parameter.  

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
redfish_config

