### PR TITLE
Remove redundant `HomebrewValidate.valid_package` calls in homebrew module.

### DIFF
--- a/changelogs/fragments/9076-remove-duplicated-homebrew-package-name-validation.yml
+++ b/changelogs/fragments/9076-remove-duplicated-homebrew-package-name-validation.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - homebrew - remove duplicated package name validation (https://github.com/ansible-collections/community.general/pull/9076).

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -401,11 +401,6 @@ class Homebrew(object):
 
     # checks ------------------------------------------------------- {{{
     def _current_package_is_installed(self):
-        if not HomebrewValidate.valid_package(self.current_package):
-            self.failed = True
-            self.message = 'Invalid package: {0}.'.format(self.current_package)
-            raise HomebrewException(self.message)
-
         cmd = [
             "{brew_path}".format(brew_path=self.brew_path),
             "info",
@@ -424,9 +419,6 @@ class Homebrew(object):
         return _check_package_in_json(data, "formulae") or _check_package_in_json(data, "casks")
 
     def _current_package_is_outdated(self):
-        if not HomebrewValidate.valid_package(self.current_package):
-            return False
-
         rc, out, err = self.module.run_command([
             self.brew_path,
             'outdated',
@@ -436,9 +428,7 @@ class Homebrew(object):
         return rc != 0
 
     def _current_package_is_installed_from_head(self):
-        if not HomebrewValidate.valid_package(self.current_package):
-            return False
-        elif not self._current_package_is_installed():
+        if not self._current_package_is_installed():
             return False
 
         rc, out, err = self.module.run_command([
@@ -534,11 +524,6 @@ class Homebrew(object):
 
     # installed ------------------------------ {{{
     def _install_current_package(self):
-        if not HomebrewValidate.valid_package(self.current_package):
-            self.failed = True
-            self.message = 'Invalid package: {0}.'.format(self.current_package)
-            raise HomebrewException(self.message)
-
         if self._current_package_is_installed():
             self.unchanged_count += 1
             self.unchanged_pkgs.append(self.current_package)
@@ -594,11 +579,6 @@ class Homebrew(object):
     # upgraded ------------------------------- {{{
     def _upgrade_current_package(self):
         command = 'upgrade'
-
-        if not HomebrewValidate.valid_package(self.current_package):
-            self.failed = True
-            self.message = 'Invalid package: {0}.'.format(self.current_package)
-            raise HomebrewException(self.message)
 
         current_package_is_installed = self._current_package_is_installed()
         if not current_package_is_installed:
@@ -667,11 +647,6 @@ class Homebrew(object):
 
     # uninstalled ---------------------------- {{{
     def _uninstall_current_package(self):
-        if not HomebrewValidate.valid_package(self.current_package):
-            self.failed = True
-            self.message = 'Invalid package: {0}.'.format(self.current_package)
-            raise HomebrewException(self.message)
-
         if not self._current_package_is_installed():
             self.unchanged_count += 1
             self.unchanged_pkgs.append(self.current_package)
@@ -716,11 +691,6 @@ class Homebrew(object):
 
     # linked --------------------------------- {{{
     def _link_current_package(self):
-        if not HomebrewValidate.valid_package(self.current_package):
-            self.failed = True
-            self.message = 'Invalid package: {0}.'.format(self.current_package)
-            raise HomebrewException(self.message)
-
         if not self._current_package_is_installed():
             self.failed = True
             self.message = 'Package not installed: {0}.'.format(self.current_package)
@@ -763,11 +733,6 @@ class Homebrew(object):
 
     # unlinked ------------------------------- {{{
     def _unlink_current_package(self):
-        if not HomebrewValidate.valid_package(self.current_package):
-            self.failed = True
-            self.message = 'Invalid package: {0}.'.format(self.current_package)
-            raise HomebrewException(self.message)
-
         if not self._current_package_is_installed():
             self.failed = True
             self.message = 'Package not installed: {0}.'.format(self.current_package)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Followup to #9022. This removes duplicated calls to the `HomebrewValidate.valid_package` responsible of validating homebrew package names provided.

Because the validation logic is already present in the `current_package` property setter, any call like `HomebrewValidate.valid_package(self.current_package)` is redundant. For `self.current_package` to exist, it must have been set (hence going throw the setter validation logic).

Here is a before/after using the same instrumentation used in the linked PR. The duplicated validation calls are removed correctly:
```diff
_run starting ...
    _upgrade_packages starting ...
        HomebrewValidate.valid_package(btop)
        _upgrade_current_package starting ...
            HomebrewValidate.valid_package(btop)
            _current_package_is_installed starting ...
-                HomebrewValidate.valid_package(btop)
            _current_package_is_installed took 1048.91 ms
            _current_package_is_installed starting ...
-                HomebrewValidate.valid_package(btop)
            _current_package_is_installed took 1065.79 ms
            _current_package_is_outdated starting ...
-                HomebrewValidate.valid_package(btop)
            _current_package_is_outdated took 1065.01 ms
        _upgrade_current_package took 3179.85 ms
        HomebrewValidate.valid_package(dust)
        _upgrade_current_package starting ...
            HomebrewValidate.valid_package(dust)
            _current_package_is_installed starting ...
-                HomebrewValidate.valid_package(dust)
            _current_package_is_installed took 1136.11 ms
            _current_package_is_installed starting ...
-                HomebrewValidate.valid_package(dust)
            _current_package_is_installed took 1122.59 ms
            _current_package_is_outdated starting ...
-                HomebrewValidate.valid_package(dust)
            _current_package_is_outdated took 1064.98 ms
        _upgrade_current_package took 3323.78 ms
    _upgrade_packages took 6503.71 ms
_run took 6503.72 ms
```

I did not add a changelog fragment yet because it's pure refactoring and will have little user facing impact. Let me know if it's still needed.

##### ISSUE TYPE
- Refactoring Pull Request

##### COMPONENT NAME
homebrew

##### ADDITIONAL INFORMATION
I used the same instrumentation as for the other PR to detect this.
