### PR TITLE
zypper: add simple_errors option - fixes #8416

### DIFF
--- a/changelogs/fragments/9270-zypper-add-simple_errors.yaml
+++ b/changelogs/fragments/9270-zypper-add-simple_errors.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zypper - add simple_errors option (https://github.com/ansible-collections/community.general/pull/9270).

--- a/changelogs/fragments/9270-zypper-add-simple_errors.yaml
+++ b/changelogs/fragments/9270-zypper-add-simple_errors.yaml
@@ -1,2 +1,3 @@
 minor_changes:
   - zypper - add ``simple_errors`` option (https://github.com/ansible-collections/community.general/pull/9270).
+  - zypper - add ``quiet`` option (https://github.com/ansible-collections/community.general/pull/9270).

--- a/changelogs/fragments/9270-zypper-add-simple_errors.yaml
+++ b/changelogs/fragments/9270-zypper-add-simple_errors.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - zypper - add simple_errors option (https://github.com/ansible-collections/community.general/pull/9270).
+  - zypper - add ``simple_errors`` option (https://github.com/ansible-collections/community.general/pull/9270).

--- a/plugins/modules/zypper.py
+++ b/plugins/modules/zypper.py
@@ -363,7 +363,7 @@ def parse_zypper_xml(m, cmd, fail_not_found=True, packages=None):
         return packages, rc, stdout, stderr
 
     if m.params['simple_errors']:
-        stdout = get_simple_errors(dom)
+        stdout = get_simple_errors(dom) or stdout
 
     m.fail_json(msg='Zypper run command failed with return code %s.' % rc, rc=rc, stdout=stdout, stderr=stderr, cmd=cmd)
 

--- a/plugins/modules/zypper.py
+++ b/plugins/modules/zypper.py
@@ -368,7 +368,7 @@ def parse_zypper_xml(m, cmd, fail_not_found=True, packages=None):
             # run zypper again with the same command to complete update
             return parse_zypper_xml(m, cmd, fail_not_found=fail_not_found, packages=packages)
 
-        # apply simple_errors logic to rc 0,102,103,106 
+        # apply simple_errors logic to rc 0,102,103,106
         if m.params['simple_errors']:
             simple_errors = get_simple_errors(dom)
             if simple_errors is not None:

--- a/plugins/modules/zypper.py
+++ b/plugins/modules/zypper.py
@@ -612,7 +612,7 @@ def main():
         elif state in ['installed', 'present', 'latest']:
             packages_changed, retvals = package_present(module, name, state == 'latest')
 
-        retvals['changed'] = retvals['rc'] in [0, 102] and bool(packages_changed)
+    retvals['changed'] = retvals['rc'] in [0, 102] and bool(packages_changed)
 
     if module._diff:
         set_diff(module, retvals, packages_changed)

--- a/plugins/modules/zypper.py
+++ b/plugins/modules/zypper.py
@@ -376,9 +376,7 @@ def parse_zypper_xml(m, cmd, fail_not_found=True, packages=None):
 
     # apply simple_errors logic to rc other than 0,102,103,106
     if m.params['simple_errors']:
-        simple_errors = get_simple_errors(dom)
-        if simple_errors is not None:
-            stdout = simple_errors
+        stdout = get_simple_errors(dom) or stdout
 
     m.fail_json(msg='Zypper run command failed with return code %s.' % rc, rc=rc, stdout=stdout, stderr=stderr, cmd=cmd)
 

--- a/plugins/modules/zypper.py
+++ b/plugins/modules/zypper.py
@@ -370,9 +370,7 @@ def parse_zypper_xml(m, cmd, fail_not_found=True, packages=None):
 
         # apply simple_errors logic to rc 0,102,103,106
         if m.params['simple_errors']:
-            simple_errors = get_simple_errors(dom)
-            if simple_errors is not None:
-                stdout = simple_errors
+            stdout = get_simple_errors(dom) or stdout
 
         return packages, rc, stdout, stderr
 

--- a/plugins/modules/zypper.py
+++ b/plugins/modules/zypper.py
@@ -374,7 +374,7 @@ def get_simple_errors(dom):
     simple_errors = []
     message_xml_tags = dom.getElementsByTagName('message')
 
-    if message_xml_tags is None: 
+    if message_xml_tags is None:
         return None
 
     for x in message_xml_tags:

--- a/plugins/modules/zypper.py
+++ b/plugins/modules/zypper.py
@@ -363,7 +363,9 @@ def parse_zypper_xml(m, cmd, fail_not_found=True, packages=None):
         return packages, rc, stdout, stderr
 
     if m.params['simple_errors']:
-        stdout = get_simple_errors(dom) or stdout
+        simple_errors = get_simple_errors(dom)
+        if simple_errors is not None:
+            stdout = simple_errors
 
     m.fail_json(msg='Zypper run command failed with return code %s.' % rc, rc=rc, stdout=stdout, stderr=stderr, cmd=cmd)
 
@@ -371,6 +373,10 @@ def parse_zypper_xml(m, cmd, fail_not_found=True, packages=None):
 def get_simple_errors(dom):
     simple_errors = []
     message_xml_tags = dom.getElementsByTagName('message')
+
+    if message_xml_tags is None: 
+        return None
+
     for x in message_xml_tags:
         simple_errors.append(x.firstChild.data)
     return " ".join(simple_errors)

--- a/plugins/modules/zypper.py
+++ b/plugins/modules/zypper.py
@@ -364,8 +364,9 @@ def parse_zypper_xml(m, cmd, fail_not_found=True, packages=None):
 
     if m.params['simple_errors']:
         stdout = get_simple_errors(dom)
-        
+
     m.fail_json(msg='Zypper run command failed with return code %s.' % rc, rc=rc, stdout=stdout, stderr=stderr, cmd=cmd)
+
 
 def get_simple_errors(dom):
     simple_errors = []

--- a/plugins/modules/zypper.py
+++ b/plugins/modules/zypper.py
@@ -147,8 +147,8 @@ options:
     required: false
     default: false
     description:
-      - Provides a simplified error output (parses only the <message> tag text in the XML output)
-    version_added: '10.1.1'
+      - When set to V(true), provide a simplified error output (parses only the C(<message>) tag text in the XML output).
+    version_added: '10.2.0'
 notes:
   - When used with a C(loop:) each package will be processed individually, it is much more efficient to pass the list directly to the O(name)
     option.


### PR DESCRIPTION
##### SUMMARY
This fixes #8416 

It adds a `simple_errors` option for the zypper module which can be used to simplify or reduce the error output of the zypper module during package installs/updates so that only the content of `<message>` tags are displayed.  (Default is `false` so the default behavior is unaffected)

It also adds a `quiet` option for the zypper module to allow for the option to disable the `--quiet` parameter from being passed to the zypper command. (Default is `true` so the default behavior is unaffected.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zypper module
