### PR TITLE
purestorage: deprecate leftovers

### DIFF
--- a/changelogs/fragments/9432-deprecate-pure.yml
+++ b/changelogs/fragments/9432-deprecate-pure.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - purestorage doc_fragments - modules using this were removed in community.general 3.0.0 (https://github.com/ansible-collections/community.general/pull/9432).
+  - pure module_utils - modules using this were removed in community.general 3.0.0 (https://github.com/ansible-collections/community.general/pull/9432).

--- a/changelogs/fragments/9432-deprecate-pure.yml
+++ b/changelogs/fragments/9432-deprecate-pure.yml
@@ -1,3 +1,3 @@
 deprecated_features:
-  - purestorage doc_fragments - modules using this were removed in community.general 3.0.0 (https://github.com/ansible-collections/community.general/pull/9432).
-  - pure module_utils - modules using this were removed in community.general 3.0.0 (https://github.com/ansible-collections/community.general/pull/9432).
+  - purestorage doc fragments - the doc fragment is deprecated and will be removed from community.general 12.0.0. The modules using this were removed in community.general 3.0.0 (https://github.com/ansible-collections/community.general/pull/9432).
+  - pure module utils - the module utils is deprecated and will be removed from community.general 12.0.0. The modules using this were removed in community.general 3.0.0 (https://github.com/ansible-collections/community.general/pull/9432).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -808,11 +808,6 @@ plugin_routing:
         removal_version: 3.0.0
         warning_text: Use community.general.xenserver_guest_info instead.
   doc_fragments:
-    rackspace:
-      tombstone:
-        removal_version: 9.0.0
-        warning_text: This doc fragment was used by rax modules, that relied on the deprecated
-          package pyrax.
     _gcp:
       redirect: community.google._gcp
     docker:
@@ -827,11 +822,16 @@ plugin_routing:
       redirect: infoblox.nios_modules.nios
     postgresql:
       redirect: community.postgresql.postgresql
-  module_utils:
-    rax:
+    purestorage:
+      deprecation:
+      removal_version: 12.0.0
+      warning_text: The modules for purestorage were removed in community.general 3.0.0, this document fragment was left behind.
+    rackspace:
       tombstone:
         removal_version: 9.0.0
-        warning_text: This module util relied on the deprecated package pyrax.
+        warning_text: This doc fragment was used by rax modules, that relied on the deprecated
+          package pyrax.
+  module_utils:
     docker.common:
       redirect: community.docker.common
     docker.swarm:
@@ -850,6 +850,14 @@ plugin_routing:
       redirect: infoblox.nios_modules.api
     postgresql:
       redirect: community.postgresql.postgresql
+    pure:
+      deprecation:
+      removal_version: 12.0.0
+      warning_text: The modules for purestorage were removed in community.general 3.0.0, this module util was left behind.
+    rax:
+      tombstone:
+        removal_version: 9.0.0
+        warning_text: This module util relied on the deprecated package pyrax.
     remote_management.dellemc.dellemc_idrac:
       redirect: dellemc.openmanage.dellemc_idrac
     remote_management.dellemc.ome:

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -824,8 +824,8 @@ plugin_routing:
       redirect: community.postgresql.postgresql
     purestorage:
       deprecation:
-      removal_version: 12.0.0
-      warning_text: The modules for purestorage were removed in community.general 3.0.0, this document fragment was left behind.
+        removal_version: 12.0.0
+        warning_text: The modules for purestorage were removed in community.general 3.0.0, this document fragment was left behind.
     rackspace:
       tombstone:
         removal_version: 9.0.0
@@ -852,8 +852,8 @@ plugin_routing:
       redirect: community.postgresql.postgresql
     pure:
       deprecation:
-      removal_version: 12.0.0
-      warning_text: The modules for purestorage were removed in community.general 3.0.0, this module util was left behind.
+        removal_version: 12.0.0
+        warning_text: The modules for purestorage were removed in community.general 3.0.0, this module util was left behind.
     rax:
       tombstone:
         removal_version: 9.0.0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Modules supporting purestorage were removed from the collection in version 3.0.0 but the module utils and a doc fragment were left behind. This PR deprecates them.

(Additionally, this PR fixes the ordering for the old rackspace removal in those two sections of runtime.yml)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/doc_fragments/purestorage.py
plugins/module_utils/pure.py