### PR TITLE
zypper_repository: preserve attributes enabled, autorefresh and gpgcheck if provided from the task parameters

### DIFF
--- a/changelogs/fragments/8783-preserve-parameters-provided-from-task-in-zypper-module.yaml
+++ b/changelogs/fragments/8783-preserve-parameters-provided-from-task-in-zypper-module.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_client - fix TypeError when sanitizing the ``saml.signing.private.key`` attribute in the module's diff or state output. The ``sanitize_cr`` function expected a dict where in some cases a list might occur (https://github.com/ansible-collections/community.general/pull/8403).

--- a/changelogs/fragments/8783-preserve-parameters-provided-from-task-in-zypper-module.yaml
+++ b/changelogs/fragments/8783-preserve-parameters-provided-from-task-in-zypper-module.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - zypper-module - only read attributes ``enabled``, ``disable_gpg_check`` and ``autorefresh`` from local repo files, if the parameters weren't already provided by the task parameters
+  - zypper-module - only read attributes ``enabled``, ``disable_gpg_check`` and ``autorefresh`` from local repo files, if the parameters were not already provided by the task parameters (https://github.com/ansible-collections/community.general/pull/9108).

--- a/changelogs/fragments/8783-preserve-parameters-provided-from-task-in-zypper-module.yaml
+++ b/changelogs/fragments/8783-preserve-parameters-provided-from-task-in-zypper-module.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - keycloak_client - fix TypeError when sanitizing the ``saml.signing.private.key`` attribute in the module's diff or state output. The ``sanitize_cr`` function expected a dict where in some cases a list might occur (https://github.com/ansible-collections/community.general/pull/8403).
+  - zypper-module - only read attributes ``enabled``, ``disable_gpg_check`` and ``autorefresh`` from local repo files, if the parameters weren't already provided by the task parameters

--- a/plugins/modules/zypper_repository.py
+++ b/plugins/modules/zypper_repository.py
@@ -357,17 +357,17 @@ def main():
         'priority': module.params['priority'],
     }
     # rewrite bools in the language that zypper lr -x provides for easier comparison
-    if 'enabled' in module.params 
+    if 'enabled' in module.params:
         if module.params['enabled']:
             repodata['enabled'] = '1'
         else:
             repodata['enabled'] = '0'
-    if 'disable_gpg_check' in module.params
+    if 'disable_gpg_check' in module.params:
         if module.params['disable_gpg_check']:
             repodata['gpgcheck'] = '0'
         else:
             repodata['gpgcheck'] = '1'
-    if 'autorefresh' in module.params
+    if 'autorefresh' in module.params:
         if module.params['autorefresh']:
             repodata['autorefresh'] = '1'
         else:
@@ -438,17 +438,25 @@ def main():
 
         # Map additional values, if available
         if 'name' in repofile_items:
-            if 'name' not in repodata
+            if 'name' not in repodata:
                 repodata['name'] = repofile_items['name']
         if 'enabled' in repofile_items:
-            if 'enabled' not in repodata
+            if 'enabled' not in repodata:
                 repodata['enabled'] = repofile_items['enabled']
         if 'autorefresh' in repofile_items:
-            if 'autorefresh' not in repodata
+            if 'autorefresh' not in repodata:
                 repodata['autorefresh'] = repofile_items['autorefresh']
         if 'gpgcheck' in repofile_items:
-            if 'gpgcheck' not in repodata
+            if 'gpgcheck' not in repodata:
                 repodata['gpgcheck'] = repofile_items['gpgcheck']
+
+    # finally, fill empty attributes with defaults
+    if 'enabled' not in repodata:
+        repodata['enabled'] = '0'
+    if 'autorefresh' not in repodata:
+        repodata['autorefresh'] = '0'
+    if 'gpgcheck' not in repodata:
+        repodata['gpgcheck'] = '0'
 
     exists, mod, old_repos = repo_exists(module, repodata, overwrite_multiple)
 

--- a/plugins/modules/zypper_repository.py
+++ b/plugins/modules/zypper_repository.py
@@ -330,7 +330,7 @@ def main():
             runrefresh=dict(required=False, default=False, type='bool'),
             description=dict(required=False),
             disable_gpg_check=dict(required=False, default=False, type='bool'),
