### PR TITLE
Disable snap tests on RHEL 8.8

### DIFF
--- a/tests/integration/targets/snap/aliases
+++ b/tests/integration/targets/snap/aliases
@@ -11,3 +11,4 @@ skip/freebsd
 skip/osx
 skip/macos
 skip/docker
+skip/rhel8.8  # TODO: fix


### PR DESCRIPTION
##### SUMMARY
Tests are broken for them currently, so deactive them.

Ref: #9656

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
snap
