### PR TITLE
cloudflare_dns: handle exhausted response stream in case of http error

### DIFF
--- a/changelogs/fragments/9818-cloudflare-dns-exhausted-response.yml
+++ b/changelogs/fragments/9818-cloudflare-dns-exhausted-response.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cloudlare_dns - handle exhausted response stream in case of http error to show nice error message to the user (https://github.com/ansible-collections/community.general/pull/9818).

--- a/changelogs/fragments/9818-cloudflare-dns-exhausted-response.yml
+++ b/changelogs/fragments/9818-cloudflare-dns-exhausted-response.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - cloudlare_dns - handle exhausted response stream in case of http error to show nice error message to the user (https://github.com/ansible-collections/community.general/pull/9818).
+  - cloudlare_dns - handle exhausted response stream in case of HTTP errors to show nice error message to the user (https://github.com/ansible-collections/community.general/issues/9782, https://github.com/ansible-collections/community.general/pull/9818).

--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -551,6 +551,9 @@ class CloudflareAPI(object):
         try:
             content = resp.read()
         except AttributeError:
+            content = None
+
+        if not content:
             if info['body']:
                 content = info['body']
             else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When fetch_url encouters http error, it will [exhaust the response stream](https://github.com/ansible/ansible/blob/01ca9b1d0ec882f5eea7fc42ef7f7dab9ea76d19/lib/ansible/module_utils/urls.py#L1288), and record the response body in [info['body']](https://github.com/ansible/ansible/blob/01ca9b1d0ec882f5eea7fc42ef7f7dab9ea76d19/lib/ansible/module_utils/urls.py#L1301)

Let's account for that by trying to fall back on `[info['body']` when response stream reads empty.


Related to https://github.com/ansible-collections/community.general/issues/9782

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
- cloudflare_dns

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:

```text
fatal: [localhost]: FAILED! => {
    "changed": false,
    "msg": "API bad request; Status: 400; Method: POST: Call: /zones/REDACTED/dns_records"
}
```

After:

```text
fatal: [localhost]: FAILED! => {
    "changed": false,
    "msg": "API bad request; Status: 400; Method: POST: Call: /zones/REDACTED/dns_records; Error details: code: 81054, error: A CNAME record with that host already exists. For more details, refer to <https://developers.cloudflare.com/dns/manage-dns-records/troubleshooting/records-with-same-name/>.; "
}
```