### PR TITLE
create new proxmox_backup_schedule module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1148,6 +1148,8 @@ files:
     maintainers: IamLunchbox
   $modules/proxmox_backup_info.py:
     maintainers: raoufnezhad mmayabi
+  $modules/proxmox_backup_schedule.py:
+    maintainers: raoufnezhad mmayabi
   $modules/proxmox_nic.py:
     maintainers: Kogelvis krauthosting
   $modules/proxmox_node_info.py:

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -17,7 +17,8 @@ action_groups:
   proxmox:
     - proxmox
     - proxmox_backup
-    - proxmox_backup_info    
+    - proxmox_backup_info
+    - proxmox_backup_schedule
     - proxmox_disk
     - proxmox_domain_info
     - proxmox_group_info

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -39,8 +39,8 @@ options:
     type: str
   state:
     description:
-        - If V(present), the module will update backup job with new VM ID.
-        - If V(absent), the module will remove the VM ID from all backup jobs where the VM ID has existed.
+        - If V(present), ensure that VM is present in the backup job on defined O(backup_id).
+        - If V(absent), ensure that VM is not present in the backup job if O(backup_id) is defined, and otherwise, it should not exist in any of the backup jobs.
     required: true
     choices: ["present", "absent"]
     type: str
@@ -53,7 +53,7 @@ extends_documentation_fragment:
 """
 
 EXAMPLES = """
-- name: Scheduling VM Backups based on VM name
+- name: Ensure that VM is present in the backup job
   proxmox_backup_schedule:
     api_user: 'myUser@pam'
     api_password: '*******'
@@ -62,7 +62,7 @@ EXAMPLES = """
     backup_id: 'backup-b2adffdc-316e'
     state: 'present'
 
-- name: Scheduling VM Backups based on VM ID
+- name: Ensure that vmid is present in the backup job
   proxmox_backup_schedule:
     api_user: 'myUser@pam'
     api_password: '*******'
@@ -71,7 +71,7 @@ EXAMPLES = """
     backup_id: 'backup-b2adffdc-316e'
     state: 'present'
 
-- name: Removing backup setting based on VM name
+- name: Ensure that there is no scheduled backup for VM name within all backup jobs
   proxmox_backup_schedule:
     api_user: 'myUser@pam'
     api_password: '*******'
@@ -79,7 +79,7 @@ EXAMPLES = """
     vm_name: 'VM Name'
     state: 'absent'
 
-- name: Removing backup setting based on VM ID
+- name: Ensure that there is no scheduled backup for vmid within all backup jobs
   proxmox_backup_schedule:
     api_user: 'myUser@pam'
     api_password: '*******'
@@ -87,7 +87,7 @@ EXAMPLES = """
     vm_id: 'VM ID'
     state: 'absent'
 
-- name: Removing backup setting based on VM name from specific backup job
+- name: Ensure that there is no scheduled backup for VM within specific backup job
   proxmox_backup_schedule:
     api_user: 'myUser@pam'
     api_password: '*******'
@@ -96,7 +96,7 @@ EXAMPLES = """
     backup_id: 'backup-b2adffdc-316e'
     state: 'absent'
 
-- name: Removing backup setting based on VM ID from specific backup job
+- name: Ensure that there is no scheduled backup for vmid within specific backup job
   proxmox_backup_schedule:
     api_user: 'myUser@pam'
     api_password: '*******'

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -40,7 +40,7 @@ options:
   state:
     description:
         - If V(present), ensure that VM is present in the backup job on defined O(backup_id).
-        - If V(absent), ensure that VM is not present in the backup job if O(backup_id) is defined, and otherwise, it should not exist in any of the backup jobs.
+        - If V(absent), ensure that VM is not present in the backup job if O(backup_id) is defined and otherwise, it should not exist in any of the backup jobs.
     required: true
     choices: ["present", "absent"]
     type: str

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -107,13 +107,6 @@ EXAMPLES = """
 """
 
 RETURN = """
----
-changed:
-  description:
-    - If V(present), the backup_schedule will return True after adding the VM ID to the backup job.
-    - If V(absent), the backup_schedule will return True after removing it from the backup job.
-  returned: always, but can be empty
-  type: bool
 """
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -13,9 +13,9 @@ DOCUMENTATION = """
 ---
 module: proxmox_backup_schedule
 
-short_description: Scheduling VM backups and removing them.
+short_description: Schedule VM backups and remove them
 
-version_added: 10.3.0
+version_added: 10.5.0
 
 description: The module modifies backup jobs such as set or delete C(vmid).
 
@@ -108,12 +108,12 @@ EXAMPLES = """
 
 RETURN = """
 ---
-backup_schedule:
+changed:
   description:
-    - If V(present), the backup_schedule will return True after adding the VM ID to the backup job.
-    - If V(absent), the backup_schedule will return True after removing it from the backup job.
+    - If V(present), the changed will return True after adding the VM ID to the backup job.
+    - If V(absent), the changed will return True after removing it from the backup job.
   returned: always, but can be empty
