### PR TITLE
manageiq_alert_profiles: improve handling param requirements

### DIFF
--- a/changelogs/fragments/9449-manageiq-alert-profiles-reqs.yml
+++ b/changelogs/fragments/9449-manageiq-alert-profiles-reqs.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - manageiq_alert_profiles - improve handling of parameter requirements (https://github.com/ansible-collections/community.general/pull/9449).

--- a/plugins/modules/manageiq_alert_profiles.py
+++ b/plugins/modules/manageiq_alert_profiles.py
@@ -37,7 +37,7 @@ options:
     type: str
     description:
       - The unique alert profile name in ManageIQ.
-      - Required when state is "absent" or "present".
+    required: true
   resource_type:
     type: str
     description:
@@ -114,8 +114,7 @@ class ManageIQAlertProfiles(object):
         """
         alerts = []
         for alert_description in alert_descriptions:
-            alert = self.manageiq.find_collection_resource_or_fail("alert_definitions",
-                                                                   description=alert_description)
+            alert = self.manageiq.find_collection_resource_or_fail("alert_definitions", description=alert_description)
             alerts.append(alert['href'])
 
         return alerts
@@ -253,7 +252,7 @@ class ManageIQAlertProfiles(object):
 
 def main():
     argument_spec = dict(
-        name=dict(type='str'),
+        name=dict(type='str', required=True),
         resource_type=dict(type='str', choices=['Vm',
                                                 'ContainerNode',
                                                 'MiqServer',
@@ -270,8 +269,7 @@ def main():
     argument_spec.update(manageiq_argument_spec())
 
     module = AnsibleModule(argument_spec=argument_spec,
-                           required_if=[('state', 'present', ['name', 'resource_type']),
-                                        ('state', 'absent', ['name'])])
+                           required_if=[('state', 'present', ['resource_type', 'alerts'])])
 
     state = module.params['state']
     name = module.params['name']
@@ -279,8 +277,7 @@ def main():
     manageiq = ManageIQ(module)
     manageiq_alert_profiles = ManageIQAlertProfiles(manageiq)
 
-    existing_profile = manageiq.find_collection_resource_by("alert_definition_profiles",
-                                                            name=name)
+    existing_profile = manageiq.find_collection_resource_by("alert_definition_profiles", name=name)
 
     # we need to add or update the alert profile
     if state == "present":


### PR DESCRIPTION
Basically two changes:
* `name` is already required when state is either present or absent, and there are no other states, so making it fully required and removing the conditional
* `alerts` is documented as required when state=present, this has been verified in the code, so added that parameter to the existing `required_if` spec.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
manageiq_alert_profiles