### PR TITLE
Allow Xen Host and/or Xen VM names instead of their UUIDs

### DIFF
--- a/changelogs/fragments/9769-xoa_allow_using_names_in_inventory.yml
+++ b/changelogs/fragments/9769-xoa_allow_using_names_in_inventory.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - xen_orchestra inventory plugin - add ``use_vm_uuid`` and ``use_host_uuid`` boolean options to allow switching over to using VM/Xen name labels instead of UUIDs as item names (https://github.com/ansible-collections/community.general/pull/9769).

--- a/changelogs/fragments/9769-xoa_allow_using_names_in_inventory.yml
+++ b/changelogs/fragments/9769-xoa_allow_using_names_in_inventory.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - xen_orchestra inventory plugin - add ``use_vm_uuid`` and ``use_host_uuid`` boolean options to allow switching over to using VM/Xen name labels instead of UUIDs as item names (https://github.com/ansible-collections/community.general/pull/9769).

--- a/changelogs/fragments/9787-xoa_allow_using_names_in_inventory.yml
+++ b/changelogs/fragments/9787-xoa_allow_using_names_in_inventory.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - xen_orchestra inventory plugin - add ``use_vm_uuid`` and ``use_host_uuid`` boolean options to allow switching over to using VM/Xen name labels instead of UUIDs as item names (https://github.com/ansible-collections/community.general/pull/9787).

--- a/plugins/inventory/xen_orchestra.py
+++ b/plugins/inventory/xen_orchestra.py
@@ -60,14 +60,14 @@ DOCUMENTATION = '''
         use_vm_uuid:
             description:
                 - Import Xen VMs to inventory using their UUID as the VM entry name.
-                - If set to V(false) use VM name labels instead of UUID's.
+                - If set to V(false) use VM name labels instead of UUIDs.
             type: boolean
             default: true
             version_added: 10.4.0
         use_host_uuid:
             description:
                 - Import Xen Hosts to inventory using their UUID as the Host entry name.
-                - If set to V(false) use Host name labels instead of UUID's.
+                - If set to V(false) use Host name labels instead of UUIDs.
             type: boolean
             default: true
             version_added: 10.4.0

--- a/plugins/inventory/xen_orchestra.py
+++ b/plugins/inventory/xen_orchestra.py
@@ -63,12 +63,14 @@ DOCUMENTATION = '''
                 - If set to V(false) use VM name labels instead of UUID's.
             type: boolean
             default: true
+            version_added: 10.4.0
         use_host_uuid:
             description:
                 - Import Xen Hosts to inventory using their UUID as the Host entry name.
                 - If set to V(false) use Host name labels instead of UUID's.
             type: boolean
             default: true
+            version_added: 10.4.0
 '''
 
 

--- a/plugins/inventory/xen_orchestra.py
+++ b/plugins/inventory/xen_orchestra.py
@@ -211,8 +211,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def _add_vms(self, vms, hosts, pools):
         vm_name_list = []
-        if not hasattr(self, 'vm_entry_name_type'):
-            self.vm_entry_name_type = 'uuid'
         for uuid, vm in vms.items():
             if self.vm_entry_name_type == 'name_label':
                 if vm['name_label'] not in vm_name_list:
@@ -273,8 +271,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def _add_hosts(self, hosts, pools):
         host_name_list = []
-        if not hasattr(self, 'host_entry_name_type'):
-            self.host_entry_name_type = 'uuid'
         for host in hosts.values():
             if self.host_entry_name_type == 'name_label':
                 if host['name_label'] not in host_name_list:

--- a/tests/unit/plugins/inventory/test_xen_orchestra.py
+++ b/tests/unit/plugins/inventory/test_xen_orchestra.py
@@ -158,6 +158,8 @@ def test_verify_file_bad_config(inventory):
 
 
 def test_populate(inventory, mocker):
+    inventory.host_entry_name_type = 'uuid'
+    inventory.vm_entry_name_type = 'uuid'
     inventory.get_option = mocker.MagicMock(side_effect=get_option)
     inventory._populate(objects)
     actual = sorted(inventory.inventory.hosts.keys())


### PR DESCRIPTION
This is a redo of a previously closed PR where I messed up git rebase and figured it would be quicker to just make a new PR with a fresh branch.
( https://github.com/ansible-collections/community.general/pull/9767 )

### SUMMARY
Currently the inventory entry names are created exclusively using UUID's as the inventory items name.
Sometimes we would prefer to use the Host/VM names in the inventory so I've added some options to allow adding Hosts/VMs using their names (name_labels) instead of their UUIDs from Xen.

By default UUID's will be used just like how it currently exists.
If you set use_vm_uuids or use_host_uuids to false then names will be used instead.

### WHY
Currently since every VM is using UUIDs this means you cannot use host patterns/limits for controlling where your jobs run (as far as I know) and you're stuck using flow controls from tags and other bits of metadata that need to be in your playbooks directly.

Another major benefit to this is if you're using AWX/Tower this will make your dynamic inventory much more easily searchable/usable.

With that in mind there is a glaringly obvious downside to using names which is duplicate names are possible with Xen so this may cause issues as this PR does not currently consider duplicate name handling though there is some logic to append a number count to any duplicate names to get around this.

### ISSUE TYPE
Feature Pull Request

### COMPONENT NAME
Xen Orchestra

### EXAMPLE OUTPUT
[pr-9787-xoa_allow_using_names_in_inventory.json](https://github.com/user-attachments/files/18898270/pr-9787-xoa_allow_using_names_in_inventory.json)

