### PR TITLE
opentelemetry callback plugin: remove unused code

### DIFF
--- a/changelogs/fragments/9503-opentelemetry-remove-unused-code.yml
+++ b/changelogs/fragments/9503-opentelemetry-remove-unused-code.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - opentelemetry callback plugin - remove code handling Python versions prior to 3.7 (https://github.com/ansible-collections/community.general/pull/9503).

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -166,7 +166,6 @@ try:
     )
 except ImportError as imp_exc:
     OTEL_LIBRARY_IMPORT_ERROR = imp_exc
-    OTEL_LIBRARY_TIME_NS_ERROR = imp_exc
 else:
     OTEL_LIBRARY_IMPORT_ERROR = None
 


### PR DESCRIPTION
##### SUMMARY

Part of https://github.com/ansible-collections/community.general/issues/9454

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

`plugins/callback/opentelemetry.py`


##### ADDITIONAL INFORMATION

`OTEL_LIBRARY_TIME_NS_ERROR` was introduced at https://github.com/ansible-collections/community.general/pull/5342#discussion_r989462459 and partially removed in https://github.com/ansible-collections/community.general/pull/9482

I'm testing this PR in [here](https://github.com/v1v/otel-ansible-callback-plugin/actions/runs/12558081324) - that's a basic test framework using logs validations that I built some time ago.
