### PR TITLE
gitlab_instance_variable: Add support for 'raw' property

### DIFF
--- a/changelogs/fragments/9425-gitlab-instance-raw-variable.yml
+++ b/changelogs/fragments/9425-gitlab-instance-raw-variable.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - gitlab_instance_variable - add support for ``raw`` variables suboption (https://github.com/ansible-collections/community.general/pull/9425).

--- a/plugins/modules/gitlab_instance_variable.py
+++ b/plugins/modules/gitlab_instance_variable.py
@@ -77,7 +77,7 @@ options:
       raw:
         description:
           - Whether variable value is raw or not.
-          - Support for raw values requires GitLab >= 15.7
+          - Support for raw values requires GitLab >= 15.7.
         type: bool
         default: false
       variable_type:

--- a/plugins/modules/gitlab_instance_variable.py
+++ b/plugins/modules/gitlab_instance_variable.py
@@ -80,6 +80,7 @@ options:
           - Support for raw values requires GitLab >= 15.7.
         type: bool
         default: false
+        version_added: 10.2.0
       variable_type:
         description:
           - Whether a variable is an environment variable (V(env_var)) or a file (V(file)).

--- a/plugins/modules/gitlab_instance_variable.py
+++ b/plugins/modules/gitlab_instance_variable.py
@@ -74,6 +74,12 @@ options:
           - Whether variable value is protected or not.
         type: bool
         default: false
+      raw:
+        description:
+          - Whether variable value is raw or not.
+          - Support for raw values requires GitLab >= 15.7
+        type: bool
+        default: false
       variable_type:
         description:
           - Whether a variable is an environment variable (V(env_var)) or a file (V(file)).
@@ -160,6 +166,7 @@ class GitlabInstanceVariables(object):
             "value": var_obj.get('value'),
             "masked": var_obj.get('masked'),
             "protected": var_obj.get('protected'),
+            "raw": var_obj.get('raw'),
             "variable_type": var_obj.get('variable_type'),
         }
 
@@ -227,6 +234,8 @@ def native_python_main(this_gitlab, purge, requested_variables, state, module):
             item['protected'] = False
         if item.get('masked') is None:
             item['masked'] = False
+        if item.get('raw') is None:
+            item['raw'] = False
         if item.get('variable_type') is None:
             item['variable_type'] = 'env_var'
 
@@ -297,6 +306,7 @@ def main():
             value=dict(type='str', no_log=True),
             masked=dict(type='bool', default=False),
             protected=dict(type='bool', default=False),
+            raw=dict(type='bool', default=False),
             variable_type=dict(type='str', default='env_var', choices=["env_var", "file"])
         )),
         state=dict(type='str', default="present", choices=["absent", "present"]),


### PR DESCRIPTION
##### SUMMARY

Adds support for the "raw" property on CI variables, which also makes the module idempotent when used against GitLab versions that support this property. Fixes #9424 

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
gitlab_instance_variable