### PR TITLE
ipa_host: Maintain the host certificates

### DIFF
--- a/changelogs/fragments/9694-ipa-host-certificate-revoked.yml
+++ b/changelogs/fragments/9694-ipa-host-certificate-revoked.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - host_add - fix. The module revoked existing host certificates even if ``user_certificates`` was not given. (https://github.com/ansible-collections/community.general/pull/9694).

--- a/changelogs/fragments/9694-ipa-host-certificate-revoked.yml
+++ b/changelogs/fragments/9694-ipa-host-certificate-revoked.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ipa_host - module revoked existing host certificates even if ``user_certificate`` was not given. (https://github.com/ansible-collections/community.general/pull/9694).
+  - ipa_host - module revoked existing host certificates even if ``user_certificate`` was not given (https://github.com/ansible-collections/community.general/pull/9694).

--- a/changelogs/fragments/9694-ipa-host-certificate-revoked.yml
+++ b/changelogs/fragments/9694-ipa-host-certificate-revoked.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - host_add - fix. The module revoked existing host certificates even if ``user_certificates`` was not given. (https://github.com/ansible-collections/community.general/pull/9694).
+  - ipa_host - module revoked existing host certificates even if ``user_certificate`` was not given. (https://github.com/ansible-collections/community.general/pull/9694).

--- a/plugins/modules/ipa_host.py
+++ b/plugins/modules/ipa_host.py
@@ -270,6 +270,10 @@ def ensure(module, client):
                     data = {}
                     for key in diff:
                         data[key] = module_host.get(key)
+                    if "usercertificate" not in data:
+                        data["usercertificate"] = [
+                            cert['__base64__'] for cert in ipa_host.get("usercertificate", [])
+                        ]
                     ipa_host_show = client.host_show(name=name)
                     if ipa_host_show.get('has_keytab', True) and (state == 'disabled' or module.params.get('random_password')):
                         client.host_disable(name=name)


### PR DESCRIPTION
Fix #9693

##### SUMMARY

Before this change, existing host certificates will be revoked even if the `user_certificates` option was not given. This contradicts the module documentation.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ipa_host

##### ADDITIONAL INFORMATION

Fixes #9693 