### PR TITLE
onepassword_doc: fix 1Password Connect support

### DIFF
--- a/changelogs/fragments/9625-onepassword_doc.yml
+++ b/changelogs/fragments/9625-onepassword_doc.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "onepassword_doc lookup plugin - ensure that 1Password Connect support also works for this plugin (https://github.com/ansible-collections/community.general/pull/9625)."

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -553,9 +553,7 @@ class OnePassCLIv2(OnePassCLIBase):
         environment_update = {"OP_SECRET_KEY": self.secret_key}
         return self._run(args, command_input=to_bytes(self.master_password), environment_update=environment_update)
 
-    def get_raw(self, item_id, vault=None, token=None):
-        args = ["item", "get", item_id, "--format", "json"]
-
+    def _add_parameters_and_run(self, args, vault=None, token=None):
         if self.account_id:
             args.extend(["--account", self.account_id])
 
@@ -581,6 +579,10 @@ class OnePassCLIv2(OnePassCLIBase):
             args += [to_bytes("--session=") + token]
 
         return self._run(args)
+
+    def get_raw(self, item_id, vault=None, token=None):
+        args = ["item", "get", item_id, "--format", "json"]
+        return self._add_parameters_and_run(args, vault=vault, token=token)
 
     def signin(self):
         self._check_required_params(['master_password'])

--- a/plugins/lookup/onepassword_doc.py
+++ b/plugins/lookup/onepassword_doc.py
@@ -46,28 +46,13 @@ RETURN = """
 """
 
 from ansible_collections.community.general.plugins.lookup.onepassword import OnePass, OnePassCLIv2
-from ansible.errors import AnsibleLookupError
-from ansible.module_utils.common.text.converters import to_bytes
 from ansible.plugins.lookup import LookupBase
 
 
 class OnePassCLIv2Doc(OnePassCLIv2):
     def get_raw(self, item_id, vault=None, token=None):
         args = ["document", "get", item_id]
-        if vault is not None:
-            args = [*args, f"--vault={vault}"]
-
-        if self.service_account_token:
-            if vault is None:
-                raise AnsibleLookupError("'vault' is required with 'service_account_token'")
-
-            environment_update = {"OP_SERVICE_ACCOUNT_TOKEN": self.service_account_token}
-            return self._run(args, environment_update=environment_update)
-
-        if token is not None:
-            args = [*args, to_bytes("--session=") + token]
-
-        return self._run(args)
+        return self._add_parameters_and_run(args, vault=vault, token=token)
 
 
 class LookupModule(LookupBase):


### PR DESCRIPTION
##### SUMMARY
It seems that when #7116 and #7490 were merged, onepassword_doc.py ended up with the CLI parameters from `OnePassCLIv2.get_raw()` before 1Password Connect support was merged for onepassword.py. I'm not 100% sure all these parameters work with docs as well, but I think it's better to move adding these parameters to a separate function so it can be used from other derivatives of `OnePassCLIv2`.

@samdoran would be great if you could take a look :)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
onepassword_doc
