### PR TITLE
launchd: Add plist option

### DIFF
--- a/changelogs/fragments/5932-launchd-plist.yml
+++ b/changelogs/fragments/5932-launchd-plist.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - launchd - add ``plist`` option for services such as sshd, where the plist filename doesn't match the service name (https://github.com/ansible-collections/community.general/pull/9102).


### PR DESCRIPTION
##### SUMMARY
This allows the module to be used with services such as com.openssh.sshd, when the name of the plist file doesn't match the service name.

fixes #5932

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
launchd

##### ADDITIONAL INFORMATION

Before
```console
$ ansible -m community.general.launchd -a "name=org.openssh.sshd state=stopped" localhost 
localhost | FAILED! => {
    "changed": false,
    "msg": "Unable to infer the path of org.openssh.sshd service plist file"
}
$ echo $?
2

```

After
```console
$ ansible -m community.general.launchd -a "name=org.openssh.sshd plist=ssh.plist state=stopped" localhost
localhost | SUCCESS => {
    "changed": false,
    "name": "org.openssh.sshd",
    "status": {
        "current_pid": "-",
        "current_state": "unloaded",
        "error": "",
        "previous_pid": "-",
        "previous_state": "unloaded",
        "status_code": null
    }
}
```