### PR TITLE
Example typo in homebrew_services.py

### DIFF
--- a/plugins/modules/homebrew_services.py
+++ b/plugins/modules/homebrew_services.py
@@ -72,7 +72,7 @@ EXAMPLES = r"""
 - name: Remove the foo service (equivalent to `brew services stop foo`)
   community.general.homebrew_services:
     name: foo
-    service_state: absent
+    state: absent
 """
 
 RETURN = r"""


### PR DESCRIPTION
##### SUMMARY

Maybe this was mixed up with the _brew_service_state() function? I get this error as-written:
```
fatal: [eahmm3]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (community.general.homebrew_services) module: service
_state. Supported parameters include: name, path, state (formula)."}
```

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
homebrew_services
