### PR TITLE
Ssh config other options

### DIFF
--- a/changelogs/fragments/ssh_config_add_other_options.yml
+++ b/changelogs/fragments/ssh_config_add_other_options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ssh_config - add ``other_options`` option as per feature request issue 8053 (https://github.com/ansible-collections/community.general/pull/<>).

--- a/changelogs/fragments/ssh_config_add_other_options.yml
+++ b/changelogs/fragments/ssh_config_add_other_options.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ssh_config - add ``other_options`` option as per feature request issue 8053 (https://github.com/ansible-collections/community.general/pull/<>).
+  - ssh_config - add ``other_options`` option as per feature request issue 8053 (https://github.com/ansible-collections/community.general/pull/9684).

--- a/changelogs/fragments/ssh_config_add_other_options.yml
+++ b/changelogs/fragments/ssh_config_add_other_options.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ssh_config - add ``other_options`` option as per feature request issue 8053 (https://github.com/ansible-collections/community.general/pull/9684).
+  - ssh_config - add ``other_options`` option (https://github.com/ansible-collections/community.general/issues/8053, https://github.com/ansible-collections/community.general/pull/9684).

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -11,17 +11,18 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-DOCUMENTATION = r"""
+DOCUMENTATION = r'''
+---
 module: ssh_config
 short_description: Manage SSH config for user
 version_added: '2.0.0'
 description:
-  - Configures SSH hosts with special C(IdentityFile)s and hostnames.
+    - Configures SSH hosts with special C(IdentityFile)s and hostnames.
 author:
-  - Björn Andersson (@gaqzi)
-  - Abhijeet Kasurde (@Akasurde)
+    - Björn Andersson (@gaqzi)
+    - Abhijeet Kasurde (@Akasurde)
 extends_documentation_fragment:
-  - community.general.attributes
+    - community.general.attributes
 attributes:
   check_mode:
     support: full
@@ -32,7 +33,7 @@ options:
     description:
       - Whether a host entry should exist or not.
     default: present
-    choices: ['present', 'absent']
+    choices: [ 'present', 'absent' ]
     type: str
   user:
     description:
@@ -49,7 +50,8 @@ options:
   host:
     description:
       - The endpoint this configuration is valid for.
-      - Can be an actual address on the internet or an alias that will connect to the value of O(hostname).
+      - Can be an actual address on the internet or an alias that will
+        connect to the value of O(hostname).
     required: true
     type: str
   hostname:
@@ -66,14 +68,17 @@ options:
     type: str
   identity_file:
     description:
-      - The path to an identity file (SSH private key) that will be used when connecting to this host.
+      - The path to an identity file (SSH private key) that will be used
+        when connecting to this host.
       - File need to exist and have mode V(0600) to be valid.
     type: path
   identities_only:
     description:
-      - Specifies that SSH should only use the configured authentication identity and certificate files (either the default
-        files, or those explicitly configured in the C(ssh_config) files or passed on the ssh command-line), even if C(ssh-agent)
-        or a C(PKCS11Provider) or C(SecurityKeyProvider) offers more identities.
+      - Specifies that SSH should only use the configured authentication
+        identity and certificate files (either the default files, or
+        those explicitly configured in the C(ssh_config) files or passed on
+        the ssh command-line), even if ssh-agent or a PKCS11Provider or
+        SecurityKeyProvider offers more identities.
     type: bool
     version_added: 8.2.0
   user_known_hosts_file:
@@ -84,7 +89,7 @@ options:
     description:
       - Whether to strictly check the host key when doing connections to the remote host.
       - The value V(accept-new) is supported since community.general 8.6.0.
-    choices: ['yes', 'no', 'ask', 'accept-new']
+    choices: [ 'yes', 'no', 'ask', 'accept-new' ]
     type: str
   proxycommand:
     description:
@@ -121,7 +126,7 @@ options:
   controlmaster:
     description:
       - Sets the C(ControlMaster) option.
-    choices: ['yes', 'no', 'ask', 'auto', 'autoask']
+    choices: [ 'yes', 'no', 'ask', 'auto', 'autoask' ]
     type: str
     version_added: 8.1.0
   controlpath:
@@ -134,16 +139,16 @@ options:
       - Sets the C(ControlPersist) option.
     type: str
     version_added: 8.1.0
-  dynamicforward:
+  other_options:
     description:
-      - Sets the C(DynamicForward) option.
-    type: str
-    version_added: 10.1.0
+      - Provides the option to specify arbitrary general SSH config entry options via a dictionary
+    type: dict
+    version_added: 10.4.0
 requirements:
-  - paramiko
-"""
+- paramiko
+'''
 
-EXAMPLES = r"""
+EXAMPLES = r'''
 - name: Add a host in the configuration
   community.general.ssh_config:
     user: akasurde
@@ -152,15 +157,17 @@ EXAMPLES = r"""
     identity_file: "/home/akasurde/.ssh/id_rsa"
     port: '2223'
     state: present
+    other_options:
+      serveraliveinterval: 30
 
 - name: Delete a host from the configuration
   community.general.ssh_config:
     ssh_config_file: "{{ ssh_config_test }}"
     host: "example.com"
     state: absent
-"""
+'''
 
-RETURN = r"""
+RETURN = r'''
 hosts_added:
   description: A list of host added.
   returned: success
@@ -196,7 +203,7 @@ hosts_change_diff:
       }
     }
   ]
-"""
+'''
 
 import os
 
@@ -272,8 +279,10 @@ class SSHConfig(object):
             controlmaster=self.params.get('controlmaster'),
             controlpath=self.params.get('controlpath'),
             controlpersist=fix_bool_str(self.params.get('controlpersist')),
-            dynamicforward=self.params.get('dynamicforward'),
         )
+        if self.params.get('other_options'):
+            for key, value in self.params.get('other_options').items():
+              args[key] = value
 
         config_changed = False
         hosts_changed = []
@@ -361,6 +370,7 @@ def main():
             host_key_algorithms=dict(type='str', no_log=False),
             identity_file=dict(type='path'),
             identities_only=dict(type='bool'),
+            other_options=dict(type='dict'),
             port=dict(type='str'),
             proxycommand=dict(type='str', default=None),
             proxyjump=dict(type='str', default=None),
@@ -377,7 +387,6 @@ def main():
             controlmaster=dict(type='str', default=None, choices=['yes', 'no', 'ask', 'auto', 'autoask']),
             controlpath=dict(type='str', default=None),
             controlpersist=dict(type='str', default=None),
-            dynamicforward=dict(type='str'),
             user=dict(default=None, type='str'),
             user_known_hosts_file=dict(type='str', default=None),
         ),

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -284,7 +284,7 @@ class SSHConfig(object):
         )
         if self.params.get('other_options'):
             for key, value in self.params.get('other_options').items():
-                args[key] = value
+                args[key] = str(value)
 
         config_changed = False
         hosts_changed = []

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -159,7 +159,7 @@ EXAMPLES = r"""
     port: '2223'
     state: present
     other_options:
-      serveraliveinterval: 30
+      serveraliveinterval: '30'
 
 - name: Delete a host from the configuration
   community.general.ssh_config:
@@ -212,6 +212,7 @@ from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
+from ansible.module_utils.six import string_types
 from ansible_collections.community.general.plugins.module_utils._stormssh import ConfigParser, HAS_PARAMIKO, PARAMIKO_IMPORT_ERROR
 from ansible_collections.community.general.plugins.module_utils.ssh import determine_config_file
 
@@ -284,7 +285,10 @@ class SSHConfig(object):
         )
         if self.params.get('other_options'):
             for key, value in self.params.get('other_options').items():
-                args[key] = str(value)
+                if key not in args:
+                    if not isinstance(value, string_types):
+                        self.module.fail_json(msg="The other_options value provided for key %s must be a string" % key )
+                    args[key] = str(value)
 
         config_changed = False
         hosts_changed = []

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -72,7 +72,7 @@ options:
     type: path
   identities_only:
     description:
-      - Specifies that SSH should only use the configured authentication identity and certificate files (either the default 
+      - Specifies that SSH should only use the configured authentication identity and certificate files (either the default
         files, or those explicitly configured in the C(ssh_config) files or passed on the ssh command-line), even if C(ssh-agent)
         or a C(PKCS11Provider) or C(SecurityKeyProvider) offers more identities.
     type: bool
@@ -146,7 +146,7 @@ options:
     type: dict
     version_added: 10.4.0
 requirements:
-- paramiko
+  - paramiko
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -287,7 +287,7 @@ class SSHConfig(object):
             for key, value in self.params.get('other_options').items():
                 if key not in args:
                     if not isinstance(value, string_types):
-                        self.module.fail_json(msg="The other_options value provided for key %s must be a string" % key)
+                        self.module.fail_json(msg="The other_options value provided for key {key!r} must be a string, got {type}".format(key=key, type=type(value)))
                     args[key] = value
 
         config_changed = False

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -12,7 +12,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 DOCUMENTATION = r"""
----
 module: ssh_config
 short_description: Manage SSH config for user
 version_added: '2.0.0'

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -288,7 +288,7 @@ class SSHConfig(object):
                 if key not in args:
                     if not isinstance(value, string_types):
                         self.module.fail_json(msg="The other_options value provided for key %s must be a string" % key )
-                    args[key] = str(value)
+                    args[key] = value
 
         config_changed = False
         hosts_changed = []

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -141,7 +141,8 @@ options:
     version_added: 10.1.0
   other_options:
     description:
-      - Provides the option to specify arbitrary general SSH config entry options via a dictionary
+      - Provides the option to specify arbitrary SSH config entry options via a dictionary.
+      - The values must be strings. Other values are rejected.
     type: dict
     version_added: 10.4.0
 requirements:

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -284,7 +284,7 @@ class SSHConfig(object):
         )
         if self.params.get('other_options'):
             for key, value in self.params.get('other_options').items():
-              args[key] = value
+                args[key] = value
 
         config_changed = False
         hosts_changed = []

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -287,7 +287,7 @@ class SSHConfig(object):
             for key, value in self.params.get('other_options').items():
                 if key not in args:
                     if not isinstance(value, string_types):
-                        self.module.fail_json(msg="The other_options value provided for key %s must be a string" % key )
+                        self.module.fail_json(msg="The other_options value provided for key %s must be a string" % key)
                     args[key] = value
 
         config_changed = False

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -287,8 +287,11 @@ class SSHConfig(object):
             for key, value in self.params.get('other_options').items():
                 if key not in args:
                     if not isinstance(value, string_types):
-                        self.module.fail_json(msg="The other_options value provided for key {key!r} must be a string, got {type}".format(key=key, type=type(value)))
+                        self.module.fail_json(msg="The other_options value provided for key {key!r} must be a string, got {type}".format(key=key,
+                                                                                                                                         type=type(value)))
                     args[key] = value
+                else:
+                    self.module.fail_json(msg="Multiple values provided for key {key!r}".format(key=key))
 
         config_changed = False
         hosts_changed = []

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -142,6 +142,7 @@ options:
   other_options:
     description:
       - Provides the option to specify arbitrary SSH config entry options via a dictionary.
+      - The key names must be lower case. Keys with upper case values are rejected.
       - The values must be strings. Other values are rejected.
     type: dict
     version_added: 10.4.0
@@ -285,6 +286,8 @@ class SSHConfig(object):
         )
         if self.params.get('other_options'):
             for key, value in self.params.get('other_options').items():
+                if key.lower() != key:
+                    self.module.fail_json(msg="The other_options key {key!r} must be lower case".format(key=key))
                 if key not in args:
                     if not isinstance(value, string_types):
                         self.module.fail_json(msg="The other_options value provided for key {key!r} must be a string, got {type}".format(key=key,

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -11,18 +11,18 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
 ---
 module: ssh_config
 short_description: Manage SSH config for user
 version_added: '2.0.0'
 description:
-    - Configures SSH hosts with special C(IdentityFile)s and hostnames.
+  - Configures SSH hosts with special C(IdentityFile)s and hostnames.
 author:
-    - Björn Andersson (@gaqzi)
-    - Abhijeet Kasurde (@Akasurde)
+  - Björn Andersson (@gaqzi)
+  - Abhijeet Kasurde (@Akasurde)
 extends_documentation_fragment:
-    - community.general.attributes
+  - community.general.attributes
 attributes:
   check_mode:
     support: full
@@ -33,7 +33,7 @@ options:
     description:
       - Whether a host entry should exist or not.
     default: present
-    choices: [ 'present', 'absent' ]
+    choices: ['present', 'absent']
     type: str
   user:
     description:
@@ -50,8 +50,7 @@ options:
   host:
     description:
       - The endpoint this configuration is valid for.
-      - Can be an actual address on the internet or an alias that will
-        connect to the value of O(hostname).
+      - Can be an actual address on the internet or an alias that will connect to the value of O(hostname).
     required: true
     type: str
   hostname:
@@ -68,17 +67,14 @@ options:
     type: str
   identity_file:
     description:
-      - The path to an identity file (SSH private key) that will be used
-        when connecting to this host.
+      - The path to an identity file (SSH private key) that will be used when connecting to this host.
       - File need to exist and have mode V(0600) to be valid.
     type: path
   identities_only:
     description:
-      - Specifies that SSH should only use the configured authentication
-        identity and certificate files (either the default files, or
-        those explicitly configured in the C(ssh_config) files or passed on
-        the ssh command-line), even if ssh-agent or a PKCS11Provider or
-        SecurityKeyProvider offers more identities.
+      - Specifies that SSH should only use the configured authentication identity and certificate files (either the default 
+        files, or those explicitly configured in the C(ssh_config) files or passed on the ssh command-line), even if C(ssh-agent)
+        or a C(PKCS11Provider) or C(SecurityKeyProvider) offers more identities.
     type: bool
     version_added: 8.2.0
   user_known_hosts_file:
@@ -89,7 +85,7 @@ options:
     description:
       - Whether to strictly check the host key when doing connections to the remote host.
       - The value V(accept-new) is supported since community.general 8.6.0.
-    choices: [ 'yes', 'no', 'ask', 'accept-new' ]
+    choices: ['yes', 'no', 'ask', 'accept-new']
     type: str
   proxycommand:
     description:
@@ -126,7 +122,7 @@ options:
   controlmaster:
     description:
       - Sets the C(ControlMaster) option.
-    choices: [ 'yes', 'no', 'ask', 'auto', 'autoask' ]
+    choices: ['yes', 'no', 'ask', 'auto', 'autoask']
     type: str
     version_added: 8.1.0
   controlpath:
@@ -139,6 +135,11 @@ options:
       - Sets the C(ControlPersist) option.
     type: str
     version_added: 8.1.0
+  dynamicforward:
+    description:
+      - Sets the C(DynamicForward) option.
+    type: str
+    version_added: 10.1.0
   other_options:
     description:
       - Provides the option to specify arbitrary general SSH config entry options via a dictionary
@@ -146,9 +147,9 @@ options:
     version_added: 10.4.0
 requirements:
 - paramiko
-'''
+"""
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: Add a host in the configuration
   community.general.ssh_config:
     user: akasurde
@@ -165,9 +166,9 @@ EXAMPLES = r'''
     ssh_config_file: "{{ ssh_config_test }}"
     host: "example.com"
     state: absent
-'''
+"""
 
-RETURN = r'''
+RETURN = r"""
 hosts_added:
   description: A list of host added.
   returned: success
@@ -203,7 +204,7 @@ hosts_change_diff:
       }
     }
   ]
