### PR TITLE
yaml callback plugin: deprecation

### DIFF
--- a/changelogs/fragments/9456-yaml-callback-deprecation.yml
+++ b/changelogs/fragments/9456-yaml-callback-deprecation.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - yaml callback plugin - deprecate plugin in favor of ``result_format=yaml`` in plugin ``ansible.bulitin.default`` (https://github.com/ansible-collections/community.general/pull/9456).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -83,6 +83,10 @@ plugin_routing:
         removal_version: 2.0.0
         warning_text: Use the 'default' callback plugin with 'display_failed_stderr
           = yes' option.
+    yaml:
+      deprecation:
+        removal_version: 12.0.0
+        warning_text: The plugin has been superseded by the the option `result_format=yaml` in callback plugin ansible.builtin.default from ansible-core 2.13 onwards.
   connection:
     docker:
       redirect: community.docker.docker

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -85,7 +85,7 @@ plugin_routing:
           = yes' option.
     yaml:
       deprecation:
-        removal_version: 12.0.0
+        removal_version: 13.0.0
         warning_text: The plugin has been superseded by the the option `result_format=yaml` in callback plugin ansible.builtin.default from ansible-core 2.13 onwards.
   connection:
     docker:

--- a/plugins/callback/yaml.py
+++ b/plugins/callback/yaml.py
@@ -12,6 +12,10 @@ author: Unknown (!UNKNOWN)
 name: yaml
 type: stdout
 short_description: YAML-ized Ansible screen output
+deprecated:
+  removed_in: 12.0.0
+  why: Starting in ansible-core 2.13, the default callback has support for printing output in YAML format.
+  alternative: Use O(ansible.builtin.default#callback:result_format=yaml).
 description:
   - Ansible output that can be quite a bit easier to read than the default JSON formatting.
 extends_documentation_fragment:

--- a/plugins/callback/yaml.py
+++ b/plugins/callback/yaml.py
@@ -14,7 +14,7 @@ type: stdout
 short_description: YAML-ized Ansible screen output
 deprecated:
   removed_in: 12.0.0
-  why: Starting in ansible-core 2.13, the default callback has support for printing output in YAML format.
+  why: Starting in ansible-core 2.13, the P(ansible.builtin.default#callback) callback has support for printing output in YAML format.
   alternative: Use O(ansible.builtin.default#callback:result_format=yaml).
 description:
   - Ansible output that can be quite a bit easier to read than the default JSON formatting.

--- a/plugins/callback/yaml.py
+++ b/plugins/callback/yaml.py
@@ -13,7 +13,7 @@ name: yaml
 type: stdout
 short_description: YAML-ized Ansible screen output
 deprecated:
-  removed_in: 12.0.0
+  removed_in: 13.0.0
   why: Starting in ansible-core 2.13, the P(ansible.builtin.default#callback) callback has support for printing output in YAML format.
   alternative: Use O(ansible.builtin.default#callback:result_format=yaml).
 description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The plugin itself has a note stating that since ansible-core 2.13 (as of Dec '24 the minimum verison of ansible-core supported by community.general) has the functionality implemented within its default callback plugin.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/callback/yaml.py