### PR TITLE
apache2-mod-proxy: receive results from fetch_url as tuple of vars

### DIFF
--- a/changelogs/fragments/9608-apache2-mod-proxy-revamp3.yml
+++ b/changelogs/fragments/9608-apache2-mod-proxy-revamp3.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - apache2_mod_proxy - improve readability when using results from ``fecth_url()`` (https://github.com/ansible-collections/community.general/pull/9608).

--- a/plugins/modules/apache2_mod_proxy.py
+++ b/plugins/modules/apache2_mod_proxy.py
@@ -257,13 +257,13 @@ class BalancerMember(object):
     def get_member_attributes(self):
         """ Returns a dictionary of a balancer member's attributes."""
 
-        balancer_member_page = fetch_url(self.module, self.management_url)
+        resp, info = fetch_url(self.module, self.management_url)
 
-        if balancer_member_page[1]['status'] != 200:
-            self.module.fail_json(msg="Could not get balancer_member_page, check for connectivity! " + balancer_member_page[1])
+        if info['status'] != 200:
+            self.module.fail_json(msg="Could not get balancer_member_page, check for connectivity! " + str(info))
         else:
             try:
-                soup = BeautifulSoup(balancer_member_page[0])
+                soup = BeautifulSoup(resp)
             except TypeError as exc:
                 self.module.fail_json(msg="Cannot parse balancer_member_page HTML! " + str(exc))
             else:
@@ -292,12 +292,12 @@ class BalancerMember(object):
                           'ignore_errors': '&w_status_I'}
 
         request_body = regexp_extraction(self.management_url, EXPRESSION, 1)
-        values_url = "".join("{0}={1}".format(url_param, 1 if values[mode] else 0) for mode, url_param in iteritems(values_mapping))
+        values_url = "".join("{0}={1}".format(url_param, 1 if values[mode] else 0) for mode, url_param in values_mapping.items())
         request_body = "{0}{1}".format(request_body, values_url)
 
-        response = fetch_url(self.module, self.management_url, data=request_body)
-        if response[1]['status'] != 200:
-            self.module.fail_json(msg="Could not set the member status! " + self.host + " " + response[1]['status'])
+        response, info = fetch_url(self.module, self.management_url, data=request_body)
+        if info['status'] != 200:
+            self.module.fail_json(msg="Could not set the member status! " + self.host + " " + info['status'])
 
     attributes = property(get_member_attributes)
     status = property(get_member_status, set_member_status)
@@ -332,11 +332,11 @@ class Balancer(object):
 
     def fetch_balancer_page(self):
         """ Returns the balancer management html page as a string for later parsing."""
-        page = fetch_url(self.module, str(self.url))
-        if page[1]['status'] != 200:
-            self.module.fail_json(msg="Could not get balancer page! HTTP status response: " + str(page[1]['status']))
+        resp, info = fetch_url(self.module, str(self.url))
+        if info['status'] != 200:
+            self.module.fail_json(msg="Could not get balancer page! HTTP status response: " + str(info['status']))
         else:
-            content = page[0].read()
+            content = resp.read()
             apache_version = regexp_extraction(content.upper(), APACHE_VERSION_EXPRESSION, 1)
             if apache_version:
                 if not re.search(pattern=r"2\.4\.[\d]*", string=apache_version):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Improve readability of code by receiving the result of `fetch_url` as a tuple of variables instead of a single variable that is used with indexes later.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
apache2_mod_proxy