### PR TITLE
nmcli update the wireguard option to add peers

### DIFF
--- a/changelogs/fragments/8936-wireguard-option-add-peers.yml
+++ b/changelogs/fragments/8936-wireguard-option-add-peers.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - nmcli - Added support for WireGuard peer configuration with new parameters: ``wgpeer_public_key``, ``wgpeer_allowed_ips``, ``wgpeer_endpoint`` and ``wgpeer_persistent_keepalive`` to enable peer management in WireGuard connections. (https://github.com/ansible-collections/community.general/pull/9024)
+  - "nmcli - added support for WireGuard peer configuration with new parameters: ``wgpeer_public_key``, ``wgpeer_allowed_ips``, ``wgpeer_endpoint`` and ``wgpeer_persistent_keepalive`` to enable peer management in WireGuard connections (https://github.com/ansible-collections/community.general/pull/9024)."

--- a/changelogs/fragments/8936-wireguard-option-add-peers.yml
+++ b/changelogs/fragments/8936-wireguard-option-add-peers.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmcli - Added support for WireGuard peer configuration with new parameters: ``wgpeer_public_key``, ``wgpeer_allowed_ips``, ``wgpeer_endpoint`` and ``wgpeer_persistent_keepalive`` to enable peer management in WireGuard connections. (https://github.com/ansible-collections/community.general/pull/9024)

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -967,21 +967,21 @@ options:
                 description:
                     - The 32-bit fwmark for outgoing packets.
                     - The use of fwmark is optional and is by default off. Setting it to 0 disables it.
-                    - Note that O(wireguard.ip4_auto_default_route) or O(wireguard.ip6_auto_default_route) enabled, implies to automatically choose a fwmark.
+                    - Note that O(wireguard.ip4-auto-default-route) or O(wireguard.ip6-auto-default-route) enabled, implies to automatically choose a fwmark.
                 type: int
-            ip4_auto_default_route:
+            ip4-auto-default-route:
                 description:
                     - Whether to enable special handling of the IPv4 default route.
-                    - If enabled, the IPv4 default route from O(wireguard.peer_routes) will be placed to a dedicated routing-table and two policy
+                    - If enabled, the IPv4 default route from O(wireguard.peer-routes) will be placed to a dedicated routing-table and two policy
                         routing rules will be added.
                     - The fwmark number is also used as routing-table for the default-route, and if fwmark is zero, an unused fwmark/table is chosen
                         automatically. This corresponds to what wg-quick does with Table=auto and what WireGuard calls "Improved Rule-based Routing"
                 type: bool
-            ip6_auto_default_route:
+            ip6-auto-default-route:
                 description:
-                    - Like O(wireguard.ip4_auto_default_route), but for the IPv6 default route.
+                    - Like O(wireguard.ip4-auto-default-route), but for the IPv6 default route.
                 type: bool
-            listen_port:
+            listen-port:
                 description: The WireGuard connection listen-port. If not specified, the port will be chosen randomly when the
                     interface comes up.
                 type: int
@@ -991,7 +991,7 @@ options:
                     - If zero a default MTU is used. Note that contrary to wg-quick's MTU setting, this does not take into account the current routes
                         at the time of activation.
                 type: int
-            peer_routes:
+            peer-routes:
                 description:
                     - Whether to automatically add routes for the AllowedIPs ranges of the peers.
                     - If V(true) (the default), NetworkManager will automatically add routes in the routing tables according to C(ipv4.route-table) and
@@ -1001,28 +1001,28 @@ options:
                     - Note that if the peer's AllowedIPs is V(0.0.0.0/0) or V(::/0) and the profile's C(ipv4.never-default) or C(ipv6.never-default)
                         setting is enabled, the peer route for this peer won't be added automatically.
                 type: bool
-            private_key:
+            private-key:
                 description: The 256 bit private-key in base64 encoding.
                 type: str
-                no_log=True)
-            private_key_flags:
-                description: C(NMSettingSecretFlags) indicating how to handle the O(wireguard.private_key) property.
+                no_log: True
+            private-key-flags:
+                description: C(NMSettingSecretFlags) indicating how to handle the O(wireguard.private-key) property.
                 type: int
                 choices: [ 0, 1, 2 ]
                 no_log: true
-            peer_public_key:
+            peer-public-key:
                 description: Public key of the WireGuard peer.
                 type: str
                 version_added: 10.0.0
-            peer_allowed_ips:
+            peer-allowed-ips:
                 description: The allowed IPs for the WireGuard peer.
                 type: str
                 version_added: 10.0.0
-            peer_endpoint:
+            peer-endpoint:
                 description: Endpoint address (IP:Port) for the WireGuard peer.
                 type: str
                 version_added: 10.0.0
-            peer_persistent_keepalive:
+            peer-persistent-keepalive:
                 description: Time in seconds to keep the connection alive (persistent keep-alive) for the WireGuard peer.
                 type: int
                 version_added: 10.0.0
@@ -1484,12 +1484,12 @@ EXAMPLES = r'''
     conn_name: my-wg-provider
     ifname: mywg0
     wireguard:
-        listen_port: 51820
-        private_key: my-private-key
-        peer_public_key: "your_peer_public_key"
-        peer_allowed_ips: "10.0.0.2/32"
-        peer_endpoint: "192.168.1.1:51820"
-        peer_persistent_keepalive: 25
+        listen-port: 51820
+        private-key: my-private-key
+        peer-public-key: "your_peer_public_key"
+        peer-allowed-ips: "10.0.0.2/32"
+        peer-endpoint: "192.168.1.1:51820"
+        peer-persistent-keepalive: 25
     autoconnect: true
     state: present
 

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -967,21 +967,21 @@ options:
                 description:
                     - The 32-bit fwmark for outgoing packets.
                     - The use of fwmark is optional and is by default off. Setting it to 0 disables it.
-                    - Note that O(wireguard.ip4-auto-default-route) or O(wireguard.ip6-auto-default-route) enabled, implies to automatically choose a fwmark.
+                    - Note that O(wireguard.ip4_auto_default_route) or O(wireguard.ip6_auto_default_route) enabled, implies to automatically choose a fwmark.
                 type: int
-            ip4-auto-default-route:
+            ip4_auto_default_route:
                 description:
                     - Whether to enable special handling of the IPv4 default route.
-                    - If enabled, the IPv4 default route from O(wireguard.peer-routes) will be placed to a dedicated routing-table and two policy
+                    - If enabled, the IPv4 default route from O(wireguard.peer_routes) will be placed to a dedicated routing-table and two policy
                         routing rules will be added.
                     - The fwmark number is also used as routing-table for the default-route, and if fwmark is zero, an unused fwmark/table is chosen
                         automatically. This corresponds to what wg-quick does with Table=auto and what WireGuard calls "Improved Rule-based Routing"
                 type: bool
-            ip6-auto-default-route:
+            ip6_auto_default_route:
                 description:
-                    - Like O(wireguard.ip4-auto-default-route), but for the IPv6 default route.
+                    - Like O(wireguard.ip4_auto_default_route), but for the IPv6 default route.
                 type: bool
-            listen-port:
+            listen_port:
                 description: The WireGuard connection listen-port. If not specified, the port will be chosen randomly when the
                     interface comes up.
                 type: int
@@ -991,7 +991,7 @@ options:
                     - If zero a default MTU is used. Note that contrary to wg-quick's MTU setting, this does not take into account the current routes
                         at the time of activation.
                 type: int
-            peer-routes:
+            peer_routes:
                 description:
                     - Whether to automatically add routes for the AllowedIPs ranges of the peers.
                     - If V(true) (the default), NetworkManager will automatically add routes in the routing tables according to C(ipv4.route-table) and
@@ -1001,11 +1001,12 @@ options:
                     - Note that if the peer's AllowedIPs is V(0.0.0.0/0) or V(::/0) and the profile's C(ipv4.never-default) or C(ipv6.never-default)
                         setting is enabled, the peer route for this peer won't be added automatically.
                 type: bool
-            private-key:
+            private_key:
                 description: The 256 bit private-key in base64 encoding.
                 type: str
-            private-key-flags:
-                description: C(NMSettingSecretFlags) indicating how to handle the O(wireguard.private-key) property.
+                no_log=True)
+            private_key_flags:
+                description: C(NMSettingSecretFlags) indicating how to handle the O(wireguard.private_key) property.
                 type: int
                 choices: [ 0, 1, 2 ]
                 no_log: true
@@ -1483,8 +1484,8 @@ EXAMPLES = r'''
     conn_name: my-wg-provider
     ifname: mywg0
     wireguard:
-        listen-port: 51820
-        private-key: my-private-key
+        listen_port: 51820
+        private_key: my-private-key
         peer_public_key: "your_peer_public_key"
         peer_allowed_ips: "10.0.0.2/32"
         peer_endpoint: "192.168.1.1:51820"
@@ -2631,12 +2632,12 @@ def main():
                     listen_port=dict(type='int', required=False),
                     mtu=dict(type='int', required=False),
                     peer_routes=dict(type='bool', required=False),
-                    private_key=dict(type='str', required=False),
-                    private_key_flags=dict(type='int', required=False,no_log=True),
+                    private_key=dict(type='str', required=False, no_log=True),
+                    private_key_flags=dict(type='int', required=False, no_log=True),
                     peer_public_key=dict(type='str', required=False),
-                    peer_allowed_ips=dict(type='str',required=False),
-                    peer_endpoint=dict(type='str',required=False),
-                    peer_persistent_keepalive=dict(type='int',required=False),                    
+                    peer_allowed_ips=dict(type='str', required=False),
+                    peer_endpoint=dict(type='str', required=False),
+                    peer_persistent_keepalive=dict(type='int', required=False),           
                 )
             ),
             vpn=dict(type='dict'),

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1940,26 +1940,7 @@ class Nmcli(object):
                 raise NmcliModuleError('type is macvlan but all of the following are missing: macvlan')
         elif self.type == 'wireguard':
             if self.wireguard:
