### PR TITLE
test helper: improvements

### DIFF
--- a/tests/unit/plugins/modules/helper.py
+++ b/tests/unit/plugins/modules/helper.py
@@ -35,12 +35,10 @@ class Helper(object):
         for ext in extensions:
             test_spec_filename = test_module.__file__.replace('.py', ext)
             if os.path.exists(test_spec_filename):
-                break
-        else:
-            raise FileNotFoundError(f"Cannot find test case file for {0} with one of the extensions: {1}".format(test_module.__file__, ", ".join(extensions)))
+                with open(test_spec_filename, "r") as test_spec_filehandle:
+                    return Helper.from_file(ansible_module, test_module, test_spec_filehandle, mocks=mocks)
 
-        with open(test_spec_filename, "r") as test_spec_filehandle:
-            return Helper.from_file(ansible_module, test_module, test_spec_filehandle, mocks=mocks)
+        raise Exception(f"Cannot find test case file for {0} with one of the extensions: {1}".format(test_module.__file__, extensions))
 
     def add_func_to_test_module(self, name, func):
         setattr(self.test_module, name, func)

--- a/tests/unit/plugins/modules/helper.py
+++ b/tests/unit/plugins/modules/helper.py
@@ -38,7 +38,7 @@ class Helper(object):
                 with open(test_spec_filename, "r") as test_spec_filehandle:
                     return Helper.from_file(ansible_module, test_module, test_spec_filehandle, mocks=mocks)
 
-        raise Exception(f"Cannot find test case file for {0} with one of the extensions: {1}".format(test_module.__file__, extensions))
+        raise Exception("Cannot find test case file for {0} with one of the extensions: {1}".format(test_module.__file__, extensions))
 
     def add_func_to_test_module(self, name, func):
         setattr(self.test_module, name, func)

--- a/tests/unit/plugins/modules/helper.py
+++ b/tests/unit/plugins/modules/helper.py
@@ -6,6 +6,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
 import sys
 import json
 
@@ -13,49 +14,51 @@ import yaml
 import pytest
 
 
-from ansible.module_utils.common._collections_compat import Sequence
-
-
 class Helper(object):
     TEST_SPEC_VALID_SECTIONS = ["anchors", "test_cases"]
 
     @staticmethod
-    def from_spec(test_module, ansible_module, test_spec, mocks=None):
-        helper = Helper(test_module, ansible_module, test_spec=test_spec, mocks=mocks)
+    def from_spec(ansible_module, test_module, test_spec, mocks=None):
+        helper = Helper(ansible_module, test_module, test_spec=test_spec, mocks=mocks)
         return helper
 
     @staticmethod
-    def from_file(test_module, ansible_module, filename, mocks=None):
-        with open(filename, "r") as test_cases:
-            test_spec = yaml.safe_load(test_cases)
-        return Helper.from_spec(test_module, ansible_module, test_spec, mocks)
+    def from_file(ansible_module, test_module, test_spec_filehandle, mocks=None):
+        test_spec = yaml.safe_load(test_spec_filehandle)
+        return Helper.from_spec(ansible_module, test_module, test_spec, mocks)
 
+    # @TODO: calculate the test_module_name automatically, remove one more parameter
     @staticmethod
-    def from_module(ansible_module, test_module_name, test_spec=None, mocks=None):
+    def from_module(ansible_module, test_module_name, mocks=None):
         test_module = sys.modules[test_module_name]
-        if test_spec is None:
-            test_spec = test_module.__file__.replace('.py', '.yaml')
-        return Helper.from_file(test_module, ansible_module, test_spec, mocks=mocks)
+        extensions = ['.yaml', '.yml']
+        for ext in extensions:
+            test_spec_filename = test_module.__file__.replace('.py', ext)
+            if os.path.exists(test_spec_filename):
+                break
+        else:
+            raise FileNotFoundError(f"Cannot find test case file for {0} with one of the extensions: {1}".format(test_module.__file__, ", ".join(extensions)))
+
+        with open(test_spec_filename, "r") as test_spec_filehandle:
+            return Helper.from_file(ansible_module, test_module, test_spec_filehandle, mocks=mocks)
 
     def add_func_to_test_module(self, name, func):
         setattr(self.test_module, name, func)
 
-    def __init__(self, test_module, ansible_module, test_spec, mocks=None):
-        self.test_module = test_module
+    def __init__(self, ansible_module, test_module, test_spec, mocks=None):
         self.ansible_module = ansible_module
+        self.test_module = test_module
         self.test_cases = []
         self.fixtures = {}
