### PR TITLE
Update Lxml Version

### DIFF
--- a/plugins/modules/xml.py
+++ b/plugins/modules/xml.py
@@ -139,7 +139,7 @@ options:
     type: bool
     default: false
 requirements:
-  - lxml >= 2.3.0
+  - lxml >= 2.3.0 and <= 5.1.0
 notes:
   - Use the C(--check) and C(--diff) options when testing your expressions.
   - The diff output is automatically pretty-printed, so may not reflect the actual file content, only the file structure.


### PR DESCRIPTION
lxml version cannot be over 5.1.0 because _ElementStringResult has been deprecated. 

Code must be adapt tu use newer version (My case cas about delete nodes in multi namespace xml files)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
xml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
