### PR TITLE
redhat_registration: use 'enable_content' D-Bus option when available

### DIFF
--- a/changelogs/fragments/9778-redhat_subscription-ensure-to-enable-content.yml
+++ b/changelogs/fragments/9778-redhat_subscription-ensure-to-enable-content.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - |
+    redhat_subscription - use the "enable_content" option (when available) when
+    registering using D-Bus, to ensure that subscription-manager enables the
+    content on registration; this is particular important on EL 10+ and Fedora
+    41+
+    (https://github.com/ansible-collections/community.general/pull/9778).


### PR DESCRIPTION
##### SUMMARY

This makes sure that subscription-manager always enables the content for the system right after the registration.

This is particular important on EL 10+ and Fedora 41+.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

subscription_manager