### PR TITLE
keycloak_clientscope_type fix checkmode

### DIFF
--- a/changelogs/fragments/9092-keycloak-clientscope-type-fix-check-mode.yml
+++ b/changelogs/fragments/9092-keycloak-clientscope-type-fix-check-mode.yml
@@ -1,2 +1,2 @@
-minor_changes:
+bugfixes:
   - keycloak_clientscope_type - fix detect changes in check mode (https://github.com/ansible-collections/community.general/pull/9093).

--- a/changelogs/fragments/9092-keycloak-clientscope-type-fix-check-mode.yml
+++ b/changelogs/fragments/9092-keycloak-clientscope-type-fix-check-mode.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - keycloak_clientscope_type - fix detect changes in check mode.
+  - keycloak_clientscope_type - fix detect changes in check mode (https://github.com/ansible-collections/community.general/pull/9093).

--- a/changelogs/fragments/9092-keycloak-clientscope-type-fix-check-mode.yml
+++ b/changelogs/fragments/9092-keycloak-clientscope-type-fix-check-mode.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - keycloak_clientscope_type - fix detect changes in check mode (https://github.com/ansible-collections/community.general/pull/9093).
+  - keycloak_clientscope_type - fix detect changes in check mode (https://github.com/ansible-collections/community.general/issues/9092, https://github.com/ansible-collections/community.general/pull/9093).

--- a/changelogs/fragments/9092-keycloak-clientscope-type-fix-check-mode.yml
+++ b/changelogs/fragments/9092-keycloak-clientscope-type-fix-check-mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak_clientscope_type - fix detect changes in check mode.

--- a/plugins/modules/keycloak_clientscope_type.py
+++ b/plugins/modules/keycloak_clientscope_type.py
@@ -252,11 +252,7 @@ def main():
     default_clientscopes_delete = clientscopes_to_delete(default_clientscopes_existing, default_clientscopes_real)
     optional_clientscopes_delete = clientscopes_to_delete(optional_clientscopes_existing, optional_clientscopes_real)
 
-    result["changed"] = (
-        len(default_clientscopes_add) > 0
-        or len(optional_clientscopes_add) > 0
-        or len(default_clientscopes_delete) > 0
-        or len(optional_clientscopes_delete) > 0
+    result["changed"] = any(len(x) > 0 for x in [default_clientscopes_add, optional_clientscopes_add, default_clientscopes_delete, optional_clientscopes_delete])
     )
 
     if module.check_mode:

--- a/plugins/modules/keycloak_clientscope_type.py
+++ b/plugins/modules/keycloak_clientscope_type.py
@@ -246,14 +246,21 @@ def main():
     if module._diff:
         result['diff'] = dict(before=result['existing'], after=result['proposed'])
 
-    if module.check_mode:
-        module.exit_json(**result)
-
     default_clientscopes_add = clientscopes_to_add(default_clientscopes_existing, default_clientscopes_real)
     optional_clientscopes_add = clientscopes_to_add(optional_clientscopes_existing, optional_clientscopes_real)
 
     default_clientscopes_delete = clientscopes_to_delete(default_clientscopes_existing, default_clientscopes_real)
     optional_clientscopes_delete = clientscopes_to_delete(optional_clientscopes_existing, optional_clientscopes_real)
+
+    result["changed"] = (
+        len(default_clientscopes_add) > 0
+        or len(optional_clientscopes_add) > 0
+        or len(default_clientscopes_delete) > 0
+        or len(optional_clientscopes_delete) > 0
+    )
+
+    if module.check_mode:
+        module.exit_json(**result)
 
     # first delete so clientscopes can change type
     for clientscope in default_clientscopes_delete:
@@ -265,13 +272,6 @@ def main():
         kc.add_default_clientscope(clientscope['id'], realm, client_id)
     for clientscope in optional_clientscopes_add:
         kc.add_optional_clientscope(clientscope['id'], realm, client_id)
-
-    result["changed"] = (
-        len(default_clientscopes_add) > 0
-        or len(optional_clientscopes_add) > 0
-        or len(default_clientscopes_delete) > 0
-        or len(optional_clientscopes_delete) > 0
-    )
 
     result['end_state'].update({
         'default_clientscopes': extract_field(kc.get_default_clientscopes(realm, client_id)),

--- a/plugins/modules/keycloak_clientscope_type.py
+++ b/plugins/modules/keycloak_clientscope_type.py
@@ -252,8 +252,9 @@ def main():
     default_clientscopes_delete = clientscopes_to_delete(default_clientscopes_existing, default_clientscopes_real)
     optional_clientscopes_delete = clientscopes_to_delete(optional_clientscopes_existing, optional_clientscopes_real)
 
-    result["changed"] = any(len(x) > 0 for x in [default_clientscopes_add, optional_clientscopes_add, default_clientscopes_delete, optional_clientscopes_delete])
-    )
+    result["changed"] = any(len(x) > 0 for x in [
+        default_clientscopes_add, optional_clientscopes_add, default_clientscopes_delete, optional_clientscopes_delete
+    ])
 
     if module.check_mode:
         module.exit_json(**result)


### PR DESCRIPTION
##### SUMMARY

Exit json with `result` only after evaluating `default_clientscopes_add`, `optional_clientscopes_add`, `default_clientscopes_delete`, `optional_clientscopes_delete` and after updating `result["changed"]`. Otherwise, `keycloak_clientscope_type` will not detect changes in **check mode**.

Fixes #9092 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`keycloak_clientscope_type`

##### ADDITIONAL INFORMATION

Before fix (check mode)

![Capture d’écran de 2024-11-01 01-40-05](https://github.com/user-attachments/assets/51162565-c5c9-4de7-9e62-c0e8bf552426)

After fix (check mode)

![Capture d’écran de 2024-11-01 01-21-26](https://github.com/user-attachments/assets/02db0c50-9f52-42ee-b997-48a181defe57)
