### PR TITLE
fixing broken check mode in the github_key

### DIFF
--- a/changelogs/fragments/9186-fix-broken-check-mode-in-github-key.yml
+++ b/changelogs/fragments/9186-fix-broken-check-mode-in-github-key.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - github_key - when check_mode was set, a faulty call to ```datetime.strftime(...)``` was being made which generated an exception. (https://github.com/ansible-collections/community.general/issues/9185)

--- a/changelogs/fragments/9186-fix-broken-check-mode-in-github-key.yml
+++ b/changelogs/fragments/9186-fix-broken-check-mode-in-github-key.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - github_key - when check_mode was set, a faulty call to ```datetime.strftime(...)``` was being made which generated an exception. (https://github.com/ansible-collections/community.general/issues/9185)
+  - github_key - in check mode, a faulty call to ```datetime.strftime(...)``` was being made which generated an exception (https://github.com/ansible-collections/community.general/issues/9185).

--- a/plugins/modules/github_key.py
+++ b/plugins/modules/github_key.py
@@ -162,7 +162,7 @@ def create_key(session, name, pubkey, check_mode):
             'key': pubkey,
             'title': name,
             'url': 'http://example.com/CHECK_MODE_GITHUB_KEY',
-            'created_at': datetime.strftime(now_t, '%Y-%m-%dT%H:%M:%SZ'),
+            'created_at': datetime.datetime.strftime(now_t, '%Y-%m-%dT%H:%M:%SZ'),
             'read_only': False,
             'verified': False
         }


### PR DESCRIPTION
##### SUMMARY

Fixes #9185 (broken check mode in the github_key.py module) 

 ##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
github_key

##### ADDITIONAL INFORMATION
It looks as if this is a recent regression caused by #8222 
The change in the previous PR makes sense but it was missing the datetime class 
ie, datetime.strftime(...) instead of datetime.datetime.strftime(...)