-            autorefresh=dict(required=False, default=False, type='bool', aliases=['refresh']),
+            autorefresh=dict(required=False, default=True, type='bool', aliases=['refresh']),
             priority=dict(required=False, type='int'),
             enabled=dict(required=False, default=True, type='bool'),
             overwrite_multiple=dict(required=False, default=False, type='bool'),

--- a/plugins/modules/zypper_repository.py
+++ b/plugins/modules/zypper_repository.py
@@ -356,22 +356,6 @@ def main():
         'name': module.params['description'],
         'priority': module.params['priority'],
     }
-    # rewrite bools in the language that zypper lr -x provides for easier comparison
-    if 'enabled' in module.params:
-        if module.params['enabled']:
-            repodata['enabled'] = '1'
-        else:
-            repodata['enabled'] = '0'
-    if 'disable_gpg_check' in module.params:
-        if module.params['disable_gpg_check']:
-            repodata['gpgcheck'] = '0'
-        else:
-            repodata['gpgcheck'] = '1'
-    if 'autorefresh' in module.params:
-        if module.params['autorefresh']:
-            repodata['autorefresh'] = '1'
-        else:
-            repodata['autorefresh'] = '0'
 
     def exit_unchanged():
         module.exit_json(changed=False, repodata=repodata, state=state)
@@ -395,6 +379,15 @@ def main():
     else:
         if not alias and state == "present":
             module.fail_json(msg='Name required when adding non-repo files.')
+
+
+    # fill boolean attributes with defaults
+    if 'enabled' not in repodata:
+        repodata['enabled'] = '0'
+    if 'autorefresh' not in repodata:
+        repodata['autorefresh'] = '0'
+    if 'gpgcheck' not in repodata:
+        repodata['gpgcheck'] = '0'
 
     # Download / Open and parse .repo file to ensure idempotency
     if repo and repo.endswith('.repo'):
@@ -438,25 +431,31 @@ def main():
 
         # Map additional values, if available
         if 'name' in repofile_items:
-            if 'name' not in repodata:
-                repodata['name'] = repofile_items['name']
+            repodata['name'] = repofile_items['name']
         if 'enabled' in repofile_items:
-            if 'enabled' not in repodata:
-                repodata['enabled'] = repofile_items['enabled']
+            repodata['enabled'] = repofile_items['enabled']
         if 'autorefresh' in repofile_items:
-            if 'autorefresh' not in repodata:
-                repodata['autorefresh'] = repofile_items['autorefresh']
+            repodata['autorefresh'] = repofile_items['autorefresh']
         if 'gpgcheck' in repofile_items:
-            if 'gpgcheck' not in repodata:
-                repodata['gpgcheck'] = repofile_items['gpgcheck']
+            repodata['gpgcheck'] = repofile_items['gpgcheck']
 
-    # finally, fill empty attributes with defaults
-    if 'enabled' not in repodata:
-        repodata['enabled'] = '0'
-    if 'autorefresh' not in repodata:
-        repodata['autorefresh'] = '0'
-    if 'gpgcheck' not in repodata:
-        repodata['gpgcheck'] = '0'
+    # override boolean parameters in repodata with provided entries in module.params
+    # in the language that zypper lr -x provides for easier comparison
+    if 'enabled' in module.params:
+        if module.params['enabled']:
+            repodata['enabled'] = '1'
+        else:
+            repodata['enabled'] = '0'
+    if 'disable_gpg_check' in module.params:
+        if module.params['disable_gpg_check']:
+            repodata['gpgcheck'] = '0'
+        else:
+            repodata['gpgcheck'] = '1'
+    if 'autorefresh' in module.params:
+        if module.params['autorefresh']:
+            repodata['autorefresh'] = '1'
+        else:
+            repodata['autorefresh'] = '0'
 
     exists, mod, old_repos = repo_exists(module, repodata, overwrite_multiple)
 

--- a/plugins/modules/zypper_repository.py
+++ b/plugins/modules/zypper_repository.py
@@ -380,7 +380,6 @@ def main():
         if not alias and state == "present":
             module.fail_json(msg='Name required when adding non-repo files.')
 
-
     # fill boolean attributes with defaults
     if 'enabled' not in repodata:
         repodata['enabled'] = '0'

