### PR TITLE
remove stearz as maintainer

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1380,8 +1380,10 @@ files:
     keywords: sophos utm
     maintainers: $team_e_spirit
   $modules/utm_ca_host_key_cert.py:
+    ignore: stearz
     maintainers: $team_e_spirit
   $modules/utm_ca_host_key_cert_info.py:
+    ignore: stearz
     maintainers: $team_e_spirit
   $modules/utm_network_interface_address.py:
     maintainers: steamx
@@ -1389,6 +1391,7 @@ files:
     maintainers: steamx
   $modules/utm_proxy_auth_profile.py:
     keywords: sophos utm
+    ignore: stearz
     maintainers: $team_e_spirit
   $modules/utm_proxy_exception.py:
     keywords: sophos utm

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1380,16 +1380,16 @@ files:
     keywords: sophos utm
     maintainers: $team_e_spirit
   $modules/utm_ca_host_key_cert.py:
-    maintainers: stearz
+    maintainers: $team_e_spirit
   $modules/utm_ca_host_key_cert_info.py:
-    maintainers: stearz
+    maintainers: $team_e_spirit
   $modules/utm_network_interface_address.py:
     maintainers: steamx
   $modules/utm_network_interface_address_info.py:
     maintainers: steamx
   $modules/utm_proxy_auth_profile.py:
     keywords: sophos utm
-    maintainers: $team_e_spirit stearz
+    maintainers: $team_e_spirit
   $modules/utm_proxy_exception.py:
     keywords: sophos utm
     maintainers: $team_e_spirit RickS-C137


### PR DESCRIPTION
##### SUMMARY
As I do not work with Sophos UTMs anymore I am no longer able to test/maintain and therfor removed 'stearz' as maintainer. I added team_e_spirit as maintainer as I think they are still using and willing to support the modules.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
plugins/utm_*

##### ADDITIONAL INFORMATION
n/a
