### PR TITLE
jenkins_node: Add launch_ssh option and suboptions

### DIFF
--- a/changelogs/fragments/9101-jenkins_node-add-launch_ssh-option.yaml
+++ b/changelogs/fragments/9101-jenkins_node-add-launch_ssh-option.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - jenkins_node - Implement ``launch_ssh`` option which will configure a node to use the SSH launcher if specified and common suboptions.

--- a/changelogs/fragments/9101-jenkins_node-add-launch_ssh-option.yaml
+++ b/changelogs/fragments/9101-jenkins_node-add-launch_ssh-option.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - jenkins_node - Implement ``launch_ssh`` option which will configure a node to use the SSH launcher if specified and common suboptions.
+  - jenkins_node - implement ``launch_ssh`` option which will configure a node to use the SSH launcher if specified and common suboptions (https://github.com/ansible-collections/community.general/pull/9101).

--- a/plugins/modules/jenkins_node.py
+++ b/plugins/modules/jenkins_node.py
@@ -98,7 +98,7 @@ options:
           - When set, sets the SSH host key non-verifying strategy.
         type: bool
         choices:
-          - True
+          - true
       host_key_verify_known_hosts:
         description:
           - When set, sets the SSH host key known hosts file verification strategy.

--- a/plugins/modules/jenkins_node.py
+++ b/plugins/modules/jenkins_node.py
@@ -240,7 +240,7 @@ with deps.declare(
 IS_PYTHON_2 = sys.version_info[0] <= 2
 
 
-if IS_PYTHON_2:
+if sys.version_info[0] <= 3 or sys.version_info[1] < 8:
     class cached_property(object):  # noqa
         def __init__(self, func):
             self.func = func
@@ -452,14 +452,6 @@ class ProvidedSSHHostKeyVerifyConfig(KnownHostsSSHHostKeyVerifyConfig):
             updated = True
 
         return updated
-
-
-SSH_HOST_KEY_VERIFY_TYPES = {
-    "none": NoneSSHHostKeyVerifyConfig,
-    "known_hosts": KnownHostsSSHHostKeyVerifyConfig,
-    "content": ProvidedSSHHostKeyVerifyConfig,
-    "approve": TrustedSSHHostKeyVerifyConfig,
-}
 
 
 class SSHLauncherElement(LauncherElement):

--- a/plugins/modules/jenkins_node.py
+++ b/plugins/modules/jenkins_node.py
@@ -130,7 +130,7 @@ options:
               - When specified, enables or disables the requiring manual verification of
                 the first connected host for this node.
             type: bool
-    version_added: 10.0.0
+    version_added: 10.1.0
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/jenkins_node.py
+++ b/plugins/modules/jenkins_node.py
@@ -104,7 +104,7 @@ options:
           - When set, sets the SSH host key known hosts file verification strategy.
         type: bool
         choices:
-          - True
+          - true
       host_key_verify_provided:
         description:
           - When specified, sets the SSH host key manually provided verification strategy.

--- a/plugins/modules/jenkins_node.py
+++ b/plugins/modules/jenkins_node.py
@@ -112,7 +112,7 @@ options:
         suboptions:
           algorithm:
             description:
-              - Key type e.g. V(ssh-rsa).
+              - Key type, for example V(ssh-rsa).
             type: str
             required: true
           key:


### PR DESCRIPTION
* Implement launch_ssh option which will configure a node to use the SSH launcher method if specified.

* Implement common suboptions for launch_ssh option, notably the various SSH host verification strategies.

* Establish a pattern for dealing with non-trivial XML in this module - ...Element wrappers for handling structural XML and ...Config for idempotent application of configuration.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
jenkins_node
