### PR TITLE
slack: add file upload functionality

### DIFF
--- a/changelogs/fragments/slack.yml
+++ b/changelogs/fragments/slack.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Slack upload file - feature added support for uploading files to Slack (https://github.com/ansible-collections/community.general/pull/9472).

--- a/changelogs/fragments/slack.yml
+++ b/changelogs/fragments/slack.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Slack upload file - feature added support for uploading files to Slack (https://github.com/ansible-collections/community.general/pull/9472).
+  - slack - add support for uploading files to Slack (https://github.com/ansible-collections/community.general/pull/9472).

--- a/plugins/modules/slack.py
+++ b/plugins/modules/slack.py
@@ -607,11 +607,18 @@ def upload_file_to_slack(module, token, channel, file_upload):
                 module.fail_json(
                     msg="Error during upload completion: %s (HTTP %s)" % (info['msg'], info['status'])
                 )
-            upload_url_data = json.load(response)
-        except ValueError:
-            module.fail_json(
-                msg="The Slack API response is not valid JSON: %s" % response.read()
-            )
+            try:
+                upload_url_data = json.load(response)
+            except ValueError:
+                module.fail_json(
+                    msg="The Slack API response is not valid JSON: %s" % response.read()
+                )
+            if not upload_url_data.get("ok"):
+                module.fail_json(
+                    msg="Failed to complete the upload: %s" % upload_url_data
+                )
+        except Exception as e:
+            module.fail_json(msg="Error uploading file: %s" % str(e))
         if not upload_url_data.get("ok"):
             module.fail_json(msg="Failed to complete the upload: %s" % upload_url_data)
         return upload_url_data

--- a/plugins/modules/slack.py
+++ b/plugins/modules/slack.py
@@ -148,8 +148,8 @@ options:
     type: dict
     description:
       - Specify details to upload a file to Slack. The file can include metadata such as an initial comment, alt text, snipped and title.
-      - See Slack's file upload API for details at U(https://api.slack.com/methods/files.getUploadURLExternal).
-      - See Slack's file upload API for details at U(https://api.slack.com/methods/files.completeUploadExternal).
+      - See Slack's file upload API for details at U(https://api.slack.com/methods/files.getUploadURLExternal) or
+        U(https://api.slack.com/methods/files.completeUploadExternal).
     suboptions:
       path:
         type: str

--- a/plugins/modules/slack.py
+++ b/plugins/modules/slack.py
@@ -176,6 +176,7 @@ options:
         type: str
         description:
           - Optional timestamp of parent message to thread this message, see U(https://api.slack.com/docs/message-threading).
+    version_added: 10.2.0
 """
 
 EXAMPLES = r"""


### PR DESCRIPTION
##### SUMMARY
Add file upload functionality to upload the files with the new API SLACK.

Continuation of #9431.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- Slack

##### ADDITIONAL INFORMATION
This enhancement allows you to upload files with the new version of the Slack API
https://api.slack.com/methods/files.completeUploadExternal
https://api.slack.com/methods/files.getUploadURLExternal

Example usage:
```yml
    - name: Upload a file to Slack
      community.general.slack:
        token: thetoken/generatedby/slack
        channel: 'kuma'
        upload_file:
          path: "/tmp/test.py"
          title: "main.py"
         snippet_type: "python"
```