### PR TITLE
modprobe: document when 'persistent' was added.

### DIFF
--- a/plugins/modules/modprobe.py
+++ b/plugins/modules/modprobe.py
@@ -46,6 +46,7 @@ options:
         type: str
         choices: [ disabled, absent, present ]
         default: disabled
+        version_added: 7.0.0
         description:
             - Persistency between reboots for configured module.
             - This option creates files in C(/etc/modules-load.d/) and C(/etc/modprobe.d/) that make your module configuration persistent during reboots.


### PR DESCRIPTION
##### SUMMARY
Add version_added for the `persistent` option in modprobe. 
This is based on git tag --contains 29f5033737a7fd86349ff3daab7d7ee7db66ad00.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
modprobe

##### ADDITIONAL INFORMATION
N/A
