### PR TITLE
atomic_*: deprecation

### DIFF
--- a/changelogs/fragments/9487-atomic-deprecation.yml
+++ b/changelogs/fragments/9487-atomic-deprecation.yml
@@ -1,4 +1,4 @@
 deprecated_features:
-  -atomic_container - module is deprecated and will be removed in community.general 13.0.0 (https://github.com/ansible-collections/community.general/pull/9487).
-  -atomic_host - module is deprecated and will be removed in community.general 13.0.0 (https://github.com/ansible-collections/community.general/pull/9487).
-  -atomic_image - module is deprecated and will be removed in community.general 13.0.0 (https://github.com/ansible-collections/community.general/pull/9487).
+  - atomic_container - module is deprecated and will be removed in community.general 13.0.0 (https://github.com/ansible-collections/community.general/pull/9487).
+  - atomic_host - module is deprecated and will be removed in community.general 13.0.0 (https://github.com/ansible-collections/community.general/pull/9487).
+  - atomic_image - module is deprecated and will be removed in community.general 13.0.0 (https://github.com/ansible-collections/community.general/pull/9487).

--- a/changelogs/fragments/9487-atomic-deprecation.yml
+++ b/changelogs/fragments/9487-atomic-deprecation.yml
@@ -1,0 +1,4 @@
+deprecated_features:
+  -atomic_container - module is deprecated and will be removed in community.general 13.0.0 (https://github.com/ansible-collections/community.general/pull/9487).
+  -atomic_host - module is deprecated and will be removed in community.general 13.0.0 (https://github.com/ansible-collections/community.general/pull/9487).
+  -atomic_image - module is deprecated and will be removed in community.general 13.0.0 (https://github.com/ansible-collections/community.general/pull/9487).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -104,6 +104,18 @@ plugin_routing:
     nios_next_network:
       redirect: infoblox.nios_modules.nios_next_network
   modules:
+    atomic_container:
+      deprecation:
+        removal_version: 13.0.0
+        warning_text: Poject Atomic was sunset by the end of 2019.
+    atomic_host:
+      deprecation:
+        removal_version: 13.0.0
+        warning_text: Poject Atomic was sunset by the end of 2019.
+    atomic_image:
+      deprecation:
+        removal_version: 13.0.0
+        warning_text: Poject Atomic was sunset by the end of 2019.
     consul_acl:
       tombstone:
         removal_version: 10.0.0

--- a/plugins/modules/atomic_container.py
+++ b/plugins/modules/atomic_container.py
@@ -15,6 +15,10 @@ short_description: Manage the containers on the atomic host platform
 description:
   - Manage the containers on the atomic host platform.
   - Allows to manage the lifecycle of a container on the atomic host platform.
+deprecated:
+  removed_in: 13.0.0
+  why: Project Atomic was sunset by the end of 2019.
+  alternative: There is none.
 author: "Giuseppe Scrivano (@giuseppe)"
 requirements:
   - atomic

--- a/plugins/modules/atomic_host.py
+++ b/plugins/modules/atomic_host.py
@@ -14,6 +14,10 @@ short_description: Manage the atomic host platform
 description:
   - Manage the atomic host platform.
   - Rebooting of Atomic host platform should be done outside this module.
+deprecated:
+  removed_in: 13.0.0
+  why: Project Atomic was sunset by the end of 2019.
+  alternative: There is none.
 author:
   - Saravanan KR (@krsacme)
 notes:

--- a/plugins/modules/atomic_image.py
+++ b/plugins/modules/atomic_image.py
@@ -14,6 +14,10 @@ short_description: Manage the container images on the atomic host platform
 description:
   - Manage the container images on the atomic host platform.
   - Allows to execute the commands specified by the RUN label in the container image when present.
+deprecated:
+  removed_in: 13.0.0
+  why: Project Atomic was sunset by the end of 2019.
+  alternative: There is none.
 author:
   - Saravanan KR (@krsacme)
 notes:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Project Atomic was sunset by the end of 2019. The alternative for that product is, allegedly Fedora CoreOS or one of the existing ¨container-oriented" distros out there. There is no specific alternative for the Ansible modules though.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/modules/atomic_container.py
plugins/modules/atomic_host.py
plugins/modules/atomic_image.py
