### PR TITLE
New systemd_facts module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1364,6 +1364,8 @@ files:
     maintainers: konstruktoid
   $modules/systemd_creds_encrypt.py:
     maintainers: konstruktoid
+  $modules/systemd_facts.py:
+    maintainers: NomakCooper
   $modules/sysupgrade.py:
     maintainers: precurse
   $modules/taiga_issue.py:

--- a/plugins/modules/systemd_facts.py
+++ b/plugins/modules/systemd_facts.py
@@ -1,0 +1,296 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2025, Marco Noce <nce.marco@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: systemd_facts
+short_description: Gather C(systemd) unit facts.
+description:
+  - This module gathers facts about systemd units (services, targets, sockets).
+  - It runs C(systemctl list-units) (or processes selected units) and collects properties
+    for each unit using C(systemctl show).
+  - Even if a unit has a loadstate of "not-found" or "masked", it is added to the fact,
+    but only with the minimal properties ( name, loadstate, activestate, substate).
+  - When O(select) is used, the module first checks if the unit exists. If not, the unit
+    is recorded with minimal information.
+  - The gathered information is added to ansible facts under the key systemd_units.
+version_added: "10.4.0"
+options:
+  select:
+    description:
+      - When set to V(true), only the units specified in O(unitname) are processed.
+    type: bool
+    default: false
+  unitname:
+    description:
+      - List of unit names to process when O(select) is V(true).
+    type: list
+    elements: str
+    default: []
+  properties:
+    description:
+      - Additional properties to retrieve (appended to the default ones).
+    type: list
+    elements: str
+    default: []
+author:
+  - Marco Noce (@NomakCooper)
+'''
+
+EXAMPLES = r'''
+# Gather facts for all systemd services, targets, and sockets
+- name: Gather all systemd unit facts
+  community.general.systemd_facts:
+
+# Gather facts for selected units with extra properties.
+- name: Gather facts for selected unit(s)
+  community.general.systemd_facts:
+    select: true
+    unitname:
+      - sshd.service
+      - sshd-keygen.target
+      - systemd-journald.socket
+    properties:
+      - Description
+'''
+
+RETURN = r'''
+ansible_facts:
+  description: Dictionary of systemd unit facts keyed by unit name.
+  returned: always
+  type: complex
+  contains:
+    systemd_units:
+      description: Properties of systemd units
+      returned: always
+      type: list
+      elements: dict
+      contains:
+        name:
+          description: Unit name.
+          returned: always
+          type: str
+          sample: sshd.service
+        loadstate:
+          description:
+          - The state of the unit's configuration load
+          - Either V(loaded), V(not-found), V(masked).
+          returned: always
+          type: str
+          sample: running
+        activestate:
+          description:
+          - The current active state of the unit.
+          - Either V(active), V(inactive), V(failed).
+          returned: always
+          type: str
+          sample: enabled
+        substate:
+          description:
+          - The detailed state of the unit.
+          - Either V(running), V(dead), V(exited), V(failed), V(listening), V(active).
+          returned: always
+          type: str
+          sample: arp-ethers.service
+        fragmentpath:
+          description: The path to the unit file fragment.
+          returned: always
+          type: str
+          sample: /usr/lib/systemd/system/sshd.service
+        unitfilestate:
+          description:
+          - The state of the unit file
+          - Either V(enabled), V(disabled).
+          returned: always
+          type: str
+          sample: enabled
+        unitfilepreset:
+          description:
+          - The preset configuration for the unit file.
+          - Either V(enabled), V(disabled).
+          returned: always
+          type: str
+          sample: disabled
+        mainpid:
+          description: The main process ID
+          returned: Only for service units.
+          type: str
+          sample: 798
+        execmainpid:
+          description: The effective main process ID
+          returned: Only for service units.
+          type: str
+          sample: 798
+'''
+
+import os
+from ansible.module_utils.basic import AnsibleModule
+
+
+def is_systemd():
+    if os.path.exists("/run/systemd/system"):
+        return True
+    try:
+        with open("/proc/1/comm", "r") as f:
+            return f.read().strip() == "systemd"
+    except Exception:
+        return False
+
+
+def run_command(module, cmd):
+    rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
+    if rc != 0:
+        module.fail_json(msg="Command '{0}' failed: {1}".format(" ".join(cmd), stderr.strip()))
+    return stdout.strip()
+
+
+def parse_show_output(output):
+    result = {}
+    for line in output.splitlines():
+        if "=" in line:
+            key, val = line.split("=", 1)
+            result[key.lower()] = val
+    return result
+
+
+def get_unit_properties(module, systemctl_bin, unit, prop_list):
+    cmd = [systemctl_bin, "show", unit, "-p", ",".join(prop_list)]
+    output = run_command(module, cmd)
+    return parse_show_output(output)
+
+
+def determine_category(unit):
+    if unit.endswith('.service'):
+        return 'service'
+    elif unit.endswith('.target'):
+        return 'target'
+    elif unit.endswith('.socket'):
+        return 'socket'
+    else:
+        return None
+
+
+def add_properties(fact, unit_data, prop_list):
+    for prop in prop_list:
+        key = prop.lower()
+        if key in unit_data:
+            fact[key] = unit_data[key]
+
+
+def unit_exists(module, systemctl_bin, unit):
+    rc, stdout, stderr = module.run_command([systemctl_bin, "show", unit, "-p", "LoadState"], use_unsafe_shell=True)
+    return (rc == 0)
+
+
+def main():
+    module_args = dict(
+        select=dict(type='bool', default=False),
+        unitname=dict(type='list', elements='str', default=[]),
+        properties=dict(type='list', elements='str', default=[])
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    if not is_systemd():
+        module.fail_json(msg="This module only runs on hosts using systemd as the init system.")
+
+    systemctl_bin = module.get_bin_path('systemctl', required=True)
+
+    base_properties = {
+        'service': ['FragmentPath', 'UnitFileState', 'UnitFilePreset', 'MainPID', 'ExecMainPID'],
+        'target': ['FragmentPath', 'UnitFileState', 'UnitFilePreset'],
+        'socket': ['FragmentPath', 'UnitFileState', 'UnitFilePreset']
+    }
+
+    state_props = ['LoadState', 'ActiveState', 'SubState']
+
+    systemd_units = {}
+
+    if not module.params['select']:
+        list_cmd = [
+            systemctl_bin, "list-units",
+            "--no-pager",
+            "--type", "service,target,socket",
+            "--all",
+            "--plain",
+            "--no-legend"
+        ]
+        list_output = run_command(module, list_cmd)
+        for line in list_output.splitlines():
+            tokens = line.split()
+
+            if len(tokens) < 4:
+                continue
+
+            unit_name = tokens[0]
+            loadstate = tokens[1]
+            activestate = tokens[2]
+            substate = tokens[3]
+
+            fact = {
+                "name": unit_name,
+                "loadstate": loadstate,
+                "activestate": activestate,
+                "substate": substate
+            }
+
+            if loadstate in ("not-found", "masked"):
+                systemd_units[unit_name] = fact
+                continue
+
+            category = determine_category(unit_name)
+            if not category:
+                systemd_units[unit_name] = fact
+                continue
+
+            props = base_properties.get(category, [])
+            full_props = list(set(props + state_props))
+            unit_data = get_unit_properties(module, systemctl_bin, unit_name, full_props)
+
+            add_properties(fact, unit_data, full_props)
+            systemd_units[unit_name] = fact
+
+    else:
+        selected_units = module.params['unitname']
+        extra_properties = module.params['properties']
+        if not selected_units:
+            module.fail_json(msg="When select is true, provide at least one unit name in 'unitname'.")
+
+        for unit in selected_units:
+            if not unit_exists(module, systemctl_bin, unit):
+                systemd_units[unit] = {"name": unit, "loadstate": "not-found", "activestate": "", "substate": ""}
+                continue
+
+            category = determine_category(unit)
+            if not category:
+                systemd_units[unit] = {"name": unit, "loadstate": "unknown", "activestate": "", "substate": ""}
+                continue
+
+            props = base_properties.get(category, [])
+            full_props = list(set(props + state_props + extra_properties))
+            unit_data = get_unit_properties(module, systemctl_bin, unit, full_props)
+
+            fact = {"name": unit}
+            minimal_keys = ["LoadState", "ActiveState", "SubState"]
+            add_properties(fact, unit_data, minimal_keys)
+
+            ls = unit_data.get("loadstate", "").lower()
+            if ls not in ("not-found", "masked"):
+                add_properties(fact, unit_data, full_props)
+            systemd_units[unit] = fact
+
+    module.exit_json(changed=False, ansible_facts={"systemd_units": systemd_units})
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/systemd_facts/aliases
+++ b/tests/integration/targets/systemd_facts/aliases
@@ -1,3 +1,7 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 needs/root
 azp/posix/1
 skip/aix

--- a/tests/integration/targets/systemd_facts/aliases
+++ b/tests/integration/targets/systemd_facts/aliases
@@ -1,0 +1,6 @@
+needs/root
+azp/posix/1
+skip/aix
+skip/freebsd
+skip/osx
+skip/macos

--- a/tests/integration/targets/systemd_facts/tasks/main.yml
+++ b/tests/integration/targets/systemd_facts/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+# Copyright: (c) 2025, Marco Noce <nce.marco@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: check ansible_service_mgr
+  ansible.builtin.assert:
+    that: ansible_service_mgr == 'systemd'
+
+- name: Test systemd_facts
+  block:
+
+  - name: Run tests
+    import_tasks: tests.yml
+
+  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ansible_distribution_major_version is version('7', '>=')) or ansible_distribution == 'Fedora' or (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('15.04', '>=')) or (ansible_distribution == 'Debian' and ansible_distribution_version is version('8', '>=')) or ansible_os_family == 'Suse'

--- a/tests/integration/targets/systemd_facts/tasks/main.yml
+++ b/tests/integration/targets/systemd_facts/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
-# Copyright: (c) 2025, Marco Noce <nce.marco@gmail.com>
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: skip Alpine
+  meta: end_host
+  when: ansible_distribution == 'Alpine'
 
 - name: check ansible_service_mgr
   ansible.builtin.assert:

--- a/tests/integration/targets/systemd_facts/tasks/tests.yml
+++ b/tests/integration/targets/systemd_facts/tasks/tests.yml
@@ -1,3 +1,7 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 - name: Gather all units from shell
   ansible.builtin.shell: systemctl list-units --no-pager --type service,target,socket --all --plain --no-legend
   register: all_units

--- a/tests/integration/targets/systemd_facts/tasks/tests.yml
+++ b/tests/integration/targets/systemd_facts/tasks/tests.yml
@@ -1,0 +1,102 @@
+- name: Gather all units from shell
+  ansible.builtin.shell: systemctl list-units --no-pager --type service,target,socket --all --plain --no-legend
+  register: all_units
+
+- name: Assert command run successfully
+  ansible.builtin.assert:
+    that:
+      - all_units.rc == 0
+
+- name: Gather all units
+  community.general.systemd_facts:
+
+- name: Check all units exists
+  ansible.builtin.assert:
+    that: 
+      - ansible_facts.systemd_units is defined
+      - ansible_facts.systemd_units | length == all_units.stdout_lines | length
+    success_msg: "Success: All units collected."
+
+- name: Build all units list
+  set_fact:
+    shell_units: "{{ all_units.stdout_lines | map('split') | list }}"
+
+- name: Check all units properties
+  ansible.builtin.assert:
+    that:
+      - ansible_facts.systemd_units[item[0]].name == item[0]
+      - ansible_facts.systemd_units[item[0]].loadstate == item[1]
+      - ansible_facts.systemd_units[item[0]].activestate == item[2]
+      - ansible_facts.systemd_units[item[0]].substate == item[3]
+  loop: "{{ shell_units }}"
+  loop_control:
+    label: "{{ item[0] }}"
+
+- name: Gather systemd-journald.service properties from shell
+  ansible.builtin.shell: systemctl show systemd-journald.service -p Id,LoadState,ActiveState,SubState,FragmentPath,MainPID,ExecMainPID,UnitFileState,UnitFilePreset,Description,Restart
+  register: journald_prop
+
+- name: Assert command run successfully
+  ansible.builtin.assert:
+    that:
+      - journald_prop.rc == 0
+
+- name: Gather systemd-journald.service
+  community.general.systemd_facts:
+    select: true
+    unitname:
+      - systemd-journald.service
+
+- name: Check unit facts and all properties
+  ansible.builtin.assert:
+    that: 
+      - ansible_facts.systemd_units is defined
+      - ansible_facts.systemd_units['systemd-journald.service'] is defined
+      - ansible_facts.systemd_units['systemd-journald.service'].name is defined
+      - ansible_facts.systemd_units['systemd-journald.service'].loadstate is defined
+      - ansible_facts.systemd_units['systemd-journald.service'].activestate is defined
+      - ansible_facts.systemd_units['systemd-journald.service'].substate is defined
+      - ansible_facts.systemd_units['systemd-journald.service'].fragmentpath is defined
+      - ansible_facts.systemd_units['systemd-journald.service'].mainpid is defined
+      - ansible_facts.systemd_units['systemd-journald.service'].execmainpid is defined
+      - ansible_facts.systemd_units['systemd-journald.service'].unitfilestate is defined
+      - ansible_facts.systemd_units['systemd-journald.service'].unitfilepreset is defined
+    success_msg: "Success: All properties collected."
+
+- name: Create dict of properties from shell
+  ansible.builtin.set_fact:
+    journald_shell: "{{ dict(journald_prop.stdout_lines | map('split', '=', 1) | list) }}"
+
+- name: Check properties content
+  ansible.builtin.assert:
+    that:
+      - ansible_facts.systemd_units['systemd-journald.service'].name == journald_shell.Id
+      - ansible_facts.systemd_units['systemd-journald.service'].loadstate == journald_shell.LoadState
+      - ansible_facts.systemd_units['systemd-journald.service'].activestate == journald_shell.ActiveState
+      - ansible_facts.systemd_units['systemd-journald.service'].substate == journald_shell.SubState
+      - ansible_facts.systemd_units['systemd-journald.service'].fragmentpath == journald_shell.FragmentPath
+      - ansible_facts.systemd_units['systemd-journald.service'].mainpid == journald_shell.MainPID
+      - ansible_facts.systemd_units['systemd-journald.service'].execmainpid == journald_shell.ExecMainPID
+      - ansible_facts.systemd_units['systemd-journald.service'].unitfilestate == journald_shell.UnitFileState
+      - ansible_facts.systemd_units['systemd-journald.service'].unitfilepreset == journald_shell.UnitFilePreset
+    success_msg: "Success: Property values are correct."
+
+- name: Gather systemd-journald.service extra properties
+  community.general.systemd_facts:
+    select: true
+    unitname:
+      - systemd-journald.service
+    properties:
+      - Description
+      - Restart
+
+- name: Check new properties
+  ansible.builtin.assert:
+    that:
+      - ansible_facts.systemd_units is defined
+      - ansible_facts.systemd_units['systemd-journald.service'] is defined
+      - ansible_facts.systemd_units['systemd-journald.service'].description is defined
+      - ansible_facts.systemd_units['systemd-journald.service'].restart is defined
+      - ansible_facts.systemd_units['systemd-journald.service'].description == journald_shell.Description
+      - ansible_facts.systemd_units['systemd-journald.service'].restart == journald_shell.Restart
+    success_msg: "Success: Extra property values are correct."

--- a/tests/integration/targets/systemd_facts/tasks/tests.yml
+++ b/tests/integration/targets/systemd_facts/tasks/tests.yml
@@ -47,7 +47,6 @@
 
 - name: Gather systemd-journald.service
   community.general.systemd_facts:
-    select: true
     unitname:
       - systemd-journald.service
 
@@ -87,7 +86,6 @@
 
 - name: Gather systemd-journald.service extra properties
   community.general.systemd_facts:
-    select: true
     unitname:
       - systemd-journald.service
     properties:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds a new module, **systemd_facts**, to the **`community.general`** collection. 

**`Systemd`** is becoming increasingly important for hosts that use it by default, yet Ansible currently lacks a module that collects its data in a consistent and efficient manner.

I decided to develop the **`systemd_facts`** module to give all Ansible users the ability to gather detailed information about systemd units ( **`service`**,**`target`**,**`socket`**  ).

The module gathers detailed **`systemd`** unit ( **`service`**,**`target`**,**`socket`**  ) facts using the **`systemctl`** command. 
It supports both global and select modes, and includes the ability to collect additional properties as specified by the user.

### Key Features

- **Global and Select Modes:**
  - **Global mode:** Retrieves facts for all systemd units using **`systemctl`**.
  - ```
      $ systemctl list-units --no-pager --type service,target,socket --all --plain --no-legend
    ```
  - ```
      $ systemctl show 'UNIT_NAME' -p 'PROPERTIES_LIST'
    ```
  - **Select mode:** Processes only the units specified in the **`unitname`** parameter. The module first verifies unit existence and, if not found, returns minimal information.
  
- **Customizable Properties:**
  - The `properties` parameter allows users to request extra unit properties beyond the defaults.

- **Robust Handling:**
  - Even if a unit has a **`loadstate`** of **`not-found`** or **`masked`**, it is recorded but with minimal details.
  
- **Detailed Return Values:**
  - The module returns an **`ansible_facts`** dict named **`systemd_units`** containing detailed properties for each unit.
  
### Usage Examples

- **Gather all systemd unit facts:**
  ```yaml
  - name: Gather all systemd unit facts
    community.general.systemd_facts:
  ```
 - **Gather all systemd unit selected facts and an extra property:**
    ```yaml
    - name: Gather facts for selected unit(s)
      community.general.systemd_facts:
        select: true
        unitname:
          - sshd.service
          - sshd-keygen.target
          - systemd-journald.socket
        properties:
          - Description
    ```
### Return Examples

```json
"systemd_units": {
    "sshd.service": {
        "name": "sshd.service",
        "loadstate": "loaded",
        "activestate": "active",
        "substate": "running",
        "fragmentpath": "/usr/lib/systemd/system/sshd.service",
        "unitfilestate": "enabled",
        "unitfilepreset": "enabled",
        "mainpid": "798",
        "execmainpid": "798",
        "description": "OpenSSH Daemon"
    },
    "non_existent.service": {
        "name": "non_existent.service",
        "loadstate": "not-found",
        "activestate": "",
        "substate": ""
    }
}
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- New Module/Plugin Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
systemd_facts
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
In this PR:

- Added the **`systemd_facts`** module in **`plugins/modules/systemd_facts.py`**.
- Added an integration test in **`tests/integration/targets/systemd_facts/`**.
- Added an entry in **`.github/BOTMETA.yml`**.

Ansible sanity and integration tests were successfully run locally using Docker.
<!--- Paste verbatim command output below, e.g. before and after your change -->

