### PR TITLE
Fix VerifyBiosAttributes command on Systems with multiple entries

### DIFF
--- a/changelogs/fragments/9234-fix-verify-bios-attributes-multi-system.yml
+++ b/changelogs/fragments/9234-fix-verify-bios-attributes-multi-system.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redfish_utils module utils - Fix VerifyBiosAttributes command on multi system resource nodes (https://github.com/ansible-collections/community.general/pull/9234).

--- a/changelogs/fragments/9234-fix-verify-bios-attributes-multi-system.yml
+++ b/changelogs/fragments/9234-fix-verify-bios-attributes-multi-system.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - redfish_utils module utils - Fix VerifyBiosAttributes command on multi system resource nodes (https://github.com/ansible-collections/community.general/pull/9234).
+  - redfish_utils module utils - Fix ``VerifyBiosAttributes`` command on multi system resource nodes (https://github.com/ansible-collections/community.general/pull/9234).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -3616,7 +3616,7 @@ class RedfishUtils(object):
 
     def verify_bios_attributes(self, bios_attributes):
         # This method verifies BIOS attributes against the provided input
-        server_bios = self.get_multi_bios_attributes()
+        server_bios = self.get_bios_attributes(self.systems_uri)
         if server_bios["ret"] is False:
             return server_bios
 
@@ -3625,8 +3625,8 @@ class RedfishUtils(object):
 
         # Verify bios_attributes with BIOS settings available in the server
         for key, value in bios_attributes.items():
-            if key in server_bios["entries"][0][1]:
-                if server_bios["entries"][0][1][key] != value:
+            if key in server_bios["entries"]:
+                if server_bios["entries"][key] != value:
                     bios_dict.update({key: value})
             else:
                 wrong_param.update({key: value})


### PR DESCRIPTION
##### SUMMARY

Fixes #9230

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redfish_utils

##### ADDITIONAL INFORMATION
Previously, this command was working on single system resource systems due to `get_multi_bios_attributes()` returning a consistent response. When running on a system with multiple system resources the response from `get_multi_bios_attributes()` includes additional output structure that was not being accounted for in the method.

Due to this command being part of the `redfish_command` the `data_modification=True` attribute is set which requires passing in `resource_id` on nodes with multiple managers/systems/chassis. We can switch to using the singular `get_bios_attributes` method and eliminate the extra parsing as we will never have multiple system entries worth of data to handle.

Before this change on a system with multiple system entries:
```
Traceback (most recent call last):
  File "/home/user/.ansible/tmp/ansible-tmp-1733524983.8725114-939343-222145990725532/AnsiballZ_redfish_command.py", line 259, in <module>
    _ansiballz_main()
  File "/home/user/.ansible/tmp/ansible-tmp-1733524983.8725114-939343-222145990725532/AnsiballZ_redfish_command.py", line 246, in _ansiballz_main
    exitcode = debug(sys.argv[1], zipped_mod, ANSIBALLZ_PARAMS)
  File "/home/user/.ansible/tmp/ansible-tmp-1733524983.8725114-939343-222145990725532/AnsiballZ_redfish_command.py", line 213, in debug
    runpy.run_module(mod_name='ansible_collections.community.general.plugins.modules.redfish_command', init_globals=None, run_name='__main__', alter_sys=True)
  File "/usr/lib/python3.10/runpy.py", line 224, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.10/runpy.py", line 96, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/user/.ansible/tmp/ansible-tmp-1733524983.8725114-939343-222145990725532/debug_dir/ansible_collections/community/general/plugins/modules/redfish_command.py", line 1128, in <module>
    main()
  File "/home/user/.ansible/tmp/ansible-tmp-1733524983.8725114-939343-222145990725532/debug_dir/ansible_collections/community/general/plugins/modules/redfish_command.py", line 1124, in main
    module.fail_json(msg=(result['msg']))
KeyError: 'msg'
```

Expected failure (missing bios attribute):
```
fatal: [localhost]: FAILED! => changed=false
  invocation:
    module_args:
      account_properties: {}
      account_types: null
      auth_token: null
      baseuri: x.x.x.x
      bios_attributes:
        ScottFakeAttr: Disable
      boot_next: null
      boot_override_mode: null
      bootdevice: null
      category: Systems
      ciphers: null
      command:
      - VerifyBiosAttributes
      id: null
      new_password: null
      new_username: null
      oem_account_types: null
      password: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
      reset_to_defaults_mode: null
      resource_id: Self
      roleid: null
      session_uri: null
      strip_etag_quotes: false
      timeout: 60
      uefi_target: null
      update_apply_time: null
      update_creds: null
      update_handle: null
      update_image_file: null
      update_image_uri: null
      update_oem_params: null
      update_protocol: null
      update_targets: []
      update_username: null
      username: admin
      virtual_media: null
      wait: false
      wait_timeout: 120
  msg: 'Wrong parameters are provided: {''ScottFakeAttr'': ''Disable''}'
```

Successful verification:
```
ok: [localhost] => changed=false
  invocation:
    module_args:
      account_properties: {}
      account_types: null
      auth_token: null
      baseuri: x.x.x.x
      bios_attributes:
        EagleStream0002: Enable
      boot_next: null
      boot_override_mode: null
      bootdevice: null
      category: Systems
      ciphers: null
      command:
      - VerifyBiosAttributes
      id: null
      new_password: null
      new_username: null
      oem_account_types: null
      password: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
      reset_to_defaults_mode: null
      resource_id: Self
      roleid: null
      session_uri: null
      strip_etag_quotes: false
      timeout: 60
      uefi_target: null
      update_apply_time: null
      update_creds: null
      update_handle: null
      update_image_file: null
      update_image_uri: null
      update_oem_params: null
      update_protocol: null
      update_targets: []
      update_username: null
      username: admin
      virtual_media: null
      wait: false
      wait_timeout: 120
  msg: Action was successful
  return_values: {}
  session: {}
```

Expected failure (when missing `resource_id`):
```
fatal: [localhost]: FAILED! => changed=false
  invocation:
    module_args:
      account_properties: {}
      account_types: null
      auth_token: null
      baseuri: x.x.x.x
      bios_attributes:
        EagleStream0002: Enable
      boot_next: null
      boot_override_mode: null
      bootdevice: null
      category: Systems
      ciphers: null
      command:
      - VerifyBiosAttributes
      id: null
      new_password: null
      new_username: null
      oem_account_types: null
      password: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
      reset_to_defaults_mode: null
      resource_id: null
      roleid: null
      session_uri: null
      strip_etag_quotes: false
      timeout: 60
      uefi_target: null
      update_apply_time: null
      update_creds: null
      update_handle: null
      update_image_file: null
      update_image_uri: null
      update_oem_params: null
      update_protocol: null
      update_targets: []
      update_username: null
      username: admin
      virtual_media: null
      wait: false
      wait_timeout: 120
  msg: Issuing a data modification command without specifying the ID of the target System resource when there is more than one System is no longer allowed. Use the `resource_id` option to specify the target System ID.
```

Running against a single resource system (without specifying `resource_id`):
```
fatal: [localhost]: FAILED! => changed=false
  invocation:
    module_args:
      account_properties: {}
      account_types: null
      auth_token: null
      baseuri: x.x.x.x
      bios_attributes:
        PxeDev1Interface: NIC.Slot.31-1
      boot_next: null
      boot_override_mode: null
      bootdevice: null
      category: Systems
      ciphers: null
      command:
      - VerifyBiosAttributes
      id: null
      new_password: null
      new_username: null
      oem_account_types: null
      password: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
      reset_to_defaults_mode: null
      resource_id: null
      roleid: null
      session_uri: null
      strip_etag_quotes: false
      timeout: 60
      uefi_target: null
      update_apply_time: null
      update_creds: null
      update_custom_oem_header: null
      update_custom_oem_mime_type: null
      update_custom_oem_params: null
      update_handle: null
      update_image_file: null
      update_image_uri: null
      update_oem_params: null
      update_protocol: null
      update_targets: []
      update_username: null
      username: root
      virtual_media: null
      wait: false
      wait_timeout: 120
  msg: 'BIOS parameters are not matching: {''PxeDev1Interface'': ''NIC.Slot.31-1''}'
```

Successful run on single resource system:
```
ok: [localhost] => changed=false
  invocation:
    module_args:
      account_properties: {}
      account_types: null
      auth_token: null
      baseuri: x.x.x.x
      bios_attributes:
        BootSeqRetry: Enabled
      boot_next: null
      boot_override_mode: null
      bootdevice: null
      category: Systems
      ciphers: null
      command:
      - VerifyBiosAttributes
      id: null
      new_password: null
      new_username: null
      oem_account_types: null
      password: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
      reset_to_defaults_mode: null
      resource_id: null
      roleid: null
      session_uri: null
      strip_etag_quotes: false
      timeout: 60
      uefi_target: null
      update_apply_time: null
      update_creds: null
      update_custom_oem_header: null
      update_custom_oem_mime_type: null
      update_custom_oem_params: null
      update_handle: null
      update_image_file: null
      update_image_uri: null
      update_oem_params: null
      update_protocol: null
      update_targets: []
      update_username: null
      username: root
      virtual_media: null
      wait: false
      wait_timeout: 120
  msg: Action was successful
  return_values: {}
  session: {}
```