### PR TITLE
consul_kv: add argument for the datacenter option on consul api

### DIFF
--- a/changelogs/fragments/9026-consul_kv-datacenter.yml
+++ b/changelogs/fragments/9026-consul_kv-datacenter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - consul_kv - add argument for the datacenter option on consul api
+  - consul_kv - add argument for the datacenter option on Consul API (https://github.com/ansible-collections/community.general/pull/9026).

--- a/changelogs/fragments/9026-consul_kv-datacenter.yml
+++ b/changelogs/fragments/9026-consul_kv-datacenter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - consul_kv - add argument for the datacenter option on consul api

--- a/plugins/modules/consul_kv.py
+++ b/plugins/modules/consul_kv.py
@@ -116,6 +116,7 @@ options:
           - The name of the datacenter to query. If unspecified, the query will default
             to the datacenter of the Consul agent on O(host).
         type: str
+        version_added: 10.0.0
 '''
 
 

--- a/plugins/modules/consul_kv.py
+++ b/plugins/modules/consul_kv.py
@@ -111,6 +111,11 @@ options:
           - Whether to verify the tls certificate of the consul agent.
         type: bool
         default: true
+    datacenter:
+        description:
+          - The name of the datacenter to query. If unspecified, the query will default
+            to the datacenter of the Consul agent on O(host).
+        type: str
 '''
 
 
@@ -291,7 +296,8 @@ def get_consul_api(module):
                          port=module.params.get('port'),
                          scheme=module.params.get('scheme'),
                          verify=module.params.get('validate_certs'),
-                         token=module.params.get('token'))
+                         token=module.params.get('token'),
+                         dc=module.params.get('datacenter'))
 
 
 def test_dependencies(module):
@@ -305,6 +311,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             cas=dict(type='str'),
+            datacenter=dict(type='str', default=None),
             flags=dict(type='str'),
             key=dict(type='str', required=True, no_log=False),
             host=dict(type='str', default='localhost'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
consul_kv

##### ADDITIONAL INFORMATION
Consul supports a `datacenter` feature allowing to use a consul agent to connect to a different consul datacenter.

Here is the [consul CLI documentation](https://developer.hashicorp.com/consul/commands/kv/put#datacenter).

Here is the [python-consul documentation](https://python-consul.readthedocs.io/en/latest/#consul).