--- a/plugins/modules/zypper_repository.py
+++ b/plugins/modules/zypper_repository.py
@@ -329,10 +329,10 @@ def main():
             state=dict(choices=['present', 'absent'], default='present'),
             runrefresh=dict(required=False, default=False, type='bool'),
             description=dict(required=False),
-            disable_gpg_check=dict(required=False, default=False, type='bool'),
-            autorefresh=dict(required=False, default=True, type='bool', aliases=['refresh']),
+            disable_gpg_check=dict(required=False, type='bool'),
+            autorefresh=dict(required=False, type='bool', aliases=['refresh']),
             priority=dict(required=False, type='int'),
-            enabled=dict(required=False, default=True, type='bool'),
+            enabled=dict(required=False, type='bool'),
             overwrite_multiple=dict(required=False, default=False, type='bool'),
             auto_import_keys=dict(required=False, default=False, type='bool'),
         ),
@@ -441,17 +441,17 @@ def main():
     # override boolean parameters in repodata with provided entries in module.params
     # in the language that zypper lr -x provides for easier comparison
     if 'enabled' in module.params:
-        if module.params['enabled']:
+        if module.params['enabled'] is not None:
             repodata['enabled'] = '1'
         else:
             repodata['enabled'] = '0'
     if 'disable_gpg_check' in module.params:
-        if module.params['disable_gpg_check']:
+        if module.params['disable_gpg_check'] is not None:
             repodata['gpgcheck'] = '0'
         else:
             repodata['gpgcheck'] = '1'
     if 'autorefresh' in module.params:
-        if module.params['autorefresh']:
+        if module.params['autorefresh'] is not None:
             repodata['autorefresh'] = '1'
         else:
             repodata['autorefresh'] = '0'

--- a/plugins/modules/zypper_repository.py
+++ b/plugins/modules/zypper_repository.py
@@ -329,10 +329,10 @@ def main():
             state=dict(choices=['present', 'absent'], default='present'),
             runrefresh=dict(required=False, default=False, type='bool'),
             description=dict(required=False),
-            disable_gpg_check=dict(required=False, type='bool'),
-            autorefresh=dict(required=False, type='bool', aliases=['refresh']),
+            disable_gpg_check=dict(required=False, default=False, type='bool'),
+            autorefresh=dict(required=False, default=False, type='bool', aliases=['refresh']),
             priority=dict(required=False, type='int'),
-            enabled=dict(required=False, type='bool'),
+            enabled=dict(required=False, default=True, type='bool'),
             overwrite_multiple=dict(required=False, default=False, type='bool'),
             auto_import_keys=dict(required=False, default=False, type='bool'),
         ),
@@ -440,21 +440,9 @@ def main():
 
     # override boolean parameters in repodata with provided entries in module.params
     # in the language that zypper lr -x provides for easier comparison
-    if 'enabled' in module.params:
-        if module.params['enabled'] is not None:
-            repodata['enabled'] = '1'
-        else:
-            repodata['enabled'] = '0'
-    if 'disable_gpg_check' in module.params:
-        if module.params['disable_gpg_check'] is not None:
-            repodata['gpgcheck'] = '0'
-        else:
-            repodata['gpgcheck'] = '1'
-    if 'autorefresh' in module.params:
-        if module.params['autorefresh'] is not None:
-            repodata['autorefresh'] = '1'
-        else:
-            repodata['autorefresh'] = '0'
+    repodata['enabled'] = '1' if module.params['enabled'] else '0'
+    repodata['gpgcheck'] = '0' if module.params['disable_gpg_check'] else '1'
+    repodata['autorefresh'] = '1' if module.params['autorefresh'] else '0'
 
     exists, mod, old_repos = repo_exists(module, repodata, overwrite_multiple)
 

--- a/plugins/modules/zypper_repository.py
+++ b/plugins/modules/zypper_repository.py
@@ -357,18 +357,21 @@ def main():
         'priority': module.params['priority'],
     }
     # rewrite bools in the language that zypper lr -x provides for easier comparison
