### PR TITLE
lvg: Add parameter to disable removal of extra physical volumes

### DIFF
--- a/changelogs/fragments/9698-lvg-remove-extra-pvs-parameter.yml
+++ b/changelogs/fragments/9698-lvg-remove-extra-pvs-parameter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - lvg: add ``remove_extra_pvs`` parameter to control if ansible should remove physical volumes which are not in the ``pvs`` parameter (https://github.com/ansible-collections/community.general/pull/9698)
+  - lvg - add ``remove_extra_pvs`` parameter to control if ansible should remove physical volumes which are not in the ``pvs`` parameter (https://github.com/ansible-collections/community.general/pull/9698)

--- a/changelogs/fragments/9698-lvg-remove-extra-pvs-parameter.yml
+++ b/changelogs/fragments/9698-lvg-remove-extra-pvs-parameter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - lvg - add ``remove_extra_pvs`` parameter to control if ansible should remove physical volumes which are not in the ``pvs`` parameter (https://github.com/ansible-collections/community.general/pull/9698)
+  - lvg - add ``remove_extra_pvs`` parameter to control if ansible should remove physical volumes which are not in the ``pvs`` parameter (https://github.com/ansible-collections/community.general/pull/9698).

--- a/changelogs/fragments/9698-lvg-remove-extra-pvs-parameter.yml
+++ b/changelogs/fragments/9698-lvg-remove-extra-pvs-parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - lvg: add ``remove_extra_pvs`` parameter to control if ansible should remove physical volumes which are not in the ``pvs`` parameter (https://github.com/ansible-collections/community.general/pull/9698)

--- a/changelogs/fragments/XXXX-lvg-remove-extra-pvs-parameter.yml
+++ b/changelogs/fragments/XXXX-lvg-remove-extra-pvs-parameter.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - lvg: add ``remove_extra_pvs`` parameter to control if ansible should remove physical volumes which are not in the ``pvs`` parameter

--- a/changelogs/fragments/XXXX-lvg-remove-extra-pvs-parameter.yml
+++ b/changelogs/fragments/XXXX-lvg-remove-extra-pvs-parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - lvg: add ``remove_extra_pvs`` parameter to control if ansible should remove physical volumes which are not in the ``pvs`` parameter

--- a/plugins/modules/lvg.py
+++ b/plugins/modules/lvg.py
@@ -90,10 +90,10 @@ options:
     version_added: 7.1.0
   remove_extra_pvs:
     description:
-    - Remove physical volumes from the volume group which are not in O(pvs)
+      - Remove physical volumes from the volume group which are not in O(pvs).
     type: bool
     default: true
-    version_added: X.X.X
+    version_added: 10.4.0
 seealso:
   - module: community.general.filesystem
   - module: community.general.lvol

--- a/plugins/modules/lvg.py
+++ b/plugins/modules/lvg.py
@@ -501,7 +501,7 @@ def main():
             current_devs = [os.path.realpath(pv['name']) for pv in pvs if pv['vg_name'] == vg]
             devs_to_remove = list(set(current_devs) - set(dev_list))
             devs_to_add = list(set(dev_list) - set(current_devs))
-            
+
             if not remove_extra_pvs:
                 devs_to_remove = []
 

--- a/plugins/modules/lvg.py
+++ b/plugins/modules/lvg.py
@@ -34,6 +34,7 @@ options:
       - List of comma-separated devices to use as physical devices in this volume group.
       - Required when creating or resizing volume group.
       - The module will take care of running pvcreate if needed.
+      - O(remove_extra_pvs) controls whether or not unspecified physical devices are removed from the volume group.
     type: list
     elements: str
   pesize:

--- a/tests/integration/targets/lvg/tasks/main.yml
+++ b/tests/integration/targets/lvg/tasks/main.yml
@@ -24,6 +24,8 @@
 
     - import_tasks: test_grow_reduce.yml
 
+    - import_tasks: test_remove_extra_pvs.yml
+
     - import_tasks: test_pvresize.yml
 
     - import_tasks: test_active_change.yml

--- a/tests/integration/targets/lvg/tasks/test_remove_extra_pvs.yml
+++ b/tests/integration/targets/lvg/tasks/test_remove_extra_pvs.yml
@@ -1,0 +1,40 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# test_grow_reduce already checks the base case with default parameters (remove additional PVs)
+
+- name: "Create volume group on first disk"
+  lvg:
+    vg: testvg
+    pvs: "{{ loop_device1 }}"
+
+- name: "get lvm facts"
+  setup:
+
+- debug: var=ansible_lvm
+
+- name: "Assert the testvg span only on first disk"
+  assert:
+    that:
+      - ansible_lvm.pvs[loop_device1].vg == "testvg"
+      - 'loop_device2 not in ansible_lvm.pvs or
+        ansible_lvm.pvs[loop_device2].vg == ""'
+
+- name: "Extend to second disk AND keep first disk"
+  lvg:
+    vg: testvg
+    pvs: "{{ loop_device2 }}"
+    remove_extra_pvs: false
+
+- name: "get lvm facts"
+  setup:
+
+- debug: var=ansible_lvm
+
+- name: "Assert the testvg spans on both disks"
+  assert:
+    that:
+      - ansible_lvm.pvs[loop_device1].vg == "testvg"
+      - ansible_lvm.pvs[loop_device2].vg == "testvg"


### PR DESCRIPTION
##### SUMMARY
Add parameter `remove_extra_pvs` to allow ansible to keep extra physical volumes on volume groups.  
Currently ansible removes all phyisical volumes that are not given in the `pvs` parameter.  
Setting `remove_extra_pvs` to `False` allows one to manage a volume group in ansible and to extend it outside of ansible with additional PVs.  

`remove_extra_pvs`  default parameter is set to `True` so it does not change current behavior.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lvg
