### PR TITLE
Redfish: Added handling for trailing slashes in URIs when extracting member identifiers

### DIFF
--- a/changelogs/fragments/9047-redfish-uri-parsing.yml
+++ b/changelogs/fragments/9047-redfish-uri-parsing.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - redfish_utils - fix issue with URI parsing to gracefully handling trailing slashes when extracting member identifiers (https://github.com/ansible-collections/community.general/issues/9047).
+  - redfish_utils module utils - fix issue with URI parsing to gracefully handling trailing slashes when extracting member identifiers (https://github.com/ansible-collections/community.general/issues/9047).

--- a/changelogs/fragments/9047-redfish-uri-parsing.yml
+++ b/changelogs/fragments/9047-redfish-uri-parsing.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - redfish_utils module utils - fix issue with URI parsing to gracefully handling trailing slashes when extracting member identifiers (https://github.com/ansible-collections/community.general/issues/9047).
+  - redfish_utils module utils - fix issue with URI parsing to gracefully handling trailing slashes when extracting member identifiers (https://github.com/ansible-collections/community.general/issues/9047, https://github.com/ansible-collections/community.general/pull/9057).

--- a/changelogs/fragments/9047-redfish-uri-parsing.yml
+++ b/changelogs/fragments/9047-redfish-uri-parsing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redfish_utils - fix issue with URI parsing to gracefully handling trailing slashes when extracting member identifiers (https://github.com/ansible-collections/community.general/issues/9047).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -695,7 +695,7 @@ class RedfishUtils(object):
                         entry[prop] = logEntry.get(prop)
                 if entry:
                     list_of_log_entries.append(entry)
-            log_name = log_svcs_uri.split('/')[-1]
+            log_name = log_svcs_uri.rstrip('/').split('/')[-1]
             logs[log_name] = list_of_log_entries
             list_of_logs.append(logs)
 
@@ -1052,7 +1052,7 @@ class RedfishUtils(object):
                                     if 'Drives' in data[u'Links']:
                                         for link in data[u'Links'][u'Drives']:
                                             drive_id_link = link[u'@odata.id']
-                                            drive_id = drive_id_link.split("/")[-1]
+                                            drive_id = drive_id_link.rstrip('/').split('/')[-1]
                                             drive_id_list.append({'Id': drive_id})
                                         volume_result['Linked_drives'] = drive_id_list
                                 volume_results.append(volume_result)
@@ -3432,7 +3432,7 @@ class RedfishUtils(object):
 
         # Capture list of URIs that match a specified HostInterface resource Id
         if hostinterface_id:
-            matching_hostinterface_uris = [uri for uri in uris if hostinterface_id in uri.split('/')[-1]]
+            matching_hostinterface_uris = [uri for uri in uris if hostinterface_id in uri.rstrip('/').split('/')[-1]]
         if hostinterface_id and matching_hostinterface_uris:
             hostinterface_uri = list.pop(matching_hostinterface_uris)
         elif hostinterface_id and not matching_hostinterface_uris:
@@ -3551,12 +3551,12 @@ class RedfishUtils(object):
         result = {}
         if manager is None:
             if len(self.manager_uris) == 1:
-                manager = self.manager_uris[0].split('/')[-1]
+                manager = self.manager_uris[0].rstrip('/').split('/')[-1]
             elif len(self.manager_uris) > 1:
                 entries = self.get_multi_manager_inventory()['entries']
                 managers = [m[0]['manager_uri'] for m in entries if m[1].get('ServiceIdentification')]
                 if len(managers) == 1:
-                    manager = managers[0].split('/')[-1]
+                    manager = managers[0].rstrip('/').split('/')[-1]
                 else:
                     self.module.fail_json(msg=[
                         "Multiple managers with ServiceIdentification were found: %s" % str(managers),
@@ -3714,7 +3714,7 @@ class RedfishUtils(object):
         # Matching Storage Subsystem ID with user input
         self.storage_subsystem_uri = ""
         for storage_subsystem_uri in self.storage_subsystems_uris:
-            if storage_subsystem_uri.split("/")[-2] == storage_subsystem_id:
+            if storage_subsystem_uri.rstrip('/').split('/')[-1] == storage_subsystem_id:
                 self.storage_subsystem_uri = storage_subsystem_uri
 
         if not self.storage_subsystem_uri:
@@ -3742,7 +3742,7 @@ class RedfishUtils(object):
 
         # Delete each volume
         for volume in self.volume_uris:
-            if volume.split("/")[-1] in volume_ids:
+            if volume.rstrip('/').split('/')[-1] in volume_ids:
                 response = self.delete_request(self.root_uri + volume)
                 if response['ret'] is False:
                     return response
@@ -3776,7 +3776,7 @@ class RedfishUtils(object):
         # Matching Storage Subsystem ID with user input
         self.storage_subsystem_uri = ""
         for storage_subsystem_uri in self.storage_subsystems_uris:
-            if storage_subsystem_uri.split("/")[-2] == storage_subsystem_id:
+            if storage_subsystem_uri.rstrip('/').split('/')[-1] == storage_subsystem_id:
                 self.storage_subsystem_uri = storage_subsystem_uri
 
         if not self.storage_subsystem_uri:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some implementations have trailing slashes in their URIs. While most of this module's code does not rely on exact URIs, some places will take the last URI segment using the `split` function when determining identifiers for collection members. In these cases, it'll be an empty string. Specifically for volume management, the `split` function was assuming trailing slashes were always present.

The change here always removes trailing slashes before trying to extract member identifiers.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fix #9047 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
redfish_utils