-    if module.params['enabled']:
-        repodata['enabled'] = '1'
-    else:
-        repodata['enabled'] = '0'
-    if module.params['disable_gpg_check']:
-        repodata['gpgcheck'] = '0'
-    else:
-        repodata['gpgcheck'] = '1'
-    if module.params['autorefresh']:
-        repodata['autorefresh'] = '1'
-    else:
-        repodata['autorefresh'] = '0'
+    if 'enabled' in module.params 
+        if module.params['enabled']:
+            repodata['enabled'] = '1'
+        else:
+            repodata['enabled'] = '0'
+    if 'disable_gpg_check' in module.params
+        if module.params['disable_gpg_check']:
+            repodata['gpgcheck'] = '0'
+        else:
+            repodata['gpgcheck'] = '1'
+    if 'autorefresh' in module.params
+        if module.params['autorefresh']:
+            repodata['autorefresh'] = '1'
+        else:
+            repodata['autorefresh'] = '0'
 
     def exit_unchanged():
         module.exit_json(changed=False, repodata=repodata, state=state)
@@ -435,13 +438,17 @@ def main():
 
         # Map additional values, if available
         if 'name' in repofile_items:
-            repodata['name'] = repofile_items['name']
+            if 'name' not in repodata
+                repodata['name'] = repofile_items['name']
         if 'enabled' in repofile_items:
-            repodata['enabled'] = repofile_items['enabled']
+            if 'enabled' not in repodata
+                repodata['enabled'] = repofile_items['enabled']
         if 'autorefresh' in repofile_items:
-            repodata['autorefresh'] = repofile_items['autorefresh']
+            if 'autorefresh' not in repodata
+                repodata['autorefresh'] = repofile_items['autorefresh']
         if 'gpgcheck' in repofile_items:
-            repodata['gpgcheck'] = repofile_items['gpgcheck']
+            if 'gpgcheck' not in repodata
+                repodata['gpgcheck'] = repofile_items['gpgcheck']
 
     exists, mod, old_repos = repo_exists(module, repodata, overwrite_multiple)
 

--- a/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -246,6 +246,44 @@
       that:
         - added_again_by_repo_file is not changed
 
+  - name: change the repository config by name with flag - disable
+    community.general.zypper_repository:
+      name: systemsmanagement_Uyuni_Stable
+      state: present
+      enabled: false
+    register: modified_repo_file_result
+
+  - name: modified_repo_file_result is changed
+    assert:
+      that:
+        - modified_repo_file_result is changed
+
+  - name: get repository details again from zypper after disabling the repository
+    command: zypper --xmlout lr systemsmanagement_Uyuni_Stable
+    register: get_repository_details_from_zypper
+
+  - name: verify modifying via .repo file was successful - the module is now disabled
+    assert:
+      that:
+        - "'enabled=\"0\"' in get_repository_details_from_zypper.stdout"
+
+  - name: change flag autorefresh in the same zypper-module
+    community.general.zypper_repository:
+      name: systemsmanagement_Uyuni_Stable
+      state: present
+      autorefresh: false
+    register: modified_repo_file_result
+
+  - name: get repository details again from zypper after disabling the repository
+    command: zypper --xmlout lr systemsmanagement_Uyuni_Stable
+    register: get_repository_details_from_zypper
+
+  - name: verify modifying via .repo file was successful - the autorefesh is disabled, but the enabled-flag was not modified (it is still disabled)
+    assert:
+      that:
+        - "'enabled=\"0\"' in get_repository_details_from_zypper.stdout"
+        - "'autorefresh=\"0\"' in get_repository_details_from_zypper.stdout"
+
   - name: remove repository via url to .repo file
     community.general.zypper_repository:
       repo: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_{{ ansible_distribution_version }}/systemsmanagement:Uyuni:Stable.repo


### PR DESCRIPTION
… task parameters

Currently, the values are overridden with the data found on the file system Instead, these values should only be updated, if they were not provided in the parameters. That way, repositories on the system could be enabled/disabled and the flags could be updated again

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The code currently looks up the repo-file on the local disk and if it exists, it loads the optional attributes ``enabled``, ``autorefresh`` and ``gpgcheck`` and these values are used to fill up the repository-object that is later written to disk.
Unfortunately, these values are overriding the parameters, if they were provided from the task in ansible - which makes it impossible to modify the values for a repository that is already registered on the system.
So I changed the code, to:
1. set default values into
2. override with existing values from file
3. override with attributes from the ansible task configuration, if provided

Fixes #8783

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
zypper_repository


##### ADDITIONAL INFORMATION
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. Register a repostory, e.g. via ansible
2. use ansible to modify any of the parameters. The task will not change them


