### PR TITLE
one_image/one_image_info: Fix class typo

### DIFF
--- a/plugins/modules/one_image.py
+++ b/plugins/modules/one_image.py
@@ -462,7 +462,7 @@ class ImageModule(OpenNebulaModule):
         if changed and not self.module.check_mode:
             self.one.image.enable(image.ID, enable)
 
-        result = OpenNebulaModule.get_image_info(image)
+        result = OpenNebulaModule.get_image_info(self, image)
         result['changed'] = changed
 
         return result
@@ -486,7 +486,7 @@ class ImageModule(OpenNebulaModule):
         if changed and not self.module.check_mode:
             self.one.image.persistent(image.ID, enable)
 
-        result = OpenNebulaModule.get_image_info(image)
+        result = OpenNebulaModule.get_image_info(self, image)
         result['changed'] = changed
 
         return result
@@ -497,7 +497,7 @@ class ImageModule(OpenNebulaModule):
 
         tmp_image = self.get_image_by_name(new_name)
         if tmp_image:
-            result = OpenNebulaModule.get_image_info(tmp_image)
+            result = OpenNebulaModule.get_image_info(self, tmp_image)
             result['changed'] = False
             return result
 
@@ -509,7 +509,7 @@ class ImageModule(OpenNebulaModule):
             self.wait_for_ready(new_id)
             image = self.one.image.info(new_id)
 
-        result = OpenNebulaModule.get_image_info(image)
+        result = OpenNebulaModule.get_image_info(self, image)
         result['changed'] = True
 
         return result
@@ -519,7 +519,7 @@ class ImageModule(OpenNebulaModule):
             self.module.fail_json(msg="'new_name' option has to be specified when the state is 'renamed'")
 
         if new_name == image.NAME:
-            result = OpenNebulaModule.get_image_info(image)
+            result = OpenNebulaModule.get_image_info(self, image)
             result['changed'] = False
             return result
 
@@ -530,7 +530,7 @@ class ImageModule(OpenNebulaModule):
         if not self.module.check_mode:
             self.one.image.rename(image.ID, new_name)
 
-        result = OpenNebulaModule.get_image_info(image)
+        result = OpenNebulaModule.get_image_info(self, image)
         result['changed'] = True
         return result
 

--- a/plugins/modules/one_image_info.py
+++ b/plugins/modules/one_image_info.py
@@ -307,7 +307,7 @@ class ImageInfoModule(OpenNebulaModule):
             images = self.get_all_images().IMAGE
 
         self.result = {
-            'images': [OpenNebulaModule.get_image_info(image) for image in images]
+            'images': [OpenNebulaModule.get_image_info(self, image) for image in images]
         }
 
         self.exit()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Hello! There are typo in both modules which leads to an error 
I suppose these changes are **self**-explanatory :)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
`one_image`
`one_image_info`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I moved some of the commonly used functions to a `opennebula` module utils but unfortunately made a typo back in https://github.com/ansible-collections/community.general/pull/8889/files
So I tested `one_image_info` locally and it seems to be working well (see picture)
<!--- Paste verbatim command output below, e.g. before and after your change -->
![image](https://github.com/user-attachments/assets/4fe4967c-cae4-48a9-814d-7a00d02ec8f0)