-                for name, value in self.wireguard.items():
-                    options.update({
-                        'wireguard.%s' % name: value,
-                    })
-                if self.wireguard.get('wgpeer_public_key'):
-                    options.update({
-                        'wireguard.peer.key': self.wireguard['wgpeer_public_key']
-                    })
-                if self.wireguard.get('wgpeer_allowed_ips'):
-                    options.update({
-                        'wireguard.peer.allowed-ips': self.wireguard['wgpeer_allowed_ips']
-                    })
-                if self.wireguard.get('wgpeer_endpoint'):
-                    options.update({
-                        'wireguard.peer.endpoint': self.wireguard['wgpeer_endpoint']
-                    })
-                if self.wireguard.get('wgpeer_persistent_keepalive'):
-                    options.update({
-                        'wireguard.peer.persistent-keepalive': str(self.wireguard['wgpeer_persistent_keepalive'])
-                    })
+                options.update(self.wireguard)      
         elif self.type == 'vpn':
             if self.vpn:
                 vpn_data_values = ''
@@ -2640,14 +2621,11 @@ def main():
                               parent=dict(type='str', required=True),
                               promiscuous=dict(type='bool'),
                               tap=dict(type='bool'))),
-            wireguard=dict(type='dict',
-                           suboptions=dict(
-                               wgpeer_public_key=dict(type='str', required=False),
-                               wgpeer_allowed_ips=dict(type='str', required=False),
-                               wgpeer_endpoint=dict(type='str', required=False),
-                               wgpeer_persistent_keepalive=dict(type='int', required=False)
-                            )
-            ),
+            wireguard=dict(type='dict', options=dict(
+                              peer_key=dict(type='str', required=False, alias='wireguard.peer.key'),
+                              peer_allowed_ips=dict(type='str', required=False, alias='wireguard.peer.allowed-ips'),
+                              peer_endpoint=dict(type='str', required=False, alias='wireguard.peer.endpoint'),
+                              peer_persistent_keepalive=dict(type='int', required=False, alias='wireguard.peer.persistent-keepalive'))),
             vpn=dict(type='dict'),
             transport_mode=dict(type='str', choices=['datagram', 'connected']),
         ),

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1008,6 +1008,7 @@ options:
                 description: C(NMSettingSecretFlags) indicating how to handle the O(wireguard.private-key) property.
                 type: int
                 choices: [ 0, 1, 2 ]
