### PR TITLE
mattermost: add support for message priority

### DIFF
--- a/changelogs/fragments/9087-mattermost-priority.yaml
+++ b/changelogs/fragments/9087-mattermost-priority.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - mattermost - adds support for message priority (https://github.com/ansible-collections/community.general/issues/9068)
+  - mattermost - adds support for message priority (https://github.com/ansible-collections/community.general/issues/9068).

--- a/changelogs/fragments/9087-mattermost-priority.yaml
+++ b/changelogs/fragments/9087-mattermost-priority.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - mattermost - adds support for message priority (https://github.com/ansible-collections/community.general/issues/9068)

--- a/changelogs/fragments/9087-mattermost-priority.yaml
+++ b/changelogs/fragments/9087-mattermost-priority.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - mattermost - adds support for message priority (https://github.com/ansible-collections/community.general/issues/9068).
+  - mattermost - adds support for message priority (https://github.com/ansible-collections/community.general/issues/9068, https://github.com/ansible-collections/community.general/pull/9087).

--- a/plugins/modules/mattermost.py
+++ b/plugins/modules/mattermost.py
@@ -72,7 +72,9 @@ options:
   priority:
     type: str
     description:
-      - Set a priority for the message. For supported values, see mattermost doc.
+      - Set a priority for the message.
+    choices: [ important, urgent ]
+    version_added: 10.0.0
   validate_certs:
     description:
       - If V(false), SSL certificates will not be validated. This should only be used
@@ -96,6 +98,7 @@ EXAMPLES = """
     channel: notifications
     username: 'Ansible on {{ inventory_hostname }}'
     icon_url: http://www.example.com/some-image-file.png
+    priority: important
 
 - name: Send attachments message via Mattermost
   community.general.mattermost:
@@ -139,7 +142,7 @@ def main():
             channel=dict(type='str', default=None),
             username=dict(type='str', default='Ansible'),
             icon_url=dict(type='str', default='https://docs.ansible.com/favicon.ico'),
-            priority=dict(type='str', default=None),
+            priority=dict(type='str', default=None, choices=['important', 'urgent']),
             validate_certs=dict(default=True, type='bool'),
             attachments=dict(type='list', elements='dict'),
         ),

--- a/plugins/modules/mattermost.py
+++ b/plugins/modules/mattermost.py
@@ -62,13 +62,17 @@ options:
   username:
     type: str
     description:
-      - This is the sender of the message (Username Override need to be enabled by mattermost admin, see mattermost doc.
+      - This is the sender of the message (Username Override need to be enabled by mattermost admin, see mattermost doc).
     default: Ansible
   icon_url:
     type: str
     description:
       - URL for the message sender's icon.
     default: https://docs.ansible.com/favicon.ico
+  priority:
+    type: str
+    description:
+      - Set a priority for the message. For supported values, see mattermost doc.
   validate_certs:
     description:
       - If V(false), SSL certificates will not be validated. This should only be used
@@ -135,6 +139,7 @@ def main():
             channel=dict(type='str', default=None),
             username=dict(type='str', default='Ansible'),
             icon_url=dict(type='str', default='https://docs.ansible.com/favicon.ico'),
+            priority=dict(type='str', default=None),
             validate_certs=dict(default=True, type='bool'),
             attachments=dict(type='list', elements='dict'),
         ),
@@ -154,6 +159,8 @@ def main():
     for param in ['text', 'channel', 'username', 'icon_url', 'attachments']:
         if module.params[param] is not None:
             payload[param] = module.params[param]
+    if module.params['priority'] is not None:
+        payload['priority'] = {'priority': module.params['priority']}
 
     payload = module.jsonify(payload)
     result['payload'] = payload


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add support for module parameter `priority` that is passed to Mattermost server for Message Priority feature.

Fixes #9068 

Also add a missing closing parenthesis to docs.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
mattermost

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
