### PR TITLE
bitwarden lookup: add options to filter by collection_name and validate number of results

### DIFF
--- a/changelogs/fragments/9728-bitwarden-collection-name-filter.yml
+++ b/changelogs/fragments/9728-bitwarden-collection-name-filter.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - bitwarden lookup - add new option to filter results by collection name
+  - bitwarden lookup - add new option to validate number of results

--- a/changelogs/fragments/9728-bitwarden-collection-name-filter.yml
+++ b/changelogs/fragments/9728-bitwarden-collection-name-filter.yml
@@ -1,3 +1,2 @@
 minor_changes:
-  - bitwarden lookup - add new option to filter results by collection name
-  - bitwarden lookup - add new option to validate number of results
+  - bitwarden lookup plugin - add new option ``collection_name`` to filter results by collection name, and new option ``result_count`` to validate number of results (https://github.com/ansible-collections/community.general/pull/9728).

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -281,8 +281,11 @@ class LookupModule(LookupBase):
         else:
             collection_ids = [collection_id]
 
-        results = [_bitwarden.get_field(field, term, search_field, collection_id, organization_id) for collection_id in
-                   collection_ids for term in terms]
+        results = [
+            _bitwarden.get_field(field, term, search_field, collection_id, organization_id) 
+            for collection_id in collection_ids 
+            for term in terms
+        ]
 
         for result in results:
             if result_count is not None and len(result) != result_count:

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -37,11 +37,15 @@ DOCUMENTATION = """
         description: Field to fetch. Leave unset to fetch whole response.
         type: str
       collection_id:
-        description: Collection ID to filter results by collection. Leave unset to skip filtering.
+        description: 
+            - Collection ID to filter results by collection. Leave unset to skip filtering.
+            - O(collection_id) and O(collection_name) are mutually exclusive.
         type: str
         version_added: 6.3.0
       collection_name:
-        description: Collection name to filter results by collection. Leave unset to skip filtering.
+        description: 
+            - Collection name to filter results by collection. Leave unset to skip filtering.
+            - O(collection_id) and O(collection_name) are mutually exclusive.
         type: str
         version_added: 10.4.0
       organization_id:
@@ -119,7 +123,7 @@ RETURN = """
 
 from subprocess import Popen, PIPE
 
-from ansible.errors import AnsibleError
+from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.parsing.ajson import AnsibleJSONDecoder
 from ansible.plugins.lookup import LookupBase
@@ -268,7 +272,9 @@ class LookupModule(LookupBase):
         if not terms:
             terms = [None]
 
-        if collection_name and not collection_id:
+        if collection_name and collection_id:
+            raise AnsibleOptionsError("'collection_name' and 'collection_id' are mutually exclusive!")
+        elif collection_name:
             collection_ids = _bitwarden.get_collection_ids(collection_name, organization_id)
             if not collection_ids:
                 raise BitwardenException("No matching collections found!")

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -38,8 +38,8 @@ DOCUMENTATION = """
         type: str
       collection_id:
         description:
-            - Collection ID to filter results by collection. Leave unset to skip filtering.
-            - O(collection_id) and O(collection_name) are mutually exclusive.
+          - Collection ID to filter results by collection. Leave unset to skip filtering.
+          - O(collection_id) and O(collection_name) are mutually exclusive.
         type: str
         version_added: 6.3.0
       collection_name:

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -43,7 +43,7 @@ DOCUMENTATION = """
       collection_name:
         description: Collection name to filter results by collection. Leave unset to skip filtering.
         type: str
-        version_added: 10.5.0
+        version_added: 10.4.0
       organization_id:
         description: Organization ID to filter results by organization. Leave unset to skip filtering.
         type: str

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -278,9 +278,10 @@ class LookupModule(LookupBase):
         results = [_bitwarden.get_field(field, term, search_field, collection_id, organization_id) for collection_id in
                    collection_ids for term in terms]
 
-        if result_count is not None and len(results[0]) != result_count:
-            raise BitwardenException(
-                f"Number of results doesn't match result_count! ({len(results[0])} != {result_count})")
+        for result in results:
+            if result_count is not None and len(result) != result_count:
+                raise BitwardenException(
+                    f"Number of results doesn't match result_count! ({len(result)} != {result_count})")
 
         return results
 

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -37,13 +37,13 @@ DOCUMENTATION = """
         description: Field to fetch. Leave unset to fetch whole response.
         type: str
       collection_id:
-        description: 
+        description:
             - Collection ID to filter results by collection. Leave unset to skip filtering.
             - O(collection_id) and O(collection_name) are mutually exclusive.
         type: str
         version_added: 6.3.0
       collection_name:
-        description: 
+        description:
             - Collection name to filter results by collection. Leave unset to skip filtering.
             - O(collection_id) and O(collection_name) are mutually exclusive.
         type: str

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -44,8 +44,8 @@ DOCUMENTATION = """
         version_added: 6.3.0
       collection_name:
         description:
-            - Collection name to filter results by collection. Leave unset to skip filtering.
-            - O(collection_id) and O(collection_name) are mutually exclusive.
+          - Collection name to filter results by collection. Leave unset to skip filtering.
+          - O(collection_id) and O(collection_name) are mutually exclusive.
         type: str
         version_added: 10.4.0
       organization_id:

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -56,7 +56,7 @@ DOCUMENTATION = """
         description: Number of results expected for the lookup query. Task will fail if result_count
             is set but doesn't match the number of query results. Leave empty to skip this check.
         type: int
-        version_added: 10.5.0
+        version_added: 10.4.0
 """
 
 EXAMPLES = """

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -53,8 +53,9 @@ DOCUMENTATION = """
         type: str
         version_added: 8.4.0
       result_count:
-        description: Number of results expected for the lookup query. Task will fail if result_count
-            is set but doesn't match the number of query results. Leave empty to skip this check.
+        description:
+          - Number of results expected for the lookup query. Task will fail if O(result_count)
+            is set but does not match the number of query results. Leave empty to skip this check.
         type: int
         version_added: 10.4.0
 """

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -244,7 +244,7 @@ class Bitwarden(object):
         # This includes things that matched in different fields.
         initial_matches = AnsibleJSONDecoder().raw_decode(out)[0]
 
-        # Filter to only return the id of a collections with exactly matching name
+        # Filter to only return the ID of a collections with exactly matching name
         return [item['id'] for item in initial_matches
                 if str(item.get('name')).lower() == collection_name.lower()]
 

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -282,8 +282,8 @@ class LookupModule(LookupBase):
             collection_ids = [collection_id]
 
         results = [
-            _bitwarden.get_field(field, term, search_field, collection_id, organization_id) 
-            for collection_id in collection_ids 
+            _bitwarden.get_field(field, term, search_field, collection_id, organization_id)
+            for collection_id in collection_ids
             for term in terms
         ]
 

--- a/tests/unit/plugins/lookup/test_bitwarden.py
+++ b/tests/unit/plugins/lookup/test_bitwarden.py
@@ -13,7 +13,7 @@ from ansible_collections.community.general.tests.unit.compat.mock import patch
 from ansible.errors import AnsibleError
 from ansible.module_utils import six
 from ansible.plugins.loader import lookup_loader
-from ansible_collections.community.general.plugins.lookup.bitwarden import Bitwarden
+from ansible_collections.community.general.plugins.lookup.bitwarden import Bitwarden, BitwardenException
 from ansible.parsing.ajson import AnsibleJSONEncoder
 
 MOCK_COLLECTION_ID = "3b12a9da-7c49-40b8-ad33-aede017a7ead"
@@ -131,7 +131,21 @@ MOCK_RECORDS = [
         "reprompt": 0,
         "revisionDate": "2024-14-15T11:30:00.000Z",
         "type": 1
-    }
+    },
+    {
+        "object": "collection",
+        "id": MOCK_COLLECTION_ID,
+        "organizationId": MOCK_ORGANIZATION_ID,
+        "name": "MOCK_COLLECTION",
+        "externalId": None
+    },
+    {
+        "object": "collection",
+        "id": "3b12a9da-7c49-40b8-ad33-aede017a8ead",
+        "organizationId": "3b12a9da-7c49-40b8-ad33-aede017a9ead",
+        "name": "some/other/collection",
+        "externalId": None
+    },
 ]
 
 
@@ -164,6 +178,9 @@ class MockBitwarden(Bitwarden):
 
                 items = []
                 for item in MOCK_RECORDS:
+                    if item.get('object') != 'item':
+                        continue
+
                     if search_value and not re.search(search_value, item.get('name')):
                         continue
                     if collection_to_filter and collection_to_filter not in item.get('collectionIds', []):
@@ -172,6 +189,35 @@ class MockBitwarden(Bitwarden):
                         continue
                     items.append(item)
                 return AnsibleJSONEncoder().encode(items), ''
+            elif args[1] == 'collections':
+                try:
+                    search_value = args[args.index('--search') + 1]
+                except ValueError:
+                    search_value = None
+
+                try:
+                    collection_to_filter = args[args.index('--collectionid') + 1]
+                except ValueError:
+                    collection_to_filter = None
+
+                try:
+                    organization_to_filter = args[args.index('--organizationid') + 1]
+                except ValueError:
+                    organization_to_filter = None
+
+                collections = []
+                for item in MOCK_RECORDS:
+                    if item.get('object') != 'collection':
+                        continue
+
+                    if search_value and not re.search(search_value, item.get('name')):
+                        continue
+                    if collection_to_filter and collection_to_filter not in item.get('collectionIds', []):
+                        continue
+                    if organization_to_filter and item.get('organizationId') != organization_to_filter:
+                        continue
+                    collections.append(item)
+                return AnsibleJSONEncoder().encode(collections), ''
 
         return '[]', ''
 
@@ -261,3 +307,15 @@ class TestLookupModule(unittest.TestCase):
     def test_bitwarden_plugin_full_collection_organization(self):
         self.assertEqual([MOCK_RECORDS[0], MOCK_RECORDS[2]], self.lookup.run(None,
                          collection_id=MOCK_COLLECTION_ID, organization_id=MOCK_ORGANIZATION_ID)[0])
+
+    @patch('ansible_collections.community.general.plugins.lookup.bitwarden._bitwarden', new=MockBitwarden())
+    def test_bitwarden_plugin_collection_name_filter(self):
+        # all passwords from MOCK_COLLECTION
+        self.assertEqual([MOCK_RECORDS[0], MOCK_RECORDS[2]], self.lookup.run(None,
+                                                                             collection_name="MOCK_COLLECTION")[0])
+        # Existing collection, no results
+        self.assertEqual([], self.lookup.run(None, collection_name="some/other/collection")[0])
+
+        # Non-Existent collection
+        with self.assertRaises(BitwardenException):
+            self.lookup.run(None, collection_name="nonexistent")

--- a/tests/unit/plugins/lookup/test_bitwarden.py
+++ b/tests/unit/plugins/lookup/test_bitwarden.py
@@ -319,3 +319,14 @@ class TestLookupModule(unittest.TestCase):
         # Non-Existent collection
         with self.assertRaises(BitwardenException):
             self.lookup.run(None, collection_name="nonexistent")
+
+    @patch('ansible_collections.community.general.plugins.lookup.bitwarden._bitwarden', new=MockBitwarden())
+    def test_bitwarden_plugin_result_count_check(self):
+        self.lookup.run(None, collection_id=MOCK_COLLECTION_ID, organization_id=MOCK_ORGANIZATION_ID, result_count=2)
+        with self.assertRaises(BitwardenException):
+            self.lookup.run(None, collection_id=MOCK_COLLECTION_ID, organization_id=MOCK_ORGANIZATION_ID,
+                            result_count=1)
+
+        self.lookup.run(None, organization_id=MOCK_ORGANIZATION_ID, result_count=3)
+        with self.assertRaises(BitwardenException):
+            self.lookup.run(None, organization_id=MOCK_ORGANIZATION_ID, result_count=0)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds two new option to the bitwarden lookup:
-  collection_name: Allows to filter results by bitwarden collection name instead of ID. This is especially usefull if your bitwarden is organized similar to your inventory structure, since it enables mapping bitwarden credentials from collection to inventory without having to lookup the exact collection IDs.
- result_count: This option allows to validate the number of results in your bitwarden lookup. While this would also be possible using ansible.builtin.assert, this is way more convenient to use when integrated into the lookup directly and helps to avoid password mismatches (or to detect if a required password isn't set in bitwarden yet)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
lookup / bitwarden

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
