### PR TITLE
proxmox_kvm: add support for ciupgrade parameter

### DIFF
--- a/changelogs/fragments/9066-proxmox-kvm-ciupgrade.yml
+++ b/changelogs/fragments/9066-proxmox-kvm-ciupgrade.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox_kvm - adds the ``ciupgrade`` parameter to specify whether cloud-init should upgrade system packages at first boot (https://github.com/ansible-collections/community.general/pull/9066).

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -91,6 +91,7 @@ options:
       - 'cloud-init: do an automatic package upgrade after the first boot.'
     type: bool
     default: true
+    version_added: 10.0.0
   ciuser:
     description:
       - 'cloud-init: username of default user to create.'

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -90,7 +90,6 @@ options:
     description:
       - 'cloud-init: do an automatic package upgrade after the first boot.'
     type: bool
-    default: true
     version_added: 10.0.0
   ciuser:
     description:

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -86,6 +86,11 @@ options:
     type: str
     choices: ['nocloud', 'configdrive2']
     version_added: 1.3.0
+  ciupgrade:
+    description:
+      - 'cloud-init: do an automatic package upgrade after the first boot.'
+    type: bool
+    default: true
   ciuser:
     description:
       - 'cloud-init: username of default user to create.'
@@ -984,6 +989,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
         # Available only in PVE 4
         only_v4 = ['force', 'protection', 'skiplock']
         only_v6 = ['ciuser', 'cipassword', 'sshkeys', 'ipconfig', 'tags']
+        only_v8 = ['ciupgrade']
 
         # valid clone parameters
         valid_clone_params = ['format', 'full', 'pool', 'snapname', 'storage', 'target']
@@ -1009,6 +1015,12 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
         # The features work only on PVE 6
         if pve_major_version < 6:
             for p in only_v6:
+                if p in kwargs:
+                    del kwargs[p]
+
+        # The features work only on PVE 8
+        if pve_major_version < 8:
+            for p in only_v8:
                 if p in kwargs:
                     del kwargs[p]
 
@@ -1207,6 +1219,7 @@ def main():
         cicustom=dict(type='str'),
         cipassword=dict(type='str', no_log=True),
         citype=dict(type='str', choices=['nocloud', 'configdrive2']),
+        ciupgrade=dict(type='bool'),
         ciuser=dict(type='str'),
         clone=dict(type='str'),
         cores=dict(type='int'),
@@ -1414,6 +1427,7 @@ def main():
                               cicustom=module.params['cicustom'],
                               cipassword=module.params['cipassword'],
                               citype=module.params['citype'],
+                              ciupgrade=module.params['ciupgrade'],
                               ciuser=module.params['ciuser'],
                               cpulimit=module.params['cpulimit'],
                               cpuunits=module.params['cpuunits'],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR implements the `ciupgrade` parameter of the proxmox API in the `proxmox_kvm` module to allow opting out of package upgrades at first boot when using cloud-init.

I'm not super familiar with the module's code so I had a quick read, looked into how the other cloud-init parameters were handled and took clues from that, in particular Proxmox version handling (according to their [roadmap page](https://pve.proxmox.com/wiki/Roadmap#Proxmox_VE_8.0), it was introduced in version 8.0). So essentially, this PR just adds the new parameter and drops it from the arguments if `pve_major_version < 8`. I've set the `version_added` doc attribute to `10.0.0` as this seems to be the next planned release.

Fixes #8119 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
proxmox_kvm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->