### PR TITLE
json_query filter docs: fix typo cluster2 when cluster1 is mentioned

### DIFF
--- a/docs/docsite/rst/filter_guide_selecting_json_data.rst
+++ b/docs/docsite/rst/filter_guide_selecting_json_data.rst
@@ -124,7 +124,7 @@ To get a hash map with all ports and names of a cluster:
         var: item
       loop: "{{ domain_definition | community.general.json_query(server_name_cluster1_query) }}"
       vars:
-        server_name_cluster1_query: "domain.server[?cluster=='cluster2'].{name: name, port: port}"
+        server_name_cluster1_query: "domain.server[?cluster=='cluster1'].{name: name, port: port}"
 
 To extract ports from all clusters with name starting with 'server1':
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Typo: everything is cluster1 but the actual query
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
doc community.general.json_query

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
