### PR TITLE
modprobe: fix --check mode not being honored for persistent option

### DIFF
--- a/plugins/modules/modprobe.py
+++ b/plugins/modules/modprobe.py
@@ -163,8 +163,9 @@ class Modprobe(object):
     def create_module_file(self):
         file_path = os.path.join(MODULES_LOAD_LOCATION,
                                  self.name + '.conf')
-        with open(file_path, 'w') as file:
-            file.write(self.name + '\n')
+        if not self.check_mode:
+            with open(file_path, 'w') as file:
+                file.write(self.name + '\n')
 
     @property
     def module_options_file_content(self):
@@ -175,8 +176,9 @@ class Modprobe(object):
     def create_module_options_file(self):
         new_file_path = os.path.join(PARAMETERS_FILES_LOCATION,
                                      self.name + '.conf')
-        with open(new_file_path, 'w') as file:
-            file.write(self.module_options_file_content)
+        if not self.check_mode:
+            with open(new_file_path, 'w') as file:
+                file.write(self.module_options_file_content)
 
     def disable_old_params(self):
 
@@ -190,7 +192,7 @@ class Modprobe(object):
                     file_content[index] = '#' + line
                     content_changed = True
 
-            if content_changed:
+            if not self.check_mode and content_changed:
                 with open(modprobe_file, 'w') as file:
                     file.write('\n'.join(file_content))
 
@@ -206,7 +208,7 @@ class Modprobe(object):
                     file_content[index] = '#' + line
                     content_changed = True
 
-            if content_changed:
+            if not self.check_mode and content_changed:
                 with open(module_file, 'w') as file:
                     file.write('\n'.join(file_content))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->
This change fixes an issue in the `community.general.modprobe` module where the `--check` mode was not being honored when the `persistent` option was set. 
Previously, even in `--check` mode, the module would attempt to modify system files, which is not the expected behavior. 
With this fix, when `--check` mode is enabled, the module will simulate the changes without making any modifications to the system, ensuring correct dry-run behavior.

Fixes https://github.com/ansible-collections/community.general/issues/9051

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
modprobe

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
1. Create an Ansible playbook with the following task
```yaml (paste below)
- name: Load dummy module
  community.general.modprobe:
    name: dummy
    persistent: present
    # persistent: absent
```
2. Run the playbook in --check mode
```
ansible-playbook playbook.yml --check
```
3. Observe that the module modifies the system even in `--check` mode, which should not happen.

After the fix:
- Running the playbook in `--check` mode will no longer apply changes to the system, and will only simulate the action.
