### PR TITLE
dnf_config_manager: use --assumeyes when changing state

### DIFF
--- a/changelogs/fragments/9124-dnf_config_manager.yml
+++ b/changelogs/fragments/9124-dnf_config_manager.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - dnf_config_manager - fix hanging when prompting to import GPG keys (https://github.com/ansible-collections/community.general/pull/9124)
+  - dnf_config_manager - fix hanging when prompting to import GPG keys (https://github.com/ansible-collections/community.general/pull/9124, https://github.com/ansible-collections/community.general/issues/8830).

--- a/changelogs/fragments/9124-dnf_config_manager.yml
+++ b/changelogs/fragments/9124-dnf_config_manager.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnf_config_manager - fix hanging when prompting to import GPG keys (https://github.com/ansible-collections/community.general/pull/9124)

--- a/plugins/modules/dnf_config_manager.py
+++ b/plugins/modules/dnf_config_manager.py
@@ -153,7 +153,7 @@ def get_repo_states(module):
 
 
 def set_repo_states(module, repo_ids, state):
-    module.run_command([DNF_BIN, 'config-manager', '--set-{0}'.format(state)] + repo_ids, check_rc=True)
+    module.run_command([DNF_BIN, 'config-manager', '--assumeyes', '--set-{0}'.format(state)] + repo_ids, check_rc=True)
 
 
 def pack_repo_states_for_return(states):

--- a/tests/unit/plugins/modules/test_dnf_config_manager.py
+++ b/tests/unit/plugins/modules/test_dnf_config_manager.py
@@ -254,8 +254,8 @@ expected_repo_states_crb_disabled = {'disabled': ['appstream-debuginfo',
                                                  'rpmfusion-nonfree-updates']}
 
 call_get_repo_states = call(['/usr/bin/dnf', 'repolist', '--all', '--verbose'], check_rc=True)
-call_disable_crb = call(['/usr/bin/dnf', 'config-manager', '--set-disabled', 'crb'], check_rc=True)
-call_enable_crb = call(['/usr/bin/dnf', 'config-manager', '--set-enabled', 'crb'], check_rc=True)
+call_disable_crb = call(['/usr/bin/dnf', 'config-manager', '--assumeyes', '--set-disabled', 'crb'], check_rc=True)
+call_enable_crb = call(['/usr/bin/dnf', 'config-manager',  '--assumeyes', '--set-enabled', 'crb'], check_rc=True)
 
 
 class TestDNFConfigManager(ModuleTestCase):

--- a/tests/unit/plugins/modules/test_dnf_config_manager.py
+++ b/tests/unit/plugins/modules/test_dnf_config_manager.py
@@ -255,7 +255,7 @@ expected_repo_states_crb_disabled = {'disabled': ['appstream-debuginfo',
 
 call_get_repo_states = call(['/usr/bin/dnf', 'repolist', '--all', '--verbose'], check_rc=True)
 call_disable_crb = call(['/usr/bin/dnf', 'config-manager', '--assumeyes', '--set-disabled', 'crb'], check_rc=True)
-call_enable_crb = call(['/usr/bin/dnf', 'config-manager',  '--assumeyes', '--set-enabled', 'crb'], check_rc=True)
+call_enable_crb = call(['/usr/bin/dnf', 'config-manager', '--assumeyes', '--set-enabled', 'crb'], check_rc=True)
 
 
 class TestDNFConfigManager(ModuleTestCase):


### PR DESCRIPTION
##### SUMMARY
Runs `dnf config-manager` with `--assumeyes` to automatically import GPG keys instead of hanging at y/N prompt.

Fixes #8830 

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
dnf_config_manager

##### ADDITIONAL INFORMATION