-  type: raw
+  type: bool
 """
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
@@ -246,12 +246,12 @@ def main():
         vm_id = proxmox.vmname_2_vmid(vm_name)
 
     if state == 'present':
-        result['backup_schedule'] = proxmox.backup_present(vm_id, backup_id)
+        backup_schedule = proxmox.backup_present(vm_id, backup_id)
 
     if state == 'absent':
-        result['backup_schedule'] = proxmox.backup_absent(vm_id, backup_id)
+        backup_schedule = proxmox.backup_absent(vm_id, backup_id)
 
-    if result['backup_schedule']:
+    if backup_schedule:
         result['changed'] = True
         result['message'] = 'The backup schedule has been changed successfully.'
     else:

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -90,15 +90,17 @@ EXAMPLES = """
 
 RETURN = """
 ---
-backup_schedule:
-  description:
-    - When backup_action is 'update_vmid', the backup_schedule will return True after successfully adding the VM ID to the backup job.
-    - When backup_action is 'delete_vmid', the backup_schedule will return a list of backup job IDs where the VM ID has been removed.
-  returned: always, but can be empty
-  type: bool | list
-  sample:
-    - True
-    - ['backup-job-id1', 'backup-job-id2']
+update_result:
+  description: True if the VM ID was successfully added to the backup job.
+  returned: when backup_action is 'update_vmid'
+  type: bool
+  sample: true
+
+delete_result:
+  description: A list of backup job IDs where the VM ID has been removed.
+  returned: when backup_action is 'delete_vmid'
+  type: list
+  sample: ['backup-job-id1', 'backup-job-id2']
 """
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2025 Marzieh Raoufnezhad <raoufnezhad@gmail.com>
-# Copyright (c) 2024 Maryam Mayabi <mayabi.ahm at gmail.com>
+# Copyright (c) 2025 Maryam Mayabi <mayabi.ahm at gmail.com>
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -13,7 +13,7 @@ DOCUMENTATION = """
 ---
 module: proxmox_backup_schedule
 
-short_description: Schedule VM backups and remove them
+short_description: Schedule VM backups and removing them
 
 version_added: 10.5.0
 
@@ -108,12 +108,12 @@ EXAMPLES = """
 
 RETURN = """
 ---
-changed:
+backup_schedule:
   description:
-    - If V(present), the changed will return True after adding the VM ID to the backup job.
-    - If V(absent), the changed will return True after removing it from the backup job.
+    - If V(present), the backup_schedule will return True after adding the VM ID to the backup job.
+    - If V(absent), the backup_schedule will return True after removing it from the backup job.
   returned: always, but can be empty
-  type: bool
+  type: raw
 """
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
@@ -246,13 +246,14 @@ def main():
         vm_id = proxmox.vmname_2_vmid(vm_name)
 
     if state == 'present':
-        backup_schedule = proxmox.backup_present(vm_id, backup_id)
+        backup_schedule_result = proxmox.backup_present(vm_id, backup_id)
 
     if state == 'absent':
-        backup_schedule = proxmox.backup_absent(vm_id, backup_id)
+        backup_schedule_result = proxmox.backup_absent(vm_id, backup_id)
 
-    if backup_schedule:
-        result['changed'] = True
+    if backup_schedule_result:
+        result['changed'] = backup_schedule_result
+        result['vm_id'] = vm_id
         result['message'] = 'The backup schedule has been changed successfully.'
     else:
         result['message'] = 'The backup schedule did not change anything.'

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -42,7 +42,7 @@ options:
         - If V(update_vmid), the module will update backup job with new VM ID.
         - If V(delete_vmid), the module will remove the VM ID from all backup jobs where the VM ID has existed.
     required: true
-    choices: [update_vmid, delete_vmid]
+    choices: ["update_vmid", "delete_vmid"]
     type: str
 
 extends_documentation_fragment:
@@ -180,7 +180,7 @@ def main():
         vm_name=dict(type='str'),
         vm_id=dict(type='str'),
         backup_id=dict(type='str'),
-        backup_action=dict(type='str', required=True)
+        backup_action=dict(choices=['update_vmid', 'delete_vmid'], required=True)
     )
     args.update(backup_schedule_args)
 

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -95,8 +95,10 @@ backup_schedule:
     - If V(update_vmid), the backup_schedule will return True after adding the VM ID to the backup job.
     - If V(delete_vmid), the backup_schedule will return a list of backup job IDs where the VM ID has existed after removing it.
   returned: always, but can be empty
