### PR TITLE
redfish_utils: remove undocumented default applytime

### DIFF
--- a/changelogs/fragments/9114-redfish-utils-update-remove-default-applytime.yml
+++ b/changelogs/fragments/9114-redfish-utils-update-remove-default-applytime.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_utils module utils - remove undocumented default applytime (https://github.com/ansible-collections/community.general/pull/9114).

--- a/changelogs/fragments/9114-redfish-utils-update-remove-default-applytime.yml
+++ b/changelogs/fragments/9114-redfish-utils-update-remove-default-applytime.yml
@@ -1,2 +1,2 @@
-minor_changes:
+bugfixes:
   - redfish_utils module utils - remove undocumented default applytime (https://github.com/ansible-collections/community.general/pull/9114).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1958,7 +1958,7 @@ class RedfishUtils(object):
         update_uri = data['MultipartHttpPushUri']
 
         # Assemble the JSON payload portion of the request
-        payload = {"@Redfish.OperationApplyTime": "Immediate"}
+        payload = {}
         if targets:
             payload["Targets"] = targets
         if apply_time:


### PR DESCRIPTION
##### SUMMARY
The `@Redfish.OperationApplyTime` parameter is optional as per Redfish
spec version 1.21.0, paragraph 7.11 [1]. Some systems reject the
request rather than ignore it, causing failures that can not be
workarounded.

Removing this default resolves compatibility issues.

[1] https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.21.0.html

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redfish_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
