### PR TITLE
redhat_subscription: stop manual unsubscribing on unregistration

### DIFF
--- a/changelogs/fragments/9578-redhat_subscription-no-remove-on-unregister.yml
+++ b/changelogs/fragments/9578-redhat_subscription-no-remove-on-unregister.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - |
+    redhat_subscription - do not try to unsubscribe (i.e. remove subscriptions)
+    when unregistering a system: newer versions of subscription-manager, as
+    available in EL 10 and Fedora 41+, do not support entitlements anymore, and
+    thus unsubscribing will fail
+    (https://github.com/ansible-collections/community.general/pull/9578).

--- a/plugins/modules/redhat_subscription.py
+++ b/plugins/modules/redhat_subscription.py
@@ -1119,7 +1119,6 @@ def main():
             module.exit_json(changed=False, msg="System already unregistered.")
         else:
             try:
-                rhsm.unsubscribe()
                 rhsm.unregister()
             except Exception as e:
                 module.fail_json(msg="Failed to unregister: %s" % to_native(e))

--- a/tests/unit/plugins/modules/test_redhat_subscription.py
+++ b/tests/unit/plugins/modules/test_redhat_subscription.py
@@ -200,11 +200,6 @@ TEST_CASES = [
                     (0, 'system identity: b26df632-25ed-4452-8f89-0308bfd167cb', '')
                 ),
                 (
-                    ['/testbin/subscription-manager', 'remove', '--all'],
-                    {'check_rc': True},
-                    (0, '', '')
-                ),
-                (
                     ['/testbin/subscription-manager', 'unregister'],
                     {'check_rc': True},
                     (0, '', '')


### PR DESCRIPTION
##### SUMMARY

Unregistering a system also drops all the resources for it automatically, so there is no need to manually unsubscribing (which actually means removing all the subscriptions).

In addition to that, newer versions of subscription-manager drop all the support for entitlements, so the "remove" subcommand (used by unsubscribe()) does not exist anymore, and thus the unregistration fails with those versions.

This fixes the registration on EL 10 systems, and Fedora 41 and greater.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

redhat_subscription