### PR TITLE
Greatly speed up homebrew module when multiple packages are passed in the `name` key 

### DIFF
--- a/changelogs/fragments/9181-improve-homebrew-module-performance.yml
+++ b/changelogs/fragments/9181-improve-homebrew-module-performance.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - homebrew - greatly speed up homebrew module when multiple packages are passed in the `name` key (https://github.com/ansible-collections/community.general/pull/9181).

--- a/changelogs/fragments/9181-improve-homebrew-module-performance.yml
+++ b/changelogs/fragments/9181-improve-homebrew-module-performance.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - homebrew - greatly speed up homebrew module when multiple packages are passed in the ``name`` option (https://github.com/ansible-collections/community.general/pull/9181).
+  - homebrew - greatly speed up module when multiple packages are passed in the ``name`` option (https://github.com/ansible-collections/community.general/pull/9181).

--- a/changelogs/fragments/9181-improve-homebrew-module-performance.yml
+++ b/changelogs/fragments/9181-improve-homebrew-module-performance.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - homebrew - greatly speed up homebrew module when multiple packages are passed in the `name` key (https://github.com/ansible-collections/community.general/pull/9181).
+  - homebrew - greatly speed up homebrew module when multiple packages are passed in the ``name`` option (https://github.com/ansible-collections/community.general/pull/9181).

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -365,9 +365,6 @@ class Homebrew(object):
 
         return self.brew_path
 
-    def _status(self):
-        return (self.failed, self.changed, self.message)
-
     def _validate_packages_names(self):
         invalid_packages = []
         for package in self.packages:
@@ -411,6 +408,7 @@ class Homebrew(object):
             self._run()
         except HomebrewException:
             pass
+
         changed_count = len(self.changed_pkgs)
         unchanged_count = len(self.unchanged_pkgs)
         if not self.failed and (changed_count + unchanged_count > 1):
@@ -418,9 +416,7 @@ class Homebrew(object):
                 changed_count,
                 unchanged_count,
             )
-        (failed, changed, message) = self._status()
-
-        return (failed, changed, message)
+        return (self.failed, self.changed, self.message)
 
     # commands ----------------------------------------------------- {{{
     def _run(self):

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -422,36 +422,6 @@ class Homebrew(object):
 
         return (failed, changed, message)
 
-    # checks ------------------------------------------------------- {{{
-    def _current_package_is_installed(self):
-        cmd = [
-            "{brew_path}".format(brew_path=self.brew_path),
-            "info",
-            "--json=v2",
-            self.current_package,
-        ]
-        if self.force_formula:
-            cmd.append("--formula")
-        rc, out, err = self.module.run_command(cmd)
-        if rc != 0:
-            self.failed = True
-            self.message = err.strip() or ("Unknown failure with exit code %d" % rc)
-            raise HomebrewException(self.message)
-        data = json.loads(out)
-
-        return _check_package_in_json(data, "formulae") or _check_package_in_json(data, "casks")
-
-    def _current_package_is_outdated(self):
-        rc, out, err = self.module.run_command([
-            self.brew_path,
-            'outdated',
-            self.current_package,
-        ])
-
-        return rc != 0
-
-    # /checks ------------------------------------------------------ }}}
-
     # commands ----------------------------------------------------- {{{
     def _run(self):
         if self.update_homebrew:

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -373,7 +373,7 @@ class Homebrew(object):
 
         if invalid_packages:
             self.failed = True
-            self.message = 'Invalid package{0}: {0}'.format(
+            self.message = 'Invalid package{0}: {1}'.format(
                 "s" if len(invalid_packages) > 1 else "",
                 ", ".join(invalid_packages),
             )

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -396,11 +396,17 @@ class Homebrew(object):
             raise HomebrewException(self.message)
 
         data = json.loads(out)
-        for package_detail in data.get("formulae", []) + data.get("casks", []):
+        for package_detail in data.get("formulae", []):
             if bool(package_detail.get("installed")):
                 self.installed_packages.add(package_detail["name"])
             if bool(package_detail.get("outdated")):
                 self.outdated_packages.add(package_detail["name"])
+
+        for package_detail in data.get("casks", []):
+            if bool(package_detail.get("installed")):
+                self.installed_packages.add(package_detail["token"])
+            if bool(package_detail.get("outdated")):
+                self.outdated_packages.add(package_detail["token"])
     # /prep -------------------------------------------------------- }}}
 
     def run(self):

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -347,8 +347,6 @@ class Homebrew(object):
     def _setup_status_vars(self):
         self.failed = False
         self.changed = False
-        self.changed_count = 0
-        self.unchanged_count = 0
         self.changed_pkgs = []
         self.unchanged_pkgs = []
         self.message = ''
@@ -389,11 +387,12 @@ class Homebrew(object):
             self._run()
         except HomebrewException:
             pass
-
-        if not self.failed and (self.changed_count + self.unchanged_count > 1):
+        changed_count = len(self.changed_pkgs)
+        unchanged_count = len(self.unchanged_pkgs)
+        if not self.failed and (changed_count + unchanged_count > 1):
             self.message = "Changed: %d, Unchanged: %d" % (
-                self.changed_count,
-                self.unchanged_count,
+                changed_count,
+                unchanged_count,
             )
         (failed, changed, message) = self._status()
 
@@ -509,7 +508,6 @@ class Homebrew(object):
     # installed ------------------------------ {{{
     def _install_current_package(self):
         if self._current_package_is_installed():
-            self.unchanged_count += 1
             self.unchanged_pkgs.append(self.current_package)
             self.message = 'Package already installed: {0}'.format(
                 self.current_package,
@@ -542,7 +540,6 @@ class Homebrew(object):
         rc, out, err = self.module.run_command(cmd)
 
         if rc == 0:
-            self.changed_count += 1
             self.changed_pkgs.append(self.current_package)
             self.changed = True
             self.message = 'Package installed: {0}'.format(self.current_package)
@@ -572,7 +569,6 @@ class Homebrew(object):
             self.message = 'Package is already upgraded: {0}'.format(
                 self.current_package,
             )
-            self.unchanged_count += 1
             self.unchanged_pkgs.append(self.current_package)
             return True
 
@@ -592,7 +588,6 @@ class Homebrew(object):
         rc, out, err = self.module.run_command(cmd)
 
         if rc == 0:
-            self.changed_count += 1
             self.changed_pkgs.append(self.current_package)
             self.changed = True
             self.message = 'Package upgraded: {0}'.format(self.current_package)
@@ -632,7 +627,6 @@ class Homebrew(object):
     # uninstalled ---------------------------- {{{
     def _uninstall_current_package(self):
         if not self._current_package_is_installed():
-            self.unchanged_count += 1
             self.unchanged_pkgs.append(self.current_package)
             self.message = 'Package already uninstalled: {0}'.format(
                 self.current_package,
@@ -655,7 +649,6 @@ class Homebrew(object):
         rc, out, err = self.module.run_command(cmd)
 
         if not self._current_package_is_installed():
-            self.changed_count += 1
             self.changed_pkgs.append(self.current_package)
             self.changed = True
             self.message = 'Package uninstalled: {0}'.format(self.current_package)
@@ -696,7 +689,6 @@ class Homebrew(object):
         rc, out, err = self.module.run_command(cmd)
 
         if rc == 0:
-            self.changed_count += 1
             self.changed_pkgs.append(self.current_package)
             self.changed = True
             self.message = 'Package linked: {0}'.format(self.current_package)
@@ -738,7 +730,6 @@ class Homebrew(object):
         rc, out, err = self.module.run_command(cmd)
 
         if rc == 0:
-            self.changed_count += 1
             self.changed_pkgs.append(self.current_package)
             self.changed = True
             self.message = 'Package unlinked: {0}'.format(self.current_package)

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -696,44 +696,47 @@ class Homebrew(object):
     # /uninstalled ----------------------------- }}}
 
     # linked --------------------------------- {{{
-    def _link_current_package(self):
-        if not self._current_package_is_installed():
+    def _link_packages(self):
+        missing_packages = set(self.packages) - self.installed_packages
+        if missing_packages:
             self.failed = True
-            self.message = 'Package not installed: {0}.'.format(self.current_package)
+            self.message = 'Package{0} not installed: {1}.'.format(
+                "s" if len(missing_packages) > 1 else "",
+                ", ".join(missing_packages),
+            )
             raise HomebrewException(self.message)
 
         if self.module.check_mode:
             self.changed = True
-            self.message = 'Package would be linked: {0}'.format(
-                self.current_package
+            self.message = 'Package{0} would be linked: {1}'.format(
+                "s" if len(self.packages) > 1 else "",
+                ", ".join(self.packages)
             )
             raise HomebrewException(self.message)
 
         opts = (
             [self.brew_path, 'link']
             + self.install_options
-            + [self.current_package]
+            + self.packages
         )
         cmd = [opt for opt in opts if opt]
         rc, out, err = self.module.run_command(cmd)
 
         if rc == 0:
-            self.changed_pkgs.append(self.current_package)
+            self.changed_pkgs.extend(self.packages)
             self.changed = True
-            self.message = 'Package linked: {0}'.format(self.current_package)
-
+            self.message = 'Package{0} linked: {1}'.format(
+                "s" if len(self.packages) > 1 else "",
+                ", ".join(self.packages)
+            )
             return True
         else:
             self.failed = True
-            self.message = 'Package could not be linked: {0}.'.format(self.current_package)
+            self.message = 'Package{0} could not be linked: {1}.'.format(
+                "s" if len(self.packages) > 1 else "",
+                ", ".join(self.packages)
+            )
             raise HomebrewException(self.message)
-
-    def _link_packages(self):
-        for package in self.packages:
-            self.current_package = package
-            self._link_current_package()
-
-        return True
     # /linked -------------------------------- }}}
 
     # unlinked ------------------------------- {{{

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -427,22 +427,6 @@ class Homebrew(object):
 
         return rc != 0
 
-    def _current_package_is_installed_from_head(self):
-        if not self._current_package_is_installed():
-            return False
-
-        rc, out, err = self.module.run_command([
-            self.brew_path,
-            'info',
-            self.current_package,
-        ])
-
-        try:
-            version_info = [line for line in out.split('\n') if line][0]
-        except IndexError:
-            return False
-
-        return version_info.split(' ')[-1] == 'HEAD'
     # /checks ------------------------------------------------------ }}}
 
     # commands ----------------------------------------------------- {{{

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -740,44 +740,47 @@ class Homebrew(object):
     # /linked -------------------------------- }}}
 
     # unlinked ------------------------------- {{{
-    def _unlink_current_package(self):
-        if not self._current_package_is_installed():
+    def _unlink_packages(self):
+        missing_packages = set(self.packages) - self.installed_packages
+        if missing_packages:
             self.failed = True
-            self.message = 'Package not installed: {0}.'.format(self.current_package)
+            self.message = 'Package{0} not installed: {1}.'.format(
+                "s" if len(missing_packages) > 1 else "",
+                ", ".join(missing_packages),
+            )
             raise HomebrewException(self.message)
 
         if self.module.check_mode:
             self.changed = True
-            self.message = 'Package would be unlinked: {0}'.format(
-                self.current_package
+            self.message = 'Package{0} would be unlinked: {1}'.format(
+                "s" if len(self.packages) > 1 else "",
+                ", ".join(self.packages)
             )
             raise HomebrewException(self.message)
 
         opts = (
             [self.brew_path, 'unlink']
             + self.install_options
-            + [self.current_package]
+            + self.packages
         )
         cmd = [opt for opt in opts if opt]
         rc, out, err = self.module.run_command(cmd)
 
         if rc == 0:
-            self.changed_pkgs.append(self.current_package)
+            self.changed_pkgs.extend(self.packages)
             self.changed = True
-            self.message = 'Package unlinked: {0}'.format(self.current_package)
-
+            self.message = 'Package{0} unlinked: {1}'.format(
+                "s" if len(self.packages) > 1 else "",
+                ", ".join(self.packages)
+            )
             return True
         else:
             self.failed = True
-            self.message = 'Package could not be unlinked: {0}.'.format(self.current_package)
+            self.message = 'Package{0} could not be unlinked: {1}.'.format(
+                "s" if len(self.packages) > 1 else "",
+                ", ".join(self.packages)
+            )
             raise HomebrewException(self.message)
-
-    def _unlink_packages(self):
-        for package in self.packages:
-            self.current_package = package
-            self._unlink_current_package()
-
-        return True
     # /unlinked ------------------------------ }}}
     # /commands ---------------------------------------------------- }}}
 

--- a/tests/integration/targets/homebrew/tasks/formulae.yml
+++ b/tests/integration/targets/homebrew/tasks/formulae.yml
@@ -56,6 +56,9 @@
   - assert:
       that:
         - package_result.changed
+        - "package_result.msg == 'Package installed: gnu-tar'"
+        - "package_result.changed_pkgs == ['gnu-tar']"
+        - "package_result.unchanged_pkgs == []"
 
   - name: Again install {{ package_name }} package using homebrew
     homebrew:
@@ -69,6 +72,41 @@
   - assert:
       that:
         - not package_result.changed
+        - "package_result.msg == 'Package already installed: gnu-tar'"
+        - "package_result.changed_pkgs == []"
+        - "package_result.unchanged_pkgs == ['gnu-tar']"
+
+  - name: Unlink {{ package_name }} package using homebrew
+    homebrew:
+      name: "{{ package_name }}"
+      state: unlinked
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - package_result.changed
+        - "package_result.msg == 'Package unlinked: gnu-tar'"
+        - "package_result.changed_pkgs == ['gnu-tar']"
+        - "package_result.unchanged_pkgs == []"
+
+  - name: Link {{ package_name }} package using homebrew
+    homebrew:
+      name: "{{ package_name }}"
+      state: linked
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - package_result.changed
+        - "package_result.msg == 'Package linked: gnu-tar'"
+        - "package_result.changed_pkgs == ['gnu-tar']"
+        - "package_result.unchanged_pkgs == []"
 
   - name: Uninstall {{ package_name }} package using homebrew
     homebrew:
@@ -82,6 +120,9 @@
   - assert:
       that:
         - package_result.changed
+        - "package_result.msg == 'Package uninstalled: gnu-tar'"
+        - "package_result.changed_pkgs == ['gnu-tar']"
+        - "package_result.unchanged_pkgs == []"
 
   - name: Again uninstall {{ package_name }} package using homebrew
     homebrew:
@@ -95,3 +136,188 @@
   - assert:
       that:
         - not package_result.changed
+        - "package_result.msg == 'Package already uninstalled: gnu-tar'"
+        - "package_result.changed_pkgs == []"
+        - "package_result.unchanged_pkgs == ['gnu-tar']"
+
+  - name: Upgrade {{ package_name }} package using homebrew
+    homebrew:
+      name: "{{ package_name }}"
+      state: latest
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - package_result.changed
+        - "package_result.msg == 'Package upgraded: gnu-tar'"
+        - "package_result.changed_pkgs == ['gnu-tar']"
+        - "package_result.unchanged_pkgs == []"
+
+  - name: Again upgrade {{ package_name }} package using homebrew
+    homebrew:
+      name: "{{ package_name }}"
+      state: latest
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - not package_result.changed
+        - "package_result.msg == 'Package already upgraded: gnu-tar'"
+        - "package_result.changed_pkgs == []"
+        - "package_result.unchanged_pkgs == ['gnu-tar']"
+
+- vars:
+    package_names:
+      - gnu-tar
+      - gnu-time
+
+  block:
+  - name: Make sure {{ package_names }} packages are not installed
+    homebrew:
+      name: "{{ package_names }}"
+      state: absent
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+
+  - name: Install only {{ package_names[0] }} package using homebrew
+    homebrew:
+      name: "{{ package_names[0] }}"
+      state: present
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+
+  - name: Install {{ package_names }} packages using homebrew (one is already installed)
+    homebrew:
+      name: "{{ package_names }}"
+      state: present
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - package_result.changed
+        - "package_result.msg == 'Changed: 1, Unchanged: 1'"
+        - "package_result.changed_pkgs == ['gnu-time']"
+        - "package_result.unchanged_pkgs == ['gnu-tar']"
+
+  - name: Again install {{ package_names }} packages using homebrew
+    homebrew:
+      name: "{{ package_names }}"
+      state: present
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - not package_result.changed
+        - "package_result.msg == 'Changed: 0, Unchanged: 2'"
+        - "package_result.changed_pkgs == []"
+        - "package_result.unchanged_pkgs | sort == ['gnu-tar', 'gnu-time']"
+
+  - name: Unlink {{ package_names }} packages using homebrew
+    homebrew:
+      name: "{{ package_names }}"
+      state: unlinked
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - package_result.changed
+        - "package_result.msg == 'Changed: 2, Unchanged: 0'"
+        - "package_result.changed_pkgs | sort == ['gnu-tar', 'gnu-time']"
+        - "package_result.unchanged_pkgs == []"
+
+  - name: Link {{ package_names }} packages using homebrew
+    homebrew:
+      name: "{{ package_names }}"
+      state: linked
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - package_result.changed
+        - "package_result.msg == 'Changed: 2, Unchanged: 0'"
+        - "package_result.changed_pkgs | sort == ['gnu-tar', 'gnu-time']"
+        - "package_result.unchanged_pkgs == []"
+
+  - name: Uninstall {{ package_names }} packages using homebrew
+    homebrew:
+      name: "{{ package_names }}"
+      state: absent
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - package_result.changed
+        - "package_result.msg == 'Changed: 2, Unchanged: 0'"
+        - "package_result.changed_pkgs | sort == ['gnu-tar', 'gnu-time']"
+        - "package_result.unchanged_pkgs == []"
+
+  - name: Again uninstall {{ package_names }} packages using homebrew
+    homebrew:
+      name: "{{ package_names }}"
+      state: absent
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - not package_result.changed
+        - "package_result.msg == 'Changed: 0, Unchanged: 2'"
+        - "package_result.changed_pkgs == []"
+        - "package_result.unchanged_pkgs | sort == ['gnu-tar', 'gnu-time']"
+
+  - name: Upgrade {{ package_names }} packages using homebrew
+    homebrew:
+      name: "{{ package_names }}"
+      state: latest
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - package_result.changed
+        - "package_result.msg == 'Changed: 2, Unchanged: 0'"
+        - "package_result.changed_pkgs | sort == ['gnu-tar', 'gnu-time']"
+        - "package_result.unchanged_pkgs == []"
+
+  - name: Again upgrade {{ package_names }} packages using homebrew
+    homebrew:
+      name: "{{ package_names }}"
+      state: latest
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - not package_result.changed
+        - "package_result.msg == 'Changed: 0, Unchanged: 2'"
+        - "package_result.changed_pkgs == []"
+        - "package_result.unchanged_pkgs | sort == ['gnu-tar', 'gnu-time']"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This is a rather big refactoring pull request but with rather big performance improvements.
**This makes this simple brew task 5-15x faster on my machine** by leveraging brew ability to work with multiple packages at a time.  Only 1 brew call is made to install N packages instead of N brew calls previously, greatly reducing the overall runtime.
```yml
- name: Install & upgrade brew packages
  community.general.homebrew:
    name: "{{ thibaut_brew_packages }}"
    state: latest
    update_homebrew: true
```

**Review commit per commit is highly recommended.** 
The first commit adds a few tests to increase coverage and validate more strictly the outputs. 
Then I tried to keep the commits contained and made sure tests are passing for each one of them.

##### ISSUE TYPE
- Refactoring Pull Request
- Test Pull Request

##### COMPONENT NAME
homebrew

##### ADDITIONAL INFORMATION
Here are the improvement I measured locally working with 15 packages (with package sizes from 2 to 250Mo)

- **It went from ~25s to ~1.5s** for the noop case (15 packages already up to date) 
- **It went from ~35s to ~7s** for the few updates case (5/15 packages updated) 

Any brew call takes ~1s because of the overhead of brew itself, this PR tries to cut most of it by doing batch brew calls instead of brew calls in a loop. The performance difference is even more noticeable for small packages were the actual install is fast compared to the brew overhead.

PS: If it makes sense, I'll be more than welcome to be marked as a maintainer of this module. I've seen you might be looking for one in https://github.com/ansible-collections/community.general/issues/8709#issuecomment-2335050203
PS2: This MR is a followup to #9022 were this optimization idea was first mentioned.