### PR TITLE
redfish_command: add update_custom_oem options

### DIFF
--- a/changelogs/fragments/9123-redfish-command-custom-oem-params.yml
+++ b/changelogs/fragments/9123-redfish-command-custom-oem-params.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_command - add update_custom_oem_header and update_custom_oem_params options (https://github.com/ansible-collections/community.general/pull/9123).

--- a/changelogs/fragments/9123-redfish-command-custom-oem-params.yml
+++ b/changelogs/fragments/9123-redfish-command-custom-oem-params.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redfish_command - add update_custom_oem_header and update_custom_oem_params options (https://github.com/ansible-collections/community.general/pull/9123).
+  - redfish_command - add ``update_custom_oem_header`` and ``update_custom_oem_params`` options (https://github.com/ansible-collections/community.general/pull/9123).

--- a/changelogs/fragments/9123-redfish-command-custom-oem-params.yml
+++ b/changelogs/fragments/9123-redfish-command-custom-oem-params.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redfish_command - add ``update_custom_oem_header`` and ``update_custom_oem_params`` options (https://github.com/ansible-collections/community.general/pull/9123).
+  - redfish_command - add ``update_custom_oem_header``, ``update_custom_oem_params``, and ``update_custom_oem_mime_type`` options (https://github.com/ansible-collections/community.general/pull/9123).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1934,6 +1934,7 @@ class RedfishUtils(object):
         apply_time = update_opts.get('update_apply_time')
         oem_params = update_opts.get('update_oem_params')
         custom_oem_header = update_opts.get('update_custom_oem_header')
+        custom_oem_mime_type = update_opts.get('update_custom_oem_mime_type')
         custom_oem_params = update_opts.get('update_custom_oem_params')
 
         # Ensure the image file is provided
@@ -1972,7 +1973,9 @@ class RedfishUtils(object):
             'UpdateFile': {'filename': image_file, 'content': image_payload, 'mime_type': 'application/octet-stream'}
         }
         if custom_oem_params:
-            multipart_payload[custom_oem_header] = {'content': json.dumps(custom_oem_params), 'mime_type': 'application/json'}
+            multipart_payload[custom_oem_header] = {'content': custom_oem_params}
+            if custom_oem_mime_type:
+                multipart_payload[custom_oem_header]['mime_type'] = custom_oem_mime_type
 
         response = self.post_request(self.root_uri + update_uri, multipart_payload, multipart=True)
         if response['ret'] is False:

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1933,6 +1933,8 @@ class RedfishUtils(object):
         targets = update_opts.get('update_targets')
         apply_time = update_opts.get('update_apply_time')
         oem_params = update_opts.get('update_oem_params')
+        custom_oem_header = update_opts.get('update_custom_oem_header')
+        custom_oem_params = update_opts.get('update_custom_oem_params')
 
         # Ensure the image file is provided
         if not image_file:
@@ -1969,6 +1971,9 @@ class RedfishUtils(object):
             'UpdateParameters': {'content': json.dumps(payload), 'mime_type': 'application/json'},
             'UpdateFile': {'filename': image_file, 'content': image_payload, 'mime_type': 'application/octet-stream'}
         }
+        if custom_oem_params:
+            multipart_payload[custom_oem_header] = {'content': json.dumps(custom_oem_params), 'mime_type': 'application/json'}
+
         response = self.post_request(self.root_uri + update_uri, multipart_payload, multipart=True)
         if response['ret'] is False:
             return response

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -223,19 +223,20 @@ options:
         the Multipart HTTP push update.
       - The header shall start with "Oem" according to DMTF
         Redfish spec 12.6.2.2.
-      - If set, then `update_custom_oem_params` is required too.
+      - For more details, see U(https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.21.0.html)
+      - If set, then O(update_custom_oem_params) is required too.
     type: str
     version_added: '10.1.0'
   update_custom_oem_params:
     required: false
     description:
       - Custom OEM properties for HTTP Multipart Push updates.
-      - If set, then `update_custom_oem_header` is required too.
+      - If set, then O(update_custom_oem_header) is required too.
       - The properties will be passed raw without any validation or conversion by Ansible.
         This means the content can be a file, a string, or any other data.
         If the content is a dict that should be converted to JSON, then the
         content must be converted to JSON before passing it to this module using the
-        `to_json` filter.
+        P(ansible.builtin.to_json#filter) filter.
     type: raw
     version_added: '10.1.0'
   update_custom_oem_mime_type:

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -216,6 +216,24 @@ options:
       - Handle to check the status of an update in progress.
     type: str
     version_added: '6.1.0'
+  update_custom_oem_header:
+    required: false
+    description:
+      - Optional OEM header, sent as separate form-data for
+        the Multipart HTTP push update.
+      - The header shall start with "Oem" according to DMTF
+        Redfish spec 12.6.2.2.
+      - If set, then `update_custom_oem_params` is required too.
+    type: str
+    version_added: '10.1.0'
+  update_custom_oem_params:
+    required: false
+    description:
+      - Custom OEM properties for HTTP Multipart Push Updates.
+      - If set, then `update_custom_oem_header` is required too.
+      - The content will be sent as JSON with application/json MIME type.
+    type: dict
+    version_added: '10.1.0'
   virtual_media:
     required: false
     description:
@@ -654,6 +672,22 @@ EXAMPLES = '''
       update_oem_params:
         PreserveConfiguration: false
 
+  - name: Multipart HTTP push with custom OEM options
+    community.general.redfish_command:
+      category: Update
+      command: MultipartHTTPPushUpdate
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      update_image_file: ~/images/myupdate.img
+      update_targets:
+        - /redfish/v1/UpdateService/FirmwareInventory/BMC
+      update_oem_params:
+        PreserveConfiguration: false
+      update_custom_oem_header: OemParameters
+      update_custom_oem_params:
+        ImageType: BMC
+
   - name: Perform requested operations to continue the update
     community.general.redfish_command:
       category: Update
@@ -863,6 +897,8 @@ def main():
             update_protocol=dict(),
             update_targets=dict(type='list', elements='str', default=[]),
             update_oem_params=dict(type='dict'),
+            update_custom_oem_header=dict(type='str'),
+            update_custom_oem_params=dict(type='dict'),
             update_creds=dict(
                 type='dict',
                 options=dict(
@@ -895,6 +931,7 @@ def main():
         ),
         required_together=[
             ('username', 'password'),
+            ('update_custom_oem_header', 'update_custom_oem_params'),
         ],
         required_one_of=[
             ('username', 'auth_token'),
@@ -941,6 +978,8 @@ def main():
         'update_creds': module.params['update_creds'],
         'update_apply_time': module.params['update_apply_time'],
         'update_oem_params': module.params['update_oem_params'],
+        'update_custom_oem_header': module.params['update_custom_oem_header'],
+        'update_custom_oem_params': module.params['update_custom_oem_params'],
         'update_handle': module.params['update_handle'],
     }
 


### PR DESCRIPTION
##### SUMMARY
The Multipart HTTP push update implementation allows OEM specific parts that are not part of the `UpdateParameters` body part, but a separate one. This OEM part shall start with `Oem` and is optional. The OEM part implementation is specified in the Redfish spec point 12.6.2.2 [1].

Right now, the implementation will only support JSON as MIME Type, although it is not limited to JSON.

[1] https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.21.0.html#oem

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
redfish_command

##### ADDITIONAL INFORMATION