### PR TITLE
jenkins_plugin: also use false value for force_basic_auth param

### DIFF
--- a/changelogs/fragments/add_force_basic_auth_param_to_jenkins_plugin_module
+++ b/changelogs/fragments/add_force_basic_auth_param_to_jenkins_plugin_module
@@ -1,0 +1,2 @@
+bugfixes:
+    - jenkins_plugin - use force_basic_auth param to create basic auth headers if set to true

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-namespace: community
+namespace: webfx
 name: general
 version: 10.1.0
 readme: README.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-namespace: webfx
+namespace: community
 name: general
 version: 10.1.0
 readme: README.md

--- a/plugins/modules/jenkins_plugin.py
+++ b/plugins/modules/jenkins_plugin.py
@@ -350,8 +350,8 @@ class JenkinsPlugin(object):
         self.params = self.module.params
         self.url = self.params['url']
         self.timeout = self.params['timeout']
-        self.username = self.params['username']
-        self.password = self.params['password']
+        self.username = self.params['url_username']
+        self.password = self.params['url_password']
         self.force_basic_auth = self.params['force_basic_auth']
 
         # Crumb
@@ -366,8 +366,8 @@ class JenkinsPlugin(object):
         # Get list of installed plugins
         self._get_installed_plugins()
 
-    def _create_basic_auth_header(username, password):
-        credentials = f"{username}:{password}"
+    def _create_basic_auth_header(self):
+        credentials = f"{self.username}:{self.password}"
 
         encoded_credentials = base64.b64encode(credentials.encode("utf-8")).decode("utf-8")
 
@@ -451,7 +451,7 @@ class JenkinsPlugin(object):
 
         # If force_basic_auth is True, add the Authorization header
         if self.force_basic_auth:
-            headers["Authorization"] = self._create_basic_auth_header(self.username, self.password)
+            headers["Authorization"] = self._create_basic_auth_header()
 
         # Get the URL data
         try:

--- a/plugins/modules/jenkins_plugin.py
+++ b/plugins/modules/jenkins_plugin.py
@@ -345,7 +345,6 @@ class JenkinsPlugin(object):
     def __init__(self, module):
         # To be able to call fail_json
         self.module = module
-        self.force_basic_auth = self.module.params['force_basic_auth']
 
         # Shortcuts for the params
         self.params = self.module.params
@@ -353,6 +352,7 @@ class JenkinsPlugin(object):
         self.timeout = self.params['timeout']
         self.username = self.params['username']
         self.password = self.params['password']
+        self.force_basic_auth = self.params['force_basic_auth']
 
         # Crumb
         self.crumb = {}
@@ -844,7 +844,7 @@ def main():
         url_password=dict(no_log=True),
         version=dict(),
         with_dependencies=dict(default=True, type='bool'),
-        force_basic_auth=dict(default=True, type='bool')  # Add force_basic_auth to arguments
+        force_basic_auth=dict(default=False, type='bool')  # Add force_basic_auth to arguments
     )
     # Module settings
     module = AnsibleModule(
@@ -852,9 +852,6 @@ def main():
         add_file_common_args=True,
         supports_check_mode=True,
     )
-
-    # Force basic authentication
-    module.params['force_basic_auth'] = True
 
     # Convert timeout to float
     try:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
force_basic_auth param is specified in documentation: https://docs.ansible.com/ansible/latest/collections/community/general/jenkins_plugin_module.html
I noticed this was not actually being used in the jenkins plugin module. We need to set authorization headers when downloading plugins in certain situations so if force_basic_auth is set to true, we create basic auth headers.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
jenkins_plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
We found that when we have SSO enabled on our Jenkins instance, we have issues with retrieving a crumb to download our plugins: https://webpagefx.mangoapps.com/msc/MjAyNTYyNl8xNDIwNTQ1Mw
We can get around this problem by using an API token instead, but we need to create basic auth headers and use the API token in place of the password - this can be controlled by the force_basic_auth param which previously was not being used in the module.
After this update, we are able to install plugins without issues: https://webpagefx.mangoapps.com/msc/MjAzNjk4MV8xNDIzMDMyOQ

```