+                no_log: true
             peer_public_key:
                 description: Public key of the WireGuard peer.
                 type: str
@@ -1940,17 +1941,7 @@ class Nmcli(object):
                 raise NmcliModuleError('type is macvlan but all of the following are missing: macvlan')
         elif self.type == 'wireguard':
             if self.wireguard:
-                options.update({
-                    'peer_key', self.wireguard.peer.ke
-                })
-        if 'peer_key' in self.wireguard:
-            options['wireguard.peer.key'] = self.wireguard['peer_key']
-        if 'peer_allowed_ips' in self.wireguard:
-            options['wireguard.peer.allowed-ips'] = self.wireguard['peer_allowed_ips']
-        if 'peer_endpoint' in self.wireguard:
-            options['wireguard.peer.endpoint'] = self.wireguard['peer_endpoint']
-        if 'peer_persistent_keepalive' in self.wireguard:
-            options['wireguard.peer.persistent-keepalive'] = str(self.wireguard['peer_persistent_keepalive'])
+                options.update(self.wireguard)
         elif self.type == 'vpn':
             if self.vpn:
                 vpn_data_values = ''
@@ -2640,10 +2631,12 @@ def main():
                     listen_port=dict(type='int', required=False),
                     mtu=dict(type='int', required=False),
                     peer_routes=dict(type='bool', required=False),
-                    peer_public_key=dict(type='str', required=False),
                     private_key=dict(type='str', required=False),
