### PR TITLE
ipa_getkeytab: Fix example task

### DIFF
--- a/plugins/modules/ipa_getkeytab.py
+++ b/plugins/modules/ipa_getkeytab.py
@@ -98,11 +98,9 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = r'''
-- name: Get kerberos ticket
-  ansible.builtin.shell: kinit admin
-  args:
-    stdin: "{{ aldpro_admin_password }}"
-  changed_when: true
+- name: Get Kerberos ticket using default principal
+  community.general.krb_ticket:
+    password: "{{ aldpro_admin_password }}"
 
 - name: Create keytab
   community.general.ipa_getkeytab:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Just a small fix to promote `krb_ticket` usage instead of `command` since it is now available
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
`ipa_getkeytab`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
# Before
- name: Get kerberos ticket
  ansible.builtin.shell: kinit admin
  args:
    stdin: "{{ aldpro_admin_password }}"
  changed_when: true
 
# Now
- name: Get Kerberos ticket using default principal
  community.general.krb_ticket:
    password: "{{ aldpro_admin_password }}"
```
