### PR TITLE
fix for setting mtu on ipip and gre interfaces in nmcli.py

### DIFF
--- a/changelogs/fragments/9604-mtu-allow-ipipgre-interfaces.yml
+++ b/changelogs/fragments/9604-mtu-allow-ipipgre-interfaces.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - nmcli - allow setting ``MTU`` parameter for ``ipip`` and ``gre`` interface types (https://github.com/ansible-collections/community.general/pull/9604).
+  - nmcli - allow setting ``mtu`` parameter for ``ipip`` and ``gre`` interface types (https://github.com/ansible-collections/community.general/pull/9604).

--- a/changelogs/fragments/9604-mtu-allow-ipipgre-interfaces.yml
+++ b/changelogs/fragments/9604-mtu-allow-ipipgre-interfaces.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmcli - allow setting ``MTU`` parameter for ``ipip`` and ``gre`` interface types (https://github.com/ansible-collections/community.general/pull/9604).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -2076,6 +2076,8 @@ class Nmcli(object):
             'infiniband',
             'team-slave',
             'vlan',
+            'ipip',
+            'gre',
         )
 
     @property


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When trying to edit the mtu parameter on a gre and ipip interface, nmcli always reports that nothing needs to be done, even though the specified mtu value is different than the current mtu for the gre/ipip Interface.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #9315

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
nmcli.py