### PR TITLE
Fail if Slack API response is not OK with error message

### DIFF
--- a/changelogs/fragments/9198-fail-if-slack-api-response-is-not-ok-with-error-message.yml
+++ b/changelogs/fragments/9198-fail-if-slack-api-response-is-not-ok-with-error-message.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - slack - Fail if Slack API response is not OK with error message (https://github.com/ansible-collections/community.general/pull/9198).
+  - slack - fail if Slack API response is not OK with error message (https://github.com/ansible-collections/community.general/pull/9198).

--- a/changelogs/fragments/9198-fail-if-slack-api-response-is-not-ok-with-error-message.yml
+++ b/changelogs/fragments/9198-fail-if-slack-api-response-is-not-ok-with-error-message.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - slack - Fail if Slack API response is not OK with error message (https://github.com/ansible-collections/community.general/pull/9198).

--- a/plugins/modules/slack.py
+++ b/plugins/modules/slack.py
@@ -391,6 +391,8 @@ def get_slack_message(module, token, channel, ts):
     if info['status'] != 200:
         module.fail_json(msg="failed to get slack message")
     data = module.from_json(response.read())
+    if data['ok'] is False:
+        module.fail_json(msg="failed to get slack message: %s" % data['error'])
     if len(data['messages']) < 1:
         module.fail_json(msg="no messages matching ts: %s" % ts)
     if len(data['messages']) > 1:

--- a/plugins/modules/slack.py
+++ b/plugins/modules/slack.py
@@ -76,7 +76,8 @@ options:
   message_id:
     description:
       - Optional. Message ID to edit, instead of posting a new message.
-      - If supplied O(channel) must be in form of C(C0xxxxxxx). use C({{ slack_response.channel_id }}) to get RV(ignore:channel_id) from previous task run.
+      - If supplied O(channel) must be in form of C(C0xxxxxxx). use C({{ slack_response.channel }}) to get RV(ignore:channel) from previous task run.
+      - The token needs history scope to get information on the message to edit (channels:history,groups:history,mpim:history,im:history).
       - Corresponds to C(ts) in the Slack API (U(https://api.slack.com/messaging/modifying)).
     type: str
     version_added: 1.2.0

--- a/plugins/modules/slack.py
+++ b/plugins/modules/slack.py
@@ -77,7 +77,7 @@ options:
     description:
       - Optional. Message ID to edit, instead of posting a new message.
       - If supplied O(channel) must be in form of C(C0xxxxxxx). use C({{ slack_response.channel }}) to get RV(ignore:channel) from previous task run.
-      - The token needs history scope to get information on the message to edit (channels:history,groups:history,mpim:history,im:history).
+      - The token needs history scope to get information on the message to edit (C(channels:history,groups:history,mpim:history,im:history)).
       - Corresponds to C(ts) in the Slack API (U(https://api.slack.com/messaging/modifying)).
     type: str
     version_added: 1.2.0

--- a/plugins/modules/slack.py
+++ b/plugins/modules/slack.py
@@ -391,8 +391,8 @@ def get_slack_message(module, token, channel, ts):
     if info['status'] != 200:
         module.fail_json(msg="failed to get slack message")
     data = module.from_json(response.read())
-    if data['ok'] is False:
-        module.fail_json(msg="failed to get slack message: %s" % data['error'])
+    if data.get('ok') is False:
+        module.fail_json(msg="failed to get slack message: %s" % data)
     if len(data['messages']) < 1:
         module.fail_json(msg="no messages matching ts: %s" % ts)
     if len(data['messages']) > 1:


### PR DESCRIPTION
##### SUMMARY

Currently, when I try to edit a slack message, the module call the `get_slack_message` function and fails on `if len(data['messages']) < 1:` because `messages` is not return by Slack API.
So this PR return to ansible the result of the request to show the real error to the user.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
community.general.slack

##### ADDITIONAL INFORMATION

```
  community.general.slack:
    token: "xxx"
    channel: "{{ previous_task.channel }}"
    msg: "edit message"
    message_id: "{{ previous_task.ts }}"
```

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'messages'
fatal: [mymachine -> localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/home/me/.ansible/tmp/ansible-tmp-1732624276.3207872-172112-264078090362199/AnsiballZ_slack.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/me/.ansible/tmp/ansible-tmp-1732624276.3207872-172112-264078090362199/AnsiballZ_slack.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/me/.ansible/tmp/ansible-tmp-1732624276.3207872-172112-264078090362199/AnsiballZ_slack.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.general.plugins.modules.slack', init_globals=dict(_module_fqn='ansible_collections.community.general.plugins.modules.slack', _modlib_path=modlib_path),\n  File \"<frozen runpy>\", line 226, in run_module\n  File \"<frozen runpy>\", line 98, in _run_module_code\n  File \"<frozen runpy>\", line 88, in _run_code\n  File \"/tmp/ansible_community.general.slack_payload_reagkbux/ansible_community.general.slack_payload.zip/ansible_collections/community/general/plugins/modules/slack.py\", line 520, in <module>\n  File \"/tmp/ansible_community.general.slack_payload_reagkbux/ansible_community.general.slack_payload.zip/ansible_collections/community/general/plugins/modules/slack.py\", line 488, in main\n  File \"/tmp/ansible_community.general.slack_payload_reagkbux/ansible_community.general.slack_payload.zip/ansible_collections/community/general/plugins/modules/slack.py\", line 394, in get_slack_message\nKeyError: 'messages'\n", "module_stdout": "", "msg": "MODULE FAILURE: No start of json char found\nSee stdout/stderr for the exact error", "rc": 1}
```
become
```
fatal: [mymachine -> localhost]: FAILED! => {"changed": false, "msg": "failed to get slack message: {'ok': False, 'error': 'missing_scope', 'needed': 'channels:history,groups:history,mpim:history,im:history', 'provided': 'chat:write,chat:write.customize,incoming-webhook,chat:write.public'}"}
```
