### PR TITLE
cloudflare_dns: fix crash when deleting a DNS record or when updating a record with solo=true

### DIFF
--- a/changelogs/fragments/9649-cloudflare_dns-fix-crash-when-deleting-record.yml
+++ b/changelogs/fragments/9649-cloudflare_dns-fix-crash-when-deleting-record.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - cloudflare_dns - fix crash when deleting a DNS record or when updating a record with ``solo=true`` (https://github.com/ansible-collections/community.general/pull/9649).
+  - cloudflare_dns - fix crash when deleting a DNS record or when updating a record with ``solo=true`` (https://github.com/ansible-collections/community.general/issues/9652, https://github.com/ansible-collections/community.general/pull/9649).

--- a/changelogs/fragments/9649-cloudflare_dns-fix-crash-when-deleting-record.yml
+++ b/changelogs/fragments/9649-cloudflare_dns-fix-crash-when-deleting-record.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cloudflare_dns - fix crash when deleting a DNS record or when updating a record with `solo=true` (https://github.com/ansible-collections/community.general/pull/9649).

--- a/changelogs/fragments/9649-cloudflare_dns-fix-crash-when-deleting-record.yml
+++ b/changelogs/fragments/9649-cloudflare_dns-fix-crash-when-deleting-record.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - cloudflare_dns - fix crash when deleting a DNS record or when updating a record with `solo=true` (https://github.com/ansible-collections/community.general/pull/9649).
+  - cloudflare_dns - fix crash when deleting a DNS record or when updating a record with ``solo=true`` (https://github.com/ansible-collections/community.general/pull/9649).

--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -685,6 +685,7 @@ class CloudflareAPI(object):
         else:
             search_value = content
 
+        zone_id = self._get_zone_id(params['zone'])
         records = self.get_dns_records(params['zone'], params['type'], search_record, search_value)
 
         for rr in records:
@@ -692,11 +693,11 @@ class CloudflareAPI(object):
                 if not ((rr['type'] == params['type']) and (rr['name'] == search_record) and (rr['content'] == content)):
                     self.changed = True
                     if not self.module.check_mode:
-                        result, info = self._cf_api_call('/zones/{0}/dns_records/{1}'.format(rr['zone_id'], rr['id']), 'DELETE')
+                        result, info = self._cf_api_call('/zones/{0}/dns_records/{1}'.format(zone_id, rr['id']), 'DELETE')
             else:
                 self.changed = True
                 if not self.module.check_mode:
-                    result, info = self._cf_api_call('/zones/{0}/dns_records/{1}'.format(rr['zone_id'], rr['id']), 'DELETE')
+                    result, info = self._cf_api_call('/zones/{0}/dns_records/{1}'.format(zone_id, rr['id']), 'DELETE')
         return self.changed
 
     def ensure_dns_record(self, **kwargs):


### PR DESCRIPTION

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

On 2025-01-27, Cloudflare removed the `zone_id` field from the DNS record API responses. This caused a `KeyError` in the `delete_dns_records` method, which previously relied on `rr['zone_id']`.

This commit ensures the zone ID is retrieved via `_get_zone_id()` rather than using the no-longer-provided `zone_id` field in the record response.

Reference: https://developers.cloudflare.com/dns/changelog/#2025-01-27

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
cloudflare_dns

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before fix:

`cfdnstest.yaml`
```yaml
- name: test cloudflare_dns
  hosts: localhost
  gather_facts: no
  vars:
    cloudflare_key_path: "cloudflare-token.txt"
    dns_name: cfrecordtest
    proxied_dns_zone: scopeful.io
    dest_1: "2a01:4f9:6b:4721::1"
    dest_2: "2a01:4f9:6b:4721::2"
  tasks:
    - name: "Create proxied AAAA record {{ dns_name }}.{{ proxied_dns_zone }} => {{ dest_1 }}"
      cloudflare_dns:
        zone: "{{ proxied_dns_zone }}"
        record: "{{ dns_name }}"
        type: AAAA
        solo: true
        proxied: true
        value: "{{ dest_1 }}"
        api_token: "{{ lookup('file', cloudflare_key_path) }}"

    - name: "Update proxied AAAA record {{ dns_name }}.{{ proxied_dns_zone }} => {{ dest_2 }}"
      cloudflare_dns:
        zone: "{{ proxied_dns_zone }}"
        record: "{{ dns_name }}"
        type: AAAA
        solo: true
        proxied: true
        value: "{{ dest_2 }}"
        api_token: "{{ lookup('file', cloudflare_key_path) }}"

    - name: "Delete AAAA record {{ dns_name }}.{{ proxied_dns_zone }}"
      cloudflare_dns:
        zone: "{{ proxied_dns_zone }}"
        record: "{{ dns_name }}"
        type: AAAA
        state: absent
        api_token: "{{ lookup('file', cloudflare_key_path) }}"
```

```
$ ansible-playbook cfdnstest.yaml
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [test cloudflare_dns] *******************************************************************************************************************************************************

TASK [Create proxied AAAA record cfrecordtest.scopeful.io => 2a01:4f9:6b:4721::1] ************************************************************************************************
changed: [localhost]

TASK [Update proxied AAAA record cfrecordtest.scopeful.io => 2a01:4f9:6b:4721::2] ************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'zone_id'
fatal: [localhost]: FAILED! => changed=false
  module_stderr: |-
    Traceback (most recent call last):
      File "/Users/karim/.ansible/tmp/ansible-tmp-1738197314.785573-15327-100923117162027/AnsiballZ_cloudflare_dns.py", line 107, in <module>
        _ansiballz_main()
      File "/Users/karim/.ansible/tmp/ansible-tmp-1738197314.785573-15327-100923117162027/AnsiballZ_cloudflare_dns.py", line 99, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/Users/karim/.ansible/tmp/ansible-tmp-1738197314.785573-15327-100923117162027/AnsiballZ_cloudflare_dns.py", line 47, in invoke_module
        runpy.run_module(mod_name='ansible_collections.community.general.plugins.modules.cloudflare_dns', init_globals=dict(_module_fqn='ansible_collections.community.general.plugins.modules.cloudflare_dns', _modlib_path=modlib_path),
      File "<frozen runpy>", line 226, in run_module
      File "<frozen runpy>", line 98, in _run_module_code
      File "<frozen runpy>", line 88, in _run_code
      File "/var/folders/tr/2fynb8ld26g1_kjxwsyxxmzm0000gn/T/ansible_cloudflare_dns_payload_ywbxuqcw/ansible_cloudflare_dns_payload.zip/ansible_collections/community/general/plugins/modules/cloudflare_dns.py", line 1000, in <module>
      File "/var/folders/tr/2fynb8ld26g1_kjxwsyxxmzm0000gn/T/ansible_cloudflare_dns_payload_ywbxuqcw/ansible_cloudflare_dns_payload.zip/ansible_collections/community/general/plugins/modules/cloudflare_dns.py", line 987, in main
      File "/var/folders/tr/2fynb8ld26g1_kjxwsyxxmzm0000gn/T/ansible_cloudflare_dns_payload_ywbxuqcw/ansible_cloudflare_dns_payload.zip/ansible_collections/community/general/plugins/modules/cloudflare_dns.py", line 695, in delete_dns_records
    KeyError: 'zone_id'
  module_stdout: ''
  msg: |-
    MODULE FAILURE: No start of json char found
    See stdout/stderr for the exact error
  rc: 1

PLAY RECAP ***********************************************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```

after fix:
```shell-session
$ ansible-playbook cfdnstest.yaml
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [test cloudflare_dns] *******************************************************************************************************************************************************

TASK [Create proxied AAAA record cfrecordtest.scopeful.io => 2a01:4f9:6b:4721::1] ************************************************************************************************
ok: [localhost]

TASK [Update proxied AAAA record cfrecordtest.scopeful.io => 2a01:4f9:6b:4721::2] ************************************************************************************************
changed: [localhost]

TASK [Delete AAAA record cfrecordtest.scopeful.io] *******************************************************************************************************************************
changed: [localhost]

PLAY RECAP ***********************************************************************************************************************************************************************
localhost                  : ok=3    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```