### PR TITLE
keycloak_client: compare desired and before dicts directly in checkmode

### DIFF
--- a/changelogs/fragments/9739-keycloak_client-compare-before-desired-directly.yml
+++ b/changelogs/fragments/9739-keycloak_client-compare-before-desired-directly.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - keycloak_client - In check mode, detect whether the lists in before client (for example redirect URI list) contain items that the lists in the desired client do not contain (https://github.com/ansible-collections/community.general/pull/9739).
+  - keycloak_client - in check mode, detect whether the lists in before client (for example redirect URI list) contain items that the lists in the desired client do not contain (https://github.com/ansible-collections/community.general/pull/9739).

--- a/changelogs/fragments/9739-keycloak_client-compare-before-desired-directly.yml
+++ b/changelogs/fragments/9739-keycloak_client-compare-before-desired-directly.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_client - In check mode, detect whether the lists in before client (for example redirect URI list) contain items that the lists in the desired client do not contain (https://github.com/ansible-collections/community.general/pull/9739).

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -969,6 +969,12 @@ def main():
     if before_client is None:
         before_client = {}
 
+    # kc drops the variable 'authorizationServicesEnabled' if set to false
+    # to minimize diff/changes we set it to false if not set by kc
+    if 'authorizationServicesEnabled' not in before_client:
+        before_client['authorizationServicesEnabled'] = False
+
+
     # Build a proposed changeset from parameters given to this module
     changeset = {}
 

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -771,6 +771,7 @@ def normalise_cr(clientrep, remove_ids=False):
         for key, value in clientrep['attributes'].items():
             if isinstance(value, bool):
                 clientrep['attributes'][key] = str(value).lower()
+        clientrep['attributes'].pop('client.secret.creation.time', None)
     return clientrep
 
 
@@ -1036,7 +1037,7 @@ def main():
                 if module._diff:
                     result['diff'] = dict(before=sanitize_cr(before_norm),
                                           after=sanitize_cr(desired_norm))
-                result['changed'] = not is_struct_included(desired_norm, before_norm, CLIENT_META_DATA)
+                result['changed'] = desired_norm != before_norm
 
                 module.exit_json(**result)
 

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -720,7 +720,7 @@ end_state:
 """
 
 from ansible_collections.community.general.plugins.module_utils.identity.keycloak.keycloak import KeycloakAPI, camel, \
-    keycloak_argument_spec, get_token, KeycloakError, is_struct_included
+    keycloak_argument_spec, get_token, KeycloakError
 from ansible.module_utils.basic import AnsibleModule
 import copy
 
@@ -966,14 +966,13 @@ def main():
     else:
         before_client = kc.get_client_by_id(cid, realm=realm)
 
-    if before_client is None:
-        before_client = {}
-
     # kc drops the variable 'authorizationServicesEnabled' if set to false
     # to minimize diff/changes we set it to false if not set by kc
-    if 'authorizationServicesEnabled' not in before_client:
+    if before_client and 'authorizationServicesEnabled' not in before_client:
         before_client['authorizationServicesEnabled'] = False
 
+    if before_client is None:
+        before_client = {}
 
     # Build a proposed changeset from parameters given to this module
     changeset = {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In check mode the keycloak_client module does not reliably detect changes to lists, because of the used `is_included_in_struct` method.

As long as all items in the desired list are in the before(existing) list no changes are detected. Even if there are additional items in the before list, the `changed` status is still `false`.

I think it would be better to directly compare the two dicts, to detect whether there are additional items in the before list that are not in the desired list. 

The issue with variables not set in the invocation, because they should not be changed in keycloak, is already addressed by copying the `before_client` and updating it with the desired changes.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_client
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Add additional URLs to the list of web origins or redirect URIs in the WebGUI but not the module invocation. Make a check mode run. `changed` should still be `false`.
<!--- Paste verbatim command output below, e.g. before and after your change -->
