### PR TITLE
Stop using ansible.module_utils.compat.importlib

### DIFF
--- a/changelogs/fragments/9084-collection_version-importlib.yml
+++ b/changelogs/fragments/9084-collection_version-importlib.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "collection_version lookup plugin - use ``importlib`` directly instead of the deprecated and in ansible-core 2.19 removed ``ansible.module_utils.compat.importlib`` (https://github.com/ansible-collections/community.general/pull/9084)."

--- a/plugins/lookup/collection_version.py
+++ b/plugins/lookup/collection_version.py
@@ -63,11 +63,11 @@ RETURN = """
 import json
 import os
 import re
+from importlib import import_module
 
 import yaml
 
 from ansible.errors import AnsibleLookupError
-from ansible.module_utils.compat.importlib import import_module
 from ansible.plugins.lookup import LookupBase
 
 


### PR DESCRIPTION
##### SUMMARY
This makes sanity tests (and potentially also other tests) fail right now.

Ref: https://github.com/ansible/ansible/pull/84161

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
collection_version lookup plugin
