### PR TITLE
keycloak_client: remove code that turns attributes dict into list

### DIFF
--- a/changelogs/fragments/9077-keycloak_client-fix-attributes-dict-turned-into-list.yml
+++ b/changelogs/fragments/9077-keycloak_client-fix-attributes-dict-turned-into-list.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_client - fix diff by removing code that turns the attributes dict which contains addtional settings into a list (https://github.com/ansible-collections/community.general/pull/9077).

--- a/changelogs/fragments/9077-keycloak_client-fix-attributes-dict-turned-into-list.yml
+++ b/changelogs/fragments/9077-keycloak_client-fix-attributes-dict-turned-into-list.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - keycloak_client - fix diff by removing code that turns the attributes dict which contains addtional settings into a list (https://github.com/ansible-collections/community.general/pull/9077).
+  - keycloak_client - fix diff by removing code that turns the attributes dict which contains additional settings into a list (https://github.com/ansible-collections/community.general/pull/9077).

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -805,9 +805,6 @@ def normalise_cr(clientrep, remove_ids=False):
     # Avoid the dict passed in to be modified
     clientrep = clientrep.copy()
 
-    if 'attributes' in clientrep:
-        clientrep['attributes'] = list(sorted(clientrep['attributes']))
-
     if 'defaultClientScopes' in clientrep:
         clientrep['defaultClientScopes'] = list(sorted(clientrep['defaultClientScopes']))
 
@@ -1024,13 +1021,6 @@ def main():
     for client_param in client_params:
         new_param_value = module.params.get(client_param)
 
-        # some lists in the Keycloak API are sorted, some are not.
-        if isinstance(new_param_value, list):
-            if client_param in ['attributes']:
-                try:
-                    new_param_value = sorted(new_param_value)
-                except TypeError:
-                    pass
         # Unfortunately, the ansible argument spec checker introduces variables with null values when
         # they are not specified
         if client_param == 'protocol_mappers':


### PR DESCRIPTION
##### SUMMARY
The `attribute` config item contains a dict with additional settings. The module turns the dict into a list before storing it for the diff/end_state, which turns it into a list of just the keys:

```
+    "attributes": [
+        "backchannel.logout.revoke.offline.tokens",
+        "backchannel.logout.session.required",
+        "frontchannel.logout.url"
+    ],
+    "baseUrl": "https://www.example.com/",
```

The actual data sent to the API is not changed, so only `--diff`/`end_state` is affected.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_client
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Create a client with the module with any of the `attributes` settings from above set and `--diff`.
<!--- Paste verbatim command output below, e.g. before and after your change -->
