### PR TITLE
Skip timezone test on RHEL 7.9 VMs

### DIFF
--- a/tests/integration/targets/timezone/aliases
+++ b/tests/integration/targets/timezone/aliases
@@ -7,3 +7,4 @@ destructive
 skip/aix
 skip/osx
 skip/macos
+skip/rhel7.9  # TODO: '/bin/timedatectl set-local-rtc no' fails with 'Failed to set local RTC: Failed to set RTC to local/UTC: Input/output error'


### PR DESCRIPTION
##### SUMMARY
On the RHEL 7.9 VMs, `/bin/timedatectl set-local-rtc no` fails with `Failed to set local RTC: Failed to set RTC to local/UTC: Input/output error`.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
timezone