-                    private_key_flags=dict(type='str', required=False),
-                    peer_key=dict(type='str', required=False),
+                    private_key_flags=dict(type='int', required=False,no_log=True),
+                    peer_public_key=dict(type='str', required=False),
+                    peer_allowed_ips=dict(type='str',required=False),
+                    peer_endpoint=dict(type='str',required=False),
+                    peer_persistent_keepalive=dict(type='int',required=False),                    
                 )
             ),
             vpn=dict(type='dict'),

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -2641,13 +2641,13 @@ def main():
                               promiscuous=dict(type='bool'),
                               tap=dict(type='bool'))),
             wireguard=dict(type='dict',
-                           options=dict(
+                           suboptions=dict(
                                wgpeer_public_key=dict(type='str', required=False),
                                wgpeer_allowed_ips=dict(type='str', required=False),
                                wgpeer_endpoint=dict(type='str', required=False),
                                wgpeer_persistent_keepalive=dict(type='int', required=False)
                             )
-                        ),
+            ),
             vpn=dict(type='dict'),
             transport_mode=dict(type='str', choices=['datagram', 'connected']),
         ),

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -961,6 +961,7 @@ options:
             - 'For instance to configure a listen port:
               V({listen-port: 12345}).'
         type: dict
+        required: false
         version_added: 4.3.0
         suboptions:
             fwmark:
@@ -1483,11 +1484,11 @@ EXAMPLES = r'''
     ifname: mywg0
     wireguard:
         listen-port: 51820
-        private-key: my-private-key
-        peer-public-key: "your_peer_public_key"
-        peer-allowed-ips: "10.0.0.2/32"
-        peer-endpoint: "192.168.1.1:51820"
-        peer-persistent-keepalive: 25
+        private_key: my-private-key
+        peer_public_key: "{{ peer_public_key }}"
+        peer_allowed_ips: "10.0.0.2/32"
+        peer_endpoint: "192.168.1.1:51820"
+        peer_persistent_keepalive: 25
     autoconnect: true
     state: present
 
@@ -1938,12 +1939,12 @@ class Nmcli(object):
                     })
             elif self.state == 'present':
                 raise NmcliModuleError('type is macvlan but all of the following are missing: macvlan')
-        elif self.type == 'wireguard':
+        elif self.type == 'wireguard':        
             if self.wireguard:
-                for name, value in self.wireguard.items():
-                    options.update({
-                        'wireguard.%s' % name: value,
-                    })
+                for key, value in self.wireguard.items():
+                    if value is not None:
+                        nmcli_key = 'wireguard.%s' % key.replace('_', '-')
+                        options[nmcli_key] = value
         elif self.type == 'vpn':
             if self.vpn:
                 vpn_data_values = ''
@@ -2624,7 +2625,7 @@ def main():
                               parent=dict(type='str', required=True),
                               promiscuous=dict(type='bool'),
                               tap=dict(type='bool'))),
-            wireguard=dict(type='dict'),
+            wireguard=dict(type='dict', required=False),
             vpn=dict(type='dict'),
             transport_mode=dict(type='str', choices=['datagram', 'connected']),
         ),

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1008,19 +1008,19 @@ options:
                 description: C(NMSettingSecretFlags) indicating how to handle the O(wireguard.private-key) property.
                 type: int
                 choices: [ 0, 1, 2 ]
-            wgpeer_public_key:
+            peer_public_key:
                 description: Public key of the WireGuard peer.
                 type: str
                 version_added: 10.0.0
-            wgpeer_allowed_ips:
+            peer_allowed_ips:
                 description: The allowed IPs for the WireGuard peer.
                 type: str
                 version_added: 10.0.0
-            wgpeer_endpoint:
+            peer_endpoint:
                 description: Endpoint address (IP:Port) for the WireGuard peer.
                 type: str
                 version_added: 10.0.0
-            wgpeer_persistent_keepalive:
+            peer_persistent_keepalive:
                 description: Time in seconds to keep the connection alive (persistent keep-alive) for the WireGuard peer.
                 type: int
                 version_added: 10.0.0
@@ -1940,7 +1940,7 @@ class Nmcli(object):
                 raise NmcliModuleError('type is macvlan but all of the following are missing: macvlan')
         elif self.type == 'wireguard':
             if self.wireguard:
-                options.update(self.wireguard)      
+                options.update(self.wireguard)
         elif self.type == 'vpn':
             if self.vpn:
                 vpn_data_values = ''
@@ -2622,10 +2622,11 @@ def main():
                               promiscuous=dict(type='bool'),
                               tap=dict(type='bool'))),
             wireguard=dict(type='dict', options=dict(
-                              peer_key=dict(type='str', required=False, alias='wireguard.peer.key'),
-                              peer_allowed_ips=dict(type='str', required=False, alias='wireguard.peer.allowed-ips'),
-                              peer_endpoint=dict(type='str', required=False, alias='wireguard.peer.endpoint'),
-                              peer_persistent_keepalive=dict(type='int', required=False, alias='wireguard.peer.persistent-keepalive'))),
+                            peer_key=dict(type='str', required=False, no_log=True),
+                            peer_allowed_ips=dict(type='str', required=False),
+                            peer_endpoint=dict(type='str', required=False),
+                            peer_persistent_keepalive=dict(type='int', required=False)
+                            )),
             vpn=dict(type='dict'),
             transport_mode=dict(type='str', choices=['datagram', 'connected']),
         ),

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1008,23 +1008,22 @@ options:
                 description: C(NMSettingSecretFlags) indicating how to handle the O(wireguard.private-key) property.
                 type: int
                 choices: [ 0, 1, 2 ]
-            #Attributes for WireGuard Peers
             wgpeer_public_key:
                 description: Public key of the WireGuard peer.
                 type: str
-                required: false
+                version_added: 10.0.0
             wgpeer_allowed_ips:
                 description: The allowed IPs for the WireGuard peer.
                 type: str
-                required: false
+                version_added: 10.0.0
             wgpeer_endpoint:
                 description: Endpoint address (IP:Port) for the WireGuard peer.
                 type: str
-                required: false
+                version_added: 10.0.0
             wgpeer_persistent_keepalive:
                 description: Time in seconds to keep the connection alive (persistent keep-alive) for the WireGuard peer.
                 type: int
-                required: false
+                version_added: 10.0.0
     vpn:
         description:
             - Configuration of a VPN connection (PPTP and L2TP).
@@ -1485,10 +1484,10 @@ EXAMPLES = r'''
     wireguard:
         listen-port: 51820
         private-key: my-private-key
