### PR TITLE
Speed up brew module package install & upgrade

### DIFF
--- a/changelogs/fragments/9022-improve-homebrew-perf.yml
+++ b/changelogs/fragments/9022-improve-homebrew-perf.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - homebrew - speed up brew install and upgrade (https://github.com/ansible-collections/community.general/pull/9022)
+  - homebrew - speed up brew install and upgrade (https://github.com/ansible-collections/community.general/pull/9022).

--- a/changelogs/fragments/9022-improve-homebrew-perf.yml
+++ b/changelogs/fragments/9022-improve-homebrew-perf.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - homebrew - speed up brew install and upgrade (https://github.com/ansible-collections/community.general/pull/9022)

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -572,7 +572,7 @@ class Homebrew(object):
         cmd = [opt for opt in opts if opt]
         rc, out, err = self.module.run_command(cmd)
 
-        if self._current_package_is_installed():
+        if rc == 0:
             self.changed_count += 1
             self.changed_pkgs.append(self.current_package)
             self.changed = True

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -600,10 +600,11 @@ class Homebrew(object):
             self.message = 'Invalid package: {0}.'.format(self.current_package)
             raise HomebrewException(self.message)
 
-        if not self._current_package_is_installed():
+        current_package_is_installed = self._current_package_is_installed()
+        if not current_package_is_installed:
             command = 'install'
 
-        if self._current_package_is_installed() and not self._current_package_is_outdated():
+        if current_package_is_installed and not self._current_package_is_outdated():
             self.message = 'Package is already upgraded: {0}'.format(
                 self.current_package,
             )

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -627,7 +627,7 @@ class Homebrew(object):
         cmd = [opt for opt in opts if opt]
         rc, out, err = self.module.run_command(cmd)
 
-        if self._current_package_is_installed() and not self._current_package_is_outdated():
+        if rc == 0:
             self.changed_count += 1
             self.changed_pkgs.append(self.current_package)
             self.changed = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I noticed while working with the homebrew module that it was quite slow, even when doing noops so I instrumented the code a bit to understand why.  

For the following  task:
```yaml
- name: Install brew packages
  community.general.homebrew:
    name: "{{ thibaut_brew_packages }}"
    state: latest
    update_homebrew: true
```
I got the following logs:
```
_run starting ...'
    _update_homebrew starting ...'
    _update_homebrew took 992.34 ms'
    _upgrade_packages starting ...'
        _upgrade_current_package starting ...' (ALREADY INSTALLED CASE)
            _current_package_is_installed starting ...'
            _current_package_is_installed took 780.45 ms'
            _current_package_is_installed starting ...'
            _current_package_is_installed took 738.39 ms'
            _current_package_is_outdated starting ...'
            _current_package_is_outdated took 750.32 ms'
        _upgrade_current_package took 2269.26 ms'
        _upgrade_current_package starting ...'  (NOT INSTALLED CASE)
            _current_package_is_installed starting ...'
            _current_package_is_installed took 752.09 ms'
            _current_package_is_installed starting ...'
            _current_package_is_installed took 733.06 ms'
            _current_package_is_installed starting ...'
            _current_package_is_installed took 759.49 ms'
            _current_package_is_outdated starting ...'
            _current_package_is_outdated took 751.80 ms'
        _upgrade_current_package took 4387.61 ms'
...
```
Lot's of redundant commands that are quite expensive because of `brew`.
This PR addresses some quick wins, removing duplicated `_current_package_is_installed` calls in both example above.

However, this could be improved further. Some ideas for other PRs if interest arise:
- the `current_package_is_outdated` hook is always used with `_current_package_is_installed`, requiring 2 brew call while one `brew info` returns both info.
- `_upgrade_current_package` is called in a loop, leading to a lot of `brew info` / `brew outdated` calls (N+1 issue) when the list of package is large. It would be much more efficient to fetch every packages installed first (`brew list --formula -1`), every outdated packages (`brew outdated --json=v2`) and then just check against these lists.

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Refactoring Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
homebrew

##### ADDITIONAL INFORMATION


<details>
<summary>The code I used to instrument the `Homebrew` class</summary>

```python
import time
from functools import wraps

def timing_decorator(cls):
    class MethodCallsTimingWrapper(cls):
        log = []
        stack_level = 0
        def __init__(self, *args, **kwargs):
            super().__init__(*args, **kwargs)

        def __getattribute__(self, name):
            attr = object.__getattribute__(self, name)
            if callable(attr):
                @wraps(attr)
                def wrapper(*args, **kwargs):
                    start_time = time.monotonic()
                    self.log.append(f"{'    '*self.stack_level}{attr.__name__} starting ...")
                    self.stack_level += 1

                    result = attr(*args, **kwargs)

                    end_time = time.monotonic()
                    self.stack_level -= 1
                    self.log.append(f"{'    '*self.stack_level}{attr.__name__} took {(end_time - start_time) * 1000:.2f} ms")
                    return result
                return wrapper
            return attr

    return MethodCallsTimingWrapper

@timing_decorator
class Homebrew(object):
```
```

</details>
