### PR TITLE
Add `FullPowerCycle` to Power commands

### DIFF
--- a/changelogs/fragments/9729-redfish-fullpowercycle-command.yml
+++ b/changelogs/fragments/9729-redfish-fullpowercycle-command.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_command - add ``FullPowerCycle`` to power command options (https://github.com/ansible-collections/community.general/pull/9729).

--- a/changelogs/fragments/9729-redfish-fullpowercycle-command.yml
+++ b/changelogs/fragments/9729-redfish-fullpowercycle-command.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redfish_command - add ``FullPowerCycle`` to power command options (https://github.com/ansible-collections/community.general/pull/9729).
+  - redfish_command - add ``PowerFullPowerCycle`` to power command options (https://github.com/ansible-collections/community.general/pull/9729).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1119,7 +1119,8 @@ class RedfishUtils(object):
         key = "Actions"
         reset_type_values = ['On', 'ForceOff', 'GracefulShutdown',
                              'GracefulRestart', 'ForceRestart', 'Nmi',
-                             'ForceOn', 'PushPowerButton', 'PowerCycle']
+                             'ForceOn', 'PushPowerButton', 'PowerCycle',
+                             'FullPowerCycle']
 
         # command should be PowerOn, PowerForceOff, etc.
         if not command.startswith('Power'):

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -853,8 +853,10 @@ from ansible.module_utils.common.text.converters import to_native
 # More will be added as module features are expanded
 CATEGORY_COMMANDS_ALL = {
     "Systems": ["PowerOn", "PowerForceOff", "PowerForceRestart", "PowerGracefulRestart",
-                "PowerGracefulShutdown", "PowerReboot", "PowerCycle", "PowerFullPowerCycle", "SetOneTimeBoot", "EnableContinuousBootOverride", "DisableBootOverride",
-                "IndicatorLedOn", "IndicatorLedOff", "IndicatorLedBlink", "VirtualMediaInsert", "VirtualMediaEject", "VerifyBiosAttributes"],
+                "PowerGracefulShutdown", "PowerReboot", "PowerCycle", "PowerFullPowerCycle",
+                "SetOneTimeBoot", "EnableContinuousBootOverride", "DisableBootOverride",
+                "IndicatorLedOn", "IndicatorLedOff", "IndicatorLedBlink", "VirtualMediaInsert",
+                "VirtualMediaEject", "VerifyBiosAttributes"],
     "Chassis": ["IndicatorLedOn", "IndicatorLedOff", "IndicatorLedBlink"],
     "Accounts": ["AddUser", "EnableUser", "DeleteUser", "DisableUser",
                  "UpdateUserRole", "UpdateUserPassword", "UpdateUserName",

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -853,7 +853,7 @@ from ansible.module_utils.common.text.converters import to_native
 # More will be added as module features are expanded
 CATEGORY_COMMANDS_ALL = {
     "Systems": ["PowerOn", "PowerForceOff", "PowerForceRestart", "PowerGracefulRestart",
-                "PowerGracefulShutdown", "PowerReboot", "PowerCycle", "SetOneTimeBoot", "EnableContinuousBootOverride", "DisableBootOverride",
+                "PowerGracefulShutdown", "PowerReboot", "PowerCycle", "PowerFullPowerCycle", "SetOneTimeBoot", "EnableContinuousBootOverride", "DisableBootOverride",
                 "IndicatorLedOn", "IndicatorLedOff", "IndicatorLedBlink", "VirtualMediaInsert", "VirtualMediaEject", "VerifyBiosAttributes"],
     "Chassis": ["IndicatorLedOn", "IndicatorLedOff", "IndicatorLedBlink"],
     "Accounts": ["AddUser", "EnableUser", "DeleteUser", "DisableUser",


### PR DESCRIPTION
##### SUMMARY
Add support for new DMTF Redfish "FullPowerCycle" which provides the equivalent of a full A/C power pull of a server (not just restarting the system).

Fixes #9683

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
redfish_command

##### ADDITIONAL INFORMATION
Running the following now works:
```
    - name: Redfish FullPowerCycle
      community.general.redfish_command:
        category: Systems
        command: PowerFullPowerCycle
        baseuri: "{{ bmc_address }}"
        resource_id: "Self"
        username: "{{ bmc_username }}"
        password: "{{ bmc_password }}"
      register: redfish_fullcycle
      until: redfish_fullcycle is successful
```

Sample task:
```
TASK [Redfish FullPowerCycle] ****************************************************************************************************************************************************************************
Tuesday 11 February 2025  15:58:27 +0000 (0:00:00.035)       0:00:00.035 ******
changed: [node-01] => changed=true
  ansible_facts:
    discovered_interpreter_python: /usr/bin/python3
  attempts: 1
  msg: Action was successful
  return_values: {}
  session: {}
```
