### PR TITLE
qubes connection plugin: fix display stmt

### DIFF
--- a/changelogs/fragments/9334-qubes-conn.yml
+++ b/changelogs/fragments/9334-qubes-conn.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - qubes connection plugin - fix the printing of debug information (https://github.com/ansible-collections/community.general/pull/9334).

--- a/plugins/connection/qubes.py
+++ b/plugins/connection/qubes.py
@@ -118,7 +118,7 @@ class Connection(ConnectionBase):
 
         rc, stdout, stderr = self._qubes(cmd)
 
-        display.vvvvv("STDOUT %r STDERR %r" % (stderr, stderr))
+        display.vvvvv("STDOUT %r STDERR %r" % (stdout, stderr))
         return rc, stdout, stderr
 
     def put_file(self, in_path, out_path):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The debug statement clearly means to print stdout and stderr, but stderr is printed twice.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
qubes.py