### PR TITLE
apache2-mod-proxy: make state option a list

### DIFF
--- a/changelogs/fragments/9600-apache2-mod-proxy-revamp2.yml
+++ b/changelogs/fragments/9600-apache2-mod-proxy-revamp2.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - apache2_mod_proxy - change type of ``state`` to ``list`` of ``str`` elements. No change for the users (https://github.com/ansible-collections/community.general/pull/9600).

--- a/changelogs/fragments/9600-apache2-mod-proxy-revamp2.yml
+++ b/changelogs/fragments/9600-apache2-mod-proxy-revamp2.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - apache2_mod_proxy - change type of ``state`` to ``list`` of ``str`` elements. No change for the users (https://github.com/ansible-collections/community.general/pull/9600).
+  - apache2_mod_proxy - change type of ``state`` to a list of strings. No change for the users (https://github.com/ansible-collections/community.general/pull/9600).

--- a/plugins/modules/apache2_mod_proxy.py
+++ b/plugins/modules/apache2_mod_proxy.py
@@ -371,7 +371,7 @@ def main():
         module.fail_json(msg=missing_required_lib('BeautifulSoup'), exception=BEAUTIFUL_SOUP_IMP_ERR)
 
     if module.params['state'] is not None:
-        states = module.params['state'].split(',')
+        states = module.params['state']
         if (len(states) > 1) and (("present" in states) or ("enabled" in states)):
             module.fail_json(msg="state present/enabled is mutually exclusive with other states!")
     else:

--- a/plugins/modules/apache2_mod_proxy.py
+++ b/plugins/modules/apache2_mod_proxy.py
@@ -43,11 +43,14 @@ options:
         be specified here. If undefined, apache2_mod_proxy module will return a members list of dictionaries of all the current
         balancer pool members' attributes.
   state:
-    type: str
+    type: list
+    elements: str
+    choices: [present, absent, enabled, disabled, drained, hot_standby, ignore_errors]
     description:
-      - Desired state of the member host. (absent|disabled),drained,hot_standby,ignore_errors can be simultaneously invoked
-        by separating them with a comma (for example V(state=drained,ignore_errors)).
-      - 'Accepted state values: [V(present), V(absent), V(enabled), V(disabled), V(drained), V(hot_standby), V(ignore_errors)].'
+      - Desired state of the member host.
+      - States can be simultaneously invoked by separating them with a comma (for example V(state=drained,ignore_errors)),
+        but it is recommended to specify them as a proper YAML list.
+      - States V(present) and V(absent) must be used without any other state.
   tls:
     description:
       - Use https to access balancer management page.
@@ -357,7 +360,7 @@ def main():
             balancer_vhost=dict(required=True, type='str'),
             balancer_url_suffix=dict(default="/balancer-manager/", type='str'),
             member_host=dict(type='str'),
-            state=dict(type='str'),
+            state=dict(type='list', elements='str', choices=['present', 'absent', 'enabled', 'disabled', 'drained', 'hot_standby', 'ignore_errors']),
             tls=dict(default=False, type='bool'),
             validate_certs=dict(default=True, type='bool')
         ),
@@ -371,12 +374,6 @@ def main():
         states = module.params['state'].split(',')
         if (len(states) > 1) and (("present" in states) or ("enabled" in states)):
             module.fail_json(msg="state present/enabled is mutually exclusive with other states!")
-        else:
-            for _state in states:
-                if _state not in ['present', 'absent', 'enabled', 'disabled', 'drained', 'hot_standby', 'ignore_errors']:
-                    module.fail_json(
-                        msg="State can only take values amongst 'present', 'absent', 'enabled', 'disabled', 'drained', 'hot_standby', 'ignore_errors'."
-                    )
     else:
         states = ['None']
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Parameter `state` is a `str`, but it is parsed for comma separated values with a fixed set of values allowed. Transforming that into a `list` of `str` elements makes the code simpler.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
apache2_mod_proxy