### PR TITLE
locale_gen: fix: use glibc_ubuntu mode only if files for that exists

### DIFF
--- a/changelogs/fragments/9735-locale_gen-use_glibc_ubuntu_mode_only_if_file_exists.yml
+++ b/changelogs/fragments/9735-locale_gen-use_glibc_ubuntu_mode_only_if_file_exists.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "locale_gen - use ``glibc_ubuntu`` mode only if files for that exists (https://github.com/ansible-collections/community.general/pull/9735)."
+  - "locale_gen - use ``glibc`` mode only if files for that exists. In other case us ``other_glibc`` mode (https://github.com/ansible-collections/community.general/pull/9735)."

--- a/changelogs/fragments/9735-locale_gen-use_glibc_ubuntu_mode_only_if_file_exists.yml
+++ b/changelogs/fragments/9735-locale_gen-use_glibc_ubuntu_mode_only_if_file_exists.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "locale_gen - use glibc_ubuntu mode only if files for that exists (https://github.com/ansible-collections/community.general/pull/9735)."

--- a/changelogs/fragments/9735-locale_gen-use_glibc_ubuntu_mode_only_if_file_exists.yml
+++ b/changelogs/fragments/9735-locale_gen-use_glibc_ubuntu_mode_only_if_file_exists.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "locale_gen - use glibc_ubuntu mode only if files for that exists (https://github.com/ansible-collections/community.general/pull/9735)."
+  - "locale_gen - use ``glibc_ubuntu`` mode only if files for that exists (https://github.com/ansible-collections/community.general/pull/9735)."

--- a/changelogs/fragments/9735-locale_gen-use_glibc_ubuntu_mode_only_if_file_exists.yml
+++ b/changelogs/fragments/9735-locale_gen-use_glibc_ubuntu_mode_only_if_file_exists.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "locale_gen - use ``glibc`` mode only if files for that exists. In other case us ``other_glibc`` mode (https://github.com/ansible-collections/community.general/pull/9735)."
+  - "locale_gen - use ``glibc`` mode only if files for that exists. In other case use ``other_glibc`` mode (https://github.com/ansible-collections/community.general/pull/9735)."

--- a/plugins/modules/locale_gen.py
+++ b/plugins/modules/locale_gen.py
@@ -68,8 +68,9 @@ mechanism:
   description: Mechanism used to deploy the locales.
   type: str
   choices:
-    - glibc
+    - ubuntu_glibc
     - ubuntu_legacy
+    - glibc
   returned: success
   sample: glibc
   version_added: 10.2.0
@@ -119,13 +120,20 @@ class LocaleGen(StateModuleHelper):
                 available=SUPPORTED_LOCALES,
                 apply_change=self.apply_change_ubuntu_legacy,
             ),
-            glibc=dict(
+            ubuntu_glibc=dict(
                 available=SUPPORTED_LOCALES,
+                apply_change=self.apply_change_glibc,
+            ),
+            glibc=dict(
+                available=ETC_LOCALE_GEN,
                 apply_change=self.apply_change_glibc,
             ),
         )
 
-        if os.path.exists(ETC_LOCALE_GEN):
+        if os.path.exists(ETC_LOCALE_GEN) and os.path.exists(SUPPORTED_LOCALES):
+            self.vars.ubuntu_mode = False
+            self.vars.mechanism = "ubuntu_glibc"
+        elif os.path.exists(ETC_LOCALE_GEN) and not os.path.exists(SUPPORTED_LOCALES):
             self.vars.ubuntu_mode = False
             self.vars.mechanism = "glibc"
         elif os.path.exists(VAR_LIB_LOCALES):

--- a/plugins/modules/locale_gen.py
+++ b/plugins/modules/locale_gen.py
@@ -133,7 +133,7 @@ class LocaleGen(StateModuleHelper):
         if os.path.exists(ETC_LOCALE_GEN) and os.path.exists(SUPPORTED_LOCALES):
             self.vars.ubuntu_mode = False
             self.vars.mechanism = "ubuntu_glibc"
-        elif os.path.exists(ETC_LOCALE_GEN) and not os.path.exists(SUPPORTED_LOCALES):
+        elif os.path.exists(ETC_LOCALE_GEN):
             self.vars.ubuntu_mode = False
             self.vars.mechanism = "glibc"
         elif os.path.exists(VAR_LIB_LOCALES):

--- a/plugins/modules/locale_gen.py
+++ b/plugins/modules/locale_gen.py
@@ -68,9 +68,9 @@ mechanism:
   description: Mechanism used to deploy the locales.
   type: str
   choices:
-    - ubuntu_glibc
-    - ubuntu_legacy
     - glibc
