### PR TITLE
connection plugins: use f-strings

### DIFF
--- a/changelogs/fragments/9322-fstr-connection-plugins.yml
+++ b/changelogs/fragments/9322-fstr-connection-plugins.yml
@@ -1,0 +1,11 @@
+minor_changes:
+  - chroot connection plugin - use f-strings instead of interpolations or ``format`` (https://github.com/ansible-collections/community.general/pull/9322).
+  - funcd connection plugin - use f-strings instead of interpolations or ``format`` (https://github.com/ansible-collections/community.general/pull/9322).
+  - incus connection plugin - use f-strings instead of interpolations or ``format`` (https://github.com/ansible-collections/community.general/pull/9322).
+  - iocage connection plugin - use f-strings instead of interpolations or ``format`` (https://github.com/ansible-collections/community.general/pull/9322).
+  - jail connection plugin - use f-strings instead of interpolations or ``format`` (https://github.com/ansible-collections/community.general/pull/9322).
+  - lxc connection plugin - use f-strings instead of interpolations or ``format`` (https://github.com/ansible-collections/community.general/pull/9322).
+  - lxd connection plugin - use f-strings instead of interpolations or ``format`` (https://github.com/ansible-collections/community.general/pull/9322).
+  - qubes connection plugin - use f-strings instead of interpolations or ``format`` (https://github.com/ansible-collections/community.general/pull/9322).
+  - saltstack connection plugin - use f-strings instead of interpolations or ``format`` (https://github.com/ansible-collections/community.general/pull/9322).
+  - zone connection plugin - use f-strings instead of interpolations or ``format`` (https://github.com/ansible-collections/community.general/pull/9322).

--- a/plugins/connection/funcd.py
+++ b/plugins/connection/funcd.py
@@ -72,7 +72,7 @@ class Connection(ConnectionBase):
             raise AnsibleError("Internal Error: this module does not support optimized module pipelining")
 
         # totally ignores privilege escalation
-        display.vvv("EXEC %s" % cmd, host=self.host)
+        display.vvv(f"EXEC {cmd}", host=self.host)
         p = self.client.command.run(cmd)[self.host]
         return p[0], p[1], p[2]
 
@@ -87,14 +87,14 @@ class Connection(ConnectionBase):
         """ transfer a file from local to remote """
 
         out_path = self._normalize_path(out_path, '/')
-        display.vvv("PUT %s TO %s" % (in_path, out_path), host=self.host)
+        display.vvv(f"PUT {in_path} TO {out_path}", host=self.host)
         self.client.local.copyfile.send(in_path, out_path)
 
     def fetch_file(self, in_path, out_path):
         """ fetch a file from remote to local """
 
         in_path = self._normalize_path(in_path, '/')
-        display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self.host)
+        display.vvv(f"FETCH {in_path} TO {out_path}", host=self.host)
         # need to use a tmp dir due to difference of semantic for getfile
         # ( who take a # directory as destination) and fetch_file, who
         # take a file directly

--- a/plugins/connection/incus.py
+++ b/plugins/connection/incus.py
@@ -93,14 +93,14 @@ class Connection(ConnectionBase):
         """ execute a command on the Incus host """
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
-        self._display.vvv(u"EXEC {0}".format(cmd),
+        self._display.vvv(f"EXEC {cmd}",
                           host=self._instance())
 
         local_cmd = [
             self._incus_cmd,
             "--project", self.get_option("project"),
             "exec",
-            "%s:%s" % (self.get_option("remote"), self._instance()),
+            f"{self.get_option('remote')}:{self._instance()}",
             "--",
             self._play_context.executable, "-c", cmd]
 
@@ -114,12 +114,10 @@ class Connection(ConnectionBase):
         stderr = to_text(stderr)
 
         if stderr == "Error: Instance is not running.\n":
-            raise AnsibleConnectionFailure("instance not running: %s" %
-                                           self._instance())
+            raise AnsibleConnectionFailure(f"instance not running: {self._instance()}")
 
         if stderr == "Error: Instance not found\n":
-            raise AnsibleConnectionFailure("instance not found: %s" %
-                                           self._instance())
+            raise AnsibleConnectionFailure(f"instance not found: {self._instance()}")
 
         return process.returncode, stdout, stderr
 
@@ -127,20 +125,18 @@ class Connection(ConnectionBase):
         """ put a file from local to Incus """
         super(Connection, self).put_file(in_path, out_path)
 
-        self._display.vvv(u"PUT {0} TO {1}".format(in_path, out_path),
+        self._display.vvv(f"PUT {in_path} TO {out_path}",
                           host=self._instance())
 
         if not os.path.isfile(to_bytes(in_path, errors='surrogate_or_strict')):
-            raise AnsibleFileNotFound("input path is not a file: %s" % in_path)
+            raise AnsibleFileNotFound(f"input path is not a file: {in_path}")
 
         local_cmd = [
             self._incus_cmd,
             "--project", self.get_option("project"),
             "file", "push", "--quiet",
             in_path,
-            "%s:%s/%s" % (self.get_option("remote"),
-                          self._instance(),
-                          out_path)]
+            f"{self.get_option('remote')}:{self._instance()}/{out_path}"]
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
 
@@ -150,16 +146,14 @@ class Connection(ConnectionBase):
         """ fetch a file from Incus to local """
         super(Connection, self).fetch_file(in_path, out_path)
 
-        self._display.vvv(u"FETCH {0} TO {1}".format(in_path, out_path),
+        self._display.vvv(f"FETCH {in_path} TO {out_path}",
                           host=self._instance())
 
         local_cmd = [
             self._incus_cmd,
             "--project", self.get_option("project"),
             "file", "pull", "--quiet",
-            "%s:%s/%s" % (self.get_option("remote"),
-                          self._instance(),
-                          in_path),
+            f"{self.get_option('remote')}:{self._instance()}/{in_path}",
             out_path]
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]

--- a/plugins/connection/iocage.py
+++ b/plugins/connection/iocage.py
@@ -55,11 +55,12 @@ class Connection(Jail):
 
         jail_uuid = self.get_jail_uuid()
 
-        kwargs[Jail.modified_jailname_key] = 'ioc-{0}'.format(jail_uuid)
+        kwargs[Jail.modified_jailname_key] = f'ioc-{jail_uuid}'
 
-        display.vvv(u"Jail {iocjail} has been translated to {rawjail}".format(
-            iocjail=self.ioc_jail, rawjail=kwargs[Jail.modified_jailname_key]),
-            host=kwargs[Jail.modified_jailname_key])
+        display.vvv(
+            f"Jail {self.ioc_jail} has been translated to {kwargs[Jail.modified_jailname_key]}",
+            host=kwargs[Jail.modified_jailname_key]
+        )
 
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)
 
@@ -81,6 +82,6 @@ class Connection(Jail):
         p.wait()
 
         if p.returncode != 0:
-            raise AnsibleError(u"iocage returned an error: {0}".format(stdout))
+            raise AnsibleError(f"iocage returned an error: {stdout}")
 
         return stdout.strip('\n')

--- a/plugins/connection/jail.py
+++ b/plugins/connection/jail.py
@@ -75,14 +75,14 @@ class Connection(ConnectionBase):
         self.jexec_cmd = self._search_executable('jexec')
 
         if self.jail not in self.list_jails():
-            raise AnsibleError("incorrect jail name %s" % self.jail)
+            raise AnsibleError(f"incorrect jail name {self.jail}")
 
     @staticmethod
     def _search_executable(executable):
         try:
             return get_bin_path(executable)
         except ValueError:
-            raise AnsibleError("%s command not found in PATH" % executable)
+            raise AnsibleError(f"{executable} command not found in PATH")
 
     def list_jails(self):
         p = subprocess.Popen([self.jls_cmd, '-q', 'name'],
@@ -97,7 +97,7 @@ class Connection(ConnectionBase):
         """ connect to the jail; nothing to do here """
         super(Connection, self)._connect()
         if not self._connected:
-            display.vvv(u"ESTABLISH JAIL CONNECTION FOR USER: {0}".format(self._play_context.remote_user), host=self.jail)
+            display.vvv(f"ESTABLISH JAIL CONNECTION FOR USER: {self._play_context.remote_user}", host=self.jail)
             self._connected = True
 
     def _buffered_exec_command(self, cmd, stdin=subprocess.PIPE):
@@ -115,11 +115,11 @@ class Connection(ConnectionBase):
         if self._play_context.remote_user is not None:
             local_cmd += ['-U', self._play_context.remote_user]
             # update HOME since -U does not update the jail environment
-            set_env = 'HOME=~' + self._play_context.remote_user + ' '
+            set_env = f"HOME=~{self._play_context.remote_user} "
 
         local_cmd += [self.jail, self._play_context.executable, '-c', set_env + cmd]
 
-        display.vvv("EXEC %s" % (local_cmd,), host=self.jail)
+        display.vvv(f"EXEC {local_cmd}", host=self.jail)
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
         p = subprocess.Popen(local_cmd, shell=False, stdin=stdin,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -153,7 +153,7 @@ class Connection(ConnectionBase):
     def put_file(self, in_path, out_path):
         """ transfer a file from local to jail """
         super(Connection, self).put_file(in_path, out_path)
-        display.vvv("PUT %s TO %s" % (in_path, out_path), host=self.jail)
+        display.vvv(f"PUT {in_path} TO {out_path}", host=self.jail)
 
         out_path = shlex_quote(self._prefix_login_path(out_path))
         try:
@@ -163,27 +163,27 @@ class Connection(ConnectionBase):
                 else:
                     count = ''
                 try:
-                    p = self._buffered_exec_command('dd of=%s bs=%s%s' % (out_path, BUFSIZE, count), stdin=in_file)
+                    p = self._buffered_exec_command(f'dd of={out_path} bs={BUFSIZE}{count}', stdin=in_file)
                 except OSError:
                     raise AnsibleError("jail connection requires dd command in the jail")
                 try:
                     stdout, stderr = p.communicate()
                 except Exception:
                     traceback.print_exc()
-                    raise AnsibleError("failed to transfer file %s to %s" % (in_path, out_path))
+                    raise AnsibleError(f"failed to transfer file {in_path} to {out_path}")
                 if p.returncode != 0:
-                    raise AnsibleError("failed to transfer file %s to %s:\n%s\n%s" % (in_path, out_path, to_native(stdout), to_native(stderr)))
+                    raise AnsibleError(f"failed to transfer file {in_path} to {out_path}:\n{to_native(stdout)}\n{to_native(stderr)}")
         except IOError:
-            raise AnsibleError("file or module does not exist at: %s" % in_path)
+            raise AnsibleError(f"file or module does not exist at: {in_path}")
 
     def fetch_file(self, in_path, out_path):
         """ fetch a file from jail to local """
         super(Connection, self).fetch_file(in_path, out_path)
-        display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self.jail)
+        display.vvv(f"FETCH {in_path} TO {out_path}", host=self.jail)
 
         in_path = shlex_quote(self._prefix_login_path(in_path))
         try:
-            p = self._buffered_exec_command('dd if=%s bs=%s' % (in_path, BUFSIZE))
+            p = self._buffered_exec_command(f'dd if={in_path} bs={BUFSIZE}')
         except OSError:
             raise AnsibleError("jail connection requires dd command in the jail")
 
@@ -195,10 +195,10 @@ class Connection(ConnectionBase):
                     chunk = p.stdout.read(BUFSIZE)
             except Exception:
                 traceback.print_exc()
-                raise AnsibleError("failed to transfer file %s to %s" % (in_path, out_path))
+                raise AnsibleError(f"failed to transfer file {in_path} to {out_path}")
             stdout, stderr = p.communicate()
             if p.returncode != 0:
-                raise AnsibleError("failed to transfer file %s to %s:\n%s\n%s" % (in_path, out_path, to_native(stdout), to_native(stderr)))
+                raise AnsibleError(f"failed to transfer file {in_path} to {out_path}:\n{to_native(stdout)}\n{to_native(stderr)}")
 
     def close(self):
         """ terminate the connection; nothing to do here """

--- a/plugins/connection/lxc.py
+++ b/plugins/connection/lxc.py
@@ -82,7 +82,7 @@ class Connection(ConnectionBase):
         self._display.vvv("THIS IS A LOCAL LXC DIR", host=self.container_name)
         self.container = _lxc.Container(self.container_name)
         if self.container.state == "STOPPED":
-            raise errors.AnsibleError("%s is not running" % self.container_name)
+            raise errors.AnsibleError(f"{self.container_name} is not running")
 
     @staticmethod
     def _communicate(pid, in_data, stdin, stdout, stderr):
@@ -144,10 +144,10 @@ class Connection(ConnectionBase):
                 read_stdin, write_stdin = os.pipe()
                 kwargs['stdin'] = self._set_nonblocking(read_stdin)
 
-            self._display.vvv("EXEC %s" % (local_cmd), host=self.container_name)
+            self._display.vvv(f"EXEC {local_cmd}", host=self.container_name)
             pid = self.container.attach(_lxc.attach_run_command, local_cmd, **kwargs)
             if pid == -1:
-                msg = "failed to attach to container %s" % self.container_name
+                msg = f"failed to attach to container {self.container_name}"
                 raise errors.AnsibleError(msg)
 
             write_stdout = os.close(write_stdout)
@@ -174,18 +174,18 @@ class Connection(ConnectionBase):
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to lxc '''
         super(Connection, self).put_file(in_path, out_path)
-        self._display.vvv("PUT %s TO %s" % (in_path, out_path), host=self.container_name)
+        self._display.vvv(f"PUT {in_path} TO {out_path}", host=self.container_name)
         in_path = to_bytes(in_path, errors='surrogate_or_strict')
         out_path = to_bytes(out_path, errors='surrogate_or_strict')
 
         if not os.path.exists(in_path):
-            msg = "file or module does not exist: %s" % in_path
+            msg = f"file or module does not exist: {in_path}"
             raise errors.AnsibleFileNotFound(msg)
         try:
             src_file = open(in_path, "rb")
         except IOError:
             traceback.print_exc()
-            raise errors.AnsibleError("failed to open input file to %s" % in_path)
+            raise errors.AnsibleError(f"failed to open input file to {in_path}")
         try:
             def write_file(args):
                 with open(out_path, 'wb+') as dst_file:
@@ -194,7 +194,7 @@ class Connection(ConnectionBase):
                 self.container.attach_wait(write_file, None)
             except IOError:
                 traceback.print_exc()
-                msg = "failed to transfer file to %s" % out_path
+                msg = f"failed to transfer file to {out_path}"
                 raise errors.AnsibleError(msg)
         finally:
             src_file.close()
@@ -202,7 +202,7 @@ class Connection(ConnectionBase):
     def fetch_file(self, in_path, out_path):
         ''' fetch a file from lxc to local '''
         super(Connection, self).fetch_file(in_path, out_path)
-        self._display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self.container_name)
+        self._display.vvv(f"FETCH {in_path} TO {out_path}", host=self.container_name)
         in_path = to_bytes(in_path, errors='surrogate_or_strict')
         out_path = to_bytes(out_path, errors='surrogate_or_strict')
 
@@ -210,7 +210,7 @@ class Connection(ConnectionBase):
             dst_file = open(out_path, "wb")
         except IOError:
             traceback.print_exc()
-            msg = "failed to open output file %s" % out_path
+            msg = f"failed to open output file {out_path}"
             raise errors.AnsibleError(msg)
         try:
             def write_file(args):
@@ -225,7 +225,7 @@ class Connection(ConnectionBase):
                 self.container.attach_wait(write_file, None)
             except IOError:
                 traceback.print_exc()
-                msg = "failed to transfer file from %s to %s" % (in_path, out_path)
+                msg = f"failed to transfer file from {in_path} to {out_path}"
                 raise errors.AnsibleError(msg)
         finally:
             dst_file.close()

--- a/plugins/connection/lxd.py
+++ b/plugins/connection/lxd.py
@@ -93,19 +93,19 @@ class Connection(ConnectionBase):
         """ execute a command on the lxd host """
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
-        self._display.vvv(u"EXEC {0}".format(cmd), host=self._host())
+        self._display.vvv(f"EXEC {cmd}", host=self._host())
 
         local_cmd = [self._lxc_cmd]
         if self.get_option("project"):
             local_cmd.extend(["--project", self.get_option("project")])
         local_cmd.extend([
             "exec",
-            "%s:%s" % (self.get_option("remote"), self._host()),
+            f"{self.get_option('remote')}:{self._host()}",
             "--",
             self.get_option("executable"), "-c", cmd
         ])
 
-        self._display.vvvvv(u"EXEC {0}".format(local_cmd), host=self._host())
+        self._display.vvvvv(f"EXEC {local_cmd}", host=self._host())
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
         in_data = to_bytes(in_data, errors='surrogate_or_strict', nonstring='passthru')
@@ -116,13 +116,13 @@ class Connection(ConnectionBase):
         stdout = to_text(stdout)
         stderr = to_text(stderr)
 
-        self._display.vvvvv(u"EXEC lxc output: {0} {1}".format(stdout, stderr), host=self._host())
+        self._display.vvvvv(f"EXEC lxc output: {stdout} {stderr}", host=self._host())
 
         if "is not running" in stderr:
-            raise AnsibleConnectionFailure("instance not running: %s" % self._host())
+            raise AnsibleConnectionFailure(f"instance not running: {self._host()}")
 
         if stderr.strip() == "Error: Instance not found" or stderr.strip() == "error: not found":
-            raise AnsibleConnectionFailure("instance not found: %s" % self._host())
+            raise AnsibleConnectionFailure(f"instance not found: {self._host()}")
 
         return process.returncode, stdout, stderr
 
@@ -130,10 +130,10 @@ class Connection(ConnectionBase):
         """ put a file from local to lxd """
         super(Connection, self).put_file(in_path, out_path)
 
-        self._display.vvv(u"PUT {0} TO {1}".format(in_path, out_path), host=self._host())
+        self._display.vvv(f"PUT {in_path} TO {out_path}", host=self._host())
 
         if not os.path.isfile(to_bytes(in_path, errors='surrogate_or_strict')):
-            raise AnsibleFileNotFound("input path is not a file: %s" % in_path)
+            raise AnsibleFileNotFound(f"input path is not a file: {in_path}")
 
         local_cmd = [self._lxc_cmd]
         if self.get_option("project"):
@@ -141,7 +141,7 @@ class Connection(ConnectionBase):
         local_cmd.extend([
             "file", "push",
             in_path,
-            "%s:%s/%s" % (self.get_option("remote"), self._host(), out_path)
+            f"{self.get_option('remote')}:{self._host()}/{out_path}"
         ])
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
@@ -153,14 +153,14 @@ class Connection(ConnectionBase):
         """ fetch a file from lxd to local """
         super(Connection, self).fetch_file(in_path, out_path)
 
-        self._display.vvv(u"FETCH {0} TO {1}".format(in_path, out_path), host=self._host())
+        self._display.vvv(f"FETCH {in_path} TO {out_path}", host=self._host())
 
         local_cmd = [self._lxc_cmd]
         if self.get_option("project"):
             local_cmd.extend(["--project", self.get_option("project")])
         local_cmd.extend([
             "file", "pull",
-            "%s:%s/%s" % (self.get_option("remote"), self._host(), in_path),
+            f"{self.get_option('remote')}:{self._host()}/{in_path}",
             out_path
         ])
 

--- a/plugins/connection/qubes.py
+++ b/plugins/connection/qubes.py
@@ -78,7 +78,7 @@ class Connection(ConnectionBase):
         """
         display.vvvv("CMD: ", cmd)
         if not cmd.endswith("\n"):
-            cmd = cmd + "\n"
+            cmd = f"{cmd}\n"
         local_cmd = []
 
         # For dom0
@@ -95,7 +95,7 @@ class Connection(ConnectionBase):
 
         display.vvvv("Local cmd: ", local_cmd)
 
-        display.vvv("RUN %s" % (local_cmd,), host=self._remote_vmname)
+        display.vvv(f"RUN {local_cmd}", host=self._remote_vmname)
         p = subprocess.Popen(local_cmd, shell=False, stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -114,42 +114,42 @@ class Connection(ConnectionBase):
         """Run specified command in a running QubesVM """
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
-        display.vvvv("CMD IS: %s" % cmd)
+        display.vvvv(f"CMD IS: {cmd}")
 
         rc, stdout, stderr = self._qubes(cmd)
 
-        display.vvvvv("STDOUT %r STDERR %r" % (stdout, stderr))
+        display.vvvvv(f"STDOUT {stdout!r} STDERR {stderr!r}")
         return rc, stdout, stderr
 
     def put_file(self, in_path, out_path):
         """ Place a local file located in 'in_path' inside VM at 'out_path' """
         super(Connection, self).put_file(in_path, out_path)
-        display.vvv("PUT %s TO %s" % (in_path, out_path), host=self._remote_vmname)
+        display.vvv(f"PUT {in_path} TO {out_path}", host=self._remote_vmname)
 
         with open(in_path, "rb") as fobj:
             source_data = fobj.read()
 
-        retcode, dummy, dummy = self._qubes('cat > "{0}"\n'.format(out_path), source_data, "qubes.VMRootShell")
+        retcode, dummy, dummy = self._qubes(f'cat > "{out_path}\"\n', source_data, "qubes.VMRootShell")
         # if qubes.VMRootShell service not supported, fallback to qubes.VMShell and
         # hope it will have appropriate permissions
         if retcode == 127:
-            retcode, dummy, dummy = self._qubes('cat > "{0}"\n'.format(out_path), source_data)
+            retcode, dummy, dummy = self._qubes(f'cat > "{out_path}\"\n', source_data)
 
         if retcode != 0:
-            raise AnsibleConnectionFailure('Failed to put_file to {0}'.format(out_path))
+            raise AnsibleConnectionFailure(f'Failed to put_file to {out_path}')
 
     def fetch_file(self, in_path, out_path):
         """Obtain file specified via 'in_path' from the container and place it at 'out_path' """
         super(Connection, self).fetch_file(in_path, out_path)
-        display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self._remote_vmname)
+        display.vvv(f"FETCH {in_path} TO {out_path}", host=self._remote_vmname)
 
         # We are running in dom0
-        cmd_args_list = ["qvm-run", "--pass-io", self._remote_vmname, "cat {0}".format(in_path)]
+        cmd_args_list = ["qvm-run", "--pass-io", self._remote_vmname, f"cat {in_path}"]
         with open(out_path, "wb") as fobj:
             p = subprocess.Popen(cmd_args_list, shell=False, stdout=fobj)
             p.communicate()
             if p.returncode != 0:
-                raise AnsibleConnectionFailure('Failed to fetch file to {0}'.format(out_path))
+                raise AnsibleConnectionFailure(f'Failed to fetch file to {out_path}')
 
     def close(self):
         """ Closing the connection """

--- a/plugins/connection/saltstack.py
+++ b/plugins/connection/saltstack.py
@@ -59,11 +59,11 @@ class Connection(ConnectionBase):
         if in_data:
             raise errors.AnsibleError("Internal Error: this module does not support optimized module pipelining")
 
-        self._display.vvv("EXEC %s" % cmd, host=self.host)
+        self._display.vvv(f"EXEC {cmd}", host=self.host)
         # need to add 'true;' to work around https://github.com/saltstack/salt/issues/28077
-        res = self.client.cmd(self.host, 'cmd.exec_code_all', ['bash', 'true;' + cmd])
+        res = self.client.cmd(self.host, 'cmd.exec_code_all', ['bash', f"true;{cmd}"])
         if self.host not in res:
-            raise errors.AnsibleError("Minion %s didn't answer, check if salt-minion is running and the name is correct" % self.host)
+            raise errors.AnsibleError(f"Minion {self.host} didn't answer, check if salt-minion is running and the name is correct")
 
         p = res[self.host]
         return p['retcode'], p['stdout'], p['stderr']
@@ -81,7 +81,7 @@ class Connection(ConnectionBase):
         super(Connection, self).put_file(in_path, out_path)
 
         out_path = self._normalize_path(out_path, '/')
-        self._display.vvv("PUT %s TO %s" % (in_path, out_path), host=self.host)
+        self._display.vvv(f"PUT {in_path} TO {out_path}", host=self.host)
         with open(in_path, 'rb') as in_fh:
             content = in_fh.read()
         self.client.cmd(self.host, 'hashutil.base64_decodefile', [base64.b64encode(content), out_path])
@@ -93,7 +93,7 @@ class Connection(ConnectionBase):
         super(Connection, self).fetch_file(in_path, out_path)
 
         in_path = self._normalize_path(in_path, '/')
-        self._display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self.host)
+        self._display.vvv(f"FETCH {in_path} TO {out_path}", host=self.host)
         content = self.client.cmd(self.host, 'cp.get_file_str', [in_path])[self.host]
         open(out_path, 'wb').write(content)
 

--- a/plugins/connection/zone.py
+++ b/plugins/connection/zone.py
@@ -62,14 +62,14 @@ class Connection(ConnectionBase):
         self.zlogin_cmd = to_bytes(self._search_executable('zlogin'))
 
         if self.zone not in self.list_zones():
-            raise AnsibleError("incorrect zone name %s" % self.zone)
+            raise AnsibleError(f"incorrect zone name {self.zone}")
 
     @staticmethod
     def _search_executable(executable):
         try:
             return get_bin_path(executable)
         except ValueError:
-            raise AnsibleError("%s command not found in PATH" % executable)
+            raise AnsibleError(f"{executable} command not found in PATH")
 
     def list_zones(self):
         process = subprocess.Popen([self.zoneadm_cmd, 'list', '-ip'],
@@ -94,7 +94,7 @@ class Connection(ConnectionBase):
 
         # stdout, stderr = p.communicate()
         path = process.stdout.readlines()[0].split(':')[3]
-        return path + '/root'
+        return f"{path}/root"
 
     def _connect(self):
         """ connect to the zone; nothing to do here """
@@ -117,7 +117,7 @@ class Connection(ConnectionBase):
         local_cmd = [self.zlogin_cmd, self.zone, cmd]
         local_cmd = map(to_bytes, local_cmd)
 
-        display.vvv("EXEC %s" % (local_cmd), host=self.zone)
+        display.vvv(f"EXEC {local_cmd}", host=self.zone)
         p = subprocess.Popen(local_cmd, shell=False, stdin=stdin,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -149,7 +149,7 @@ class Connection(ConnectionBase):
     def put_file(self, in_path, out_path):
         """ transfer a file from local to zone """
         super(Connection, self).put_file(in_path, out_path)
-        display.vvv("PUT %s TO %s" % (in_path, out_path), host=self.zone)
+        display.vvv(f"PUT {in_path} TO {out_path}", host=self.zone)
 
         out_path = shlex_quote(self._prefix_login_path(out_path))
         try:
@@ -159,27 +159,27 @@ class Connection(ConnectionBase):
                 else:
                     count = ''
                 try:
-                    p = self._buffered_exec_command('dd of=%s bs=%s%s' % (out_path, BUFSIZE, count), stdin=in_file)
+                    p = self._buffered_exec_command(f'dd of={out_path} bs={BUFSIZE}{count}', stdin=in_file)
                 except OSError:
                     raise AnsibleError("jail connection requires dd command in the jail")
                 try:
                     stdout, stderr = p.communicate()
                 except Exception:
                     traceback.print_exc()
-                    raise AnsibleError("failed to transfer file %s to %s" % (in_path, out_path))
+                    raise AnsibleError(f"failed to transfer file {in_path} to {out_path}")
                 if p.returncode != 0:
-                    raise AnsibleError("failed to transfer file %s to %s:\n%s\n%s" % (in_path, out_path, stdout, stderr))
+                    raise AnsibleError(f"failed to transfer file {in_path} to {out_path}:\n{stdout}\n{stderr}")
         except IOError:
-            raise AnsibleError("file or module does not exist at: %s" % in_path)
+            raise AnsibleError(f"file or module does not exist at: {in_path}")
 
     def fetch_file(self, in_path, out_path):
         """ fetch a file from zone to local """
         super(Connection, self).fetch_file(in_path, out_path)
-        display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self.zone)
+        display.vvv(f"FETCH {in_path} TO {out_path}", host=self.zone)
 
         in_path = shlex_quote(self._prefix_login_path(in_path))
         try:
-            p = self._buffered_exec_command('dd if=%s bs=%s' % (in_path, BUFSIZE))
+            p = self._buffered_exec_command(f'dd if={in_path} bs={BUFSIZE}')
         except OSError:
             raise AnsibleError("zone connection requires dd command in the zone")
 
@@ -191,10 +191,10 @@ class Connection(ConnectionBase):
                     chunk = p.stdout.read(BUFSIZE)
             except Exception:
                 traceback.print_exc()
-                raise AnsibleError("failed to transfer file %s to %s" % (in_path, out_path))
+                raise AnsibleError(f"failed to transfer file {in_path} to {out_path}")
             stdout, stderr = p.communicate()
             if p.returncode != 0:
-                raise AnsibleError("failed to transfer file %s to %s:\n%s\n%s" % (in_path, out_path, stdout, stderr))
+                raise AnsibleError(f"failed to transfer file {in_path} to {out_path}:\n{stdout}\n{stderr}")
 
     def close(self):
         """ terminate the connection; nothing to do here """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Use f-strings instead of string interpolations or string format().

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/connection/chroot.py
plugins/connection/funcd.py
plugins/connection/incus.py
plugins/connection/iocage.py
plugins/connection/jail.py
plugins/connection/lxc.py
plugins/connection/lxd.py
plugins/connection/qubes.py
plugins/connection/saltstack.py
plugins/connection/zone.py