### PR TITLE
keycloak_clientscope: remove code turning attributes dict into list

### DIFF
--- a/changelogs/fragments/9082-keycloak_clientscope-fix-attributes-dict-turned-into-list.yml
+++ b/changelogs/fragments/9082-keycloak_clientscope-fix-attributes-dict-turned-into-list.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_clientscope - fix diff and ``end_state`` by removing the code that turns the attributes dict, which contains additional config items, into a list (https://github.com/ansible-collections/community.general/pull/9082).

--- a/plugins/modules/keycloak_clientscope.py
+++ b/plugins/modules/keycloak_clientscope.py
@@ -317,9 +317,6 @@ def normalise_cr(clientscoperep, remove_ids=False):
     # Avoid the dict passed in to be modified
     clientscoperep = clientscoperep.copy()
 
-    if 'attributes' in clientscoperep:
-        clientscoperep['attributes'] = list(sorted(clientscoperep['attributes']))
-
     if 'protocolMappers' in clientscoperep:
         clientscoperep['protocolMappers'] = sorted(clientscoperep['protocolMappers'], key=lambda x: (x.get('name'), x.get('protocol'), x.get('protocolMapper')))
         for mapper in clientscoperep['protocolMappers']:
@@ -418,13 +415,6 @@ def main():
     for clientscope_param in clientscope_params:
         new_param_value = module.params.get(clientscope_param)
 
-        # some lists in the Keycloak API are sorted, some are not.
-        if isinstance(new_param_value, list):
-            if clientscope_param in ['attributes']:
-                try:
-                    new_param_value = sorted(new_param_value)
-                except TypeError:
-                    pass
         # Unfortunately, the ansible argument spec checker introduces variables with null values when
         # they are not specified
         if clientscope_param == 'protocol_mappers':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Same issue as in the keycloak_client module (https://github.com/ansible-collections/community.general/pull/9077).

The module turns the attributes dict into a list when storing the config for diff and end_state. This turns the dict into a list of just the keys:
```
+    "attributes": [
+        "consent.screen.text",
+        "display.on.consent.screen",
+        "gui.order",
+        "include.in.token.scope"
+    ],
+    "description": "sAMAccountName",
```

The changes remove the code turning the dict into a list, so that the diff looks like this:
```
+    "attributes": {
+        "consent.screen.text": "",
+        "display.on.consent.screen": "true",
+        "gui.order": "",
+        "include.in.token.scope": "true"
+    },
+    "description": "sAMAccountName",
```
The actual data sent to the API is unaffected, as the turning into a list happens in the normalize function, which is only called before storing the clientscope config in the diff or end_state.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_clientscope
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Create a clientscope with the module and some config items set in the `attributes` dict and `--diff`
<!--- Paste verbatim command output below, e.g. before and after your change -->
