### PR TITLE
bitwarden_secrets_manager lookup plugin: support more current versions of BWS CLI

### DIFF
--- a/changelogs/fragments/9028-bitwarden-secrets-manager-syntax-fix.yml
+++ b/changelogs/fragments/9028-bitwarden-secrets-manager-syntax-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "bitwarden lookup plugin - support BWS v0.3.0 syntax breaking change (https://github.com/ansible-collections/community.general/pull/9028)."

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -132,8 +132,8 @@ class BitwardenSecretsManager(object):
             '--color', 'no',
             '--access-token', bws_access_token
         ]
-
-		    # bws version 0.3.0 introduced a breaking change in the command line syntax:
+        
+        # bws version 0.3.0 introduced a breaking change in the command line syntax:
         # pre-0.3.0: verb noun
         # 0.3.0 and later: noun verb
         bws_version = self.get_bws_version()

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -79,6 +79,7 @@ from ansible.plugins.lookup import LookupBase
 
 from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 
+
 class BitwardenSecretsManagerException(AnsibleLookupError):
     pass
 

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -122,7 +122,6 @@ class BitwardenSecretsManager(object):
             raise BitwardenSecretsManagerException(to_text(err))
         return out
 
-
     def get_secret(self, secret_id, bws_access_token):
         """Get and return the secret with the given secret_id.
         """
@@ -134,7 +133,7 @@ class BitwardenSecretsManager(object):
             '--access-token', bws_access_token
         ]
 
-		# bws version 0.3.0 introduced a breaking change in the command line syntax:
+		    # bws version 0.3.0 introduced a breaking change in the command line syntax:
         # pre-0.3.0: verb noun
         # 0.3.0 and later: noun verb
         bws_version = self.get_bws_version()

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -117,7 +117,7 @@ class BitwardenSecretsManager(object):
     def get_bws_version(self):
         """Get the version of the Bitwarden Secrets Manager CLI.
         """
-        out, err, rc = self._run([ '--version' ])
+        out, err, rc = self._run(['--version'])
         if rc != 0:
             raise BitwardenSecretsManagerException(to_text(err))
         return out
@@ -132,7 +132,7 @@ class BitwardenSecretsManager(object):
             '--color', 'no',
             '--access-token', bws_access_token
         ]
-        
+
         # bws version 0.3.0 introduced a breaking change in the command line syntax:
         # pre-0.3.0: verb noun
         # 0.3.0 and later: noun verb

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -120,7 +120,8 @@ class BitwardenSecretsManager(object):
         out, err, rc = self._run(['--version'])
         if rc != 0:
             raise BitwardenSecretsManagerException(to_text(err))
-        return out
+        # strip the prefix and grab the last segment, the version number
+        return out.split()[-1]
 
     def get_secret(self, secret_id, bws_access_token):
         """Get and return the secret with the given secret_id.

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -114,6 +114,15 @@ class BitwardenSecretsManager(object):
         rc = p.wait()
         return to_text(out, errors='surrogate_or_strict'), to_text(err, errors='surrogate_or_strict'), rc
 
+    def get_bws_version(self):
+        """Get the version of the Bitwarden Secrets Manager CLI.
+        """
+        out, err, rc = self._run([ '--version' ])
+        if rc != 0:
+            raise BitwardenSecretsManagerException(to_text(err))
+        return out
+
+
     def get_secret(self, secret_id, bws_access_token):
         """Get and return the secret with the given secret_id.
         """
@@ -122,9 +131,17 @@ class BitwardenSecretsManager(object):
         # Color output was not always disabled correctly with the default 'auto' setting so explicitly disable it.
         params = [
             '--color', 'no',
-            '--access-token', bws_access_token,
-            'get', 'secret', secret_id
+            '--access-token', bws_access_token
         ]
+
+		# bws version 0.3.0 introduced a breaking change in the command line syntax:
+        # pre-0.3.0: verb noun
+        # 0.3.0 and later: noun verb
+        bws_version = self.get_bws_version()
+        if bws_version < '0.3.0':
+            params.extend(['get', 'secret', secret_id])
+        else:
+            params.extend(['secret', 'get', secret_id])
 
         out, err, rc = self._run_with_retry(params)
         if rc != 0:

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -77,6 +77,7 @@ from ansible.module_utils.common.text.converters import to_text
 from ansible.parsing.ajson import AnsibleJSONDecoder
 from ansible.plugins.lookup import LookupBase
 
+from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 
 class BitwardenSecretsManagerException(AnsibleLookupError):
     pass
@@ -138,7 +139,7 @@ class BitwardenSecretsManager(object):
         # pre-0.3.0: verb noun
         # 0.3.0 and later: noun verb
         bws_version = self.get_bws_version()
-        if bws_version < '0.3.0':
+        if LooseVersion(bws_version) < LooseVersion('0.3.0'):
             params.extend(['get', 'secret', secret_id])
         else:
             params.extend(['secret', 'get', secret_id])

--- a/tests/unit/plugins/lookup/test_bitwarden_secrets_manager.py
+++ b/tests/unit/plugins/lookup/test_bitwarden_secrets_manager.py
@@ -45,6 +45,10 @@ MOCK_SECRETS = [
 class MockBitwardenSecretsManager(BitwardenSecretsManager):
 
     def _run(self, args, stdin=None):
+        # mock the --version call
+        if args[0] == "--version":
+            return "bws 1.0.0", "", 0
+
         # secret_id is the last argument passed to the bws CLI
         secret_id = args[-1]
         rc = 1


### PR DESCRIPTION
##### SUMMARY
[Bitwarden Secrets Manager v0.3.0 introduced a breaking change](https://github.com/bitwarden/sdk/releases/tag/bws-v0.3.0), swapping the noun and verb in the CLI. This change adds a version check to the BWS lookup and uses the correct command syntax for the version you have installed.

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
bitwarden_secrets_manager