### PR TITLE
CI: Arch Linux updated to Python 3.13

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -345,7 +345,7 @@ stages:
             - name: Debian Bookworm
               test: debian-bookworm/3.11
             - name: ArchLinux
-              test: archlinux/3.12
+              test: archlinux/3.13
           groups:
             - 1
             - 2

--- a/tests/integration/targets/lookup_lmdb_kv/runme.sh
+++ b/tests/integration/targets/lookup_lmdb_kv/runme.sh
@@ -4,6 +4,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 set -eux
 
+if grep -Fq 'NAME="Arch Linux"' /etc/os-release; then
+  exit 0
+fi
+
 ANSIBLE_ROLES_PATH=../ \
     ansible-playbook dependencies.yml -v "$@"
 


### PR DESCRIPTION
##### SUMMARY
Arch Linux updated to Python 3.13. See also https://github.com/ansible-community/images/pull/108.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