-'''
+"""
 
 import os
 
@@ -279,6 +280,7 @@ class SSHConfig(object):
             controlmaster=self.params.get('controlmaster'),
             controlpath=self.params.get('controlpath'),
             controlpersist=fix_bool_str(self.params.get('controlpersist')),
+            dynamicforward=self.params.get('dynamicforward'),
         )
         if self.params.get('other_options'):
             for key, value in self.params.get('other_options').items():
@@ -387,6 +389,7 @@ def main():
             controlmaster=dict(type='str', default=None, choices=['yes', 'no', 'ask', 'auto', 'autoask']),
             controlpath=dict(type='str', default=None),
             controlpersist=dict(type='str', default=None),
+            dynamicforward=dict(type='str'),
             user=dict(default=None, type='str'),
             user_known_hosts_file=dict(type='str', default=None),
         ),

--- a/tests/integration/targets/ssh_config/tasks/options.yml
+++ b/tests/integration/targets/ssh_config/tasks/options.yml
@@ -22,6 +22,8 @@
     controlpath: "~/.ssh/sockets/%r@%h-%p"
     controlpersist: yes
     dynamicforward: '10080'
+    other_options:
+      serveraliveinterval: 30
     state: present
   register: options_add
   check_mode: true
@@ -57,6 +59,8 @@
     controlpath: "~/.ssh/sockets/%r@%h-%p"
     controlpersist: yes
     dynamicforward: '10080'
+    other_options:
+      serveraliveinterval: 30
     state: present
   register: options_add
 
@@ -81,6 +85,8 @@
     controlpath: "~/.ssh/sockets/%r@%h-%p"
     controlpersist: yes
     dynamicforward: '10080'
+    other_options:
+      serveraliveinterval: 30
     state: present
   register: options_add_again
 
@@ -109,6 +115,7 @@
       - "'controlpath ~/.ssh/sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
       - "'controlpersist yes' in slurp_ssh_config['content'] | b64decode"
       - "'dynamicforward 10080' in slurp_ssh_config['content'] | b64decode"
+      - "'serveraliveinterval 30' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Update host
   community.general.ssh_config:
@@ -123,6 +130,8 @@
     controlpath: "~/.ssh/new-sockets/%r@%h-%p"
     controlpersist: "600"
     dynamicforward: '11080'
+    other_options:
+      serveraliveinterval: 30
     state: present
   register: options_update
 
@@ -149,6 +158,8 @@
     controlpath: "~/.ssh/new-sockets/%r@%h-%p"
     controlpersist: "600"
     dynamicforward: '11080'
+    other_options:
+      serveraliveinterval: 30
     state: present
   register: options_update
 
@@ -178,6 +189,7 @@
       - "'controlpath ~/.ssh/new-sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
       - "'controlpersist 600' in slurp_ssh_config['content'] | b64decode"
       - "'dynamicforward 11080' in slurp_ssh_config['content'] | b64decode"
+      - "'serveraliveinterval 30' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Ensure no update in case option exist in ssh_config file but wasn't defined in playbook
   community.general.ssh_config:
@@ -212,6 +224,7 @@
       - "'controlpath ~/.ssh/new-sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
       - "'controlpersist 600' in slurp_ssh_config['content'] | b64decode"
       - "'dynamicforward 11080' in slurp_ssh_config['content'] | b64decode"
+      - "'serveraliveinterval 30' in slurp_ssh_config['content'] | b64decode"
 
 - name: Debug
   debug:
@@ -264,6 +277,7 @@
       - "'controlpath ~/.ssh/sockets/%r@%h-%p' not in slurp_ssh_config['content'] | b64decode"
       - "'controlpersist yes' not in slurp_ssh_config['content'] | b64decode"
       - "'dynamicforward 10080' not in slurp_ssh_config['content'] | b64decode"
+      - "'serveraliveinterval 30' not in slurp_ssh_config['content'] | b64decode"
 
 # Proxycommand and ProxyJump are mutually exclusive.
 # Reset ssh_config before testing options with proxyjump
@@ -286,6 +300,8 @@
     controlpath: "~/.ssh/sockets/%r@%h-%p"
     controlpersist: yes
     dynamicforward: '10080'
+    other_options:
+      serveraliveinterval: 30
     state: present
   register: options_add
   check_mode: true
@@ -321,6 +337,8 @@
     controlpath: "~/.ssh/sockets/%r@%h-%p"
     controlpersist: yes
     dynamicforward: '10080'
+    other_options:
+      serveraliveinterval: 30
     state: present
   register: options_add
 
@@ -345,6 +363,8 @@
     controlpath: "~/.ssh/sockets/%r@%h-%p"
     controlpersist: yes
     dynamicforward: '10080'
+    other_options:
+      serveraliveinterval: 30
     state: present
   register: options_add_again
 
@@ -373,6 +393,7 @@
       - "'controlpath ~/.ssh/sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
       - "'controlpersist yes' in slurp_ssh_config['content'] | b64decode"
       - "'dynamicforward 10080' in slurp_ssh_config['content'] | b64decode"
+      - "'serveraliveinterval 30' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Update host
   community.general.ssh_config:
@@ -387,6 +408,8 @@
     controlpath: "~/.ssh/new-sockets/%r@%h-%p"
     controlpersist: "600"
     dynamicforward: '11080'
+    other_options:
+      serveraliveinterval: 30
     state: present
   register: options_update
 
@@ -413,6 +436,8 @@
     controlpath: "~/.ssh/new-sockets/%r@%h-%p"
     controlpersist: "600"
     dynamicforward: '11080'
+    other_options:
+      serveraliveinterval: 30
     state: present
   register: options_update
 
@@ -442,6 +467,7 @@
       - "'controlpath ~/.ssh/new-sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
       - "'controlpersist 600' in slurp_ssh_config['content'] | b64decode"
       - "'dynamicforward 11080' in slurp_ssh_config['content'] | b64decode"
+      - "'serveraliveinterval 30' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Ensure no update in case option exist in ssh_config file but wasn't defined in playbook
   community.general.ssh_config:
@@ -476,6 +502,7 @@
       - "'controlpath ~/.ssh/new-sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
       - "'controlpersist 600' in slurp_ssh_config['content'] | b64decode"
       - "'dynamicforward 11080' in slurp_ssh_config['content'] | b64decode"
+      - "'serveraliveinterval 30' in slurp_ssh_config['content'] | b64decode"
 
 - name: Debug
   debug:
@@ -528,3 +555,4 @@
       - "'controlpath ~/.ssh/sockets/%r@%h-%p' not in slurp_ssh_config['content'] | b64decode"
       - "'controlpersist yes' not in slurp_ssh_config['content'] | b64decode"
       - "'dynamicforward 10080' not in slurp_ssh_config['content'] | b64decode"
+      - "'serveraliveinterval 30' not in slurp_ssh_config['content'] | b64decode"

--- a/tests/integration/targets/ssh_config/tasks/options.yml
+++ b/tests/integration/targets/ssh_config/tasks/options.yml
@@ -23,7 +23,7 @@
     controlpersist: yes
     dynamicforward: '10080'
     other_options:
-      serveraliveinterval: 30
+      serveraliveinterval: '30'
     state: present
   register: options_add
   check_mode: true
@@ -60,7 +60,7 @@
     controlpersist: yes
     dynamicforward: '10080'
     other_options:
-      serveraliveinterval: 30
+      serveraliveinterval: '30'
     state: present
   register: options_add
 
@@ -86,7 +86,7 @@
     controlpersist: yes
     dynamicforward: '10080'
     other_options:
-      serveraliveinterval: 30
+      serveraliveinterval: '30'
     state: present
   register: options_add_again
 
@@ -131,7 +131,7 @@
     controlpersist: "600"
     dynamicforward: '11080'
     other_options:
-      serveraliveinterval: 30
+      serveraliveinterval: '30'
     state: present
   register: options_update
 
@@ -159,7 +159,7 @@
     controlpersist: "600"
     dynamicforward: '11080'
     other_options:
-      serveraliveinterval: 30
+      serveraliveinterval: '30'
     state: present
   register: options_update
 
@@ -301,7 +301,7 @@
     controlpersist: yes
     dynamicforward: '10080'
     other_options:
-      serveraliveinterval: 30
+      serveraliveinterval: '30'
     state: present
   register: options_add
   check_mode: true
@@ -338,7 +338,7 @@
     controlpersist: yes
     dynamicforward: '10080'
     other_options:
-      serveraliveinterval: 30
+      serveraliveinterval: '30'
     state: present
   register: options_add
 
@@ -364,7 +364,7 @@
     controlpersist: yes
     dynamicforward: '10080'
     other_options:
-      serveraliveinterval: 30
+      serveraliveinterval: '30'
     state: present
   register: options_add_again
 
@@ -409,7 +409,7 @@
     controlpersist: "600"
     dynamicforward: '11080'
     other_options:
-      serveraliveinterval: 30
+      serveraliveinterval: '30'
     state: present
   register: options_update
 
@@ -437,7 +437,7 @@
     controlpersist: "600"
     dynamicforward: '11080'
     other_options:
-      serveraliveinterval: 30
+      serveraliveinterval: '30'
     state: present
   register: options_update
 


### PR DESCRIPTION
##### SUMMARY
Adds `other_options` to ssh_config module to allow arbitrary ssh config options to be added to each new entry, as per issue [8053](https://github.com/ansible-collections/community.general/issues/8053)

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
ssh_config

##### ADDITIONAL INFORMATION

Usage example with`other_options` set shown below

```
- name: Add a host in the configuration
  community.general.ssh_config:
    user: akasurde
    host: "example.com"
    hostname: "github.com"
    identity_file: "/home/akasurde/.ssh/id_rsa"
    port: '2223'
    state: present
    other_options:
      serveraliveinterval: '30'
      serveralivecountmax: '10'
```