-    wgpeer_public_key: "your_peer_public_key"
-    wgpeer_allowed_ips: "10.0.0.2/32"
-    wgpeer_endpoint: "192.168.1.1:51820"
-    wgpeer_persistent_keepalive: 25
+        wgpeer_public_key: "your_peer_public_key"
+        wgpeer_allowed_ips: "10.0.0.2/32"
+        wgpeer_endpoint: "192.168.1.1:51820"
+        wgpeer_persistent_keepalive: 25
     autoconnect: true
     state: present
 
@@ -1945,22 +1944,21 @@ class Nmcli(object):
                     options.update({
                         'wireguard.%s' % name: value,
                     })
-                # Handle WireGuard peers, if provided
-                if module.params.get('wgpeer_public_key'):
+                if self.wireguard.get('wgpeer_public_key'):
                     options.update({
-                        'wireguard.peer.key': module.params['wgpeer_public_key']
+                        'wireguard.peer.key': self.wireguard['wgpeer_public_key']
                     })
-                if module.params.get('wgpeer_allowed_ips'):
+                if self.wireguard.get('wgpeer_allowed_ips'):
                     options.update({
-                        'wireguard.peer.allowed-ips': module.params['wgpeer_allowed_ips']
+                        'wireguard.peer.allowed-ips': self.wireguard['wgpeer_allowed_ips']
                     })
-                if module.params.get('wgpeer_endpoint'):
+                if self.wireguard.get('wgpeer_endpoint'):
                     options.update({
-                        'wireguard.peer.endpoint': module.params['wgpeer_endpoint']
+                        'wireguard.peer.endpoint': self.wireguard['wgpeer_endpoint']
                     })
-                if module.params.get('wgpeer_persistent_keepalive'):
+                if self.wireguard.get('wgpeer_persistent_keepalive'):
                     options.update({
-                        'wireguard.peer.persistent-keepalive': str(module.params['wgpeer_persistent_keepalive'])
+                        'wireguard.peer.persistent-keepalive': str(self.wireguard['wgpeer_persistent_keepalive'])
                     })
         elif self.type == 'vpn':
             if self.vpn:
@@ -2642,14 +2640,13 @@ def main():
                               parent=dict(type='str', required=True),
                               promiscuous=dict(type='bool'),
                               tap=dict(type='bool'))),
-            wireguard=dict(type='dict'),
+            wireguard=dict(type='dict', suboptions=dict(
+                                wgpeer_public_key=dict(type='str', required=False),
+                                wgpeer_allowed_ips=dict(type='str', required=False),
+                                wgpeer_endpoint=dict(type='str', required=False),
+                                wgpeer_persistent_keepalive=dict(type='int', required=False))),
             vpn=dict(type='dict'),
             transport_mode=dict(type='str', choices=['datagram', 'connected']),