+    - ubuntu_legacy
+    - other_glibc
   returned: success
   sample: glibc
   version_added: 10.2.0
@@ -120,11 +120,11 @@ class LocaleGen(StateModuleHelper):
                 available=SUPPORTED_LOCALES,
                 apply_change=self.apply_change_ubuntu_legacy,
             ),
-            ubuntu_glibc=dict(
+            glibc=dict(
                 available=SUPPORTED_LOCALES,
                 apply_change=self.apply_change_glibc,
             ),
-            glibc=dict(
+            other_glibc=dict(
                 available=ETC_LOCALE_GEN,
                 apply_change=self.apply_change_glibc,
             ),
@@ -132,10 +132,10 @@ class LocaleGen(StateModuleHelper):
 
         if os.path.exists(ETC_LOCALE_GEN) and os.path.exists(SUPPORTED_LOCALES):
             self.vars.ubuntu_mode = False
-            self.vars.mechanism = "ubuntu_glibc"
+            self.vars.mechanism = "glibc"
         elif os.path.exists(ETC_LOCALE_GEN):
             self.vars.ubuntu_mode = False
-            self.vars.mechanism = "glibc"
+            self.vars.mechanism = "other_glibc"
         elif os.path.exists(VAR_LIB_LOCALES):
             self.vars.ubuntu_mode = True
             self.vars.mechanism = "ubuntu_legacy"

--- a/tests/integration/targets/locale_gen/tasks/main.yml
+++ b/tests/integration/targets/locale_gen/tasks/main.yml
@@ -19,7 +19,7 @@
   loop_control:
     loop_var: locale_basic
   when:
-    - "ansible_distribution in ('Ubuntu', 'Debian')"
+    - ansible_os_family == 'Debian'
 
 - name: Run tests auto-detecting mechanism [Archlinux, RedHat]
   ansible.builtin.include_tasks:

--- a/tests/integration/targets/locale_gen/tasks/main.yml
+++ b/tests/integration/targets/locale_gen/tasks/main.yml
@@ -10,10 +10,19 @@
 
 - name: Bail out if not supported
   ansible.builtin.meta: end_play
-  when: ansible_distribution not in ('Ubuntu', 'Debian')
+  when:
+    - "ansible_os_family not in ('Debian', 'Archlinux', 'RedHat')"
 
-- name: Run tests auto-detecting mechanism
+- name: Run tests auto-detecting mechanism [Debian]
   ansible.builtin.include_tasks: basic.yml
   loop: "{{ locale_list_basic }}"
   loop_control:
     loop_var: locale_basic
+  when:
+    - "ansible_distribution in ('Ubuntu', 'Debian')"
+
+- name: Run tests auto-detecting mechanism [Archlinux, RedHat]
+  ansible.builtin.include_tasks:
+    file: "non_debian.yml"
+  when:
+    - "ansible_os_family in ('RedHat', 'Archlinux')"

--- a/tests/integration/targets/locale_gen/tasks/non_debian.yml
+++ b/tests/integration/targets/locale_gen/tasks/non_debian.yml
@@ -8,24 +8,16 @@
   when:
     - ansible_pkg_mgr == 'yum'
 
-- name: "Prepare locale packages"
-  block:
-    - name: "Install locale packages for RedHat"
-      ansible.builtin.dnf:
-        name:
-          - "glibc-langpack-pl"
-          - "glibc-langpack-en"
-        state: "present"
-      when:
-        - "ansible_os_family == 'RedHat'"
-    - name: "Install locale packages for Archlinux"
-      community.general.pacman:
-        name: "glibc-locales"
-        state: "present"
-      when:
-        - "ansible_os_family == 'Archlinux'"
+- name: "Install locale packages for RedHat"
+  ansible.builtin.dnf:
+    name:
+      - "glibc-langpack-pl"
+      - "glibc-langpack-en"
+    state: "present"
+  when:
+    - "ansible_os_family == 'RedHat'"
 
-- name: "Prepare locale.gen file for RedHat or Archlinux"
+- name: "Prepare locale.gen file for RedHat"
   ansible.builtin.template:
     src: "locale_gen.j2"
     dest: "/etc/locale.gen"
@@ -33,6 +25,8 @@
     group: "root"
     mode: "0644"
     force: true
+  when:
+    - "ansible_os_family == 'RedHat'"
 
 - name: "Check for locale that pack are not installed"
   locale_gen:

--- a/tests/integration/targets/locale_gen/tasks/non_debian.yml
+++ b/tests/integration/targets/locale_gen/tasks/non_debian.yml
@@ -33,7 +33,7 @@
     owner: "root"
     group: "root"
     mode: "0644"
-    force: "yes"
+    force: true
 
 - name: "Check for locale that pack are not installed"
   locale_gen:

--- a/tests/integration/targets/locale_gen/tasks/non_debian.yml
+++ b/tests/integration/targets/locale_gen/tasks/non_debian.yml
@@ -6,7 +6,7 @@
 - name: "Non dnf RedHat systemd are not supported"
   ansible.builtin.meta: "end_play"
   when:
-    - "ansible_pkg_mgr == 'yum'"
+    - ansible_pkg_mgr == 'yum'
 
 - name: "Prepare locale packages"
   block:

--- a/tests/integration/targets/locale_gen/tasks/non_debian.yml
+++ b/tests/integration/targets/locale_gen/tasks/non_debian.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: "Non dnf RedHat systemd are not supported"
+- name: "Non dnf RedHat system are not supported"
   ansible.builtin.meta: "end_play"
   when:
     - ansible_pkg_mgr == 'yum'

--- a/tests/integration/targets/locale_gen/tasks/non_debian.yml
+++ b/tests/integration/targets/locale_gen/tasks/non_debian.yml
@@ -22,7 +22,6 @@
       community.general.pacman:
         name: "glibc-locales"
         state: "present"
-        update_cache: "yes"
       when:
         - "ansible_os_family == 'Archlinux'"
 

--- a/tests/integration/targets/locale_gen/tasks/non_debian.yml
+++ b/tests/integration/targets/locale_gen/tasks/non_debian.yml
@@ -1,0 +1,52 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: "Non dnf RedHat systemd are not supported"
+  ansible.builtin.meta: "end_play"
+  when:
+    - "ansible_pkg_mgr == 'yum'"
+
+- name: "Prepare locale packages"
+  block:
+    - name: "Install locale packages for RedHat"
+      ansible.builtin.dnf:
+        name:
+          - "glibc-langpack-pl"
+          - "glibc-langpack-en"
+        state: "present"
+        update_cache: "yes"
+      when:
+        - "ansible_os_family == 'RedHat'"
+    - name: "Install locale packages for Archlinux"
+      community.general.pacman:
+        name: "glibc-locales"
+        state: "present"
+        update_cache: "yes"
+      when:
+        - "ansible_os_family == 'Archlinux'"
+
+- name: "Prepare locale.gen file for RedHat or Archlinux"
+  ansible.builtin.template:
+    src: "locale_gen.j2"
+    dest: "/etc/locale.gen"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+    force: "yes"
+
+- name: "Check for locale that pack are not installed"
+  locale_gen:
+    name: "ansible.UTF-8"
+    state: "present"
+  register: "locale_gen_locale_missed_result"
+  ignore_errors: true
+
+- name: "Deploy locales"
+  locale_gen:
+    name: "{{ item['locale'] + '.' + item['charset'] }}"
+    state: "present"
+  loop: "{{ vars['locale_list_simple'] | flatten(levels=1) }}"
+  loop_control:
+    label: "{{ 'Deploy locale: ' + item['locale'] }}"

--- a/tests/integration/targets/locale_gen/tasks/non_debian.yml
+++ b/tests/integration/targets/locale_gen/tasks/non_debian.yml
@@ -16,7 +16,6 @@
           - "glibc-langpack-pl"
           - "glibc-langpack-en"
         state: "present"
-        update_cache: "yes"
       when:
         - "ansible_os_family == 'RedHat'"
     - name: "Install locale packages for Archlinux"

--- a/tests/integration/targets/locale_gen/templates/locale_gen.j2
+++ b/tests/integration/targets/locale_gen/templates/locale_gen.j2
@@ -1,0 +1,9 @@
+{#
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+#}
+
+{% for l in vars['locale_list_simple'] %}
+{{ l['locale'] + '.' + l['charset'] + ' ' + l['charset'] }}
+{% endfor %}

--- a/tests/integration/targets/locale_gen/vars/main.yml
+++ b/tests/integration/targets/locale_gen/vars/main.yml
@@ -27,3 +27,11 @@ locale_list_basic:
   - localegen: de_CH.UTF-8
     locales: [de_CH.utf8]
     skip_removal: false
+
+# Simple locales list for non Debian distro
+
+locale_list_simple:
+  - locale: 'en_US'
+    charset: 'UTF-8'
+  - locale: 'pl_PL'
+    charset: 'UTF-8'


### PR DESCRIPTION
##### SUMMARY
Fixes #9734

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
locale_gen

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
This PR fixes issue for another glibc distro. The implementation should remove ubuntu_mode at all, and use `localectl list-locales` for any systemd distro in present days IMO