### PR TITLE
cache plugins: use f-strings

### DIFF
--- a/changelogs/fragments/9320-fstr-cache-plugins.yml
+++ b/changelogs/fragments/9320-fstr-cache-plugins.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - memcached cache plugin - use f-strings instead of interpolations or ``format`` (https://github.com/ansible-collections/community.general/pull/9320).
+  - redis cache plugin - use f-strings instead of interpolations or ``format`` (https://github.com/ansible-collections/community.general/pull/9320).

--- a/plugins/cache/memcached.py
+++ b/plugins/cache/memcached.py
@@ -191,7 +191,7 @@ class CacheModule(BaseCacheModule):
         self._keys = CacheModuleKeys(self._db, self._db.get(CacheModuleKeys.PREFIX) or [])
 
     def _make_key(self, key):
-        return "{0}{1}".format(self._prefix, key)
+        return f"{self._prefix}{key}"
 
     def _expire_keys(self):
         if self._timeout > 0:

--- a/plugins/cache/redis.py
+++ b/plugins/cache/redis.py
@@ -131,7 +131,7 @@ class CacheModule(BaseCacheModule):
             connection = self._parse_connection(self.re_url_conn, uri)
             self._db = StrictRedis(*connection, **kw)
 
-        display.vv('Redis connection: %s' % self._db)
+        display.vv(f'Redis connection: {self._db}')
 
     @staticmethod
     def _parse_connection(re_patt, uri):
@@ -164,12 +164,12 @@ class CacheModule(BaseCacheModule):
                 pass  # password is optional
 
         sentinels = [self._parse_connection(self.re_sent_conn, shost) for shost in connections]
-        display.vv('\nUsing redis sentinels: %s' % sentinels)
+        display.vv(f'\nUsing redis sentinels: {sentinels}')
         scon = Sentinel(sentinels, **kw)
         try:
             return scon.master_for(self._sentinel_service_name, socket_timeout=0.2)
         except Exception as exc:
-            raise AnsibleError('Could not connect to redis sentinel: %s' % to_native(exc))
+            raise AnsibleError(f'Could not connect to redis sentinel: {to_native(exc)}')
 
     def _make_key(self, key):
         return self._prefix + key


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Use f-strings instead of string interpolations or string format().

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/cache/memcached.py
plugins/cache/redis.py