-            #WireGuard peer attributes
-            wgpeer_public_key=dict(type='str', required=False),
-            wgpeer_allowed_ips=dict(type='str', required=False),
-            wgpeer_endpoint=dict(type='str', required=False),
-            wgpeer_persistent_keepalive=dict(type='int', required=False),
         ),
         mutually_exclusive=[['never_default4', 'gw4'],
                             ['routes4_extended', 'routes4'],

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1484,10 +1484,10 @@ EXAMPLES = r'''
     wireguard:
         listen-port: 51820
         private-key: my-private-key
-        wgpeer_public_key: "your_peer_public_key"
-        wgpeer_allowed_ips: "10.0.0.2/32"
-        wgpeer_endpoint: "192.168.1.1:51820"
-        wgpeer_persistent_keepalive: 25
+        peer_public_key: "your_peer_public_key"
+        peer_allowed_ips: "10.0.0.2/32"
+        peer_endpoint: "192.168.1.1:51820"
+        peer_persistent_keepalive: 25
     autoconnect: true
     state: present
 
@@ -1940,7 +1940,17 @@ class Nmcli(object):
                 raise NmcliModuleError('type is macvlan but all of the following are missing: macvlan')
         elif self.type == 'wireguard':
             if self.wireguard:
-                options.update(self.wireguard)
+                options.update({
+                    'peer_key', self.wireguard.peer.ke
+                })
+        if 'peer_key' in self.wireguard:
+            options['wireguard.peer.key'] = self.wireguard['peer_key']
+        if 'peer_allowed_ips' in self.wireguard:
+            options['wireguard.peer.allowed-ips'] = self.wireguard['peer_allowed_ips']
+        if 'peer_endpoint' in self.wireguard:
+            options['wireguard.peer.endpoint'] = self.wireguard['peer_endpoint']
+        if 'peer_persistent_keepalive' in self.wireguard:
+            options['wireguard.peer.persistent-keepalive'] = str(self.wireguard['peer_persistent_keepalive'])
         elif self.type == 'vpn':
             if self.vpn:
                 vpn_data_values = ''
@@ -2630,8 +2640,8 @@ def main():
                     listen_port=dict(type='int', required=False),
                     mtu=dict(type='int', required=False),
                     peer_routes=dict(type='bool', required=False),
-                    peer_public_key=dict(type='str', required=False, no_log=True),
-                    private_key=dict(type='str', required=False, no_log=True),
+                    peer_public_key=dict(type='str', required=False),
+                    private_key=dict(type='str', required=False),
                     private_key_flags=dict(type='str', required=False),
                     peer_key=dict(type='str', required=False),
                 )

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -2640,11 +2640,14 @@ def main():
                               parent=dict(type='str', required=True),
                               promiscuous=dict(type='bool'),
                               tap=dict(type='bool'))),
-            wireguard=dict(type='dict', suboptions=dict(
-                                wgpeer_public_key=dict(type='str', required=False),
-                                wgpeer_allowed_ips=dict(type='str', required=False),
-                                wgpeer_endpoint=dict(type='str', required=False),
-                                wgpeer_persistent_keepalive=dict(type='int', required=False))),
+            wireguard=dict(type='dict',
+                           suboptions=dict(
+                               wgpeer_public_key=dict(type='str', required=False),
+                               wgpeer_allowed_ips=dict(type='str', required=False),
+                               wgpeer_endpoint=dict(type='str', required=False),
+                               wgpeer_persistent_keepalive=dict(type='int', required=False)
+                            )
+                        ),
             vpn=dict(type='dict'),
             transport_mode=dict(type='str', choices=['datagram', 'connected']),
         ),

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1939,7 +1939,7 @@ class Nmcli(object):
                     })
             elif self.state == 'present':
                 raise NmcliModuleError('type is macvlan but all of the following are missing: macvlan')
-        elif self.type == 'wireguard':        
+        elif self.type == 'wireguard':
             if self.wireguard:
                 for key, value in self.wireguard.items():
                     if value is not None:

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1942,7 +1942,20 @@ class Nmcli(object):
                 raise NmcliModuleError('type is macvlan but all of the following are missing: macvlan')
         elif self.type == 'wireguard':
             if self.wireguard:
-                options.update(self.wireguard)
+                options.update({
+                    'fwmark':self.wireguard['fwmark'],
+                    'ip4-auto-default-route': self.wireguard['ip4_auto_default_route'],
+                    'ip6-auto-default-route': self.wireguard['ip6_auto_default_route'],
+                    'listen-port': self.wireguard['listen_port'],
+                    'mtu': self.wireguard['mtu'],
+                    'peer-routes': self.wireguard['peer_routes'],
+                    'private-key': self.wireguard['private_key'],
+                    'private-key-flags': self.wireguard['private_key_flags'],
+                    'peer-public-key': self.wireguard['peer_public_key'],
+                    'peer-allowed-ips': self.wireguard['peer_allowed_ips'],
+                    'peer-endpoint': self.wireguard['peer_endpoint'],
+                    'peer-persistent-keepalive': self.wireguard['peer_persistent_keepalive'],
+                })
         elif self.type == 'vpn':
             if self.vpn:
                 vpn_data_values = ''

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -2621,12 +2621,21 @@ def main():
                               parent=dict(type='str', required=True),
                               promiscuous=dict(type='bool'),
                               tap=dict(type='bool'))),
-            wireguard=dict(type='dict', options=dict(
-                            peer_key=dict(type='str', required=False, no_log=True),
-                            peer_allowed_ips=dict(type='str', required=False),
-                            peer_endpoint=dict(type='str', required=False),
-                            peer_persistent_keepalive=dict(type='int', required=False)
-                            )),
+            wireguard=dict(
+                type='dict',
+                options=dict(
+                    fwmark=dict(type='int', required=False),
+                    ip4_auto_default_route=dict(type='bool', required=False),
+                    ip6_auto_default_route=dict(type='bool', required=False),
+                    listen_port=dict(type='int', required=False),
+                    mtu=dict(type='int', required=False),
+                    peer_routes=dict(type='bool', required=False),
+                    peer_public_key=dict(type='str', required=False, no_log=True),
+                    private_key=dict(type='str', required=False, no_log=True),
+                    private_key_flags=dict(type='str', required=False),
+                    peer_key=dict(type='str', required=False),
+                )
+            ),
             vpn=dict(type='dict'),
             transport_mode=dict(type='str', choices=['datagram', 'connected']),
         ),

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1004,12 +1004,10 @@ options:
             private-key:
                 description: The 256 bit private-key in base64 encoding.
                 type: str
-                no_log: True
             private-key-flags:
                 description: C(NMSettingSecretFlags) indicating how to handle the O(wireguard.private-key) property.
                 type: int
                 choices: [ 0, 1, 2 ]
-                no_log: true
             peer-public-key:
                 description: Public key of the WireGuard peer.
                 type: str
@@ -1942,20 +1940,10 @@ class Nmcli(object):
                 raise NmcliModuleError('type is macvlan but all of the following are missing: macvlan')
         elif self.type == 'wireguard':
             if self.wireguard:
-                options.update({
-                    'fwmark':self.wireguard['fwmark'],
-                    'ip4-auto-default-route': self.wireguard['ip4_auto_default_route'],
-                    'ip6-auto-default-route': self.wireguard['ip6_auto_default_route'],
-                    'listen-port': self.wireguard['listen_port'],
-                    'mtu': self.wireguard['mtu'],
-                    'peer-routes': self.wireguard['peer_routes'],
-                    'private-key': self.wireguard['private_key'],
-                    'private-key-flags': self.wireguard['private_key_flags'],
-                    'peer-public-key': self.wireguard['peer_public_key'],
-                    'peer-allowed-ips': self.wireguard['peer_allowed_ips'],
-                    'peer-endpoint': self.wireguard['peer_endpoint'],
-                    'peer-persistent-keepalive': self.wireguard['peer_persistent_keepalive'],
-                })
+                for name, value in self.wireguard.items():
+                    options.update({
+                        'wireguard.%s' % name: value,
+                    })
         elif self.type == 'vpn':
             if self.vpn:
                 vpn_data_values = ''
@@ -2636,23 +2624,7 @@ def main():
                               parent=dict(type='str', required=True),
                               promiscuous=dict(type='bool'),
                               tap=dict(type='bool'))),
-            wireguard=dict(
-                type='dict',
-                options=dict(
-                    fwmark=dict(type='int', required=False),
-                    ip4_auto_default_route=dict(type='bool', required=False),
-                    ip6_auto_default_route=dict(type='bool', required=False),
-                    listen_port=dict(type='int', required=False),
-                    mtu=dict(type='int', required=False),
-                    peer_routes=dict(type='bool', required=False),
-                    private_key=dict(type='str', required=False, no_log=True),
-                    private_key_flags=dict(type='int', required=False, no_log=True),
-                    peer_public_key=dict(type='str', required=False),
-                    peer_allowed_ips=dict(type='str', required=False),
-                    peer_endpoint=dict(type='str', required=False),
-                    peer_persistent_keepalive=dict(type='int', required=False),           
-                )
-            ),
+            wireguard=dict(type='dict'),
             vpn=dict(type='dict'),
             transport_mode=dict(type='str', choices=['datagram', 'connected']),
         ),

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -2641,7 +2641,7 @@ def main():
                               promiscuous=dict(type='bool'),
                               tap=dict(type='bool'))),
             wireguard=dict(type='dict',
-                           suboptions=dict(
+                           options=dict(
                                wgpeer_public_key=dict(type='str', required=False),
                                wgpeer_allowed_ips=dict(type='str', required=False),
                                wgpeer_endpoint=dict(type='str', required=False),

--- a/tests/unit/plugins/modules/test_nmcli.py
+++ b/tests/unit/plugins/modules/test_nmcli.py
@@ -4065,6 +4065,7 @@ def test_wireguard_connection_unchanged(mocked_wireguard_connection_unchanged, c
 
     out, err = capfd.readouterr()
     results = json.loads(out)
+    print("Results:", results)
     assert not results.get('failed')
     assert not results['changed']
 

--- a/tests/unit/plugins/modules/test_nmcli.py
+++ b/tests/unit/plugins/modules/test_nmcli.py
@@ -1350,6 +1350,10 @@ TESTCASE_WIREGUARD = [
         'wireguard': {
             'listen-port': '51820',
             'private-key': '<hidden>',
+            'peer_public_key': 'publickey123',
+            'peer_allowed_ips': '10.0.0.2/32',
+            'peer_endpoint': '192.168.1.1:51820',
+            'peer_persistent_keepalive': 25
         },
         'method4': 'manual',
         'ip4': '10.10.10.10/24',
@@ -4038,7 +4042,11 @@ def test_create_wireguard(mocked_generic_connection_create, capfd):
                   'ipv6.method', 'manual',
                   'ipv6.addresses', '2001:db8::1/128',
                   'wireguard.listen-port', '51820',
-                  'wireguard.private-key', '<hidden>']:
+                  'wireguard.private-key', '<hidden>',
+                  'wireguard.peer-public-key', 'publickey123',
+                  'wireguard.peer-allowed-ips', '10.0.0.2/32',
+                  'wireguard.peer-endpoint', '192.168.1.1:51820',
+                  'wireguard.peer-persistent-keepalive', '25']:
         assert param in add_args_text
 
     out, err = capfd.readouterr()

--- a/tests/unit/plugins/modules/test_nmcli.py
+++ b/tests/unit/plugins/modules/test_nmcli.py
@@ -1942,6 +1942,28 @@ def mocked_gsm_connection_unchanged(mocker):
 
 @pytest.fixture
 def mocked_wireguard_connection_unchanged(mocker):
+    TESTCASE_WIREGUARD_SHOW_OUTPUT = '''
+[connection]
+id=non_existent_nw_device
+type=wireguard
+interface-name=wg_non_existant
+
+[ipv4]
+method=manual
+addresses=10.10.10.10/24
+
+[ipv6]
+method=manual
+addresses=2001:db8::1/128
+
+[wireguard]
+listen-port=51820
+private-key=<hidden>
+peer-public-key=publickey123
+peer-allowed-ips=10.0.0.2/32
+peer-endpoint=192.168.1.1:51820
+peer-persistent-keepalive=25
+'''
     mocker_set(mocker,
                connection_exists=True,
                execute_return=(0, TESTCASE_WIREGUARD_SHOW_OUTPUT, ""))
@@ -4065,7 +4087,6 @@ def test_wireguard_connection_unchanged(mocked_wireguard_connection_unchanged, c
 
     out, err = capfd.readouterr()
     results = json.loads(out)
-    print("Results:", results)
     assert not results.get('failed')
     assert not results['changed']
 


### PR DESCRIPTION
##### SUMMARY
This PR adds the ability to configure WireGuard peers using the `nmcli` Ansible module. It introduces several new parameters: `wgpeer_public_key`, `wgpeer_allowed_ips`, `wgpeer_endpoint`, and `wgpeer_persistent_keepalive`, allowing users to fully configure WireGuard peers directly within the Ansible playbook.

Fixes #8936
This change implements support for configuring WireGuard peers which is currently missing in `nmcli`. It ensures that users can define peer-specific settings like public keys, allowed IPs, and endpoints, making it possible to use `nmcli` with WireGuard for more complete VPN setups.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
nmcli

##### ADDITIONAL INFORMATION
The following parameters were added for WireGuard peer support:
- `wgpeer_public_key`: Public key of the WireGuard peer.
- `wgpeer_allowed_ips`: The allowed IPs for the WireGuard peer.
- `wgpeer_endpoint`: Endpoint address (IP:Port) for the WireGuard peer.
- `wgpeer_persistent_keepalive`: Time in seconds to maintain the connection alive for the WireGuard peer.

This feature is useful for anyone configuring WireGuard connections with multiple peers using NetworkManager through `nmcli`.

```
- name: Create a WireGuard connection with peer configuration
  community.general.nmcli:
    type: wireguard
    conn_name: my-wg-connection
    ifname: wg0
    wireguard:
      listen-port: 51820
      private-key: "my-private-key"
      peer_public_key: "your_peer_public_key"
      peer_allowed_ips: "10.0.0.2/32"
      peer_endpoint: "192.168.1.1:51820"
      peer_persistent_keepalive: 25
    autoconnect: true
    state: present
```
