### PR TITLE
locale_gen: fix/improvements

### DIFF
--- a/changelogs/fragments/9131-locale-gen-rewrite.yml
+++ b/changelogs/fragments/9131-locale-gen-rewrite.yml
@@ -1,9 +1,9 @@
 minor_changes:
   - >
     locale_gen - invert the logic to determine ``ubuntu_mode``, making it look first for ``/etc/locale.gen`` (set ``ubuntu_mode`` to ``False``)
-    and only then looking for ``/var/lib/locales/supported.d/`` (set ``ubuntu_mode`` to ``True``).
+    and only then looking for ``/var/lib/locales/supported.d/`` (set ``ubuntu_mode`` to ``True``) (https://github.com/ansible-collections/community.general/pull/9238).
   - >
     locale_gen - new return value ``mechanism`` to better express the semantics of the ``ubuntu_mode``, with the possible values being either
-    ``glibc`` (``ubuntu_mode=False``) or ``debian`` (``ubuntu_mode=True``).
+    ``glibc`` (``ubuntu_mode=False``) or ``debian`` (``ubuntu_mode=True``) (https://github.com/ansible-collections/community.general/pull/9238).
 deprecated_features:
-  - locale_gen - ``ubuntu_mode=True``, or ``mechanism=debian`` is deprecated and will be removed in community.general 13.0.0.
+  - locale_gen - ``ubuntu_mode=True``, or ``mechanism=debian`` is deprecated and will be removed in community.general 13.0.0 (https://github.com/ansible-collections/community.general/pull/9238).

--- a/changelogs/fragments/9131-locale-gen-rewrite.yml
+++ b/changelogs/fragments/9131-locale-gen-rewrite.yml
@@ -1,9 +1,0 @@
-minor_changes:
-  - >
-    locale_gen - invert the logic to determine ``ubuntu_mode``, making it look first for ``/etc/locale.gen`` (set ``ubuntu_mode`` to ``False``)
-    and only then looking for ``/var/lib/locales/supported.d/`` (set ``ubuntu_mode`` to ``True``) (https://github.com/ansible-collections/community.general/pull/9238).
-  - >
-    locale_gen - new return value ``mechanism`` to better express the semantics of the ``ubuntu_mode``, with the possible values being either
-    ``glibc`` (``ubuntu_mode=False``) or ``debian`` (``ubuntu_mode=True``) (https://github.com/ansible-collections/community.general/pull/9238).
-deprecated_features:
-  - locale_gen - ``ubuntu_mode=True``, or ``mechanism=debian`` is deprecated and will be removed in community.general 13.0.0 (https://github.com/ansible-collections/community.general/pull/9238).

--- a/changelogs/fragments/9131-locale-gen-rewrite.yml
+++ b/changelogs/fragments/9131-locale-gen-rewrite.yml
@@ -1,0 +1,9 @@
+minor_changes:
+  - >
+    locale_gen - invert the logic to determine ``ubuntu_mode``, making it look first for ``/etc/locale.gen`` (set ``ubuntu_mode`` to ``False``)
+    and only then looking for ``/var/lib/locales/supported.d/`` (set ``ubuntu_mode`` to ``True``).
+  - >
+    locale_gen - new return value ``mechanism`` to better express the semantics of the ``ubuntu_mode``, with the possible values being either
+    ``glibc`` (``ubuntu_mode=False``) or ``debian`` (``ubuntu_mode=True``).
+deprecated_features:
+  - locale_gen - ``ubuntu_mode=True``, or ``mechanism=debian`` is deprecated and will be removed in community.general 13.0.0.

--- a/changelogs/fragments/9238-locale-gen-rewrite.yml
+++ b/changelogs/fragments/9238-locale-gen-rewrite.yml
@@ -1,0 +1,14 @@
+minor_changes:
+  - "locale_gen - invert the logic to determine ``ubuntu_mode``, making it look first for ``/etc/locale.gen`` (set ``ubuntu_mode`` to ``False``)
+    and only then looking for ``/var/lib/locales/supported.d/`` (set ``ubuntu_mode`` to ``True``) (
+    https://github.com/ansible-collections/community.general/pull/9238,
+    https://github.com/ansible-collections/community.general/issues/9131,
+    https://github.com/ansible-collections/community.general/issues/8487
+    )."
+  - >
+    locale_gen - new return value ``mechanism`` to better express the semantics of the ``ubuntu_mode``, with the possible values being either
+    ``glibc`` (``ubuntu_mode=False``) or ``ubuntu_legacy`` (``ubuntu_mode=True``) (https://github.com/ansible-collections/community.general/pull/9238).
+deprecated_features:
+  - >
+    locale_gen - ``ubuntu_mode=True``, or ``mechanism=ubuntu_legacy`` is deprecated and will be removed in community.general 13.0.0
+    (https://github.com/ansible-collections/community.general/pull/9238).

--- a/changelogs/fragments/9238-locale-gen-rewrite.yml
+++ b/changelogs/fragments/9238-locale-gen-rewrite.yml
@@ -1,10 +1,9 @@
 minor_changes:
   - "locale_gen - invert the logic to determine ``ubuntu_mode``, making it look first for ``/etc/locale.gen`` (set ``ubuntu_mode`` to ``False``)
-    and only then looking for ``/var/lib/locales/supported.d/`` (set ``ubuntu_mode`` to ``True``) (
-    https://github.com/ansible-collections/community.general/pull/9238,
+    and only then looking for ``/var/lib/locales/supported.d/`` (set ``ubuntu_mode`` to ``True``)
+    (https://github.com/ansible-collections/community.general/pull/9238,
     https://github.com/ansible-collections/community.general/issues/9131,
-    https://github.com/ansible-collections/community.general/issues/8487
-    )."
+    https://github.com/ansible-collections/community.general/issues/8487)."
   - >
     locale_gen - new return value ``mechanism`` to better express the semantics of the ``ubuntu_mode``, with the possible values being either
     ``glibc`` (``ubuntu_mode=False``) or ``ubuntu_legacy`` (``ubuntu_mode=True``) (https://github.com/ansible-collections/community.general/pull/9238).

--- a/plugins/modules/locale_gen.py
+++ b/plugins/modules/locale_gen.py
@@ -65,8 +65,11 @@ EXAMPLES = r"""
 
 RETURN = r"""
 mechanism:
-  description: Mechanism used to deploy the locales. It may have the value C(glibc) or C(ubuntu_legacy).
+  description: Mechanism used to deploy the locales.
   type: str
+  choices:
+    - glibc
+    - ubuntu_legacy
   returned: success
   sample: glibc
   version_added: 10.2.0

--- a/plugins/modules/locale_gen.py
+++ b/plugins/modules/locale_gen.py
@@ -12,7 +12,7 @@ DOCUMENTATION = r"""
 module: locale_gen
 short_description: Creates or removes locales
 description:
-  - Manages locales in Ubuntu systems.
+  - Manages locales in Debian and Ubuntu systems.
 author:
   - Augustus Kling (@AugustusKling)
 extends_documentation_fragment:

--- a/plugins/modules/locale_gen.py
+++ b/plugins/modules/locale_gen.py
@@ -100,7 +100,7 @@ class LocaleGen(StateModuleHelper):
     use_old_vardict = False
 
     def __init_module__(self):
-        self.MECHANISMS=dict(
+        self.MECHANISMS = dict(
             debian=dict(
                 available=SUPPORTED_LOCALES,
                 apply_change=self.apply_change_debian,

--- a/plugins/modules/locale_gen.py
+++ b/plugins/modules/locale_gen.py
@@ -61,13 +61,12 @@ EXAMPLES = r"""
     state: present
 """
 
-RETURN = r'''
-- mechanism:
-  description:
-  - Mechanism used to deploy the locales.
-  - It may have the value C(glibc) or C(debian).
+RETURN = '''
+mechanism:
+  description: Mechanism used to deploy the locales. It may have the value C(glibc) or C(debian).
   type: str
   returned: success
+  sample: glibc
   version_added: 10.2.0
 '''
 

--- a/plugins/modules/locale_gen.py
+++ b/plugins/modules/locale_gen.py
@@ -13,7 +13,7 @@ DOCUMENTATION = """
 module: locale_gen
 short_description: Creates or removes locales
 description:
-- Manages locales in Ubuntu/Debian systems.
+- Manages locales in Ubuntu systems.
 author:
 - Augustus Kling (@AugustusKling)
 extends_documentation_fragment:
@@ -40,10 +40,14 @@ options:
 notes:
 - >
   If C(/etc/locale.gen) exists, the module will assume to be using the B(glibc) mechanism,
-  else if C(/var/lib/locales/supported.d/) exists it will assume to be using the B(Debian) mechanism,
+  else if C(/var/lib/locales/supported.d/) exists it will assume to be using the B(debian) mechanism,
   else it will raise an error.
 - When using glibc mechanism, it will manage locales by editing C(/etc/locale.gen) and running C(locale-gen).
-- When using Debian mechanism, it will manage locales by editing C(/var/lib/locales/supported.d/local) and then running C(locale-gen).
+- When using debian mechanism, it will manage locales by editing C(/var/lib/locales/supported.d/local) and then running C(locale-gen).
+- >
+  Please note that the code path that uses debian mechanism has not been tested for a while, because Ubuntu is already using the glibc mechanism.
+  There is no support for that, given our inability to test it.
+  Therefore, that mechanism is B(deprecated) and will be removed in community.general 13.0.0.
 - Currently the module is B(only supported for Ubuntu) systems.
 - This module requires the package C(locales) installed in Ubuntu systems.
 """

--- a/plugins/modules/locale_gen.py
+++ b/plugins/modules/locale_gen.py
@@ -8,15 +8,16 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-DOCUMENTATION = r"""
+DOCUMENTATION = """
+---
 module: locale_gen
 short_description: Creates or removes locales
 description:
-    - Manages locales in Ubuntu systems.
+- Manages locales in Ubuntu/Debian systems.
 author:
-  - Augustus Kling (@AugustusKling)
+- Augustus Kling (@AugustusKling)
 extends_documentation_fragment:
-  - community.general.attributes
+- community.general.attributes
 attributes:
   check_mode:
     support: full
@@ -27,27 +28,28 @@ options:
     type: list
     elements: str
     description:
-      - Name and encoding of the locales, such as V(en_GB.UTF-8).
-      - Before community.general 9.3.0, this was a string. Using a string still works.
+    - Name and encoding of the locales, such as V(en_GB.UTF-8).
+    - Before community.general 9.3.0, this was a string. Using a string still works.
     required: true
   state:
     type: str
     description:
-      - Whether the locales shall be present.
-    choices: [ absent, present ]
+    - Whether the locales shall be present.
+    choices: [absent, present]
     default: present
 notes:
-  - >
-    If C(/etc/locale.gen) exists, the module will assume to be using the B(glibc) mechanism,
-    else if C(/var/lib/locales/supported.d/) exists it will assume to be using the B(Debian) mechanism,
-    else it will raise an error.
-  - When using glibc mechanism, it manages locales by editing C(/etc/locale.gen) and running C(locale-gen).
-  - When using Debian mechanism, it manages locales by editing C(/var/lib/locales/supported.d/local) and then running C(locale-gen).
-  - Currently the module is B(only supported for Ubuntu) systems.
-  - This module requires the package C(locales) installed in Ubuntu systems.
+- >
+  If C(/etc/locale.gen) exists, the module will assume to be using the B(glibc) mechanism,
+  else if C(/var/lib/locales/supported.d/) exists it will assume to be using the B(Debian) mechanism,
+  else it will raise an error.
+- When using glibc mechanism, it will manage locales by editing C(/etc/locale.gen) and running C(locale-gen).
+- When using Debian mechanism, it will manage locales by editing C(/var/lib/locales/supported.d/local) and then running C(locale-gen).
+- Currently the module is B(only supported for Ubuntu) systems.
+- This module requires the package C(locales) installed in Ubuntu systems.
 """
 
-EXAMPLES = r"""
+EXAMPLES = """
+---
 - name: Ensure a locale exists
   community.general.locale_gen:
     name: de_CH.UTF-8
@@ -56,19 +58,20 @@ EXAMPLES = r"""
 - name: Ensure multiple locales exist
   community.general.locale_gen:
     name:
-      - en_GB.UTF-8
-      - nl_NL.UTF-8
+    - en_GB.UTF-8
+    - nl_NL.UTF-8
     state: present
 """
 
-RETURN = '''
+RETURN = """
+---
 mechanism:
   description: Mechanism used to deploy the locales. It may have the value C(glibc) or C(debian).
   type: str
   returned: success
   sample: glibc
   version_added: 10.2.0
-'''
+"""
 
 import os
 import re

--- a/plugins/modules/locale_gen.py
+++ b/plugins/modules/locale_gen.py
@@ -131,6 +131,12 @@ class LocaleGen(StateModuleHelper):
         elif os.path.exists(VAR_LIB_LOCALES):
             self.vars.ubuntu_mode = True
             self.vars.mechanism = "ubuntu_legacy"
+            self.module.deprecate(
+                "On this machine mechanism=ubuntu_legacy is used. This mechanism is deprecated and will be removed from"
+                " in community.general 13.0.0. If you see this message on a modern Debian or Ubuntu version,"
+                " please create an issue in the community.general repository",
+                version="13.0.0", collection_name="community.general"
+            )
         else:
             self.do_raise('{0} and {1} are missing. Is the package "locales" installed?'.format(
                 VAR_LIB_LOCALES, ETC_LOCALE_GEN

--- a/plugins/modules/locale_gen.py
+++ b/plugins/modules/locale_gen.py
@@ -8,16 +8,15 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-DOCUMENTATION = """
----
+DOCUMENTATION = r"""
 module: locale_gen
 short_description: Creates or removes locales
 description:
-- Manages locales in Ubuntu systems.
+  - Manages locales in Ubuntu systems.
 author:
-- Augustus Kling (@AugustusKling)
+  - Augustus Kling (@AugustusKling)
 extends_documentation_fragment:
-- community.general.attributes
+  - community.general.attributes
 attributes:
   check_mode:
     support: full
@@ -28,32 +27,29 @@ options:
     type: list
     elements: str
     description:
-    - Name and encoding of the locales, such as V(en_GB.UTF-8).
-    - Before community.general 9.3.0, this was a string. Using a string still works.
+      - Name and encoding of the locales, such as V(en_GB.UTF-8).
+      - Before community.general 9.3.0, this was a string. Using a string still works.
     required: true
   state:
     type: str
     description:
-    - Whether the locales shall be present.
+      - Whether the locales shall be present.
     choices: [absent, present]
     default: present
 notes:
-- >
-  If C(/etc/locale.gen) exists, the module will assume to be using the B(glibc) mechanism,
-  else if C(/var/lib/locales/supported.d/) exists it will assume to be using the B(debian) mechanism,
-  else it will raise an error.
-- When using glibc mechanism, it will manage locales by editing C(/etc/locale.gen) and running C(locale-gen).
-- When using debian mechanism, it will manage locales by editing C(/var/lib/locales/supported.d/local) and then running C(locale-gen).
-- >
-  Please note that the code path that uses debian mechanism has not been tested for a while, because Ubuntu is already using the glibc mechanism.
-  There is no support for that, given our inability to test it.
-  Therefore, that mechanism is B(deprecated) and will be removed in community.general 13.0.0.
-- Currently the module is B(only supported for Ubuntu) systems.
-- This module requires the package C(locales) installed in Ubuntu systems.
+  - If C(/etc/locale.gen) exists, the module will assume to be using the B(glibc) mechanism, else if C(/var/lib/locales/supported.d/)
+    exists it will assume to be using the B(debian) mechanism, else it will raise an error.
+  - When using glibc mechanism, it will manage locales by editing C(/etc/locale.gen) and running C(locale-gen).
+  - When using debian mechanism, it will manage locales by editing C(/var/lib/locales/supported.d/local) and then running
+    C(locale-gen).
+  - Please note that the code path that uses debian mechanism has not been tested for a while, because Ubuntu is already using
+    the glibc mechanism. There is no support for that, given our inability to test it. Therefore, that mechanism is B(deprecated)
+    and will be removed in community.general 13.0.0.
+  - Currently the module is B(only supported for Ubuntu) systems.
+  - This module requires the package C(locales) installed in Ubuntu systems.
 """
 
-EXAMPLES = """
----
+EXAMPLES = r"""
 - name: Ensure a locale exists
   community.general.locale_gen:
     name: de_CH.UTF-8
@@ -62,13 +58,12 @@ EXAMPLES = """
 - name: Ensure multiple locales exist
   community.general.locale_gen:
     name:
-    - en_GB.UTF-8
-    - nl_NL.UTF-8
+      - en_GB.UTF-8
+      - nl_NL.UTF-8
     state: present
 """
 
-RETURN = """
----
+RETURN = r"""
 mechanism:
   description: Mechanism used to deploy the locales. It may have the value C(glibc) or C(debian).
   type: str

--- a/plugins/modules/locale_gen.py
+++ b/plugins/modules/locale_gen.py
@@ -116,7 +116,7 @@ class LocaleGen(StateModuleHelper):
                 apply_change=self.apply_change_debian,
             ),
             glibc=dict(
-                available=ETC_LOCALE_GEN,
+                available=SUPPORTED_LOCALES,
                 apply_change=self.apply_change_glibc,
             ),
         )
@@ -150,7 +150,7 @@ class LocaleGen(StateModuleHelper):
         checking either :
         * if the locale is present in /etc/locales.gen
         * or if the locale is present in /usr/share/i18n/SUPPORTED"""
-        regexp = r'^#?\s*(?P<locale>\S+[\._\S]+) (?P<charset>\S+)\s*$'
+        regexp = r'^\s*#?\s*(?P<locale>\S+[\._\S]+) (?P<charset>\S+)\s*$'
         locales_available = self.MECHANISMS[self.vars.mechanism]["available"]
 
         re_compiled = re.compile(regexp)

--- a/plugins/modules/locale_gen.py
+++ b/plugins/modules/locale_gen.py
@@ -61,6 +61,16 @@ EXAMPLES = r"""
     state: present
 """
 
+RETURN = r'''
+- mechanism:
+  description:
+  - Mechanism used to deploy the locales.
+  - It may have the value C(glibc) or C(debian).
+  type: str
+  returned: success
+  version_added: 10.2.0
+'''
+
 import os
 import re
 

--- a/tests/integration/targets/locale_gen/tasks/main.yml
+++ b/tests/integration/targets/locale_gen/tasks/main.yml
@@ -18,19 +18,19 @@
   loop_control:
     loop_var: locale_basic
 
-- name: Remove /etc/locale.gen
-  ansible.builtin.file:
-    path: /etc/locale.gen
-    state: absent
+# - name: Remove /etc/locale.gen
+#   ansible.builtin.file:
+#     path: /etc/locale.gen
+#     state: absent
 
-- name: Ensure /var/lib/locales/supported.d exists
-  ansible.builtin.file:
-    path: /var/lib/locales/supported.d
-    state: directory
-    recurse: true
+# - name: Ensure /var/lib/locales/supported.d exists
+#   ansible.builtin.file:
+#     path: /var/lib/locales/supported.d
+#     state: directory
+#     recurse: true
 
-- name: Force mechanism to be debian
-  ansible.builtin.include_tasks: basic.yml
-  loop: "{{ locale_list_basic }}"
-  loop_control:
-    loop_var: locale_basic
+# - name: Force mechanism to be debian
+#   ansible.builtin.include_tasks: basic.yml
+#   loop: "{{ locale_list_basic }}"
+#   loop_control:
+#     loop_var: locale_basic

--- a/tests/integration/targets/locale_gen/tasks/main.yml
+++ b/tests/integration/targets/locale_gen/tasks/main.yml
@@ -12,7 +12,25 @@
   ansible.builtin.meta: end_play
   when: ansible_distribution not in ('Ubuntu', 'Debian')
 
-- include_tasks: basic.yml
+- name: Run tests auto-detecting mechanism
+  ansible.builtin.include_tasks: basic.yml
+  loop: "{{ locale_list_basic }}"
+  loop_control:
+    loop_var: locale_basic
+
+- name: Remove /etc/locale.gen
+  ansible.builtin.file:
+    path: /etc/locale.gen
+    state: absent
+
+- name: Ensure /var/lib/locales/supported.d exists
+  ansible.builtin.file:
+    path: /var/lib/locales/supported.d
+    state: directory
+    recurse: true
+
+- name: Force mechanism to be debian
+  ansible.builtin.include_tasks: basic.yml
   loop: "{{ locale_list_basic }}"
   loop_control:
     loop_var: locale_basic

--- a/tests/integration/targets/locale_gen/tasks/main.yml
+++ b/tests/integration/targets/locale_gen/tasks/main.yml
@@ -17,20 +17,3 @@
   loop: "{{ locale_list_basic }}"
   loop_control:
     loop_var: locale_basic
-
-# - name: Remove /etc/locale.gen
-#   ansible.builtin.file:
-#     path: /etc/locale.gen
-#     state: absent
-
-# - name: Ensure /var/lib/locales/supported.d exists
-#   ansible.builtin.file:
-#     path: /var/lib/locales/supported.d
-#     state: directory
-#     recurse: true
-
-# - name: Force mechanism to be debian
-#   ansible.builtin.include_tasks: basic.yml
-#   loop: "{{ locale_list_basic }}"
-#   loop_control:
-#     loop_var: locale_basic


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It introduces a RV `mechanism` that declares the mode in a more descriptive way:
| ubuntu_mode | mechanism |
|--------|--------|
| False | glibc |
| True | debian |

Refer to https://github.com/ansible-collections/community.general/issues/9131#issuecomment-2526423320 for a more complete rationale.

Change the logic to determine whether `ubuntu_mode` is `True` or `False`. 

Formerly it would:
1. set `ubuntu_mode=True` if `/var/lib/locales/supported.d` existed, 
2. else `False` if `/etc/locale.gen` exists,
3. else raising an error. 
 
With this PR it will: 
1. set `ubuntu_mode=False` is `/etc/locale.gen` is present,
2. else `True` if the `/var/lib/...` directory exists, 
3. else error.

Canonical made a deliberate decision to move towards the glibc support, so all Ubuntu versions since 16.04 have `/etc/locale.gen`. I have tested locally in Debian 11 and 12 and both of them worked using glibc mode. 

The PR will include tests forcing `ubuntu_mode=True`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #8487 #9131 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
locale_gen