### PR TITLE
Dell PwrButton requires a job initated at reboot

### DIFF
--- a/changelogs/fragments/9012-dell-pwrbutton-requires-a-job-initiated-at-reboot.yml
+++ b/changelogs/fragments/9012-dell-pwrbutton-requires-a-job-initiated-at-reboot.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - redfish_utils module utils - schedule a BIOS configuration job at next
+    reboot when the BIOS config is changed
+    (https://github.com/ansible-collections/community.general/pull/9012).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -2311,11 +2311,19 @@ class RedfishUtils(object):
 
         # Construct payload and issue PATCH command
         payload = {"Attributes": attrs_to_patch}
+
+        # WORKAROUND
+        # Dell systems require manually setting the apply time to "OnReset"
+        # to spawn a proprietary job to apply the BIOS settings
+        vendor = self._get_vendor()['Vendor']
+        if vendor == 'Dell':
+            payload.update({"@Redfish.SettingsApplyTime": {"ApplyTime": "OnReset"}})
+
         response = self.patch_request(self.root_uri + set_bios_attr_uri, payload)
         if response['ret'] is False:
             return response
         return {'ret': True, 'changed': True,
-                'msg': "Modified BIOS attributes %s" % (attrs_to_patch),
+                'msg': "Modified BIOS attributes %s. A reboot is required" % (attrs_to_patch),
                 'warning': warning}
 
     def set_boot_order(self, boot_list):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Dell systems do not change the bios setting PwrButton right away. The command will return changed=true all the time, but it is not applied. Also no job is scheduled at next reboot for the change to take place. This patch aims to fix this issue.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redfish_utils / refish_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. Use curl to verify the current configuration:
```
curl -u foobar:foobar https://my.host/redfish/v1/Systems/System.Embedded.1/Bios -k -s | jq '.Attributes.PwrButton'
"Enabled"
```
2. Run `community.general.redfish_config` with params:
  ```
  community.general.redfish_config:
    category: 'Systems'
    command: 'SetBiosAttributes'
    bios_attributes:
      PwrButton: 'Disabled'
    baseuri: 'my.host.com'
    username: 'foobar'
    password: 'foobar'
  ```
3. The output will always return `{"changed": true, "msg": "Modified BIOS attributes {'PwrButton': 'Disabled'}`
4. No update job is scheduled in the iDRAC system.
5. Using curl again to verify no change took place
```
curl -u foobar:foobar https://my.host/redfish/v1/Systems/System.Embedded.1/Bios -k -s | jq '.Attributes.PwrButton'
"Enabled"
```
6. One can continuously run this task and the output will always be the same.

With my patch a job will be scheduled and the output will change as expected.
```
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "HTTP Error 400 on PATCH request to 'https://my.host/redfish/v1/Systems/System.Embedded.1/Bios/Settings', extended message: 'Pending configuration values are already committed, unable to perform another set operation.'"}
```

I'm not aware currently of what other parameters require a reboot when changing them, thus this patch is limited to only "PwrButton"