### PR TITLE
filters/dict: document the correct return value

### DIFF
--- a/plugins/filter/dict.py
+++ b/plugins/filter/dict.py
@@ -57,8 +57,8 @@ EXAMPLES = '''
 
 RETURN = '''
   _value:
-    description: The dictionary having the provided key-value pairs.
-    type: boolean
+    description: A dictionary with the provided key-value pairs.
+    type: dictionary
 '''
 
 


### PR DESCRIPTION
##### SUMMARY
The dict filter return value is documented to be a boolean, when it's actually a dictionnary, as shown in the EXAMPLES section

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
filters/dict

##### ADDITIONAL INFORMATION
N/A
