### PR TITLE
filesystem tests: reiserfsprogs is no longer available on Arch Linux

### DIFF
--- a/tests/integration/targets/filesystem/tasks/main.yml
+++ b/tests/integration/targets/filesystem/tasks/main.yml
@@ -59,6 +59,8 @@
             item.0.key == "reiserfs")'
     # reiserfs packages apparently not available with Alpine
     - 'not (ansible_distribution == "Alpine" and item.0.key == "reiserfs")'
+    # reiserfsprogs packages no longer available with Arch Linux
+    - 'not (ansible_distribution == "Archlinux" and item.0.key == "reiserfs")'
     # ocfs2 only available on Debian based distributions
     - 'not (item.0.key == "ocfs2" and ansible_os_family != "Debian")'
     # Tests use losetup which can not be used inside unprivileged container

--- a/tests/integration/targets/filesystem/tasks/setup.yml
+++ b/tests/integration/targets/filesystem/tasks/setup.yml
@@ -75,7 +75,7 @@
     state: present
   when:
     - ansible_system == 'Linux'
-    - ansible_os_family not in ['Suse', 'RedHat', 'Alpine']
+    - ansible_os_family not in ['Suse', 'RedHat', 'Alpine', 'Archlinux']
 
 - name: "Install reiserfs progs (FreeBSD)"
   ansible.builtin.package:


### PR DESCRIPTION
##### SUMMARY
The tests currently fail because of that.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
filesystem
