### PR TITLE
keycloak_clientscope_type: sort default and optional clientscope lists before diff

### DIFF
--- a/changelogs/fragments/9202-keycloak_clientscope_type-sort-lists.yml
+++ b/changelogs/fragments/9202-keycloak_clientscope_type-sort-lists.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - keycloak_clientscope_type - sort the default and optional clientscope lists to improve the diff (https://github.com/ansible-collections/community.general/pull/9202).

--- a/plugins/modules/keycloak_clientscope_type.py
+++ b/plugins/modules/keycloak_clientscope_type.py
@@ -190,6 +190,15 @@ def extract_field(dictionary, field='name'):
     return [cs[field] for cs in dictionary]
 
 
+def normalize_scopes(scopes):
+    scopes_copy = scopes.copy()
+    if isinstance(scopes_copy.get('default_clientscopes'), list):
+        scopes_copy['default_clientscopes'] = sorted(scopes_copy['default_clientscopes'])
+    if isinstance(scopes_copy.get('optional_clientscopes'), list):
+        scopes_copy['optional_clientscopes'] = sorted(scopes_copy['optional_clientscopes'])
+    return scopes_copy
+
+
 def main():
     """
     Module keycloak_clientscope_type
@@ -244,7 +253,7 @@ def main():
     })
 
     if module._diff:
-        result['diff'] = dict(before=result['existing'], after=result['proposed'])
+        result['diff'] = dict(before=normalize_scopes(result['existing']), after=normalize_scopes(result['proposed']))
 
     default_clientscopes_add = clientscopes_to_add(default_clientscopes_existing, default_clientscopes_real)
     optional_clientscopes_add = clientscopes_to_add(optional_clientscopes_existing, optional_clientscopes_real)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The change sorts the default and optional clientscope lists before the diff, to make the diff more accurate.

Before:
```
 {
     "default_clientscopes": [
+        "email",
+        "web-origins",
         "acr",
-        "profile",
-        "roles",
-        "basic",
-        "email"
+        "profile"
     ],
     "optional_clientscopes": [
-        "web-origins",
         "address",
-        "sAMAccountName",
+        "microprofile-jwt",
+        "organization",
         "offline_access",
-        "microprofile-jwt"
+        "phone"
     ]
 }
```

After:
```
 {
     "default_clientscopes": [
         "acr",
-        "basic",
         "email",
         "profile",
-        "roles"
+        "web-origins"
     ],
     "optional_clientscopes": [
         "address",
         "microprofile-jwt",
         "offline_access",
-        "sAMAccountName",
-        "web-origins"
+        "organization",
+        "phone"
     ]
 }
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_clientscope_type
