### PR TITLE
`cloudflare_dns`: add support for `comment` and `tags`

### DIFF
--- a/changelogs/fragments/9132-cloudflare_dns-comment-and-tags.yml
+++ b/changelogs/fragments/9132-cloudflare_dns-comment-and-tags.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cloudflare_dns - adds support for comment and tags (https://github.com/ansible-collections/community.general/pull/9132).

--- a/changelogs/fragments/9132-cloudflare_dns-comment-and-tags.yml
+++ b/changelogs/fragments/9132-cloudflare_dns-comment-and-tags.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - cloudflare_dns - add support for comment and tags (https://github.com/ansible-collections/community.general/pull/9132).
+  - cloudflare_dns - add support for ``comment`` and ``tags`` (https://github.com/ansible-collections/community.general/pull/9132).

--- a/changelogs/fragments/9132-cloudflare_dns-comment-and-tags.yml
+++ b/changelogs/fragments/9132-cloudflare_dns-comment-and-tags.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - cloudflare_dns - adds support for comment and tags (https://github.com/ansible-collections/community.general/pull/9132).
+  - cloudflare_dns - add support for comment and tags (https://github.com/ansible-collections/community.general/pull/9132).

--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -333,7 +333,7 @@ record:
             description: When the record comment was last modified. Omitted if there is no comment.
             returned: success
             type: str
-            sample: 2024-01-01T05:20:00.12345Z
+            sample: "2024-01-01T05:20:00.12345Z"
         content:
             description: The record content (details depend on record type).
             returned: success
@@ -407,7 +407,7 @@ record:
             description: When the record tags were last modified. Omitted if there are no tags.
             returned: success
             type: str
-            sample: 2025-01-01T05:20:00.12345Z
+            sample: "2025-01-01T05:20:00.12345Z"
         ttl:
             description: The time-to-live for the record.
             returned: success

--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -329,11 +329,13 @@ record:
             returned: success
             type: str
             sample: Domain verification record
+            version_added: 10.1.0
         comment_modified_on:
             description: When the record comment was last modified. Omitted if there is no comment.
             returned: success
             type: str
             sample: "2024-01-01T05:20:00.12345Z"
+            version_added: 10.1.0
         content:
             description: The record content (details depend on record type).
             returned: success
@@ -403,11 +405,13 @@ record:
             type: list
             elements: str
             sample: ['production', 'app']
+            version_added: 10.1.0
         tags_modified_on:
             description: When the record tags were last modified. Omitted if there are no tags.
             returned: success
             type: str
             sample: "2025-01-01T05:20:00.12345Z"
+            version_added: 10.1.0
         ttl:
             description: The time-to-live for the record.
             returned: success

--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -57,6 +57,12 @@ options:
     - Required for O(type=TLSA) when O(state=present).
     type: int
     choices: [ 0, 1, 2, 3 ]
+  comment:
+    description:
+    - Comments or notes about the DNS record.
+    type: str
+    required: false
+    version_added: 10.1.0
   flag:
     description:
     - Issuer Critical Flag.
@@ -134,6 +140,13 @@ options:
     type: str
     choices: [ absent, present ]
     default: present
+  tags:
+    description:
+    - Custom tags for the DNS record.
+    type: list
+    elements: str
+    required: false
+    version_added: 10.1.0
   timeout:
     description:
     - Timeout for Cloudflare API calls.
@@ -189,6 +202,18 @@ EXAMPLES = r'''
     record: test
     type: A
     value: 127.0.0.1
+    api_token: dummyapitoken
+
+- name: Create a record with comment and tags
+  community.general.cloudflare_dns:
+    zone: example.net
+    record: test
+    type: A
+    value: 127.0.0.1
+    comment: Local test website
+    tags:
+    - test
+    - local
     api_token: dummyapitoken
 
 - name: Create a example.net CNAME record to example.com
@@ -410,9 +435,11 @@ class CloudflareAPI(object):
         self.account_email = module.params['account_email']
         self.algorithm = module.params['algorithm']
         self.cert_usage = module.params['cert_usage']
+        self.comment = module.params['comment']
         self.hash_type = module.params['hash_type']
         self.flag = module.params['flag']
         self.tag = module.params['tag']
+        self.tags = module.params['tags']
         self.key_tag = module.params['key_tag']
         self.port = module.params['port']
         self.priority = module.params['priority']
@@ -662,7 +689,7 @@ class CloudflareAPI(object):
     def ensure_dns_record(self, **kwargs):
         params = {}
         for param in ['port', 'priority', 'proto', 'proxied', 'service', 'ttl', 'type', 'record', 'value', 'weight', 'zone',
-                      'algorithm', 'cert_usage', 'hash_type', 'selector', 'key_tag', 'flag', 'tag']:
+                      'algorithm', 'cert_usage', 'hash_type', 'selector', 'key_tag', 'flag', 'tag', 'tags', 'comment']:
             if param in kwargs:
                 params[param] = kwargs[param]
             else:
@@ -798,6 +825,9 @@ class CloudflareAPI(object):
             }
             search_value = None
 
+        new_record['comment'] = params['comment'] or ""
+        new_record['tags'] = params['tags'] or []
+
         zone_id = self._get_zone_id(params['zone'])
         records = self.get_dns_records(params['zone'], params['type'], search_record, search_value)
         # in theory this should be impossible as cloudflare does not allow
@@ -825,6 +855,10 @@ class CloudflareAPI(object):
                 if (cur_record['data'] != new_record['data']):
                     do_update = True
             if (params['type'] == 'CNAME') and (cur_record['content'] != new_record['content']):
+                do_update = True
+            if cur_record['comment'] != new_record['comment']:
+                do_update = True
+            if sorted(cur_record['tags']) != sorted(new_record['tags']):
                 do_update = True
             if do_update:
                 if self.module.check_mode:
@@ -856,11 +890,13 @@ def main():
             account_email=dict(type='str', required=False),
             algorithm=dict(type='int'),
             cert_usage=dict(type='int', choices=[0, 1, 2, 3]),
+            comment=dict(type='str'),
             hash_type=dict(type='int', choices=[1, 2]),
             key_tag=dict(type='int', no_log=False),
             port=dict(type='int'),
             flag=dict(type='int', choices=[0, 1]),
             tag=dict(type='str', choices=['issue', 'issuewild', 'iodef']),
+            tags=dict(type='list', elements='str'),
             priority=dict(type='int', default=1),
             proto=dict(type='str'),
             proxied=dict(type='bool', default=False),

--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -31,7 +31,6 @@ options:
     - "You can obtain your API token from the bottom of the Cloudflare 'My Account' page, found here: U(https://dash.cloudflare.com/)."
     - Can be specified in E(CLOUDFLARE_TOKEN) environment variable since community.general 2.0.0.
     type: str
-    required: false
     version_added: '0.2.0'
   account_api_key:
     description:
@@ -39,13 +38,11 @@ options:
     - Required for api keys authentication.
     - "You can obtain your API key from the bottom of the Cloudflare 'My Account' page, found here: U(https://dash.cloudflare.com/)."
     type: str
-    required: false
     aliases: [ account_api_token ]
   account_email:
     description:
     - Account email. Required for API keys authentication.
     type: str
-    required: false
   algorithm:
     description:
     - Algorithm number.
@@ -61,7 +58,6 @@ options:
     description:
     - Comments or notes about the DNS record.
     type: str
-    required: false
     version_added: 10.1.0
   flag:
     description:
@@ -145,7 +141,6 @@ options:
     - Custom tags for the DNS record.
     type: list
     elements: str
-    required: false
     version_added: 10.1.0
   timeout:
     description:

--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -845,7 +845,7 @@ class CloudflareAPI(object):
             }
             search_value = None
 
-        new_record['comment'] = params['comment'] or ""
+        new_record['comment'] = params['comment'] or None
         new_record['tags'] = params['tags'] or []
 
         zone_id = self._get_zone_id(params['zone'])

--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -324,6 +324,16 @@ record:
     returned: success, except on record deletion
     type: complex
     contains:
+        comment:
+            description: Comments or notes about the DNS record.
+            returned: success
+            type: str
+            sample: Domain verification record
+        comment_modified_on:
+            description: When the record comment was last modified. Omitted if there is no comment.
+            returned: success
+            type: str
+            sample: 2024-01-01T05:20:00.12345Z
         content:
             description: The record content (details depend on record type).
             returned: success
@@ -358,7 +368,7 @@ record:
             type: bool
             sample: false
         meta:
-            description: No documentation available.
+            description: Extra Cloudflare-specific information about the record.
             returned: success
             type: dict
             sample: { auto_added: false }
@@ -387,6 +397,17 @@ record:
             returned: success
             type: bool
             sample: false
+        tags:
+            description: Custom tags for the DNS record.
+            returned: success
+            type: list
+            elements: str
+            sample: ['production', 'app']
+        tags_modified_on:
+            description: When the record tags were last modified. Omitted if there are no tags.
+            returned: success
+            type: str
+            sample: 2025-01-01T05:20:00.12345Z
         ttl:
             description: The time-to-live for the record.
             returned: success


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support for `comment` and `tags` fields to Cloudflare DNS module as it's allowed by their API https://developers.cloudflare.com/api/operations/dns-records-for-a-zone-create-dns-record

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
cloudflare_dns

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