-  type: any
-  sample: "true or ['backup-job-id1', 'backup-job-id2']"
+  type: raw
+  sample:
+    - true
+    - ['backup-job-id1', 'backup-job-id2']
 """
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -90,17 +90,13 @@ EXAMPLES = """
 
 RETURN = """
 ---
-update_result:
-  description: True if the VM ID was successfully added to the backup job.
-  returned: when backup_action is 'update_vmid'
-  type: bool
-  sample: true
-
-delete_result:
-  description: A list of backup job IDs where the VM ID has been removed.
-  returned: when backup_action is 'delete_vmid'
-  type: list
-  sample: ['backup-job-id1', 'backup-job-id2']
+backup_schedule:
+  description:
+    - If V(update_vmid), the backup_schedule will return True after adding the VM ID to the backup job.
+    - If V(delete_vmid), the backup_schedule will return a list of backup job IDs where the VM ID has existed after removing it.
+  returned: always, but can be empty
+  type: any
+  sample: "true or ['backup-job-id1', 'backup-job-id2']"
 """
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -1,0 +1,227 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2025 Marzieh Raoufnezhad <raoufnezhad@gmail.com>
+# Copyright (c) 2024 Maryam Mayabi <mayabi.ahm at gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: proxmox_backup_schedule
+
+short_description: Scheduling VM backups and removing it.
+
+version_added: 10.3.0
+
+description: The module modifies backup jobs such as set or delete C(vmid).
+
+author:
+  - "Marzieh Raoufnezhad (@raoufnezhad) <raoufnezhad@gmail.com>"
+  - "Maryam Mayabi (@mmayabi) <mayabi.ahm@gmail.com>"
+
+options:
+  vm_name:
+    description:
+      - The name of the Proxmox VM.
+      - Mutually exclusive with O(vm_id).
+    type: str
+  vm_id:
+    description:
+      - The ID of the Proxmox VM.
+      - Mutually exclusive with O(vm_name).
+    type: str
+  backup_id:
+    description: The backup job ID.
+    type: str
+  backup_action:
+    description:
+        - If V(update_vmid), the module will update backup job with new VM ID.
+        - If V(delete_vmid), the module will remove the VM ID from all backup jobs where the VM ID has existed.
+    required: true
+    choices: [update_vmid, delete_vmid]
+    type: str
+
+extends_documentation_fragment:
+  - community.general.proxmox.documentation
+  - community.general.attributes
+  - community.general.attributes.info_module
+  - community.general.proxmox.actiongroup_proxmox
+"""
+
+EXAMPLES = """
+- name: Scheduling VM Backups based on VM name.
+  proxmox_backup_schedule:
+    api_user: 'myUser@pam'
+    api_password: '*******'
+    api_host: '192.168.20.20'
+    vm_name: 'VM Name'
+    backup_id: 'backup-b2adffdc-316e'
+    backup_action: 'update_vmid'
+
+- name: Scheduling VM Backups based on VM ID.
+  proxmox_backup_schedule:
+    api_user: 'myUser@pam'
+    api_password: '*******'
+    api_host: '192.168.20.20'
+    vm_id: 'VM ID'
+    backup_id: 'backup-b2adffdc-316e'
+    backup_action: 'update_vmid'
+
+- name: Removing backup setting based on VM name.
+  proxmox_backup_schedule:
+    api_user: 'myUser@pam'
+    api_password: '*******'
+    api_host: '192.168.20.20'
+    vm_name: 'VM Name'
+    backup_action: 'delete_vmid'
+
+- name: Removing backup setting based on VM ID.
+  proxmox_backup_schedule:
+    api_user: 'myUser@pam'
+    api_password: '*******'
+    api_host: '192.168.20.20'
+    vm_id: 'VM ID'
+    backup_action: 'delete_vmid'
+"""
+
+RETURN = """
+---
+  backup_schedule:
+  description:
+    - When backup_action is 'update_vmid', the backup_schedule will return True after successfully adding the VM ID to the backup job.
+    - When backup_action is 'delete_vmid', the backup_schedule will return a list of backup job IDs where the VM ID has been removed.
+  returned: always, but can be empty
+  type: bool | list
+  sample:
+    - True
+    - ['backup-job-id1', 'backup-job-id2']
+"""
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible_collections.community.general.plugins.module_utils.proxmox import (
+    proxmox_auth_argument_spec, ProxmoxAnsible, HAS_PROXMOXER, PROXMOXER_IMP_ERR)
+
+
+class ProxmoxSetVMBackupAnsible(ProxmoxAnsible):
+    # Getting backup sections
+    def get_cluster_bklist(self):
+        try:
+            backupSections = self.proxmox_api.cluster.backup.get()
+        except Exception as e:
+            self.module.fail_json(msg="Getting backup sections failed: %s" % e)
+        return backupSections
+
+    def get_cluster_specific_bkjobid(self, backup_id):
+        try:
+            specificBackupID = self.proxmox_api.cluster.backup.get(backup_id)
+        except Exception as e:
+            self.module.fail_json(msg="Getting specific backup ID failed: %s" % e)
+        return specificBackupID
+
+    def set_vmid_backup(self, backup_id, bk_id_vmids):
+        try:
+            self.proxmox_api.cluster.backup.put(backup_id, vmid=bk_id_vmids)
+        except Exception as e:
+            self.module.fail_json(msg="Setting vmid backup failed: %s" % e)
+        return
+
+    def get_vms_list(self):
+        try:
+            vms = self.proxmox_api.cluster.resources.get(type='vm')
+        except Exception as e:
+            self.module.fail_json(msg="Getting vms info from cluster failed: %s" % e)
+        return vms
+
+    # convert vm name to vm ID
+    def vmname_2_vmid(self, vmname):
+        vmInfo = self.get_vms_list()
+        vms = [vm for vm in vmInfo if vm['name'] == vmname]
+        return (vms[0]['vmid'])
+
+    # add vmid to backup job
+    def backup_update_vmid(self, vm_id, backup_id):
+        bk_id_info = self.get_cluster_specific_bkjobid(backup_id)
+
+        # If bk_id_info is a list, get the first item (assuming there's only one backup job returned)
+        if isinstance(bk_id_info, list):
+            bk_id_info = bk_id_info[0]  # Access the first item in the list
+        vms_id = bk_id_info['vmid'].split(',')
+        if vm_id not in vms_id:
+            bk_id_vmids = bk_id_info['vmid'] + ',' + str(vm_id)
+            self.set_vmid_backup(backup_id, bk_id_vmids)
+            return True
+
+    # delete vmid from backup job
+    def backup_delete_vmid(self, vm_id):
+        bkID_delvm = []
+        backupList = self.get_cluster_bklist()
+        for backupItem in backupList:
+            vmids = list(backupItem['vmid'].split(','))
+            if vm_id in vmids:
+                if len(vmids) > 1:
+                    vmids.remove(vm_id)
+                    new_vmids = ','.join(map(str, vmids))
+                    self.set_vmid_backup(backupItem['id'], new_vmids)
+                    bkID_delvm.append(backupItem['id'])
+                else:
+                    self.module.fail_json(msg="No more than one vmid is assigned to %s. You just can remove job." % backupItem['id'])
+        return bkID_delvm
+
+
+# main function
+def main():
+    # Define module args
+    args = proxmox_auth_argument_spec()
+    backup_schedule_args = dict(
+        vm_name=dict(type='str'),
+        vm_id=dict(type='str'),
+        backup_id=dict(type='str'),
+        backup_action=dict(type='str', required=True)
+    )
+    args.update(backup_schedule_args)
+
+    module = AnsibleModule(
+        argument_spec=args,
+        mutually_exclusive=[('vm_id', 'vm_name')],
+        supports_check_mode=True
+    )
+
+    # Define (init) result value
+    result = dict(
+        changed=False,
+        message=''
+    )
+
+    # Check if proxmoxer exist
+    if not HAS_PROXMOXER:
+        module.fail_json(msg=missing_required_lib('proxmoxer'), exception=PROXMOXER_IMP_ERR)
+
+    # Start to connect to proxmox to get backup data
+    proxmox = ProxmoxSetVMBackupAnsible(module)
+    vm_name = module.params['vm_name']
+    vm_id = module.params['vm_id']
+    backup_id = module.params['backup_id']
+    backup_action = module.params['backup_action']
+
+    if vm_name:
+        vm_id = proxmox.vmname_2_vmid(vm_name)
+
+    if backup_action == 'update_vmid':
+        result['backup_schedule'] = proxmox.backup_update_vmid(vm_id, backup_id)
+
+    if backup_action == 'delete_vmid':
+        result['backup_schedule'] = proxmox.backup_delete_vmid(vm_id)
+
+    if result['backup_schedule']:
+        result['changed'] = True
+        result['message'] = 'The backup schedule has been changed successfully'
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -90,7 +90,7 @@ EXAMPLES = """
 
 RETURN = """
 ---
-  backup_schedule:
+backup_schedule:
   description:
     - When backup_action is 'update_vmid', the backup_schedule will return True after successfully adding the VM ID to the backup job.
     - When backup_action is 'delete_vmid', the backup_schedule will return a list of backup job IDs where the VM ID has been removed.

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -108,12 +108,12 @@ EXAMPLES = """
 
 RETURN = """
 ---
-backup_schedule:
+changed:
   description:
     - If V(present), the backup_schedule will return True after adding the VM ID to the backup job.
     - If V(absent), the backup_schedule will return True after removing it from the backup job.
   returned: always, but can be empty
-  type: raw
+  type: bool
 """
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
@@ -246,12 +246,12 @@ def main():
         vm_id = proxmox.vmname_2_vmid(vm_name)
 
     if state == 'present':
