### PR TITLE
keycloak_client: sanitize `saml.encryption.private.key`

### DIFF
--- a/changelogs/fragments/9621-keycloak_client-sanitize-saml-encryption-key.yml
+++ b/changelogs/fragments/9621-keycloak_client-sanitize-saml-encryption-key.yml
@@ -1,2 +1,2 @@
-bugfixes:
+security_fixes:
   - keycloak_client - Sanitize ``saml.encryption.private.key`` so it does not show in the logs (https://github.com/ansible-collections/community.general/pull/9621).

--- a/changelogs/fragments/9621-keycloak_client-sanitize-saml-encryption-key.yml
+++ b/changelogs/fragments/9621-keycloak_client-sanitize-saml-encryption-key.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_client - Sanitize ``saml.encryption.private.key`` so it does not show in the logs (https://github.com/ansible-collections/community.general/pull/9621).

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -775,8 +775,11 @@ def sanitize_cr(clientrep):
         result['secret'] = 'no_log'
     if 'attributes' in result:
         attributes = result['attributes']
-        if isinstance(attributes, dict) and 'saml.signing.private.key' in attributes:
-            attributes['saml.signing.private.key'] = 'no_log'
+        if isinstance(attributes, dict):
+            if 'saml.signing.private.key' in attributes:
+                attributes['saml.signing.private.key'] = 'no_log'
+            if 'saml.encryption.private.key' in attributes:
+                attributes['saml.encryption.private.key'] = 'no_log'
     return normalise_cr(result)
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The module sanitizes only `saml.singning.private.key`, but not `saml.encryption.private.key`. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_client
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
shortened output before PR:
```
{
  "attributes": {
    "saml.encrypt": "true",
    "saml.encryption.certificate": "MIICoTCCAYk [...] BDJpxpqdXeRw=",
    "saml.encryption.private.key": "MIIEpAIBA [...] FYUiJ8nmzMfZLGtMs3bAtDpg==",
    "saml.signing.certificate": "MIICoTC [...] RT9mk1UYNU=",
    "saml.signing.private.key": "no_log",
    "saml_force_name_id_format": "false"
  }
}
```