-        if isinstance(test_spec, Sequence):
-            test_cases = test_spec
-        else:  # it is a dict
-            test_cases = test_spec['test_cases']
-            spec_diff = set(test_spec.keys()) - set(self.TEST_SPEC_VALID_SECTIONS)
-            if spec_diff:
-                raise ValueError("Test specification contain unknown keys: {0}".format(", ".join(spec_diff)))
+
+        spec_diff = set(test_spec.keys()) - set(self.TEST_SPEC_VALID_SECTIONS)
+        if spec_diff:
+            raise ValueError("Test specification contain unknown keys: {0}".format(", ".join(spec_diff)))
+
         self.mocks_map = {m.name: m for m in mocks} if mocks else {}
 
-        for test_case in test_cases:
-            tc = ModuleTestCase.make_test_case(test_case, test_module, self.mocks_map)
+        for spec_test_case in test_spec['test_cases']:
+            tc = ModuleTestCase.make_test_case(spec_test_case, test_module, self.mocks_map)
             self.test_cases.append(tc)
             self.fixtures.update(tc.fixtures)
         self.set_test_func()

--- a/tests/unit/plugins/modules/test_snap.py
+++ b/tests/unit/plugins/modules/test_snap.py
@@ -386,117 +386,119 @@ ubuntu  24.04
 kernel  6.8.0-49-generic
 """
 
-TEST_CASES = [
-    dict(
-        id="simple case",
-        input={"name": ["hello-world"]},
-        output=dict(changed=True, snaps_installed=["hello-world"]),
-        flags={},
-        mocks=dict(
-            run_command=[
-                dict(
-                    command=['/testbin/snap', 'version'],
-                    environ=default_env,
-                    rc=0,
-                    out=default_version_out,
-                    err="",
-                ),
-                dict(
-                    command=['/testbin/snap', 'info', 'hello-world'],
-                    environ=default_env,
-                    rc=0,
-                    out='name: hello-world\n',
-                    err="",
-                ),
-                dict(
-                    command=['/testbin/snap', 'list'],
-                    environ=default_env,
-                    rc=0,
-                    out="",
-                    err="",
-                ),
-                dict(
-                    command=['/testbin/snap', 'install', 'hello-world'],
-                    environ=default_env,
-                    rc=0,
-                    out="hello-world (12345/stable) v12345 from Canonical** installed\n",
-                    err="",
-                ),
-                dict(
-                    command=['/testbin/snap', 'list'],
-                    environ=default_env,
-                    rc=0,
-                    out=(
-                        "Name    Version      Rev    Tracking         Publisher    Notes"
-                        "core20  20220826     1623   latest/stable    canonical**  base"
-                        "lxd     5.6-794016a  23680  latest/stable/…  canonical**  -"
-                        "hello-world     5.6-794016a  23680  latest/stable/…  canonical**  -"
-                        "snapd   2.57.4       17336  latest/stable    canonical**  snapd"
-                        ""),
-                    err="",
-                ),
-            ],
+TEST_SPEC = dict(
+    test_cases=[
+        dict(
+            id="simple case",
+            input={"name": ["hello-world"]},
+            output=dict(changed=True, snaps_installed=["hello-world"]),
+            flags={},
+            mocks=dict(
+                run_command=[
+                    dict(
+                        command=['/testbin/snap', 'version'],
+                        environ=default_env,
+                        rc=0,
+                        out=default_version_out,
+                        err="",
+                    ),
+                    dict(
+                        command=['/testbin/snap', 'info', 'hello-world'],
+                        environ=default_env,
+                        rc=0,
+                        out='name: hello-world\n',
+                        err="",
+                    ),
+                    dict(
+                        command=['/testbin/snap', 'list'],
+                        environ=default_env,
+                        rc=0,
+                        out="",
+                        err="",
+                    ),
+                    dict(
+                        command=['/testbin/snap', 'install', 'hello-world'],
+                        environ=default_env,
+                        rc=0,
+                        out="hello-world (12345/stable) v12345 from Canonical** installed\n",
+                        err="",
+                    ),
+                    dict(
+                        command=['/testbin/snap', 'list'],
+                        environ=default_env,
+                        rc=0,
+                        out=(
+                            "Name    Version      Rev    Tracking         Publisher    Notes"
+                            "core20  20220826     1623   latest/stable    canonical**  base"
+                            "lxd     5.6-794016a  23680  latest/stable/…  canonical**  -"
+                            "hello-world     5.6-794016a  23680  latest/stable/…  canonical**  -"
+                            "snapd   2.57.4       17336  latest/stable    canonical**  snapd"
+                            ""),
+                        err="",
+                    ),
+                ],
+            ),
         ),
-    ),
-    dict(
-        id="issue_6803",
-        input={"name": ["microk8s", "kubectl"], "classic": True},
-        output=dict(changed=True, snaps_installed=["microk8s", "kubectl"]),
-        flags={},
-        mocks=dict(
-            run_command=[
-                dict(
-                    command=['/testbin/snap', 'version'],
-                    environ=default_env,
-                    rc=0,
-                    out=default_version_out,
-                    err="",
-                ),
-                dict(
-                    command=['/testbin/snap', 'info', 'microk8s', 'kubectl'],
-                    environ=default_env,
-                    rc=0,
-                    out='name: microk8s\n---\nname: kubectl\n',
-                    err="",
-                ),
-                dict(
-                    command=['/testbin/snap', 'list'],
-                    environ=default_env,
-                    rc=0,
-                    out=issue_6803_status_out,
-                    err="",
-                ),
-                dict(
-                    command=['/testbin/snap', 'install', '--classic', 'microk8s'],
-                    environ=default_env,
-                    rc=0,
-                    out=issue_6803_microk8s_out,
-                    err="",
-                ),
-                dict(
-                    command=['/testbin/snap', 'install', '--classic', 'kubectl'],
-                    environ=default_env,
-                    rc=0,
-                    out=issue_6803_kubectl_out,
-                    err="",
-                ),
-                dict(
-                    command=['/testbin/snap', 'list'],
-                    environ=default_env,
-                    rc=0,
-                    out=(
-                        "Name    Version      Rev    Tracking         Publisher    Notes"
-                        "core20  20220826     1623   latest/stable    canonical**  base"
-                        "lxd     5.6-794016a  23680  latest/stable/…  canonical**  -"
-                        "microk8s     5.6-794016a  23680  latest/stable/…  canonical**  -"
-                        "kubectl     5.6-794016a  23680  latest/stable/…  canonical**  -"
-                        "snapd   2.57.4       17336  latest/stable    canonical**  snapd"
-                        ""),
-                    err="",
-                ),
-            ],
+        dict(
+            id="issue_6803",
+            input={"name": ["microk8s", "kubectl"], "classic": True},
+            output=dict(changed=True, snaps_installed=["microk8s", "kubectl"]),
+            flags={},
+            mocks=dict(
+                run_command=[
+                    dict(
+                        command=['/testbin/snap', 'version'],
+                        environ=default_env,
+                        rc=0,
+                        out=default_version_out,
+                        err="",
+                    ),
+                    dict(
+                        command=['/testbin/snap', 'info', 'microk8s', 'kubectl'],
+                        environ=default_env,
+                        rc=0,
+                        out='name: microk8s\n---\nname: kubectl\n',
+                        err="",
+                    ),
+                    dict(
+                        command=['/testbin/snap', 'list'],
+                        environ=default_env,
+                        rc=0,
+                        out=issue_6803_status_out,
+                        err="",
+                    ),
+                    dict(
+                        command=['/testbin/snap', 'install', '--classic', 'microk8s'],
+                        environ=default_env,
+                        rc=0,
+                        out=issue_6803_microk8s_out,
+                        err="",
+                    ),
+                    dict(
+                        command=['/testbin/snap', 'install', '--classic', 'kubectl'],
+                        environ=default_env,
+                        rc=0,
+                        out=issue_6803_kubectl_out,
+                        err="",
+                    ),
+                    dict(
+                        command=['/testbin/snap', 'list'],
+                        environ=default_env,
+                        rc=0,
+                        out=(
+                            "Name    Version      Rev    Tracking         Publisher    Notes"
+                            "core20  20220826     1623   latest/stable    canonical**  base"
+                            "lxd     5.6-794016a  23680  latest/stable/…  canonical**  -"
+                            "microk8s     5.6-794016a  23680  latest/stable/…  canonical**  -"
+                            "kubectl     5.6-794016a  23680  latest/stable/…  canonical**  -"
+                            "snapd   2.57.4       17336  latest/stable    canonical**  snapd"
+                            ""),
+                        err="",
+                    ),
+                ],
+            ),
         ),
-    ),
-]
+    ]
+)
 
-Helper.from_spec(sys.modules[__name__], snap, TEST_CASES, mocks=[RunCommandMock])
+Helper.from_spec(snap, sys.modules[__name__], TEST_SPEC, mocks=[RunCommandMock])


### PR DESCRIPTION
changes:
- methods `from_module()`, `from_file()` and `from_spec()` now all have a similar order of parameters
- `from_module()` tries extensions `.yaml` and `.yml` before giving up
- remove redundant parameter `test_spec` from `from_module()`
- `from_file()` now receives an open, readable, file handle instead of a filename
- `Helper` no longer accepts a test specification that is a top-level list of testcases, it must be a dict containing the key `test_cases`, which will be the list.
- test_snap.py adjusted for the change in `from_spec()`

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
tests/unit/plugins/modules/helper.py
tests/unit/plugins/modules/test_snap.py
