### PR TITLE
CI: Add macOS 15.3

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -188,8 +188,8 @@ stages:
         parameters:
           testFormat: devel/{0}
           targets:
-            - name: macOS 14.3
-              test: macos/14.3
+            - name: macOS 15.3
+              test: macos/15.3
             - name: RHEL 9.5
               test: rhel/9.5
             - name: FreeBSD 14.2
@@ -208,6 +208,8 @@ stages:
         parameters:
           testFormat: 2.18/{0}
           targets:
+            - name: macOS 14.3
+              test: macos/14.3
             - name: RHEL 9.4
               test: rhel/9.4
             - name: FreeBSD 14.1

--- a/tests/integration/targets/python_requirements_info/tasks/main.yml
+++ b/tests/integration/targets/python_requirements_info/tasks/main.yml
@@ -8,6 +8,12 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+- name: Make sure setuptools is installed
+  pip:
+    name: setuptools
+    state: present
+  when: ansible_facts.distribution == 'MacOSX' and ansible_distribution_version is version('15', '>=')
+
 - name: run python_requirements_info module
   python_requirements_info:
   register: basic_info


### PR DESCRIPTION
##### SUMMARY
ansible-core devel's ansible-test replaced macOS 14.3 with 15.3.

Ref: https://github.com/ansible/ansible/pull/84665
Ref: https://forum.ansible.com/t/40650

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
