### PR TITLE
Add cpanm option --with-recommends

### DIFF
--- a/changelogs/fragments/9554-add-cpanm-option_with-recommands.yml
+++ b/changelogs/fragments/9554-add-cpanm-option_with-recommands.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - cpanm - enable usage of option --with-recommands (https://github.com/ansible-collections/community.general/issues/9554).
+  - cpanm - enable usage of option ``--with-recommands`` (https://github.com/ansible-collections/community.general/issues/9554, https://github.com/ansible-collections/community.general/pull/9555).

--- a/changelogs/fragments/9554-add-cpanm-option_with-recommands.yml
+++ b/changelogs/fragments/9554-add-cpanm-option_with-recommands.yml
@@ -1,2 +1,3 @@
 minor_changes:
   - cpanm - enable usage of option ``--with-recommands`` (https://github.com/ansible-collections/community.general/issues/9554, https://github.com/ansible-collections/community.general/pull/9555).
+  - cpanm - enable usage of option ``--with-suggests`` (https://github.com/ansible-collections/community.general/issues/9554, https://github.com/ansible-collections/community.general/pull/9555).

--- a/changelogs/fragments/9554-add-cpanm-option_with-recommands.yml
+++ b/changelogs/fragments/9554-add-cpanm-option_with-recommands.yml
@@ -1,3 +1,0 @@
-minor_changes:
-  - cpanm - enable usage of option ``--with-recommands`` (https://github.com/ansible-collections/community.general/issues/9554, https://github.com/ansible-collections/community.general/pull/9555).
-  - cpanm - enable usage of option ``--with-suggests`` (https://github.com/ansible-collections/community.general/issues/9554, https://github.com/ansible-collections/community.general/pull/9555).

--- a/changelogs/fragments/9554-add-cpanm-option_with-recommands.yml
+++ b/changelogs/fragments/9554-add-cpanm-option_with-recommands.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cpanm - enable usage of option --with-recommands (https://github.com/ansible-collections/community.general/issues/9554).

--- a/changelogs/fragments/9554-add-cpanm-option_with-recommends-and-suggests.yml
+++ b/changelogs/fragments/9554-add-cpanm-option_with-recommends-and-suggests.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - cpanm - enable usage of option ``--with-recommends`` (https://github.com/ansible-collections/community.general/issues/9554, https://github.com/ansible-collections/community.general/pull/9555).
+  - cpanm - enable usage of option ``--with-suggests`` (https://github.com/ansible-collections/community.general/pull/9555).

--- a/plugins/modules/cpanm.py
+++ b/plugins/modules/cpanm.py
@@ -56,6 +56,12 @@ options:
       - Only install dependencies.
     type: bool
     default: false
+  withrecommands:
+    description:
+      - Installs dependencies declared as recommends per META spec.
+      - When these dependencies fail to install, cpanm continues the installation, since they're just recommendation/suggestion.
+    type: bool
+    default: false
   version:
     description:
       - Version specification for the perl module. When O(mode) is V(new), C(cpanm) version operators are accepted.
@@ -167,6 +173,7 @@ class CPANMinus(ModuleHelper):
             mirror=dict(type='str'),
             mirror_only=dict(type='bool', default=False),
             installdeps=dict(type='bool', default=False),
+            withrecommands=dict(type='bool', default=False),
             executable=dict(type='path'),
             mode=dict(type='str', default='new', choices=['compatibility', 'new']),
             name_check=dict(type='str')
@@ -181,6 +188,7 @@ class CPANMinus(ModuleHelper):
         mirror=cmd_runner_fmt.as_opt_val('--mirror'),
         mirror_only=cmd_runner_fmt.as_bool("--mirror-only"),
         installdeps=cmd_runner_fmt.as_bool("--installdeps"),
+        withrecommands=cmd_runner_fmt.as_bool("--with-recommands"),
         pkg_spec=cmd_runner_fmt.as_list(),
         cpanm_version=cmd_runner_fmt.as_fixed("--version"),
     )

--- a/plugins/modules/cpanm.py
+++ b/plugins/modules/cpanm.py
@@ -58,13 +58,17 @@ options:
     default: false
   install_recommendations:
     description:
-      - Installs dependencies declared as recommends per META spec.
+      - If V(true), installs dependencies declared as recommends per META spec.
+      - If V(false), it ensures the dependencies declared as recommends are not installed, overriding any decision made earlier in E(PERL_CPANM_OPT).
+      - If parameter is not set, C(cpanm) will use its existing defaults.
       - When these dependencies fail to install, cpanm continues the installation, since they are just recommendation.
     type: bool
     version_added: 10.3.0
   install_suggestions:
     description:
-      - Installs dependencies declared as suggested per META spec.
+      - If V(true), installs dependencies declared as suggests per META spec.
+      - If V(false), it ensures the dependencies declared as suggests are not installed, overriding any decision made earlier in E(PERL_CPANM_OPT).
+      - If parameter is not set, C(cpanm) will use its existing defaults.
       - When these dependencies fail to install, cpanm continues the installation, since they are just suggestion.
     type: bool
     version_added: 10.3.0

--- a/plugins/modules/cpanm.py
+++ b/plugins/modules/cpanm.py
@@ -56,12 +56,17 @@ options:
       - Only install dependencies.
     type: bool
     default: false
-  withrecommands:
+  install_recommendations:
     description:
       - Installs dependencies declared as recommends per META spec.
       - When these dependencies fail to install, cpanm continues the installation, since they are just recommendation.
     type: bool
-    default: false
+    version_added: 10.3.0
+  install_suggestions:
+    description:
+      - Installs dependencies declared as suggested per META spec.
+      - When these dependencies fail to install, cpanm continues the installation, since they are just suggestion.
+    type: bool
     version_added: 10.3.0
   version:
     description:
@@ -174,7 +179,8 @@ class CPANMinus(ModuleHelper):
             mirror=dict(type='str'),
             mirror_only=dict(type='bool', default=False),
             installdeps=dict(type='bool', default=False),
-            withrecommands=dict(type='bool', default=False),
+            install_recommendations=dict(type='bool'),
+            install_suggestions=dict(type='bool'),
             executable=dict(type='path'),
             mode=dict(type='str', default='new', choices=['compatibility', 'new']),
             name_check=dict(type='str')
@@ -189,7 +195,8 @@ class CPANMinus(ModuleHelper):
         mirror=cmd_runner_fmt.as_opt_val('--mirror'),
         mirror_only=cmd_runner_fmt.as_bool("--mirror-only"),
         installdeps=cmd_runner_fmt.as_bool("--installdeps"),
-        withrecommands=cmd_runner_fmt.as_bool("--with-recommands"),
+        install_recommendations=cmd_runner_fmt.as_bool("--with-recommends", "--without-recommends", ignore_none=True),
+        install_suggestions=cmd_runner_fmt.as_bool("--with-suggests", "--without-suggests", ignore_none=True),
         pkg_spec=cmd_runner_fmt.as_list(),
         cpanm_version=cmd_runner_fmt.as_fixed("--version"),
     )

--- a/plugins/modules/cpanm.py
+++ b/plugins/modules/cpanm.py
@@ -274,7 +274,16 @@ class CPANMinus(ModuleHelper):
                 return
             pkg_spec = self.sanitize_pkg_spec_version(v[pkg_param], v.version)
 
-        with self.runner(['notest', 'locallib', 'mirror', 'mirror_only', 'installdeps', 'pkg_spec'], output_process=process) as ctx:
+        with self.runner([
+            'notest',
+            'locallib',
+            'mirror',
+            'mirror_only',
+            'installdeps',
+            'install_recommendations',
+            'install_suggestions',
+            'pkg_spec'
+        ], output_process=process) as ctx:
             self.changed = ctx.run(pkg_spec=pkg_spec)
 
 

--- a/plugins/modules/cpanm.py
+++ b/plugins/modules/cpanm.py
@@ -59,9 +59,10 @@ options:
   withrecommands:
     description:
       - Installs dependencies declared as recommends per META spec.
-      - When these dependencies fail to install, cpanm continues the installation, since they're just recommendation/suggestion.
+      - When these dependencies fail to install, cpanm continues the installation, since they are just recommendation.
     type: bool
     default: false
+    version_added: 10.3.0
   version:
     description:
       - Version specification for the perl module. When O(mode) is V(new), C(cpanm) version operators are accepted.

--- a/tests/unit/plugins/modules/test_cpanm.yaml
+++ b/tests/unit/plugins/modules/test_cpanm.yaml
@@ -357,3 +357,43 @@
         cpanm (App::cpanminus) version 1.7047 (/usr/local/bin/cpanm)
         perl version 5.041005 (/usr/local/bin/perl)
       err: ""
+- id: install_dancer_with_recommends
+  input:
+    name: Dancer2
+    install_recommendations: true
+  output:
+    changed: true
+  mocks:
+    run_command:
+    - command: [/testbin/cpanm, --version]
+      environ: *env-def-true
+      rc: 0
+      out: |
+        cpanm (App::cpanminus) version 1.7047 (/usr/local/bin/cpanm)
+        perl version 5.041005 (/usr/local/bin/perl)
+      err: ""
+    - command: [/testbin/cpanm, --with-recommends, Dancer2]
+      environ: *env-def-true
+      rc: 0
+      out: ""
+      err: ""
+- id: install_dancer_with_suggests
+  input:
+    name: Dancer2
+    install_suggestions: true
+  output:
+    changed: true
+  mocks:
+    run_command:
+    - command: [/testbin/cpanm, --version]
+      environ: *env-def-true
+      rc: 0
+      out: |
+        cpanm (App::cpanminus) version 1.7047 (/usr/local/bin/cpanm)
+        perl version 5.041005 (/usr/local/bin/perl)
+      err: ""
+    - command: [/testbin/cpanm, --with-suggests, Dancer2]
+      environ: *env-def-true
+      rc: 0
+      out: ""
+      err: ""


### PR DESCRIPTION
Fix #9554

##### SUMMARY

Fixes #9554 

This PR aims to add the use of the option --with-recommands to cpanm module

```yaml
minor_changes:
  - cpanm - enable usage of option --with-recommands (https://github.com/ansible-collections/community.general/issues/9554).
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cpanm
