### PR TITLE
sysrc: add another exclusion for ezjail

### DIFF
--- a/tests/integration/targets/sysrc/tasks/main.yml
+++ b/tests/integration/targets/sysrc/tasks/main.yml
@@ -141,10 +141,12 @@
       #
       # NOTE: currently fails with FreeBSD 12 with minor version less than 4
       # NOTE: currently fails with FreeBSD 13 with minor version less than 2
+      # NOTE: currently fails with FreeBSD 14 with minor version less than 1
       #
       when: >-
         ansible_distribution_version is version('12.4', '>=') and ansible_distribution_version is version('13', '<')
-        or ansible_distribution_version is version('13.2', '>=')
+        or ansible_distribution_version is version('13.2', '>=') and ansible_distribution_version is version('14', '<')
+        or ansible_distribution_version is version('14.1', '>=')
       block:
         - name: Setup testjail
           include_tasks: setup-testjail.yml


### PR DESCRIPTION
##### SUMMARY
Nightly tests fail because ezjail can no longer be installed on FreeBSD 14.0.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
sysrc integration tests
