### PR TITLE
pacemaker_cluster: fix run_command() calls

### DIFF
--- a/changelogs/fragments/9387-pacemaker-cluster-cmd.yml
+++ b/changelogs/fragments/9387-pacemaker-cluster-cmd.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - pacemaker_cluster - using safer mechanism to run external command (https://github.com/ansible-collections/community.general/pull/9471).
+  - pacemaker_cluster - remove unused code (https://github.com/ansible-collections/community.general/pull/9471).

--- a/plugins/modules/pacemaker_cluster.py
+++ b/plugins/modules/pacemaker_cluster.py
@@ -71,7 +71,7 @@ _PCS_CLUSTER_DOWN = "Error: cluster is not currently running on this node"
 
 
 def get_cluster_status(module):
-    cmd = "pcs cluster status"
+    cmd = ["pcs", "cluster", "status"]
     rc, out, err = module.run_command(cmd)
     if out in _PCS_CLUSTER_DOWN:
         return 'offline'
@@ -80,10 +80,8 @@ def get_cluster_status(module):
 
 
 def get_node_status(module, node='all'):
-    if node == 'all':
-        cmd = "pcs cluster pcsd-status %s" % node
-    else:
-        cmd = "pcs cluster pcsd-status"
+    node_l = ["all"] if node == "all" else []
+    cmd = ["pcs", "cluster", "pcsd-status"] + node_l
     rc, out, err = module.run_command(cmd)
     if rc == 1:
         module.fail_json(msg="Command execution failed.\nCommand: `%s`\nError: %s" % (cmd, err))
@@ -94,7 +92,7 @@ def get_node_status(module, node='all'):
 
 
 def clean_cluster(module, timeout):
-    cmd = "pcs resource cleanup"
+    cmd = ["pcs", "resource", "cleanup"]
     rc, out, err = module.run_command(cmd)
     if rc == 1:
         module.fail_json(msg="Command execution failed.\nCommand: `%s`\nError: %s" % (cmd, err))
@@ -102,11 +100,11 @@ def clean_cluster(module, timeout):
 
 def set_cluster(module, state, timeout, force):
     if state == 'online':
-        cmd = "pcs cluster start"
+        cmd = ["pcs", "cluster", "start"]
     if state == 'offline':
-        cmd = "pcs cluster stop"
+        cmd = ["pcs", "cluster", "stop"]
         if force:
-            cmd = "%s --force" % cmd
+            cmd = cmd + ["--force"]
     rc, out, err = module.run_command(cmd)
     if rc == 1:
         module.fail_json(msg="Command execution failed.\nCommand: `%s`\nError: %s" % (cmd, err))
@@ -125,19 +123,19 @@ def set_cluster(module, state, timeout, force):
 def set_node(module, state, timeout, force, node='all'):
     # map states
     if state == 'online':
-        cmd = "pcs cluster start"
+        cmd = ["pcs", "cluster", "start"]
     if state == 'offline':
-        cmd = "pcs cluster stop"
+        cmd = ["pcs", "cluster", "stop"]
         if force:
-            cmd = "%s --force" % cmd
+            cmd = cmd + ["--force"]
 
     nodes_state = get_node_status(module, node)
     for node in nodes_state:
         if node[1].strip().lower() != state:
-            cmd = "%s %s" % (cmd, node[0].strip())
-            rc, out, err = module.run_command(cmd)
-            if rc == 1:
-                module.fail_json(msg="Command execution failed.\nCommand: `%s`\nError: %s" % (cmd, err))
+            cmd = cmd + [node[0].strip()]
+    rc, out, err = module.run_command(cmd)
+    if rc == 1:
+        module.fail_json(msg="Command execution failed.\nCommand: `%s`\nError: %s" % (cmd, err))
 
     t = time.time()
     ready = False
@@ -209,9 +207,9 @@ def main():
             if cluster_state == 'online':
                 module.exit_json(changed=True, out=cluster_state)
             else:
-                module.fail_json(msg="Failed during the restart of the cluster, the cluster can't be started")
+                module.fail_json(msg="Failed during the restart of the cluster, the cluster cannot be started")
         else:
-            module.fail_json(msg="Failed during the restart of the cluster, the cluster can't be stopped")
+            module.fail_json(msg="Failed during the restart of the cluster, the cluster cannot be stopped")
 
     if state in ['cleanup']:
         if module.check_mode:

--- a/plugins/modules/pacemaker_cluster.py
+++ b/plugins/modules/pacemaker_cluster.py
@@ -120,35 +120,6 @@ def set_cluster(module, state, timeout, force):
         module.fail_json(msg="Failed to set the state `%s` on the cluster\n" % (state))
 
 
-def set_node(module, state, timeout, force, node='all'):
-    # map states
-    if state == 'online':
-        cmd = ["pcs", "cluster", "start"]
-    if state == 'offline':
-        cmd = ["pcs", "cluster", "stop"]
-        if force:
-            cmd = cmd + ["--force"]
-
-    nodes_state = get_node_status(module, node)
-    for node in nodes_state:
-        if node[1].strip().lower() != state:
-            cmd = cmd + [node[0].strip()]
-    rc, out, err = module.run_command(cmd)
-    if rc == 1:
-        module.fail_json(msg="Command execution failed.\nCommand: `%s`\nError: %s" % (cmd, err))
-
-    t = time.time()
-    ready = False
-    while time.time() < t + timeout:
-        nodes_state = get_node_status(module)
-        for node in nodes_state:
-            if node[1].strip().lower() == state:
-                ready = True
-                break
-    if not ready:
-        module.fail_json(msg="Failed to set the state `%s` on the cluster\n" % (state))
-
-
 def main():
     argument_spec = dict(
         state=dict(type='str', choices=['online', 'offline', 'restart', 'cleanup']),
@@ -196,7 +167,7 @@ def main():
                     cluster_state = get_node_status(module, node)
                     module.exit_json(changed=True, out=cluster_state)
 
-    if state in ['restart']:
+    elif state == 'restart':
         if module.check_mode:
             module.exit_json(changed=True)
         set_cluster(module, 'offline', timeout, force)
@@ -211,13 +182,12 @@ def main():
         else:
             module.fail_json(msg="Failed during the restart of the cluster, the cluster cannot be stopped")
 
-    if state in ['cleanup']:
+    elif state == 'cleanup':
         if module.check_mode:
             module.exit_json(changed=True)
         clean_cluster(module, timeout)
         cluster_state = get_cluster_status(module)
-        module.exit_json(changed=True,
-                         out=cluster_state)
+        module.exit_json(changed=True, out=cluster_state)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
While working on the doc normalization I noticed this module still used `run_command()` with a string argument, rather than a list one.

While working to fix that, I bumped into an unreported bug in the `set_node()` function. **Update:** and as it turns out, that function was not being used at all, so removing it entirely.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
pacemaker_cluster