### PR TITLE
Implement #9572 Add parameter sudo to inventory plugin iocage

### DIFF
--- a/changelogs/fragments/9573-iocage-inventory-sudo.yml
+++ b/changelogs/fragments/9573-iocage-inventory-sudo.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - iocage inventory plugin - the new parameter ``sudo`` of the plugin lets the command ``iocage list -l`` to run as root on the iocage host. This is needed to get the IPv4 of a running DHCP jail (https://github.com/ansible-collections/community.general/issues/9572).
+  - iocage inventory plugin - the new parameter ``sudo`` of the plugin lets the command ``iocage list -l`` to run as root on the iocage host. This is needed to get the IPv4 of a running DHCP jail (https://github.com/ansible-collections/community.general/issues/9572, https://github.com/ansible-collections/community.general/pull/9573).

--- a/changelogs/fragments/9573-iocage-inventory-sudo.yml
+++ b/changelogs/fragments/9573-iocage-inventory-sudo.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - iocage inventory plugin - the new parameter ``sudo`` of the plugin lets the command ``iocage list -l`` to run as root on the iocage host. This is needed to get the IP4 of a running DHCP jail (https://github.com/ansible-collections/community.general/issues/9572).

--- a/changelogs/fragments/9573-iocage-inventory-sudo.yml
+++ b/changelogs/fragments/9573-iocage-inventory-sudo.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - iocage inventory plugin - the new parameter ``sudo`` of the plugin lets the command ``iocage list -l`` to run as root on the iocage host. This is needed to get the IP4 of a running DHCP jail (https://github.com/ansible-collections/community.general/issues/9572).
+  - iocage inventory plugin - the new parameter ``sudo`` of the plugin lets the command ``iocage list -l`` to run as root on the iocage host. This is needed to get the IPv4 of a running DHCP jail (https://github.com/ansible-collections/community.general/issues/9572).

--- a/plugins/inventory/iocage.py
+++ b/plugins/inventory/iocage.py
@@ -59,6 +59,7 @@ DOCUMENTATION = '''
               - This requires C(SETENV) sudoers tag.
             type: bool
             default: false
+            version_added: 10.3.0
         get_properties:
             description:
               - Get jails' properties.

--- a/plugins/inventory/iocage.py
+++ b/plugins/inventory/iocage.py
@@ -51,7 +51,7 @@ DOCUMENTATION = '''
               - Enable execution as root.
               - This requires passwordless sudo of the command C(iocage list*)
               - If O(env) is used C(SETENV) tag is needed.
-              - For example C(admin ALL=(ALL) NOPASSWD:SETENV: /usr/local/bin/iocage list*)
+              - For example C('admin ALL=(ALL) NOPASSWD:SETENV: /usr/local/bin/iocage list*')
             type: boolean
             default: false
         get_properties:

--- a/plugins/inventory/iocage.py
+++ b/plugins/inventory/iocage.py
@@ -57,7 +57,7 @@ DOCUMENTATION = '''
               - Preserve environment if O(sudo) is enabled.
               - This requires C(SETENV) sudoers tag.
             type: bool
-            default: true
+            default: false
         get_properties:
             description:
               - Get jails' properties.
@@ -65,7 +65,9 @@ DOCUMENTATION = '''
             type: bool
             default: false
         env:
-            description: O(user)'s environment on O(host).
+            description:
+              - O(user)'s environment on O(host).
+              - Enable O(sudo_preserve_env) if O(sudo) is enabled.
             type: dict
             default: {}
     notes:
@@ -107,6 +109,7 @@ plugin: community.general.iocage
 host: 10.1.0.73
 user: admin
 sudo: true
+sudo_preserve_env: true
 env:
   CRYPTOGRAPHY_OPENSSL_NO_LEGACY: 1
 

--- a/plugins/inventory/iocage.py
+++ b/plugins/inventory/iocage.py
@@ -50,9 +50,14 @@ DOCUMENTATION = '''
             description:
               - Enable execution as root.
               - This requires passwordless sudo of the command C(iocage list*)
-              - If O(env) is used C(SETENV) tag is needed.
             type: bool
             default: false
+        sudo_preserve_env:
+            description:
+              - Preserve environment if O(sudo) is enabled.
+              - This requires C(SETENV) sudoers tag.
+            type: bool
+            default: true
         get_properties:
             description:
               - Get jails' properties.
@@ -214,6 +219,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def get_inventory(self, path):
         host = self.get_option('host')
         sudo = self.get_option('sudo')
+        sudo_preserve_env = self.get_option('sudo_preserve_env')
         env = self.get_option('env')
         get_properties = self.get_option('get_properties')
 
@@ -230,7 +236,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         cmd_list = cmd.copy()
         if sudo:
             cmd_list.append('sudo')
-            if env:
+            if sudo_preserve_env:
                 cmd_list.append('--preserve-env')
         cmd_list.append(self.IOCAGE)
         cmd_list.append('list')

--- a/plugins/inventory/iocage.py
+++ b/plugins/inventory/iocage.py
@@ -51,7 +51,6 @@ DOCUMENTATION = '''
               - Enable execution as root.
               - This requires passwordless sudo of the command C(iocage list*)
               - If O(env) is used C(SETENV) tag is needed.
-              - For example C('admin ALL=(ALL) NOPASSWD:SETENV: /usr/local/bin/iocage list*')
             type: boolean
             default: false
         get_properties:
@@ -98,6 +97,7 @@ env:
 
 ---
 # execute as root
+# sudoers example 'admin ALL=(ALL) NOPASSWD:SETENV: /usr/local/bin/iocage list*'
 plugin: community.general.iocage
 host: 10.1.0.73
 user: admin

--- a/plugins/inventory/iocage.py
+++ b/plugins/inventory/iocage.py
@@ -49,7 +49,7 @@ DOCUMENTATION = '''
         sudo:
             description:
               - Enable execution as root.
-              - This requires passwordless sudo of the command C(iocage list*)
+              - This requires passwordless sudo of the command C(iocage list*).
             type: bool
             default: false
         sudo_preserve_env:

--- a/plugins/inventory/iocage.py
+++ b/plugins/inventory/iocage.py
@@ -52,6 +52,7 @@ DOCUMENTATION = '''
               - This requires passwordless sudo of the command C(iocage list*).
             type: bool
             default: false
+            version_added: 10.3.0
         sudo_preserve_env:
             description:
               - Preserve environment if O(sudo) is enabled.

--- a/plugins/inventory/iocage.py
+++ b/plugins/inventory/iocage.py
@@ -51,13 +51,13 @@ DOCUMENTATION = '''
               - Enable execution as root.
               - This requires passwordless sudo of the command C(iocage list*)
               - If O(env) is used C(SETENV) tag is needed.
-            type: boolean
+            type: bool
             default: false
         get_properties:
             description:
               - Get jails' properties.
                 Creates dictionary C(iocage_properties) for each added host.
-            type: boolean
+            type: bool
             default: false
         env:
             description: O(user)'s environment on O(host).


### PR DESCRIPTION
##### SUMMARY
Implement #9572 Add parameter sudo to inventory plugin iocage.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
iocage.py

##### ADDITIONAL INFORMATION
Tested in Ubuntu 24.04

```bash
shell> ansible-test units --venv --python 3.12 tests/unit/plugins/inventory/test_iocage.py
Installing requirements for Python 3.12 [venv]
Unit test controller with Python 3.12
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.4, pluggy-1.5.0
rootdir: /export/scratch/collections/ansible_collections/community/general
configfile: ../../../../../../tmp/ansible-test-h6dmhd94/ansible_test/_data/pytest/config/default.ini
plugins: mock-3.14.0, xdist-3.6.1
created: 4/4 workers
4 workers [5 items]

.....                                                                    [100%]
- generated xml file: /export/scratch/collections/ansible_collections/community/general/tests/output/junit/python3.12-controller-units.xml -
============================== 5 passed in 1.94s ===============================
```
