### PR TITLE
lldp: Handling attributes that are defined multiple times

### DIFF
--- a/changelogs/fragments/9657-lldp-handling-attributes-defined-multiple-times.yml
+++ b/changelogs/fragments/9657-lldp-handling-attributes-defined-multiple-times.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - lldp - fix crash caused by certain lldpctl output where an attribute is defined as branch and leaf
+minor_changes:
+  - lldp - adds ``multivalues`` parameter to control behavior when lldpctl outputs an attribute multiple times

--- a/changelogs/fragments/9657-lldp-handling-attributes-defined-multiple-times.yml
+++ b/changelogs/fragments/9657-lldp-handling-attributes-defined-multiple-times.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - lldp - fix crash caused by certain lldpctl output where an attribute is defined as branch and leaf
+  - lldp - fix crash caused by certain lldpctl output where an attribute is defined as branch and leaf (https://github.com/ansible-collections/community.general/pull/9657).
 minor_changes:
-  - lldp - adds ``multivalues`` parameter to control behavior when lldpctl outputs an attribute multiple times
+  - lldp - adds ``multivalues`` parameter to control behavior when lldpctl outputs an attribute multiple times (https://github.com/ansible-collections/community.general/pull/9657).

--- a/plugins/modules/lldp.py
+++ b/plugins/modules/lldp.py
@@ -72,19 +72,19 @@ def gather_lldp(module):
             current_dict = output_dict
             for path_component in path_components:
                 current_dict[path_component] = current_dict.get(path_component, {})
-                if type(current_dict[path_component]) is not dict:
+                if not isinstance(current_dict[path_component], dict):
                     current_dict[path_component] = {'value': current_dict[path_component]}
                 current_dict = current_dict[path_component]
 
-            if final in current_dict and type(current_dict[final]) is dict:
+            if final in current_dict and isinstance(current_dict[final], dict):
                 current_dict = current_dict[final]
                 final = 'value'
 
             if final not in current_dict or not module.params['multivalues']:
                 current_dict[final] = value
-            elif type(current_dict[final]) is str:
+            elif isinstance(current_dict[final], str):
                 current_dict[final] = [current_dict[final], value]
-            elif type(current_dict[final]) is list:
+            elif isinstance(current_dict[final], list):
                 current_dict[final].append(value)
 
         return output_dict
@@ -92,7 +92,7 @@ def gather_lldp(module):
 
 def main():
     module_args = dict(
-        multivalues=dict(type='bool', equired=False, default=False)
+        multivalues=dict(type='bool', required=False, default=False)
     )
     module = AnsibleModule(module_args)
 

--- a/plugins/modules/lldp.py
+++ b/plugins/modules/lldp.py
@@ -67,7 +67,8 @@ def gather_lldp(module):
             for path_component in path_components:
                 current_dict[path_component] = current_dict.get(path_component, {})
                 current_dict = current_dict[path_component]
-            current_dict[final] = value
+            if final not in current_dict:
+                current_dict[final] = value
         return output_dict
 
 

--- a/plugins/modules/lldp.py
+++ b/plugins/modules/lldp.py
@@ -60,13 +60,19 @@ def gather_lldp(module):
         current_dict = {}
         lldp_entries = output.strip().split("\n")
 
+        final = ""
         for entry in lldp_entries:
             if entry.startswith('lldp'):
                 path, value = entry.strip().split("=", 1)
                 path = path.split(".")
                 path_components, final = path[:-1], path[-1]
-            else:
+            elif final in current_dict and isinstance(current_dict[final], str):
                 current_dict[final] += '\n' + entry
+                continue
+            elif final in current_dict and isinstance(current_dict[final], list):
+                current_dict[final][-1] += '\n' + entry
+                continue
+            else:
                 continue
 
             current_dict = output_dict
@@ -76,7 +82,7 @@ def gather_lldp(module):
                     current_dict[path_component] = {'value': current_dict[path_component]}
                 current_dict = current_dict[path_component]
 
-            if final in current_dict and isinstance(current_dict[final], dict):
+            if final in current_dict and isinstance(current_dict[final], dict) and module.params['multivalues']:
                 current_dict = current_dict[final]
                 final = 'value'
 


### PR DESCRIPTION
This fixes crashes when the lldpctl output has lines for unknown tlvs that redefine a key in the middle of the nested dict data structure.

Also adds a function to handle attributes that are defined multiple times.

##### SUMMARY

When the lldpctl command outputs something like the following the module crashes with the following error

**Traceback**
```
Traceback (most recent call last):
  File "/home/autom8/.ansible/tmp/ansible-tmp-1738338445.7424972-37051-54323009070053/AnsiballZ_lldp.py", line 107, in <module>
    _ansiballz_main()
  File "/home/autom8/.ansible/tmp/ansible-tmp-1738338445.7424972-37051-54323009070053/AnsiballZ_lldp.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/autom8/.ansible/tmp/ansible-tmp-1738338445.7424972-37051-54323009070053/AnsiballZ_lldp.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.community.general.plugins.modules.lldp', init_globals=dict(_module_fqn='ansible_collections.community.general.plugins.modules.lldp', _modlib_path=modlib_path),
  File "/usr/lib/python3.8/runpy.py", line 207, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.8/runpy.py", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_community.general.lldp_payload_e18eaejw/ansible_community.general.lldp_payload.zip/ansible_collections/community/general/plugins/modules/lldp.py", line 86, in <module>
  File "/tmp/ansible_community.general.lldp_payload_e18eaejw/ansible_community.general.lldp_payload.zip/ansible_collections/community/general/plugins/modules/lldp.py", line 77, in main
  File "/tmp/ansible_community.general.lldp_payload_e18eaejw/ansible_community.general.lldp_payload.zip/ansible_collections/community/general/plugins/modules/lldp.py", line 70, in gather_lldp
TypeError: 'str' object does not support item assignment
```

**Example output that causes this problem**
```
lldp.eno1.unknown-tlvs.unknown-tlv.oui=00,90,69
lldp.eno1.unknown-tlvs.unknown-tlv.subtype=1
lldp.eno1.unknown-tlvs.unknown-tlv.len=12
lldp.eno1.unknown-tlvs.unknown-tlv=4A,5A,30,32,31,38,33,30,30,37,31,31
lldp.eno1.unknown-tlvs.unknown-tlv.oui=00,90,69
lldp.eno1.unknown-tlvs.unknown-tlv.subtype=12
lldp.eno1.unknown-tlvs.unknown-tlv.len=8
lldp.eno1.unknown-tlvs.unknown-tlv=00,00,00,65,00,00,00,00
```
As seen above such output has problematic output. **lldp.eno1.unknown-tlvs.unknown-tlv** has "subkeys" and is also set to a string (The comma separated bytes).

The fix will move the string value to the *subkey* "value". So the result looks like this:
```
                "unknown-tlvs": {
                    "unknown-tlv": {
                        "len": "8",
                        "oui": "00,90,69",
                        "subtype": "12",
                        "value": "00,00,00,65,00,00,00,00"
                    }
                }
```

~~Under normal condition we do not expect lldpctl to redefine values. Therefore the simple fix is to just ignore those lines.~~

Sometimes `lldpctl` outputs an attribute mutliple times, therefore this PR also introduces the ``multivalues`` options to control how to handle such output.

This new option defaults to **false** to keep the current behavior

**Example `lldpctl` output having the same attribute multiple times**
```
lldp.eno2.chassis.mgmt-ip=172.28.1.1
lldp.eno2.chassis.mgmt-ip=10.182.99.243
lldp.eno2.chassis.mgmt-ip=fe80::ce2d:e0ff:abce:ef09
```
If ``multivalues`` is `true` it results in this structure
```json
{
    "lldp": {
        "eno2": {
            "chassis": {
                "mgmt-ip": [
                    "172.28.1.1",
                    "10.182.99.243",
                    "fe80::ce2d:e0ff:abce:ef09"
                ]
            }
        }
    }
}
```

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
lldp

##### ADDITIONAL INFORMATION

