### PR TITLE
to_ini: add allow_no_value

### DIFF
--- a/plugins/filter/to_ini.py
+++ b/plugins/filter/to_ini.py
@@ -63,7 +63,7 @@ class IniParser(ConfigParser):
     ''' Implements a configparser which sets the correct optionxform '''
 
     def __init__(self):
-        super().__init__(interpolation=None)
+        super().__init__(interpolation=None, allow_no_value=True)
         self.optionxform = str
 
 


### PR DESCRIPTION
##### SUMMARY
Add `allow_no_value=True` to `to_ini` filter like for `ini_file` module. Some configuration files are known to include settings without values like mysql.

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
to_ini

