### PR TITLE
More resilient brew formulae name handling

### DIFF
--- a/changelogs/fragments/9665-more-resilient-handling-of-homebrew-packages-names.yml
+++ b/changelogs/fragments/9665-more-resilient-handling-of-homebrew-packages-names.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - homebrew - make package name parsing more resilient (https://github.com/ansible-collections/community.general/pull/9665, https://github.com/ansible-collections/community.general/issues/9641).

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -831,7 +831,7 @@ def main():
     p = module.params
 
     if p['name']:
-        packages = p['name']
+        packages = [package_name.lower() for package_name in p['name']]
     else:
         packages = None
 

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -385,9 +385,11 @@ class Homebrew(object):
             self.outdated_packages.add(package_name)
 
     def _extract_package_name(self, package_detail, is_cask):
-        canonical_name = package_detail["full_token"] if is_cask else package_detail["full_name"]  # For ex: 'sqlite'
+        canonical_name = package_detail["full_token"] if is_cask else package_detail["full_name"]  # For ex: 'sqlite', might contain a tap prefix.
+        name = package_detail["token"] if is_cask else package_detail["name"]  # For ex: 'sqlite'
+
         all_valid_names = set(package_detail.get("aliases", []))  # For ex: {'sqlite3'}
-        all_valid_names.add(canonical_name)
+        all_valid_names.update((canonical_name, name))
 
         # Then make sure the user provided name resurface.
         return (all_valid_names & set(self.packages)).pop()

--- a/tests/integration/targets/homebrew/tasks/formulae.yml
+++ b/tests/integration/targets/homebrew/tasks/formulae.yml
@@ -364,3 +364,20 @@
         - "terraform_install_result.msg == 'Package upgraded: hashicorp/tap/terraform'"
         - "terraform_install_result.changed_pkgs == ['hashicorp/tap/terraform']"
         - "terraform_install_result.unchanged_pkgs == []"
+
+# Test irregular formulae name case
+- block:
+  - name: Install terraform from full tap name with irregular case
+    community.general.homebrew:
+      name: HasHicorp/TAp/tErRaForm
+      state: latest
+    register: terraform_install_result
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+
+  - assert:
+      that:
+        - terraform_install_result is changed
+        - "terraform_install_result.msg == 'Package upgraded: hashicorp/tap/terraform'"
+        - "terraform_install_result.changed_pkgs == ['hashicorp/tap/terraform']"
+        - "terraform_install_result.unchanged_pkgs == []"

--- a/tests/integration/targets/homebrew/tasks/formulae.yml
+++ b/tests/integration/targets/homebrew/tasks/formulae.yml
@@ -40,7 +40,6 @@
     homebrew:
       name: "{{ package_name }}"
       state: absent
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
 
@@ -48,7 +47,6 @@
     homebrew:
       name: "{{ package_name }}"
       state: present
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: package_result
@@ -64,7 +62,6 @@
     homebrew:
       name: "{{ package_name }}"
       state: present
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: package_result
@@ -80,7 +77,6 @@
     homebrew:
       name: "{{ package_name }}"
       state: unlinked
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: package_result
@@ -96,7 +92,6 @@
     homebrew:
       name: "{{ package_name }}"
       state: linked
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: package_result
@@ -112,7 +107,6 @@
     homebrew:
       name: "{{ package_name }}"
       state: absent
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: package_result
@@ -128,7 +122,6 @@
     homebrew:
       name: "{{ package_name }}"
       state: absent
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: package_result
@@ -144,7 +137,6 @@
     homebrew:
       name: "{{ package_name }}"
       state: latest
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: package_result
@@ -160,7 +152,6 @@
     homebrew:
       name: "{{ package_name }}"
       state: latest
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: package_result
@@ -182,7 +173,6 @@
     homebrew:
       name: "{{ package_names }}"
       state: absent
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
 
@@ -190,7 +180,6 @@
     homebrew:
       name: "{{ package_names[0] }}"
       state: present
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
 
@@ -198,7 +187,6 @@
     homebrew:
       name: "{{ package_names }}"
       state: present
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: package_result
@@ -214,7 +202,6 @@
     homebrew:
       name: "{{ package_names }}"
       state: present
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: package_result
@@ -230,7 +217,6 @@
     homebrew:
       name: "{{ package_names }}"
       state: unlinked
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: package_result
@@ -246,7 +232,6 @@
     homebrew:
       name: "{{ package_names }}"
       state: linked
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: package_result
@@ -262,7 +247,6 @@
     homebrew:
       name: "{{ package_names }}"
       state: absent
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: package_result
@@ -278,7 +262,6 @@
     homebrew:
       name: "{{ package_names }}"
       state: absent
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: package_result
@@ -294,7 +277,6 @@
     homebrew:
       name: "{{ package_names }}"
       state: latest
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: package_result
@@ -310,7 +292,6 @@
     homebrew:
       name: "{{ package_names }}"
       state: latest
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: package_result
@@ -328,7 +309,6 @@
     homebrew:
       name: "sqlite"
       state: absent
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
 
@@ -336,7 +316,6 @@
     homebrew:
       name: "sqlite3"
       state: present
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: install_result
@@ -352,7 +331,6 @@
     homebrew:
       name: "sqlite3"
       state: present
-      update_homebrew: false
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"
     register: reinstall_result
@@ -376,7 +354,6 @@
     community.general.homebrew:
       name: hashicorp/tap/terraform
       state: latest
-      update_homebrew: false
     register: terraform_install_result
     become: true
     become_user: "{{ brew_stat.stat.pw_name }}"

--- a/tests/integration/targets/homebrew/tasks/formulae.yml
+++ b/tests/integration/targets/homebrew/tasks/formulae.yml
@@ -381,3 +381,55 @@
         - "terraform_install_result.msg == 'Package upgraded: hashicorp/tap/terraform'"
         - "terraform_install_result.changed_pkgs == ['hashicorp/tap/terraform']"
         - "terraform_install_result.unchanged_pkgs == []"
+
+# Test tap with no public fallback
+- block:
+  - name: Tap ascii-image-converter homebrew repository
+    community.general.homebrew_tap:
+      name: TheZoraiz/ascii-image-converter
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+
+  - name: Install ascii from full tap name
+    community.general.homebrew:
+      name: TheZoraiz/ascii-image-converter/ascii-image-converter
+      state: latest
+    register: ascii_install_result
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+
+  - assert:
+      that:
+        - ascii_install_result is changed
+        - "ascii_install_result.msg == 'Package upgraded: thezoraiz/ascii-image-converter/ascii-image-converter'"
+        - "ascii_install_result.changed_pkgs == ['thezoraiz/ascii-image-converter/ascii-image-converter']"
+        - "ascii_install_result.unchanged_pkgs == []"
+
+  - name: Remove ascii from full tap name
+    homebrew:
+      name: TheZoraiz/ascii-image-converter/ascii-image-converter
+      state: absent
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+
+  - name: Install ascii from regular name
+    community.general.homebrew:
+      name: ascii-image-converter
+      state: latest
+    register: ascii_install_result
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+
+  - assert:
+      that:
+        - ascii_install_result is changed
+        - "ascii_install_result.msg == 'Package upgraded: ascii-image-converter'"
+        - "ascii_install_result.changed_pkgs == ['ascii-image-converter']"
+        - "ascii_install_result.unchanged_pkgs == []"
+
+  - name: Remove ascii from regular name
+    homebrew:
+      name: ascii-image-converter
+      state: absent
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"


### PR DESCRIPTION
##### SUMMARY
Fixes #9641, _Review by commit is advised_

---

There are actually 2 issues:

**One with the uppercase letters.** 
Apparently, brew normalize everything to lowercase. For ex:

```shell
$ brew info --json=v2 TheZoraiz/ascii-image-converter/ascii-image-converter

{
  "formulae": [
    {
      "name": "ascii-image-converter",
      "full_name": "thezoraiz/ascii-image-converter/ascii-image-converter",
      "tap": "thezoraiz/ascii-image-converter",
      ...
```

**The other is with the handling of tap with no equivalent in brew registry**
ie you cannot do `brew install ascii-image-converter` if you didn't tap `thezoraiz/ascii-image-converter` before.

We misted this case in tests because we use `hashicorp/tap/terraform` but there is a regular `terraform` package too


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
homebrew
