### PR TITLE
fix(homebrew_cask): add + to valid cask chars

### DIFF
--- a/plugins/modules/homebrew_cask.py
+++ b/plugins/modules/homebrew_cask.py
@@ -190,6 +190,7 @@ class HomebrewCask(object):
         /                   # slash (for taps)
         \-                  # dashes
         @                   # at symbol
+        \+                  # plus symbol
     '''
 
     INVALID_CASK_REGEX = _create_regex_group_complement(VALID_CASK_CHARS)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Casks now are permitted to include plus symbols. There are quite a few presently:

```bash
brew search --casks "" --quiet | grep "\+"
```

Output:

```text
4k-video-downloader+
easy-move+resize
font-m+
font-m+-nerd-font
iina+
intel-psxe-ce-c++
logi-options+
qlc+
starnet++
tla+-toolbox
xournal++
```

Trying to install one of these via the module causes the following:

```text
failed: [127.0.0.1] (item=logi-options+) => changed=false 
  ansible_loop_var: item
  item: logi-options+
  msg: 'Invalid cask: logi-options+.'
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #9025

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
homebrew_cask

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
