### PR TITLE
Update docs for github_app_access_token.py

### DIFF
--- a/plugins/lookup/github_app_access_token.py
+++ b/plugins/lookup/github_app_access_token.py
@@ -56,7 +56,7 @@ EXAMPLES = '''
   vars:
     github_token: >-
       {{ lookup('community.general.github_app_access_token', key_path='/home/to_your/key',
-             app_id='123456', installation_id='64209') }}
+                app_id='123456', installation_id='64209') }}
 '''
 
 RETURN = '''

--- a/plugins/lookup/github_app_access_token.py
+++ b/plugins/lookup/github_app_access_token.py
@@ -55,8 +55,8 @@ EXAMPLES = '''
     dest: /srv/checkout
   vars:
     github_token: >-
-      lookup('community.general.github_app_access_token', key_path='/home/to_your/key',
-             app_id='123456', installation_id='64209')
+      {{ lookup('community.general.github_app_access_token', key_path='/home/to_your/key',
+             app_id='123456', installation_id='64209') }}
 '''
 
 RETURN = '''


### PR DESCRIPTION
updating docs - github_token missing {{ }}

##### SUMMARY
Example code for github_app_access_token is missing the {{ }} around the lookup to make the variable run

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
github_app_access_token

##### ADDITIONAL INFORMATION
Using the example as it comes will give an error of:
"msg": "fatal: unable to access 'https://x-access-token:lookup(community.general.github_app_access_token,/': URL rejected: Port number was not a decimal number between 0 and 65535", "rc": 128, "stderr": "fatal: unable to access 'https://x-access-token:lookup(community.general.github_app_access_token,/': URL rejected: Port number was not a decimal number between 0 and 65535\n", "stderr_lines": ["fatal: unable to access 'https://x-access-token:lookup(community.general.github_app_access_token,/': URL rejected: Port number was not a decimal number between 0 and 65535"], "stdout": "", "stdout_lines": []}

Adding the {{ }} around the lookup will then make that run and the var contain the token required
