### PR TITLE
update gitlab label's color

### DIFF
--- a/changelogs/fragments/9010-edit-gitlab-label-color.yaml
+++ b/changelogs/fragments/9010-edit-gitlab-label-color.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Gilab label module - be able to update label's color (https://github.com/ansible-collections/community.general/pull/9010).
+  - gitlab_label - add feature to update label's color (https://github.com/ansible-collections/community.general/pull/9010).

--- a/changelogs/fragments/9010-edit-gitlab-label-color.yaml
+++ b/changelogs/fragments/9010-edit-gitlab-label-color.yaml
@@ -1,2 +1,2 @@
-minor_changes:
-  - gitlab_label - add feature to update label's color (https://github.com/ansible-collections/community.general/pull/9010).
+bugfixes:
+  - gitlab_label - update label's color (https://github.com/ansible-collections/community.general/pull/9010).

--- a/changelogs/fragments/9010-edit-gitlab-label-color.yaml
+++ b/changelogs/fragments/9010-edit-gitlab-label-color.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Gilab label module - be able to update label's color (https://github.com/ansible-collections/community.general/pull/9010).

--- a/plugins/modules/gitlab_label.py
+++ b/plugins/modules/gitlab_label.py
@@ -268,9 +268,6 @@ class GitlabLabels(object):
             return True, True
         _label = self.gitlab_object.labels.get(var_obj.get('name'))
 
-        if (var_obj.get('new_name') is None) and (var_obj.get('color') is None):
-            self._module.fail_json(msg="Failed to update label, new_name or color must be present: %s " % _label)
-
         if var_obj.get('new_name') is not None:
             _label.new_name = var_obj.get('new_name')
 

--- a/plugins/modules/gitlab_label.py
+++ b/plugins/modules/gitlab_label.py
@@ -268,6 +268,9 @@ class GitlabLabels(object):
             return True, True
         _label = self.gitlab_object.labels.get(var_obj.get('name'))
 
+        if (var_obj.get('new_name') is None) and (var_obj.get('color') is None):
+            self._module.fail_json(msg="Failed to update label, new_name or color must be present: %s " % _label)
+
         if var_obj.get('new_name') is not None:
             _label.new_name = var_obj.get('new_name')
 
@@ -275,6 +278,8 @@ class GitlabLabels(object):
             _label.description = var_obj.get('description')
         if var_obj.get('priority') is not None:
             _label.priority = var_obj.get('priority')
+        if var_obj.get('color') is not None:
+            _label.color = var_obj.get('color')
 
         # save returns None
         _label.save()


### PR DESCRIPTION
##### SUMMARY
Set Gitlab label's color when updating a label.
Fail if both `new_name` and `color` are missing when updating a label, one of them is required as described into [Gitlab API docs](https://docs.gitlab.com/ee/api/labels.html).

Fixes #8991 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Gitlab Label
