### PR TITLE
Clarify UFW documentation

### DIFF
--- a/plugins/modules/ufw.py
+++ b/plugins/modules/ufw.py
@@ -39,10 +39,10 @@ attributes:
 options:
   state:
     description:
-      - V(enabled) reloads firewall and enables firewall on boot.
-      - V(disabled) unloads firewall and disables firewall on boot.
+      - V(enabled) enables firewall.
+      - V(disabled) disables firewall.
       - V(reloaded) reloads firewall.
-      - V(reset) disables and resets firewall to installation defaults.
+      - V(reset) resets firewall to installation defaults.
     type: str
     choices: [ disabled, enabled, reloaded, reset ]
   default:


### PR DESCRIPTION
##### SUMMARY

Clarification of potentially misleading documentation. 


##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME

community.general.ufw

##### ADDITIONAL INFORMATION

It may be a weird use-case, but:

1. Enable firewall
2. Edit  `/etc/ufw/user.rules`
3. Run playbook with `state: enabled`
4. Rules aren't reloaded. 
5. Run playbook with `state: reloaded`
6. Rules are reloaded


`ufw -h` explains commands like:
> enable                          enables the firewall
> disable                         disables the firewall
> reload                          reload firewall
> reset                           reset firewall

`state: enabled` or `ufw -f enable` does not reload firewall. New rules are visible in `ufw status`, but  the iptables aren't updated.

And the part about "enabled"/"disabled" working on boot is incorrect either because the change is immediate. Like `systemctl enable --now` 
