### PR TITLE
proxmox inventory: fix urllib3 InsecureRequestWarnings not suppressing when a token is used

### DIFF
--- a/changelogs/fragments/9099-proxmox-fix-insecure.yml
+++ b/changelogs/fragments/9099-proxmox-fix-insecure.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox inventory plugin - fix urllib3 InsecureRequestWarnings not suppressing when a token is used (https://github.com/ansible-collections/community.general/pull/).

--- a/changelogs/fragments/9099-proxmox-fix-insecure.yml
+++ b/changelogs/fragments/9099-proxmox-fix-insecure.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox inventory plugin - fix urllib3 InsecureRequestWarnings not suppressing when a token is used (https://github.com/ansible-collections/community.general/pull/9099).
+  - proxmox inventory plugin - fix urllib3 ``InsecureRequestWarnings`` not being suppressed when a token is used (https://github.com/ansible-collections/community.general/pull/9099).

--- a/changelogs/fragments/9099-proxmox-fix-insecure.yml
+++ b/changelogs/fragments/9099-proxmox-fix-insecure.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox inventory plugin - fix urllib3 InsecureRequestWarnings not suppressing when a token is used (https://github.com/ansible-collections/community.general/pull/).
+  - proxmox inventory plugin - fix urllib3 InsecureRequestWarnings not suppressing when a token is used (https://github.com/ansible-collections/community.general/pull/9099).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -276,15 +276,17 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def _get_auth(self):
 
+        validate_certs = self.get_option('validate_certs')
+
+        if validate_certs is False:
+            from requests.packages.urllib3 import disable_warnings
+            disable_warnings()
+
         if self.proxmox_password:
 
             credentials = urlencode({'username': self.proxmox_user, 'password': self.proxmox_password})
 
             a = self._get_session()
-
-            if a.verify is False:
-                from requests.packages.urllib3 import disable_warnings
-                disable_warnings()
 
             ret = a.post('%s/api2/json/access/ticket' % self.proxmox_url, data=credentials)
 


### PR DESCRIPTION
##### SUMMARY

Currently, InsecureRequestWarnings are suppressed only when using password authorization. This PR fixes that issue.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`community.general.proxmox`