-        result['backup_schedule'] = proxmox.backup_present(vm_id, backup_id)
+        backup_schedule = proxmox.backup_present(vm_id, backup_id)
 
     if state == 'absent':
-        result['backup_schedule'] = proxmox.backup_absent(vm_id, backup_id)
+        backup_schedule = proxmox.backup_absent(vm_id, backup_id)
 
-    if result['backup_schedule']:
+    if backup_schedule:
         result['changed'] = True
         result['message'] = 'The backup schedule has been changed successfully.'
     else:

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -246,14 +246,13 @@ def main():
         vm_id = proxmox.vmname_2_vmid(vm_name)
 
     if state == 'present':
-        backup_schedule_result = proxmox.backup_present(vm_id, backup_id)
+        result['backup_schedule'] = proxmox.backup_present(vm_id, backup_id)
 
     if state == 'absent':
-        backup_schedule_result = proxmox.backup_absent(vm_id, backup_id)
+        result['backup_schedule'] = proxmox.backup_absent(vm_id, backup_id)
 
-    if backup_schedule_result:
-        result['changed'] = backup_schedule_result
-        result['vm_id'] = vm_id
+    if result['backup_schedule']:
+        result['changed'] = True
         result['message'] = 'The backup schedule has been changed successfully.'
     else:
         result['message'] = 'The backup schedule did not change anything.'

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -150,7 +150,7 @@ class ProxmoxSetVMBackupAnsible(ProxmoxAnsible):
         if isinstance(bk_id_info, list):
             bk_id_info = bk_id_info[0]  # Access the first item in the list
         vms_id = bk_id_info['vmid'].split(',')
-        if vm_id not in vms_id:
+        if str(vm_id) not in vms_id:
             bk_id_vmids = bk_id_info['vmid'] + ',' + str(vm_id)
             self.set_vmid_backup(backup_id, bk_id_vmids)
             return True
@@ -164,9 +164,9 @@ class ProxmoxSetVMBackupAnsible(ProxmoxAnsible):
             if isinstance(bk_id_info, list):
                 bk_id_info = bk_id_info[0]  # Access the first item in the list
             vmids = bk_id_info['vmid'].split(',')
-            if vm_id in vmids:
+            if str(vm_id) in vmids:
                 if len(vmids) > 1:
-                    vmids.remove(vm_id)
+                    vmids.remove(str(vm_id))
                     new_vmids = ','.join(map(str, vmids))
                     self.set_vmid_backup(bk_id_info['id'], new_vmids)
                     return True
@@ -178,9 +178,9 @@ class ProxmoxSetVMBackupAnsible(ProxmoxAnsible):
             backupList = self.get_cluster_bklist()
             for backupItem in backupList:
                 vmids = list(backupItem['vmid'].split(','))
-                if vm_id in vmids:
+                if str(vm_id) in vmids:
                     if len(vmids) > 1:
-                        vmids.remove(vm_id)
+                        vmids.remove(str(vm_id))
                         new_vmids = ','.join(map(str, vmids))
                         self.set_vmid_backup(backupItem['id'], new_vmids)
                         bkID_delvm.append(backupItem['id'])

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -112,7 +112,7 @@ backup_schedule:
   description:
     - If V(present), the backup_schedule will return True after adding the VM ID to the backup job.
     - If V(absent), the backup_schedule will return True after removing it from the backup job.
-  returned: always, but can be empty  
+  returned: always, but can be empty
 """
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -113,6 +113,7 @@ backup_schedule:
     - If V(present), the backup_schedule will return True after adding the VM ID to the backup job.
     - If V(absent), the backup_schedule will return True after removing it from the backup job.
   returned: always, but can be empty
+  type: raw
 """
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib

--- a/plugins/modules/proxmox_backup_schedule.py
+++ b/plugins/modules/proxmox_backup_schedule.py
@@ -86,6 +86,24 @@ EXAMPLES = """
     api_host: '192.168.20.20'
     vm_id: 'VM ID'
     state: 'absent'
+
+- name: Removing backup setting based on VM name from specific backup job
+  proxmox_backup_schedule:
+    api_user: 'myUser@pam'
+    api_password: '*******'
+    api_host: '192.168.20.20'
+    vm_name: 'VM Name'
+    backup_id: 'backup-b2adffdc-316e'
+    state: 'absent'
+
+- name: Removing backup setting based on VM ID from specific backup job
+  proxmox_backup_schedule:
+    api_user: 'myUser@pam'
+    api_password: '*******'
+    api_host: '192.168.20.20'
+    vm_id: 'VM ID'
+    backup_id: 'backup-b2adffdc-316e'
+    state: 'absent'
 """
 
 RETURN = """
@@ -93,12 +111,8 @@ RETURN = """
 backup_schedule:
   description:
     - If V(present), the backup_schedule will return True after adding the VM ID to the backup job.
