### PR TITLE
Fixed connection with proxmox without certs

### DIFF
--- a/changelogs/fragments/9178-fix-proxmox-connection-without-certs.yml
+++ b/changelogs/fragments/9178-fix-proxmox-connection-without-certs.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - proxmox inventory plugin - fix connection without certificates
+  - proxmox inventory plugin - fix connection without certificates (https://github.com/ansible-collections/community.general/pull/9178).

--- a/changelogs/fragments/9178-fix-proxmox-connection-without-certs.yml
+++ b/changelogs/fragments/9178-fix-proxmox-connection-without-certs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox inventory plugin - fix connection without certificates

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -312,7 +312,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             data = []
             s = self._get_session()
             while True:
-                ret = s.get(url, headers=self.headers)
+                ret = s.get(url, headers=self.headers, verify=s.verify)
                 if ignore_errors and ret.status_code in ignore_errors:
                     break
                 ret.raise_for_status()


### PR DESCRIPTION
##### SUMMARY
Need to add the verify argument to the get() call to successfully connect to a proxmox without a certificate.
Without it, the validate_certs parameter in proxmox.yml inventory seems to be ignored (not really used, at least).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/proxmox.py
