### PR TITLE
Fix incorrect key lookup

### DIFF
--- a/changelogs/fragments/9223-proxmox-backup-bugfixes.yml
+++ b/changelogs/fragments/9223-proxmox-backup-bugfixes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - proxmox_backup - fix incorrect key lookup in vmid permission check (https://github.com/ansible-collections/community.general/pull/9223).

--- a/plugins/modules/proxmox_backup.py
+++ b/plugins/modules/proxmox_backup.py
@@ -325,7 +325,7 @@ class ProxmoxBackupAnsible(ProxmoxAnsible):
         if "/" in permissions.keys() and permissions["/"].get(
                 "VM.Backup", 0) == 1:
             sufficient_permissions = True
-        elif "/vms" in permissions.keys() and permissions["/"].get(
+        elif "/vms" in permissions.keys() and permissions["/vms"].get(
                 "VM.Backup", 0) == 1:
             sufficient_permissions = True
         elif pool and "/pool/" + pool in permissions.keys() and permissions["/pool/" + pool].get(


### PR DESCRIPTION
##### SUMMARY
Fixes a key lookup bug in modules/proxmox_backup. May be extended with further fixes, when encountered in upcoming usage.

Currently, if the permission tree for vms does not include "/" and at the same time does contain "/vms", the module fails.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox_backup