### PR TITLE
keycloak: repair integration tests by removing jinja2 templating from conditionals (#9726)

### DIFF
--- a/changelogs/fragments/9727-keycloak-module-integration-tests-remove-jinja2-templating-in-conditionals.yaml
+++ b/changelogs/fragments/9727-keycloak-module-integration-tests-remove-jinja2-templating-in-conditionals.yaml
@@ -1,6 +1,0 @@
-bugfixes:
-  - keycloak_clientsecret_info -fix integration test errors caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
-  - keycloak_clientsecret_regenerate - fix integration test errors caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
-  - keycloak_role - fix integration test errors caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
-  - keycloak_user_federation - fix integration test warnings caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
-  - keycloak_user_rolemapping - fix integration test warnings caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).

--- a/changelogs/fragments/9727-keycloak-module-integration-tests-remove-jinja2-templating-in-conditionals.yaml
+++ b/changelogs/fragments/9727-keycloak-module-integration-tests-remove-jinja2-templating-in-conditionals.yaml
@@ -1,2 +1,6 @@
 bugfixes:
-  - keycloak_clientsecret_info, keycloak_clientsecret_regenerate, keycloak_role, keycloak_user_federation, keycloak_user_rolemapping: fix broken integration tests and warnings in integration tests caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
+  - keycloak_clientsecret_info: fix integration test errors caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
+  - keycloak_clientsecret_regenerate: fix integration test errors caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
+  - keycloak_role: fix integration test errors caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
+  - keycloak_user_federation: fix integration test warnings caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
+  - keycloak_user_rolemapping: fix integration test warnings caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).

--- a/changelogs/fragments/9727-keycloak-module-integration-tests-remove-jinja2-templating-in-conditionals.yaml
+++ b/changelogs/fragments/9727-keycloak-module-integration-tests-remove-jinja2-templating-in-conditionals.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_clientsecret_info, keycloak_clientsecret_regenerate, keycloak_role, keycloak_user_federation, keycloak_user_rolemapping: fix broken integration tests and warnings in integration tests caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).

--- a/changelogs/fragments/9727-keycloak-module-integration-tests-remove-jinja2-templating-in-conditionals.yaml
+++ b/changelogs/fragments/9727-keycloak-module-integration-tests-remove-jinja2-templating-in-conditionals.yaml
@@ -1,6 +1,6 @@
 bugfixes:
