### PR TITLE
fix(keycloak): update more than 10 sub-groups (#9690)

### DIFF
--- a/changelogs/fragments/9692-update-more-than-10-keycloak-sub-groups.yml
+++ b/changelogs/fragments/9692-update-more-than-10-keycloak-sub-groups.yml
@@ -1,2 +1,2 @@
 bugfixes:
-    - keycloak - update more than 10 sub-groups (https://github.com/ansible-collections/community.general/pull/9692).
+    - keycloak - update more than 10 sub-groups (https://github.com/ansible-collections/community.general/issues/9690, https://github.com/ansible-collections/community.general/pull/9692).

--- a/changelogs/fragments/9692-update-more-than-10-keycloak-sub-groups.yml
+++ b/changelogs/fragments/9692-update-more-than-10-keycloak-sub-groups.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - keycloak - update more than 10 sub-groups (https://github.com/ansible-collections/community.general/pull/9692).

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1551,7 +1551,7 @@ class KeycloakAPI(object):
             if parent['subGroupCount'] == 0:
                 group_children = []
             else:
-                group_children_url = URL_GROUP_CHILDREN.format(url=self.baseurl, realm=realm, groupid=parent['id'])
+                group_children_url = URL_GROUP_CHILDREN.format(url=self.baseurl, realm=realm, groupid=parent['id']) + "?max=" + str(parent['subGroupCount'])
                 group_children = self._request_and_deserialize(group_children_url, method="GET")
             subgroups = group_children
         else:


### PR DESCRIPTION
##### SUMMARY

Fixes #9690 

When we want to create or update a sub-group, we fetch children of the parent group to know which sub group exist and should be updated.
The [API is paginated by default with a maximum of 10 result](https://www.keycloak.org/docs-api/latest/rest-api/index.html#_get_adminrealmsrealmgroupsgroup_idchildren) and [the api call did not set the corresponding paremeter (`max`)](https://github.com/ansible-collections/community.general/blob/main/plugins/module_utils/identity/keycloak/keycloak.py#L1552).

This PR set `max` parameter with the number of existing sub-groups retrieve by another API endpoint

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
community.general.keycloak_group
