### PR TITLE
Add note about check_mode to dnf_config_manager

### DIFF
--- a/plugins/modules/dnf_config_manager.py
+++ b/plugins/modules/dnf_config_manager.py
@@ -40,6 +40,9 @@ options:
     required: false
     type: str
     choices: [enabled, disabled]
+notes:
+- When run in check mode, the specified repositories are not changed. This may cause failures in subsequent tasks 
+  in a test-run of a playbook. To force the repository config to be changed, specify C(check_mode: false) on the task.
 seealso:
   - module: ansible.builtin.dnf
   - module: ansible.builtin.yum_repository

--- a/plugins/modules/dnf_config_manager.py
+++ b/plugins/modules/dnf_config_manager.py
@@ -41,8 +41,8 @@ options:
     type: str
     choices: [enabled, disabled]
 notes:
-- When run in check mode, the specified repositories are not changed. This may cause failures in subsequent tasks 
-  in a test-run of a playbook. To force the repository config to be changed, specify C(check_mode: false) on the task.
+- When run in check mode, the specified repositories are not changed. This may cause failures in subsequent tasks
+  in a test-run of a playbook. To force the repository config to be changed, specify V(check_mode: false) on the task.
 seealso:
   - module: ansible.builtin.dnf
   - module: ansible.builtin.yum_repository

--- a/plugins/modules/dnf_config_manager.py
+++ b/plugins/modules/dnf_config_manager.py
@@ -41,7 +41,8 @@ options:
     type: str
     choices: [enabled, disabled]
 notes:
-- When run in check mode, the specified repositories are not changed. This may cause failures in subsequent tasks
+- >
+  When run in check mode, the specified repositories are not changed. This may cause failures in subsequent tasks
   in a test-run of a playbook. To force the repository config to be changed, set C(check_mode) to C(false) on the
   task. See R(the documentation on playbook check_mode, playbooks_checkmode).
 seealso:

--- a/plugins/modules/dnf_config_manager.py
+++ b/plugins/modules/dnf_config_manager.py
@@ -42,7 +42,8 @@ options:
     choices: [enabled, disabled]
 notes:
 - When run in check mode, the specified repositories are not changed. This may cause failures in subsequent tasks
-  in a test-run of a playbook. To force the repository config to be changed, specify V(check_mode: false) on the task.
+  in a test-run of a playbook. To force the repository config to be changed, set C(check_mode) to C(false) on the
+  task. See R(the documentation on playbook check_mode, playbooks_checkmode).
 seealso:
   - module: ansible.builtin.dnf
   - module: ansible.builtin.yum_repository


### PR DESCRIPTION
##### SUMMARY

Enabling repositories is an 'early' task in people starting to use Ansible, and in-depth knowledge of check_mode is probably not gained before trying to use a module such as this.

If this module is run in check_mode, specified repositories are not actually enabled/disabled. This can cause a playbook to fail it's tests, even though they would work in a 'real' run.

Mentioning this would help newer users of Ansible (such as myself!)


<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

community.general.dnf_config_manager documentation

##### ADDITIONAL INFORMATION

I spent a couple of days running/checking my playbooks, getting into the depths of debugging the module on a remote node before discovering that the repository I thought I was enabling _didn't_ actually get enabled in the 'check' run - and this was the cause of a subsequent task failing. 
