### PR TITLE
keycloak_realm: remove realm id requirement

### DIFF
--- a/changelogs/fragments/9768-keycloak_realm-remove-id-requirement.yaml
+++ b/changelogs/fragments/9768-keycloak_realm-remove-id-requirement.yaml
@@ -1,2 +1,2 @@
-bugfixes:
+minor_changes:
   - keycloak_realm - remove id requirement when creating a realm to allow keycloak generating its own realm id (https://github.com/ansible-collections/community.general/pull/9768).

--- a/changelogs/fragments/9768-keycloak_realm-remove-id-requirement.yaml
+++ b/changelogs/fragments/9768-keycloak_realm-remove-id-requirement.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_realm - remove id requirement when creating a realm to allow keycloak generating its own realm id (https://github.com/ansible-collections/community.general/pull/9768).

--- a/changelogs/fragments/9768-keycloak_realm-remove-id-requirement.yaml
+++ b/changelogs/fragments/9768-keycloak_realm-remove-id-requirement.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - keycloak_realm - remove id requirement when creating a realm to allow keycloak generating its own realm id (https://github.com/ansible-collections/community.general/pull/9768).
+  - keycloak_realm - remove ID requirement when creating a realm to allow Keycloak generating its own realm ID (https://github.com/ansible-collections/community.general/pull/9768).

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -456,6 +456,8 @@ class KeycloakAPI(object):
             self.module.fail_json(msg='Could not obtain realm %s: %s' % (realm, str(e)),
                                   exception=traceback.format_exc())
 
+    # the keycloak API expects the realm name (like `master`) not the id when fetching the realm data
+    # see the Keycloak API docs: https://www.keycloak.org/docs-api/latest/rest-api/#_realms_admin
     def get_realm_by_id(self, realm='master'):
         """ Obtain realm representation by id
 

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -456,8 +456,8 @@ class KeycloakAPI(object):
             self.module.fail_json(msg='Could not obtain realm %s: %s' % (realm, str(e)),
                                   exception=traceback.format_exc())
 
-    # the keycloak API expects the realm name (like `master`) not the id when fetching the realm data
-    # see the Keycloak API docs: https://www.keycloak.org/docs-api/latest/rest-api/#_realms_admin
+    # The Keycloak API expects the realm name (like `master`) not the ID when fetching the realm data.
+    # See the Keycloak API docs: https://www.keycloak.org/docs-api/latest/rest-api/#_realms_admin
     def get_realm_by_id(self, realm='master'):
         """ Obtain realm representation by id
 

--- a/plugins/modules/keycloak_realm.py
+++ b/plugins/modules/keycloak_realm.py
@@ -528,8 +528,7 @@ EXAMPLES = r"""
     auth_realm: master
     auth_username: USERNAME
     auth_password: PASSWORD
-    id: realm
-    realm: realm
+    realm: unique_realm_name
     state: present
 
 - name: Delete a Keycloak realm
@@ -539,7 +538,7 @@ EXAMPLES = r"""
     auth_realm: master
     auth_username: USERNAME
     auth_password: PASSWORD
-    id: test
+    realm: unique_realm_name
     state: absent
 """
 
@@ -554,7 +553,7 @@ proposed:
   description: Representation of proposed realm.
   returned: always
   type: dict
-  sample: {id: "test"}
+  sample: {realm: "test"}
 
 existing:
   description: Representation of existing realm (sample is truncated).

--- a/plugins/modules/keycloak_realm.py
+++ b/plugins/modules/keycloak_realm.py
@@ -767,9 +767,6 @@ def main():
         # Process a creation
         result['changed'] = True
 
-        if 'id' not in desired_realm:
-            module.fail_json(msg='id needs to be specified when creating a new realm')
-
         if module._diff:
             result['diff'] = dict(before='', after=sanitize_cr(desired_realm))
 
@@ -778,11 +775,11 @@ def main():
 
         # create it
         kc.create_realm(desired_realm)
-        after_realm = kc.get_realm_by_id(desired_realm['id'])
+        after_realm = kc.get_realm_by_id(desired_realm['realm'])
 
         result['end_state'] = sanitize_cr(after_realm)
 
-        result['msg'] = 'Realm %s has been created.' % desired_realm['id']
+        result['msg'] = 'Realm %s has been created.' % desired_realm['realm']
         module.exit_json(**result)
 
     else:

--- a/plugins/modules/keycloak_realm.py
+++ b/plugins/modules/keycloak_realm.py
@@ -813,7 +813,7 @@ def main():
                 result['diff'] = dict(before=before_realm_sanitized,
                                       after=sanitize_cr(after_realm))
 
-            result['msg'] = 'Realm %s has been updated.' % desired_realm['id']
+            result['msg'] = 'Realm %s has been updated.' % desired_realm['realm']
             module.exit_json(**result)
 
         else:
@@ -832,7 +832,7 @@ def main():
             result['proposed'] = {}
             result['end_state'] = {}
 
-            result['msg'] = 'Realm %s has been deleted.' % before_realm['id']
+            result['msg'] = 'Realm %s has been deleted.' % before_realm['realm']
 
     module.exit_json(**result)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The keycloak_realm module requires an id when creating a new realm. I think it is better to let keycloak generate the id, like when creating a realm in the GUI. 

Using the module with older keycloak versions that require an id would still be possible, but it would also allow users to create realms with uuids generated by keycloak.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_realm
