### PR TITLE
apache2_mod_proxy: follow-up for #9762, forgot one place with find_all/findAll

### DIFF
--- a/plugins/modules/apache2_mod_proxy.py
+++ b/plugins/modules/apache2_mod_proxy.py
@@ -277,7 +277,7 @@ class BalancerMember(object):
             except TypeError as exc:
                 self.module.fail_json(msg="Cannot parse balancer_member_page HTML! {0}".format(exc))
             else:
-                subsoup = find_all(soup, 'table')[1].find_all('tr')
+                subsoup = find_all(find_all(soup, 'table')[1], 'tr')
                 keys = find_all(subsoup[0], 'th')
                 for valuesset in subsoup[1::1]:
                     if re.search(pattern=self.host, string=str(valuesset)):


### PR DESCRIPTION
##### SUMMARY
#9772 showed that something isn't right with Python 2.7. (Apparently no Python 2.7 tests are run with `stable-10` and `main`?)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apache2_mod_proxy