-    - If V(absent), the backup_schedule will return a list of backup job IDs where the VM ID has existed after removing it.
-  returned: always, but can be empty
-  type: raw
-  sample:
-    - true
-    - ['backup-job-id1', 'backup-job-id2']
+    - If V(absent), the backup_schedule will return True after removing it from the backup job.
+  returned: always, but can be empty  
 """
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -132,7 +132,7 @@ RESOURCE_LIST = [
 ]
 
 BACKUP_JOBS = [
-{
+    {
         "type": "vzdump",
         "id": "backup-001",
         "storage": "local",

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -183,23 +183,23 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
 
     def test_module_fail_when_required_args_missing(self):
         with pytest.raises(AnsibleFailJson) as exc_info:
-            set_module_args({})
-            self.module.main()
+            with set_module_args({}):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["msg"] == "missing required arguments: api_host, api_user, state"
 
     def test_update_vmid_in_backup(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
-            set_module_args({
+           with set_module_args({
                 'api_host': 'proxmoxhost',
                 'api_user': 'root@pam',
                 'api_password': 'supersecret',
                 'vm_name': 'test05',
                 'backup_id': 'backup-001',
                 'state': 'present'
-            })
-            self.module.main()
+            }):
+                self.module.main()
 
         result = exc_info.value.args[0]
 
@@ -208,14 +208,14 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
 
     def test_delete_vmid_from_backup(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
-            set_module_args({
+            with set_module_args({
                 'api_host': 'proxmoxhost',
                 'api_user': 'root@pam',
                 'api_password': 'supersecret',
                 'vm_id': 101,
                 'state': 'absent'
-            })
-            self.module.main()
+            }):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result['changed'] is True

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -158,19 +158,6 @@ BACKUP_JOBS = [
     }
 ]
 
-BACKUP_JOB_SPECIFIC_BKID = {
-    "enabled": 1,
-    "id": "backup-001",
-    "mailnotification": "always",
-    "mode": "snapshot",
-    "compress": "zstd",
-    "notes-template": "{{guestname}}",
-    "schedule": "06,18:30",
-    "storage": "local",
-    "type": "vzdump",
-    "vmid": "100,101"
-}
-
 
 class TestProxmoxBackupScheduleModule(ModuleTestCase):
     def setUp(self):
@@ -213,7 +200,7 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
             })
             self.module.main()
         result = exc_info.value.args[0]
-        assert result['changed'] is True
+        assert result['changed'] == True
 
     def test_delete_vmid_from_backup(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
@@ -226,7 +213,7 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
             })
             self.module.main()
         result = exc_info.value.args[0]
-        assert result['changed'] is True
+        assert result['changed'] == True
 
 
 if __name__ == '__main__':

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -132,7 +132,7 @@ RESOURCE_LIST = [
 ]
 
 BACKUP_JOBS = [
-    {
+{
         "type": "vzdump",
         "id": "backup-001",
         "storage": "local",
@@ -200,33 +200,35 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
         assert result["msg"] == "missing required arguments: api_host, api_user, state"
 
     def test_update_vmid_in_backup(self):
-        with pytest.raises(AnsibleExitJson) as exc_info:
-            set_module_args({
-                'api_host': 'proxmoxhost',
-                'api_user': 'root@pam',
-                'api_password': 'supersecret',
-                'vm_name': 'test05',
-                'backup_id': 'backup-001',
-                'state': 'present'
-            })
-            self.module.main()
+        with patch('builtins.input', return_value='mocked input'):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                set_module_args({
+                    'api_host': 'proxmoxhost',
+                    'api_user': 'root@pam',
+                    'api_password': 'supersecret',
+                    'vm_name': 'test05',
+                    'backup_id': 'backup-001',
+                    'state': 'present'
+                })
+                self.module.main()
 
-        result = exc_info.value.args[0]
-        assert result['changed'] is True
+            result = exc_info.value.args[0]
+            assert result['changed'] is True
 
     def test_delete_vmid_from_backup(self):
-        with pytest.raises(AnsibleExitJson) as exc_info:
-            set_module_args({
-                'api_host': 'proxmoxhost',
-                'api_user': 'root@pam',
-                'api_password': 'supersecret',
-                'vm_id': '101',
-                'state': 'absent'
-            })
-            self.module.main()
+        with patch('builtins.input', return_value='mocked input'):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                set_module_args({
+                    'api_host': 'proxmoxhost',
+                    'api_user': 'root@pam',
+                    'api_password': 'supersecret',
+                    'vm_id': '101',
+                    'state': 'absent'
+                })
+                self.module.main()
 
-        result = exc_info.value.args[0]
-        assert result['changed'] is True
+            result = exc_info.value.args[0]
+            assert result['changed'] is True
 
 
 if __name__ == '__main__':

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -171,9 +171,7 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
             RESOURCE_LIST
         )
         self.connect_mock.return_value.cluster.backup.get.side_effect = (
-            lambda backup_id=None: BACKUP_JOBS if backup_id is None else [
-                job for job in BACKUP_JOBS if job['id'] == backup_id
-            ]
+            lambda backup_id=None: BACKUP_JOBS if backup_id is None else [job for job in BACKUP_JOBS if job['id'] == backup_id]
         )
 
     def tearDown(self):
@@ -189,35 +187,36 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
         assert result["msg"] == "missing required arguments: api_host, api_user, state"
 
     def test_update_vmid_in_backup(self):
-        with patch('builtins.input', return_value='mocked input'):
-            with pytest.raises(AnsibleExitJson) as exc_info:
-                set_module_args({
-                    'api_host': 'proxmoxhost',
-                    'api_user': 'root@pam',
-                    'api_password': 'supersecret',
-                    'vm_name': 'test05',
-                    'backup_id': 'backup-001',
-                    'state': 'present'
-                })
-                self.module.main()
+        with pytest.raises(AnsibleExitJson) as exc_info:
+            set_module_args({
+                'api_host': 'proxmoxhost',
+                'api_user': 'root@pam',
+                'api_password': 'supersecret',
+                'vm_name': 'test05',
+                'backup_id': 'backup-001',
+                'state': 'present'
+            })
+            self.module.main()
 
-            result = exc_info.value.args[0]
-            assert result['changed'] is True
+        result = exc_info.value.args[0]
+
+        assert result['changed'] is True
+        assert result['vm_id'] == 105
 
     def test_delete_vmid_from_backup(self):
-        with patch('builtins.input', return_value='mocked input'):
-            with pytest.raises(AnsibleExitJson) as exc_info:
-                set_module_args({
-                    'api_host': 'proxmoxhost',
-                    'api_user': 'root@pam',
-                    'api_password': 'supersecret',
-                    'vm_id': '101',
-                    'state': 'absent'
-                })
-                self.module.main()
+        with pytest.raises(AnsibleExitJson) as exc_info:
+            set_module_args({
+                'api_host': 'proxmoxhost',
+                'api_user': 'root@pam',
+                'api_password': 'supersecret',
+                'vm_id': 101,
+                'state': 'absent'
+            })
+            self.module.main()
 
-            result = exc_info.value.args[0]
-            assert result['changed'] is True
+        result = exc_info.value.args[0]
+        assert result['changed'] is True
+        assert result['vm_id'] == 101
 
 
 if __name__ == '__main__':

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -189,31 +189,35 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
         assert result["msg"] == "missing required arguments: api_host, api_user, state"
 
     def test_update_vmid_in_backup(self):
-        with pytest.raises(AnsibleExitJson) as exc_info:
-            set_module_args({
-                'api_host': 'proxmoxhost',
-                'api_user': 'root@pam',
-                'api_password': 'supersecret',
-                'vm_name': 'test05',
-                'backup_id': 'backup-001',
-                'state': 'present'
-            })
-            self.module.main()
-        result = exc_info.value.args[0]
-        assert result['changed'] is True
+        with patch('builtins.input', return_value='mocked input'):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                set_module_args({
+                    'api_host': 'proxmoxhost',
+                    'api_user': 'root@pam',
+                    'api_password': 'supersecret',
+                    'vm_name': 'test05',
+                    'backup_id': 'backup-001',
+                    'state': 'present'
+                })
+                self.module.main()
+
+            result = exc_info.value.args[0]
+            assert result['changed'] is True
 
     def test_delete_vmid_from_backup(self):
-        with pytest.raises(AnsibleExitJson) as exc_info:
-            set_module_args({
-                'api_host': 'proxmoxhost',
-                'api_user': 'root@pam',
-                'api_password': 'supersecret',
-                'vm_id': '101',
-                'state': 'absent'
-            })
-            self.module.main()
-        result = exc_info.value.args[0]
-        assert result['changed'] is True
+        with patch('builtins.input', return_value='mocked input'):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                set_module_args({
+                    'api_host': 'proxmoxhost',
+                    'api_user': 'root@pam',
+                    'api_password': 'supersecret',
+                    'vm_id': '101',
+                    'state': 'absent'
+                })
+                self.module.main()
+
+            result = exc_info.value.args[0]
+            assert result['changed'] is True  
 
 
 if __name__ == '__main__':

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -217,7 +217,7 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
                 self.module.main()
 
             result = exc_info.value.args[0]
-            assert result['changed'] is True  
+            assert result['changed'] is True
 
 
 if __name__ == '__main__':

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -171,7 +171,7 @@ BACKUP_JOB_SPECIFIC_BKID = {
     "vmid": "100,101"
 }
 EXPECTED_UPDATE_BACKUP_SCHEDULE = True
-EXPECTED_DEL_BACKUP_SCHEDULE = True 
+EXPECTED_DEL_BACKUP_SCHEDULE = True
 
 
 class TestProxmoxBackupScheduleModule(ModuleTestCase):

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -184,7 +184,9 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
             RESOURCE_LIST
         )
         self.connect_mock.return_value.cluster.backup.get.side_effect = (
-            lambda backup_id=None: BACKUP_JOBS if backup_id is None else [job for job in BACKUP_JOBS if job['id'] == backup_id]
+            lambda backup_id=None: BACKUP_JOBS if backup_id is None else [
+                job for job in BACKUP_JOBS if job['id'] == backup_id
+            ]
         )
 
     def tearDown(self):

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -202,35 +202,33 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
         assert result["msg"] == "missing required arguments: api_host, api_user, state"
 
     def test_update_vmid_in_backup(self):
-        with patch('builtins.input', return_value='mocked input'):
-            with pytest.raises(AnsibleExitJson) as exc_info:
-                set_module_args({
-                    'api_host': 'proxmoxhost',
-                    'api_user': 'root@pam',
-                    'api_password': 'supersecret',
-                    'vm_name': 'test05',
-                    'backup_id': 'backup-001',
-                    'state': 'present'
-                })
-                self.module.main()
-
-            result = exc_info.value.args[0]
-            assert result['changed'] is True
+        with pytest.raises(AnsibleExitJson) as exc_info:
+            set_module_args({
+                'api_host': 'proxmoxhost',
+                'api_user': 'root@pam',
+                'api_password': 'supersecret',
+                'vm_name': 'test05',
+                'backup_id': 'backup-001',
+                'state': 'present'
+            })
+            self.module.main()
+        
+        result = exc_info.value.args[0]
+        assert result['changed'] is True
 
     def test_delete_vmid_from_backup(self):
-        with patch('builtins.input', return_value='mocked input'):
-            with pytest.raises(AnsibleExitJson) as exc_info:
-                set_module_args({
-                    'api_host': 'proxmoxhost',
-                    'api_user': 'root@pam',
-                    'api_password': 'supersecret',
-                    'vm_id': '101',
-                    'state': 'absent'
-                })
-                self.module.main()
-
-            result = exc_info.value.args[0]
-            assert result['changed'] is True
+        with pytest.raises(AnsibleExitJson) as exc_info:
+            set_module_args({
+                'api_host': 'proxmoxhost',
+                'api_user': 'root@pam',
+                'api_password': 'supersecret',
+                'vm_id': '101',
+                'state': 'absent'
+            })
+            self.module.main()
+        
+        result = exc_info.value.args[0]
+        assert result['changed'] is True
 
 
 if __name__ == '__main__':

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -158,9 +158,6 @@ BACKUP_JOBS = [
     }
 ]
 
-EXPECTED_UPDATE_BACKUP_SCHEDULE = True
-EXPECTED_DEL_BACKUP_SCHEDULE = True
-
 
 class TestProxmoxBackupScheduleModule(ModuleTestCase):
     def setUp(self):
@@ -202,9 +199,7 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
                 self.module.main()
 
         result = exc_info.value.args[0]
-
         assert result['changed'] is True
-        assert result['backup_schedule'] == EXPECTED_UPDATE_BACKUP_SCHEDULE
 
     def test_delete_vmid_from_backup(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
@@ -219,7 +214,6 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
 
         result = exc_info.value.args[0]
         assert result['changed'] is True
-        assert result['backup_schedule'] == EXPECTED_DEL_BACKUP_SCHEDULE
 
 
 if __name__ == '__main__':

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -1,0 +1,238 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2025 Marzieh Raoufnezhad <raoufnezhad at gmail.com>
+# Copyright (c) 2025 Maryam Mayabi <mayabi.ahm at gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+import pytest
+
+proxmoxer = pytest.importorskip("proxmoxer")
+mandatory_py_version = pytest.mark.skipif(
+    sys.version_info < (2, 7),
+    reason="The proxmoxer dependency requires python2.7 or higher",
+)
+
+from ansible_collections.community.general.plugins.modules import proxmox_backup_schedule
+from ansible_collections.community.general.tests.unit.compat.mock import patch
+from ansible_collections.community.general.tests.unit.plugins.modules.utils import (
+    AnsibleExitJson,
+    AnsibleFailJson,
+    ModuleTestCase,
+    set_module_args,
+)
+import ansible_collections.community.general.plugins.module_utils.proxmox as proxmox_utils
+
+RESOURCE_LIST = [
+    {
+        "uptime": 0,
+        "diskwrite": 0,
+        "name": "test01",
+        "maxcpu": 0,
+        "node": "NODE1",
+        "mem": 0,
+        "netout": 0,
+        "netin": 0,
+        "maxmem": 0,
+        "diskread": 0,
+        "disk": 0,
+        "maxdisk": 0,
+        "status": "running",
+        "cpu": 0,
+        "id": "qemu/100",
+        "template": 0,
+        "vmid": 100,
+        "type": "qemu"
+    },
+    {
+        "uptime": 0,
+        "diskwrite": 0,
+        "name": "test02",
+        "maxcpu": 0,
+        "node": "NODE1",
+        "mem": 0,
+        "netout": 0,
+        "netin": 0,
+        "maxmem": 0,
+        "diskread": 0,
+        "disk": 0,
+        "maxdisk": 0,
+        "status": "running",
+        "cpu": 0,
+        "id": "qemu/101",
+        "template": 0,
+        "vmid": 101,
+        "type": "qemu"
+    },
+    {
+        "uptime": 0,
+        "diskwrite": 0,
+        "name": "test03",
+        "maxcpu": 0,
+        "node": "NODE2",
+        "mem": 0,
+        "netout": 0,
+        "netin": 0,
+        "maxmem": 0,
+        "diskread": 0,
+        "disk": 0,
+        "maxdisk": 0,
+        "status": "running",
+        "cpu": 0,
+        "id": "qemu/102",
+        "template": 0,
+        "vmid": 102,
+        "type": "qemu"
+    },
+    {
+        "uptime": 0,
+        "diskwrite": 0,
+        "name": "test04",
+        "maxcpu": 0,
+        "node": "NODE3",
+        "mem": 0,
+        "netout": 0,
+        "netin": 0,
+        "maxmem": 0,
+        "diskread": 0,
+        "disk": 0,
+        "maxdisk": 0,
+        "status": "running",
+        "cpu": 0,
+        "id": "qemu/103",
+        "template": 0,
+        "vmid": 103,
+        "type": "qemu"
+    },
+    {
+        "uptime": 0,
+        "diskwrite": 0,
+        "name": "test05",
+        "maxcpu": 0,
+        "node": "NODE3",
+        "mem": 0,
+        "netout": 0,
+        "netin": 0,
+        "maxmem": 0,
+        "diskread": 0,
+        "disk": 0,
+        "maxdisk": 0,
+        "status": "running",
+        "cpu": 0,
+        "id": "qemu/105",
+        "template": 0,
+        "vmid": 105,
+        "type": "qemu"
+    }
+]
+
+BACKUP_JOBS = [
+    {
+        "type": "vzdump",
+        "id": "backup-001",
+        "storage": "local",
+        "vmid": "100,101",
+        "enabled": 1,
+        "next-run": 1735138800,
+        "mailnotification": "always",
+        "schedule": "06,18:30",
+        "mode": "snapshot",
+        "notes-template": "{{guestname}}"
+    },
+    {
+        "schedule": "sat 15:00",
+        "notes-template": "{{guestname}}",
+        "mode": "snapshot",
+        "mailnotification": "always",
+        "next-run": 1735385400,
+        "type": "vzdump",
+        "enabled": 1,
+        "vmid": "101,102,103",
+        "storage": "local",
+        "id": "backup-002",
+    }
+]
+
+BACKUP_JOB_SPECIFIC_BKID = {
+    "enabled": 1,
+    "id": "backup-001",
+    "mailnotification": "always",
+    "mode": "snapshot",
+    "compress": "zstd",
+    "notes-template": "{{guestname}}",
+    "schedule": "06,18:30",
+    "storage": "local",
+    "type": "vzdump",
+    "vmid": "100,101"
+}
+EXPECTED_UPDATE_BACKUP_SCHEDULE = True
+EXPECTED_DEL_BACKUP_SCHEDULE = ["backup-001", "backup-002"]
+
+
+class TestProxmoxBackupScheduleModule(ModuleTestCase):
+    def setUp(self):
+        super(TestProxmoxBackupScheduleModule, self).setUp()
+        proxmox_utils.HAS_PROXMOXER = True
+        self.module = proxmox_backup_schedule
+        self.connect_mock = patch(
+            "ansible_collections.community.general.plugins.module_utils.proxmox.ProxmoxAnsible._connect",
+        ).start()
+        self.connect_mock.return_value.cluster.resources.get.return_value = (
+            RESOURCE_LIST
+        )
+        self.connect_mock.return_value.cluster.backup.get.side_effect = (
+            lambda backup_id=None: BACKUP_JOBS if backup_id is None else [job for job in BACKUP_JOBS if job['id'] == backup_id]
+        )
+
+    def tearDown(self):
+        self.connect_mock.stop()
+        super(TestProxmoxBackupScheduleModule, self).tearDown()
+
+    def test_module_fail_when_required_args_missing(self):
+        with pytest.raises(AnsibleFailJson) as exc_info:
+            set_module_args({})
+            self.module.main()
+
+        result = exc_info.value.args[0]
+        assert result["msg"] == "missing required arguments: api_host, api_user, backup_action"
+
+    def test_update_vmid_in_backup(self):
+        with pytest.raises(AnsibleExitJson) as exc_info:
+            set_module_args({
+                'api_host': 'proxmoxhost',
+                'api_user': 'root@pam',
+                'api_password': 'supersecret',
+                'vm_name': 'test05',
+                'backup_id': 'backup-001',
+                'backup_action': 'update_vmid'
+            })
+            self.module.main()
+
+        result = exc_info.value.args[0]
+
+        assert result['changed'] is True
+        assert result['backup_schedule'] == EXPECTED_UPDATE_BACKUP_SCHEDULE
+
+    def test_delete_vmid_from_backup(self):
+        with pytest.raises(AnsibleExitJson) as exc_info:
+            set_module_args({
+                'api_host': 'proxmoxhost',
+                'api_user': 'root@pam',
+                'api_password': 'supersecret',
+                'vm_id': 101,
+                'backup_action': 'delete_vmid'
+            })
+            self.module.main()
+
+        result = exc_info.value.args[0]
+        assert result['changed'] is True
+        assert result['backup_schedule'] == EXPECTED_DEL_BACKUP_SCHEDULE
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -171,7 +171,7 @@ BACKUP_JOB_SPECIFIC_BKID = {
     "vmid": "100,101"
 }
 EXPECTED_UPDATE_BACKUP_SCHEDULE = True
-EXPECTED_DEL_BACKUP_SCHEDULE = ["backup-001", "backup-002"]
+EXPECTED_DEL_BACKUP_SCHEDULE = True 
 
 
 class TestProxmoxBackupScheduleModule(ModuleTestCase):
@@ -199,7 +199,7 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
             self.module.main()
 
         result = exc_info.value.args[0]
-        assert result["msg"] == "missing required arguments: api_host, api_user, backup_action"
+        assert result["msg"] == "missing required arguments: api_host, api_user, state"
 
     def test_update_vmid_in_backup(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
@@ -209,7 +209,7 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
                 'api_password': 'supersecret',
                 'vm_name': 'test05',
                 'backup_id': 'backup-001',
-                'backup_action': 'update_vmid'
+                'state': 'present'
             })
             self.module.main()
 
@@ -225,7 +225,7 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
                 'api_user': 'root@pam',
                 'api_password': 'supersecret',
                 'vm_id': 101,
-                'backup_action': 'delete_vmid'
+                'state': 'absent'
             })
             self.module.main()
 

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -158,6 +158,9 @@ BACKUP_JOBS = [
     }
 ]
 
+EXPECTED_UPDATE_BACKUP_SCHEDULE = True
+EXPECTED_DEL_BACKUP_SCHEDULE = True
+
 
 class TestProxmoxBackupScheduleModule(ModuleTestCase):
     def setUp(self):
@@ -201,7 +204,7 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
         result = exc_info.value.args[0]
 
         assert result['changed'] is True
-        assert result['vm_id'] == 105
+        assert result['backup_schedule'] == EXPECTED_UPDATE_BACKUP_SCHEDULE
 
     def test_delete_vmid_from_backup(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
@@ -216,7 +219,7 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
 
         result = exc_info.value.args[0]
         assert result['changed'] is True
-        assert result['vm_id'] == 101
+        assert result['backup_schedule'] == EXPECTED_DEL_BACKUP_SCHEDULE
 
 
 if __name__ == '__main__':

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -19,7 +19,7 @@ mandatory_py_version = pytest.mark.skipif(
 )
 
 from ansible_collections.community.general.plugins.modules import proxmox_backup_schedule
-from ansible_collections.community.general.tests.unit.compat.mock import patch
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch
 from ansible_collections.community.general.tests.unit.plugins.modules.utils import (
     AnsibleExitJson,
     AnsibleFailJson,

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -220,7 +220,7 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
                 'api_host': 'proxmoxhost',
                 'api_user': 'root@pam',
                 'api_password': 'supersecret',
-                'vm_id': 101,
+                'vm_id': '101',
                 'state': 'absent'
             })
             self.module.main()

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -20,7 +20,7 @@ mandatory_py_version = pytest.mark.skipif(
 
 from ansible_collections.community.general.plugins.modules import proxmox_backup_schedule
 from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch
-from ansible_collections.community.general.tests.unit.plugins.modules.utils import (
+from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
     AnsibleExitJson,
     AnsibleFailJson,
     ModuleTestCase,
@@ -200,7 +200,7 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
             })
             self.module.main()
         result = exc_info.value.args[0]
-        assert result['changed'] == True
+        assert result['changed'] is True
 
     def test_delete_vmid_from_backup(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
@@ -213,7 +213,7 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
             })
             self.module.main()
         result = exc_info.value.args[0]
-        assert result['changed'] == True
+        assert result['changed'] is True
 
 
 if __name__ == '__main__':

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -191,7 +191,7 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
 
     def test_update_vmid_in_backup(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
-           with set_module_args({
+            with set_module_args({
                 'api_host': 'proxmoxhost',
                 'api_user': 'root@pam',
                 'api_password': 'supersecret',

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -212,7 +212,6 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
                 'state': 'present'
             })
             self.module.main()
-        
         result = exc_info.value.args[0]
         assert result['changed'] is True
 
@@ -226,7 +225,6 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
                 'state': 'absent'
             })
             self.module.main()
-        
         result = exc_info.value.args[0]
         assert result['changed'] is True
 

--- a/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_schedule.py
@@ -170,8 +170,6 @@ BACKUP_JOB_SPECIFIC_BKID = {
     "type": "vzdump",
     "vmid": "100,101"
 }
-EXPECTED_UPDATE_BACKUP_SCHEDULE = True
-EXPECTED_DEL_BACKUP_SCHEDULE = True
 
 
 class TestProxmoxBackupScheduleModule(ModuleTestCase):
@@ -214,9 +212,7 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
             self.module.main()
 
         result = exc_info.value.args[0]
-
         assert result['changed'] is True
-        assert result['backup_schedule'] == EXPECTED_UPDATE_BACKUP_SCHEDULE
 
     def test_delete_vmid_from_backup(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
@@ -231,7 +227,6 @@ class TestProxmoxBackupScheduleModule(ModuleTestCase):
 
         result = exc_info.value.args[0]
         assert result['changed'] is True
-        assert result['backup_schedule'] == EXPECTED_DEL_BACKUP_SCHEDULE
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
This contribution proposes to add a module called proxmox_backup_schedule to the Ansible community.general collection. The module would schedule VM backups and removing it in a Proxmox VE cluster.

##### ISSUE TYPE
New Module/Plugin Pull Request

##### COMPONENT NAME
proxmox_backup_schedule

##### ADDITIONAL INFORMATION
The proxmox_backup_schedule module modify backup jobs such as set or delete vmid.