### PR TITLE
sensu_*: deprecation

### DIFF
--- a/changelogs/fragments/9483-sensu-deprecation.yml
+++ b/changelogs/fragments/9483-sensu-deprecation.yml
@@ -1,0 +1,6 @@
+deprecated_features:
+  - sensu_check - module is deprecated and will be removed in community.general 13.0.0, use collection ``sensu.sensu_go`` instead (https://github.com/ansible-collections/community.general/pull/9483).
+  - sensu_client - module is deprecated and will be removed in community.general 13.0.0, use collection ``sensu.sensu_go`` instead (https://github.com/ansible-collections/community.general/pull/9483).
+  - sensu_handler - module is deprecated and will be removed in community.general 13.0.0, use collection ``sensu.sensu_go`` instead (https://github.com/ansible-collections/community.general/pull/9483).
+  - sensu_silence - module is deprecated and will be removed in community.general 13.0.0, use collection ``sensu.sensu_go`` instead (https://github.com/ansible-collections/community.general/pull/9483).
+  - sensu_subscription - module is deprecated and will be removed in community.general 13.0.0, use collection ``sensu.sensu_go`` instead (https://github.com/ansible-collections/community.general/pull/9483).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -230,6 +230,26 @@ plugin_routing:
         removal_version: 10.0.0
         warning_text: RHN is EOL, please contact the community.general maintainers
           if still using this; see the module documentation for more details.
+    sensu_check:
+      deprecation:
+        removal_version: 13.0.0
+        warning_text: Sensu Core and Sensu Enterprise products have been End of Life since 2019/20.
+    sensu_client:
+      deprecation:
+        removal_version: 13.0.0
+        warning_text: Sensu Core and Sensu Enterprise products have been End of Life since 2019/20.
+    sensu_handler:
+      deprecation:
+        removal_version: 13.0.0
+        warning_text: Sensu Core and Sensu Enterprise products have been End of Life since 2019/20.
+    sensu_silence:
+      deprecation:
+        removal_version: 13.0.0
+        warning_text: Sensu Core and Sensu Enterprise products have been End of Life since 2019/20.
+    sensu_subscription:
+      deprecation:
+        removal_version: 13.0.0
+        warning_text: Sensu Core and Sensu Enterprise products have been End of Life since 2019/20.
     stackdriver:
       tombstone:
         removal_version: 9.0.0

--- a/plugins/modules/sensu_check.py
+++ b/plugins/modules/sensu_check.py
@@ -17,6 +17,10 @@ description:
   - Most options do not have a default and will not be added to the check definition unless specified.
   - All defaults except O(path), O(state), O(backup) and O(metric) are not managed by this module,
     they are simply specified for your convenience.
+deprecated:
+  removed_in: 13.0.0
+  why: Sensu Core and Sensu Enterprise products have been End of Life since 2019/20.
+  alternative: Use Sensu Go and its accompanying collection C(sensu.sensu_go).
 extends_documentation_fragment:
   - community.general.attributes
 attributes:

--- a/plugins/modules/sensu_client.py
+++ b/plugins/modules/sensu_client.py
@@ -15,6 +15,10 @@ short_description: Manages Sensu client configuration
 description:
   - Manages Sensu client configuration.
   - 'For more information, refer to the Sensu documentation: U(https://sensuapp.org/docs/latest/reference/clients.html)'
+deprecated:
+  removed_in: 13.0.0
+  why: Sensu Core and Sensu Enterprise products have been End of Life since 2019/20.
+  alternative: Use Sensu Go and its accompanying collection C(sensu.sensu_go).
 extends_documentation_fragment:
   - community.general.attributes
 attributes:

--- a/plugins/modules/sensu_handler.py
+++ b/plugins/modules/sensu_handler.py
@@ -15,6 +15,10 @@ short_description: Manages Sensu handler configuration
 description:
   - Manages Sensu handler configuration.
   - 'For more information, refer to the Sensu documentation: U(https://sensuapp.org/docs/latest/reference/handlers.html)'
+deprecated:
+  removed_in: 13.0.0
+  why: Sensu Core and Sensu Enterprise products have been End of Life since 2019/20.
+  alternative: Use Sensu Go and its accompanying collection C(sensu.sensu_go).
 extends_documentation_fragment:
   - community.general.attributes
 attributes:

--- a/plugins/modules/sensu_silence.py
+++ b/plugins/modules/sensu_silence.py
@@ -15,6 +15,10 @@ author: Steven Bambling (@smbambling)
 short_description: Manage Sensu silence entries
 description:
   - Create and clear (delete) a silence entries using the Sensu API for subscriptions and checks.
+deprecated:
+  removed_in: 13.0.0
+  why: Sensu Core and Sensu Enterprise products have been End of Life since 2019/20.
+  alternative: Use Sensu Go and its accompanying collection C(sensu.sensu_go).
 extends_documentation_fragment:
   - community.general.attributes
 attributes:

--- a/plugins/modules/sensu_subscription.py
+++ b/plugins/modules/sensu_subscription.py
@@ -14,6 +14,10 @@ module: sensu_subscription
 short_description: Manage Sensu subscriptions
 description:
   - Manage which I(sensu channels) a machine should subscribe to.
+deprecated:
+  removed_in: 13.0.0
+  why: Sensu Core and Sensu Enterprise products have been End of Life since 2019/20.
+  alternative: Use Sensu Go and its accompanying collection C(sensu.sensu_go).
 extends_documentation_fragment:
   - community.general.attributes
 attributes:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The five modules in community.general seem to  have been written for Sensu Core and Sensu Enterprise editions, both of them EOL since 2019/2020, replaced by Sensu Go, which has its own collection `sensu.sensu_go`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/modules/sensu_check.py
plugins/modules/sensu_client.py
plugins/modules/sensu_handler.py
plugins/modules/sensu_silence.py
plugins/modules/sensu_subscription.py
