### PR TITLE
one_vnet: Fix module

### DIFF
--- a/changelogs/fragments/9019-onevnet-bugfix.yml
+++ b/changelogs/fragments/9019-onevnet-bugfix.yml
@@ -1,5 +1,2 @@
 bugfixes:
-  - one_vnet - fix ``VM_MAD`` to ``VN_MAD`` (https://github.com/ansible-collections/community.general/pull/9019).
-  - one_vnet - fix ``VMTEMPLATE`` to ``VNET`` (https://github.com/ansible-collections/community.general/pull/9019).
-  - one_vnet - fix loop for ``.AR_POOL.AR`` (https://github.com/ansible-collections/community.general/pull/9019).
-  - one_vnet - fix allocate parameter (https://github.com/ansible-collections/community.general/pull/9019).
+  - one_vnet - fix module failing due to a variable typo (https://github.com/ansible-collections/community.general/pull/9019).

--- a/changelogs/fragments/9019-onevnet-bugfix.yml
+++ b/changelogs/fragments/9019-onevnet-bugfix.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - one_vnet - fix ``VM_MAD`` to ``VN_MAD`` (https://github.com/ansible-collections/community.general/pull/9019).
+  - one_vnet - fix ``VMTEMPLATE`` to ``VNET`` (https://github.com/ansible-collections/community.general/pull/9019).
+  - one_vnet - fix loop for ``.AR_POOL.AR`` (https://github.com/ansible-collections/community.general/pull/9019).
+  - one_vnet - fix allocate parameter (https://github.com/ansible-collections/community.general/pull/9019).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Thats a hotfix for a one_vnet module
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
one_vnet

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1) VN_MAD instead of VM_MAD (https://github.com/privazio/pyone/blob/master/pyone/xsd/vnet_pool.xsd#L69) - typo
2) VNET insead of VMTEMPLATE (https://github.com/privazio/pyone/blob/master/pyone/xsd/vnet_pool.xsd#L8) - typo
3) Fix loop for `.AR_POOL.AR`, I'm as confused as you are but apparently using simple `for in` doesn't work as `.AR_POOL.AR` without specifying index ([0]) will return first ID but not the full list
4) -1 (https://github.com/acidburn0zzz/docs-2/blob/23f0ac32b5bb11caa8a180977a423076dc577cce/source/integration/system_interfaces/api.rst#onevnallocate) - lack of parameter

I'm really sorry for not testing manually these before as I thought it would be similar to a template (OpenNebula API is so weird tbh)
I tested it locally on my OpenNebula server and now it works as it should :)
Also backport is needed because without these fixes module just dont work

<!--- Paste verbatim command output below, e.g. before and after your change -->

