### PR TITLE
Feature: Gitlab module will not always work with internal service names 

### DIFF
--- a/changelogs/fragments/9537-gitlab-fix-api-compatibility.yaml
+++ b/changelogs/fragments/9537-gitlab-fix-api-compatibility.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - gitlab - improve compatibility for different API URLs (https://github.com/python-gitlab/python-gitlab/pull/2149).
+  - gitlab_* modules - improve compatibility for different API URLs when using gitlab-python 3.8.0 or newer (https://github.com/python-gitlab/python-gitlab/pull/2149).

--- a/changelogs/fragments/9537-gitlab-fix-api-compatibility.yaml
+++ b/changelogs/fragments/9537-gitlab-fix-api-compatibility.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - gitlab - improve compatibility for different API URLs (https://github.com/python-gitlab/python-gitlab/pull/2149).

--- a/changelogs/fragments/9537-gitlab-fix-api-compatibility.yaml
+++ b/changelogs/fragments/9537-gitlab-fix-api-compatibility.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - gitlab_* modules - improve compatibility for different API URLs when using gitlab-python 3.8.0 or newer (https://github.com/python-gitlab/python-gitlab/pull/2149).
+  - gitlab_* modules - improve compatibility for different API URLs when using gitlab-python 3.8.0 or newer (https://github.com/ansible-collections/community.general/pull/9537).

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -121,10 +121,10 @@ def gitlab_authentication(module, min_version=None):
 
         if gitlab.__version__ >= LooseVersion('3.8.0'):
             gitlab_instance = gitlab.Gitlab(url=gitlab_url, ssl_verify=verify, private_token=gitlab_token,
-                                        oauth_token=gitlab_oauth_token, job_token=gitlab_job_token, api_version=4, keep_base_url=True)
+                                            oauth_token=gitlab_oauth_token, job_token=gitlab_job_token, api_version=4, keep_base_url=True)
         else:
             gitlab_instance = gitlab.Gitlab(url=gitlab_url, ssl_verify=verify, private_token=gitlab_token,
-                                        oauth_token=gitlab_oauth_token, job_token=gitlab_job_token, api_version=4)
+                                            oauth_token=gitlab_oauth_token, job_token=gitlab_job_token, api_version=4)
 
         gitlab_instance.auth()
     except (gitlab.exceptions.GitlabAuthenticationError, gitlab.exceptions.GitlabGetError) as e:

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -120,7 +120,7 @@ def gitlab_authentication(module, min_version=None):
             gitlab_oauth_token = resp_data["access_token"]
 
         gitlab_instance = gitlab.Gitlab(url=gitlab_url, ssl_verify=verify, private_token=gitlab_token,
-                                        oauth_token=gitlab_oauth_token, job_token=gitlab_job_token, api_version=4)
+                                        oauth_token=gitlab_oauth_token, job_token=gitlab_job_token, api_version=4, keep_base_url=True)
         gitlab_instance.auth()
     except (gitlab.exceptions.GitlabAuthenticationError, gitlab.exceptions.GitlabGetError) as e:
         module.fail_json(msg="Failed to connect to GitLab server: %s" % to_native(e))

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -127,7 +127,7 @@ def gitlab_authentication(module, min_version=None):
             'job_token': gitlab_job_token,
             'api_version': 4,
         }
-        if gitlab.__version__ >= LooseVersion('3.8.0'):
+        if LooseVersion(gitlab.__version__) >= LooseVersion('3.8.0'):
             kwargs['keep_base_url'] = True
         gitlab_instance = gitlab.Gitlab(**kwargs)
 

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -119,8 +119,13 @@ def gitlab_authentication(module, min_version=None):
             resp_data = resp.json()
             gitlab_oauth_token = resp_data["access_token"]
 
-        gitlab_instance = gitlab.Gitlab(url=gitlab_url, ssl_verify=verify, private_token=gitlab_token,
+        if gitlab.__version__ >= LooseVersion('3.8.0'):
+            gitlab_instance = gitlab.Gitlab(url=gitlab_url, ssl_verify=verify, private_token=gitlab_token,
                                         oauth_token=gitlab_oauth_token, job_token=gitlab_job_token, api_version=4, keep_base_url=True)
+        else:
+            gitlab_instance = gitlab.Gitlab(url=gitlab_url, ssl_verify=verify, private_token=gitlab_token,
+                                        oauth_token=gitlab_oauth_token, job_token=gitlab_job_token, api_version=4)
+
         gitlab_instance.auth()
     except (gitlab.exceptions.GitlabAuthenticationError, gitlab.exceptions.GitlabGetError) as e:
         module.fail_json(msg="Failed to connect to GitLab server: %s" % to_native(e))

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -119,12 +119,17 @@ def gitlab_authentication(module, min_version=None):
             resp_data = resp.json()
             gitlab_oauth_token = resp_data["access_token"]
 
+        kwargs = {
+            'url': gitlab_url,
+            'ssl_verify': verify,
+            'private_token': gitlab_token,
+            'oauth_token': gitlab_oauth_token,
+            'job_token': gitlab_job_token,
+            'api_version': 4,
+        }
         if gitlab.__version__ >= LooseVersion('3.8.0'):
-            gitlab_instance = gitlab.Gitlab(url=gitlab_url, ssl_verify=verify, private_token=gitlab_token,
-                                            oauth_token=gitlab_oauth_token, job_token=gitlab_job_token, api_version=4, keep_base_url=True)
-        else:
-            gitlab_instance = gitlab.Gitlab(url=gitlab_url, ssl_verify=verify, private_token=gitlab_token,
-                                            oauth_token=gitlab_oauth_token, job_token=gitlab_job_token, api_version=4)
+            kwargs['keep_base_url'] = True
+        gitlab_instance = gitlab.Gitlab(**kwargs)
 
         gitlab_instance.auth()
     except (gitlab.exceptions.GitlabAuthenticationError, gitlab.exceptions.GitlabGetError) as e:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Enabling this switch allows the the gitlab module to communicate over internal host names with the api.

gitlab.example.com <- Public Host / Ingress
gitlab.gitlab.svc:8080 <- Internal Service name in Kubernetes

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Feature Pull Request
- Refactoring Pull Request

##### COMPONENT NAME
gitlab
