### PR TITLE
listen_ports_facts: pid is 0 by default

### DIFF
--- a/plugins/modules/listen_ports_facts.py
+++ b/plugins/modules/listen_ports_facts.py
@@ -113,7 +113,7 @@ ansible_facts:
           type: str
           sample: "mysqld"
         pid:
-          description: The pid of the listening process.
+          description: The pid of the listening process. If user permissions not allowed, set to C(0).
           returned: always
           type: int
           sample: 1223


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

listen_ports_facts: pid is 0 by default


fix #7620

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

listen_ports_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