-  - keycloak_clientsecret_info: fix integration test errors caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
-  - keycloak_clientsecret_regenerate: fix integration test errors caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
-  - keycloak_role: fix integration test errors caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
-  - keycloak_user_federation: fix integration test warnings caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
-  - keycloak_user_rolemapping: fix integration test warnings caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
+  - keycloak_clientsecret_info -fix integration test errors caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
+  - keycloak_clientsecret_regenerate - fix integration test errors caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
+  - keycloak_role - fix integration test errors caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
+  - keycloak_user_federation - fix integration test warnings caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).
+  - keycloak_user_rolemapping - fix integration test warnings caused by jinja2 templating used in conditionals (https://github.com/ansible-collections/community.general/issues/9726).

--- a/tests/integration/targets/keycloak_clientsecret_info/tasks/main.yml
+++ b/tests/integration/targets/keycloak_clientsecret_info/tasks/main.yml
@@ -32,7 +32,7 @@
   assert:
     that:
       - fetch_by_client_id_result.clientsecret_info.type == "secret"
-      - "{{ fetch_by_client_id_result.clientsecret_info.value | length }} >= 32"
+      - fetch_by_client_id_result.clientsecret_info.value | length >= 32
 
 - name: Keycloak Client fetch clientsecret by id
   community.general.keycloak_clientsecret_info: "{{ auth_args | combine(call_args) }}"

--- a/tests/integration/targets/keycloak_clientsecret_regenerate/tasks/main.yml
+++ b/tests/integration/targets/keycloak_clientsecret_regenerate/tasks/main.yml
@@ -32,7 +32,7 @@
   assert:
     that:
       - regenerate_by_client_id.end_state.type == "secret"
-      - "{{ regenerate_by_client_id.end_state.value | length }} >= 32"
+      - regenerate_by_client_id.end_state.value | length >= 32
 
 - name: Keycloak Client regenerate clientsecret by id
   community.general.keycloak_clientsecret_regenerate: "{{ auth_args | combine(call_args) }}"
@@ -45,5 +45,5 @@
 - name: Assert that client secret was regenerated
   assert:
     that:
-      - "{{ regenerate_by_id.end_state.value | length }} >= 32"
+      - regenerate_by_id.end_state.value | length >= 32
       - regenerate_by_id.end_state.value != regenerate_by_client_id.end_state.value

--- a/tests/integration/targets/keycloak_role/tasks/main.yml
+++ b/tests/integration/targets/keycloak_role/tasks/main.yml
@@ -45,8 +45,8 @@
     that:
       - result is changed
       - result.existing == {}
-      - result.end_state.name == "{{ role }}"
-      - result.end_state.containerId == "{{ realm }}"
+      - result.end_state.name == role
+      - result.end_state.containerId == realm
 
 - name: Create existing realm role
   community.general.keycloak_role:
@@ -89,8 +89,8 @@
   assert:
     that:
       - result is changed
-      - result.existing.description == "{{ description_1 }}"
-      - result.end_state.description == "{{ description_2 }}"
+      - result.existing.description == description_1
+      - result.end_state.description == description_2
 
 - name: Delete existing realm role
   community.general.keycloak_role:
@@ -156,8 +156,8 @@
     that:
       - result is changed
       - result.existing == {}
-      - result.end_state.name == "{{ role }}"
-      - result.end_state.containerId == "{{ client.end_state.id }}"
+      - result.end_state.name == role
+      - result.end_state.containerId == client.end_state.id
 
 - name: Create existing client role
   community.general.keycloak_role:
@@ -202,8 +202,8 @@
   assert:
     that:
       - result is changed
-      - result.existing.description == "{{ description_1 }}"
-      - result.end_state.description == "{{ description_2 }}"
+      - result.existing.description == description_1
+      - result.end_state.description == description_2
 
 - name: Delete existing client role
   community.general.keycloak_role:

--- a/tests/integration/targets/keycloak_user_federation/tasks/main.yml
+++ b/tests/integration/targets/keycloak_user_federation/tasks/main.yml
@@ -64,7 +64,7 @@
     that:
       - result is changed
       - result.existing == {}
-      - result.end_state.name == "{{ federation }}"
+      - result.end_state.name == federation
 
 - name: Create new user federation in admin realm
   community.general.keycloak_user_federation:
@@ -117,7 +117,7 @@
     that:
       - result is changed
       - result.existing == {}
-      - result.end_state.name == "{{ federation }}"
+      - result.end_state.name == federation
 
 - name: Update existing user federation (no change)
   community.general.keycloak_user_federation:
@@ -170,9 +170,9 @@
     that:
       - result is not changed
       - result.existing != {}
-      - result.existing.name == "{{ federation }}"
+      - result.existing.name == federation
       - result.end_state != {}
-      - result.end_state.name == "{{ federation }}"
+      - result.end_state.name == federation
 
 - name: Update existing user federation (no change, admin realm)
   community.general.keycloak_user_federation:
@@ -225,9 +225,9 @@
     that:
       - result is not changed
       - result.existing != {}
-      - result.existing.name == "{{ federation }}"
+      - result.existing.name == federation
       - result.end_state != {}
-      - result.end_state.name == "{{ federation }}"
+      - result.end_state.name == federation
 
 - name: Update existing user federation (with change)
   community.general.keycloak_user_federation:
@@ -296,9 +296,9 @@
     that:
       - result is changed
       - result.existing != {}
-      - result.existing.name == "{{ federation }}"
+      - result.existing.name == federation
       - result.end_state != {}
-      - result.end_state.name == "{{ federation }}"
+      - result.end_state.name == federation
 
 - name: Delete existing user federation
   community.general.keycloak_user_federation:
@@ -411,7 +411,7 @@
     that:
       - result is changed
       - result.existing == {}
-      - result.end_state.name == "{{ federation }}"
+      - result.end_state.name == federation
 
 ## no point in retesting this, just doing it to clean up introduced server changes
 - name: Delete absent user federation

--- a/tests/integration/targets/keycloak_user_rolemapping/tasks/main.yml
+++ b/tests/integration/targets/keycloak_user_rolemapping/tasks/main.yml
@@ -53,7 +53,7 @@
   assert:
     that:
       - result is changed
-      - result.end_state | selectattr("clientRole", "eq", false) | selectattr("name", "eq", "{{role}}") | list | count > 0
+      - result.end_state | selectattr("clientRole", "eq", false) | selectattr("name", "eq", role) | list | count > 0
 
 - name: Unmap a realm role from client service account
   vars:
@@ -74,8 +74,8 @@
     that:
       - result is changed
       - (result.end_state | length) == (result.existing | length) - 1
-      - result.existing | selectattr("clientRole", "eq", false) | selectattr("name", "eq", "{{role}}") | list | count > 0
-      - result.end_state | selectattr("clientRole", "eq", false) | selectattr("name", "eq", "{{role}}") | list | count == 0
+      - result.existing | selectattr("clientRole", "eq", false) | selectattr("name", "eq", role) | list | count > 0
+      - result.end_state | selectattr("clientRole", "eq", false) | selectattr("name", "eq", role) | list | count == 0
 
 - name: Delete existing realm role
   community.general.keycloak_role:
@@ -118,7 +118,7 @@
   assert:
     that:
       - result is changed
-      - result.end_state | selectattr("clientRole", "eq", true) | selectattr("name", "eq", "{{role}}") | list | count > 0
+      - result.end_state | selectattr("clientRole", "eq", true) | selectattr("name", "eq", role) | list | count > 0
 
 - name: Unmap a client role from client service account
   vars:
@@ -140,4 +140,4 @@
     that:
       - result is changed
       - result.end_state == []
-      - result.existing | selectattr("clientRole", "eq", true) | selectattr("name", "eq", "{{role}}") | list | count > 0
+      - result.existing | selectattr("clientRole", "eq", true) | selectattr("name", "eq", role) | list | count > 0


### PR DESCRIPTION
##### SUMMARY
Fix warnings and failures in keycloak module integration tests caused by use of jinja2 templating in conditionals.

Fixes #9726.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
keycloak_clientsecret_info, keycloak_clientsecret_regenerate, keycloak_role, keycloak_user_federation, keycloak_user_rolemapping

##### ADDITIONAL INFORMATION
To run the test, first start Keycloak:
```sh
docker run --rm --name mykeycloak -p 8080:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=password quay.io/keycloak/keycloak:latest start-dev --http-relative-path /auth
```

Then run one of the affected integration tests, e.g.,
```sh
ansible-test integration keycloak_role --allow-unsupported -vvv
```

Sample of existing test behaviour (in this case, causing a failure in the `keycloak_role` module tests):
```console
# ...
TASK [keycloak_role : Assert client role created] ******************************
task path: /home/armkeh/projects/ansible_collections/community/general/tests/output/.tmp/integration/keycloak_role-752i69kl-ÅÑŚÌβŁÈ/tests/integration/targets/keycloak_role/tasks/main.yml:154
[WARNING]: conditional statements should not include jinja2 templating
delimiters such as {{ }} or {% %}. Found: result.end_state.name == "{{ role }}"
[WARNING]: conditional statements should not include jinja2 templating
delimiters such as {{ }} or {% %}. Found: result.end_state.containerId == "{{
client.end_state.id }}"
fatal: [testhost]: FAILED! => {
    "msg": "The conditional check 'result.end_state.containerId == \"{{ client.end_state.id }}\"' failed. The error was: Conditional is marked as unsafe, and cannot be evaluated."
}

PLAY RECAP *********************************************************************
testhost                   : ok=20   changed=6    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0  
# ...
```
