### PR TITLE
keycloak module utils replace missing return in `get_role_composites`

### DIFF
--- a/changelogs/fragments/9691-keycloak-module-utils-replace-missing-return-in-get_role_composites.yml
+++ b/changelogs/fragments/9691-keycloak-module-utils-replace-missing-return-in-get_role_composites.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_utils/identity/keycloak - replaces missing return in get_role_composites method which caused it to return None instead of composite roles (https://github.com/ansible-collections/community.general/issues/9678)

--- a/changelogs/fragments/9691-keycloak-module-utils-replace-missing-return-in-get_role_composites.yml
+++ b/changelogs/fragments/9691-keycloak-module-utils-replace-missing-return-in-get_role_composites.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - module_utils/identity/keycloak - replaces missing return in get_role_composites method which caused it to return None instead of composite roles (https://github.com/ansible-collections/community.general/issues/9678)
+  - keycloak module utils - replaces missing return in get_role_composites method which caused it to return None instead of composite roles (https://github.com/ansible-collections/community.general/issues/9678, https://github.com/ansible-collections/community.general/pull/9691).

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1856,7 +1856,7 @@ class KeycloakAPI(object):
             else:
                 composite_url = URL_REALM_ROLE_COMPOSITES.format(url=self.baseurl, realm=realm, name=quote(rolerep["name"], safe=''))
             # Get existing composites
-            self._request_and_deserialize(composite_url, method='GET')
+            return self._request_and_deserialize(composite_url, method='GET')
         except Exception as e:
             self.fail_request(e, msg='Could not get role %s composites in realm %s: %s'
                                      % (rolerep['name'], realm, str(e)))


### PR DESCRIPTION
##### SUMMARY
Fixes #9678.

Replaces a `return` accidentally removed by #9494.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/identity/keycloak