### PR TITLE
systemd_info - add wildcards support

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -404,6 +404,8 @@ files:
     maintainers: russoz
   $module_utils/ssh.py:
     maintainers: russoz
+  $module_utils/systemd.py:
+    maintainers: NomakCooper
   $module_utils/storage/hpe3par/hpe3par.py:
     maintainers: farhan7500 gautamphegde
   $module_utils/utm_utils.py:

--- a/changelogs/fragments/9821-systemd_info-add-wildcards.yml
+++ b/changelogs/fragments/9821-systemd_info-add-wildcards.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - systemd_info - add wildcards support (https://github.com/ansible-collections/community.general/pull/9821).

--- a/changelogs/fragments/9821-systemd_info-add-wildcards.yml
+++ b/changelogs/fragments/9821-systemd_info-add-wildcards.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - systemd_info - add wildcards support (https://github.com/ansible-collections/community.general/pull/9821).
+  - systemd_info - add wildcard expression support in ``unitname`` option (https://github.com/ansible-collections/community.general/pull/9821).

--- a/plugins/module_utils/systemd.py
+++ b/plugins/module_utils/systemd.py
@@ -13,16 +13,14 @@ from ansible_collections.community.general.plugins.module_utils.cmd_runner impor
 def systemd_runner(module, command, **kwargs):
     arg_formats = dict(
         version=cmd_runner_fmt.as_fixed("--version"),
-        list_units=cmd_runner_fmt.as_fixed("list-units"),
-        no_pager=cmd_runner_fmt.as_fixed("--no-pager"),
+        list_units=cmd_runner_fmt.as_fixed(["list-units", "--no-pager"]),
         typ=cmd_runner_fmt.as_fixed("--type"),
         types=cmd_runner_fmt.as_func(lambda v: [] if not v else [",".join(v)]),
         all=cmd_runner_fmt.as_fixed("--all"),
         plain=cmd_runner_fmt.as_fixed("--plain"),
         no_legend=cmd_runner_fmt.as_fixed("--no-legend"),
         show=cmd_runner_fmt.as_fixed("show"),
-        p=cmd_runner_fmt.as_fixed("-p"),
-        props=cmd_runner_fmt.as_list(),
+        props=cmd_runner_fmt.as_func(lambda v: [] if not v else ["-p", ",".join(v)]),
         dashdash=cmd_runner_fmt.as_fixed("--"),
         unit=cmd_runner_fmt.as_list(),
     )

--- a/plugins/module_utils/systemd.py
+++ b/plugins/module_utils/systemd.py
@@ -14,8 +14,7 @@ def systemd_runner(module, command, **kwargs):
     arg_formats = dict(
         version=cmd_runner_fmt.as_fixed("--version"),
         list_units=cmd_runner_fmt.as_fixed(["list-units", "--no-pager"]),
-        typ=cmd_runner_fmt.as_fixed("--type"),
-        types=cmd_runner_fmt.as_func(lambda v: [] if not v else [",".join(v)]),
+        types=cmd_runner_fmt.as_func(lambda v: [] if not v else ["--type", ",".join(v)]),
         all=cmd_runner_fmt.as_fixed("--all"),
         plain=cmd_runner_fmt.as_fixed("--plain"),
         no_legend=cmd_runner_fmt.as_fixed("--no-legend"),

--- a/plugins/module_utils/systemd.py
+++ b/plugins/module_utils/systemd.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 from ansible_collections.community.general.plugins.module_utils.cmd_runner import CmdRunner, cmd_runner_fmt
 
 
-def systemd_info_runner(module, command, **kwargs):
+def systemd_runner(module, command, **kwargs):
     arg_formats = dict(
         version=cmd_runner_fmt.as_fixed("--version"),
         list_units=cmd_runner_fmt.as_fixed("list-units"),

--- a/plugins/module_utils/systemd_info.py
+++ b/plugins/module_utils/systemd_info.py
@@ -31,7 +31,6 @@ def systemd_info_runner(module, command, **kwargs):
         module,
         command=command,
         arg_formats=arg_formats,
-        environ_update={'LC_ALL': 'C', 'LANG': 'C'},
         check_rc=True,
         **kwargs
     )

--- a/plugins/module_utils/systemd_info.py
+++ b/plugins/module_utils/systemd_info.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025, Marco Noce <nce.marco@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+from ansible_collections.community.general.plugins.module_utils.cmd_runner import CmdRunner, cmd_runner_fmt
+
+
+systemd_info_arg_formats = {
+    'version':   cmd_runner_fmt.as_fixed("--version"),
+    'list_units': cmd_runner_fmt.as_fixed("list-units"),
+    'no_pager':  cmd_runner_fmt.as_fixed("--no-pager"),
+    'typ':       cmd_runner_fmt.as_fixed("--type"),
+    'types':     cmd_runner_fmt.as_func(lambda v: [",".join(v)] if isinstance(v, list) else [v]),
+    'all':       cmd_runner_fmt.as_fixed("--all"),
+    'plain':     cmd_runner_fmt.as_fixed("--plain"),
+    'no_legend': cmd_runner_fmt.as_fixed("--no-legend"),
+    'show':      cmd_runner_fmt.as_fixed("show"),
+    'p':         cmd_runner_fmt.as_fixed("-p"),
+    'props':     cmd_runner_fmt.as_list(),
+    'dashdash':  cmd_runner_fmt.as_fixed("--"),
+    'unit':      cmd_runner_fmt.as_list(),
+}
+
+
+default_systemd_info_args_order = "version list_units no_pager typ types all plain no_legend show p props dashdash unit"
+
+
+def systemd_info_runner(module, command, **kwargs):
+    return CmdRunner(
+        module,
+        command=command,
+        arg_formats=systemd_info_arg_formats,
+        default_args_order=default_systemd_info_args_order,
+        check_rc=True,
+        **kwargs
+    )

--- a/plugins/module_utils/systemd_info.py
+++ b/plugins/module_utils/systemd_info.py
@@ -10,32 +10,29 @@ __metaclass__ = type
 from ansible_collections.community.general.plugins.module_utils.cmd_runner import CmdRunner, cmd_runner_fmt
 
 
-systemd_info_arg_formats = {
-    'version':   cmd_runner_fmt.as_fixed("--version"),
-    'list_units': cmd_runner_fmt.as_fixed("list-units"),
-    'no_pager':  cmd_runner_fmt.as_fixed("--no-pager"),
-    'typ':       cmd_runner_fmt.as_fixed("--type"),
-    'types':     cmd_runner_fmt.as_func(lambda v: [",".join(v)] if isinstance(v, list) else [v]),
-    'all':       cmd_runner_fmt.as_fixed("--all"),
-    'plain':     cmd_runner_fmt.as_fixed("--plain"),
-    'no_legend': cmd_runner_fmt.as_fixed("--no-legend"),
-    'show':      cmd_runner_fmt.as_fixed("show"),
-    'p':         cmd_runner_fmt.as_fixed("-p"),
-    'props':     cmd_runner_fmt.as_list(),
-    'dashdash':  cmd_runner_fmt.as_fixed("--"),
-    'unit':      cmd_runner_fmt.as_list(),
-}
-
-
-default_systemd_info_args_order = "version list_units no_pager typ types all plain no_legend show p props dashdash unit"
-
-
 def systemd_info_runner(module, command, **kwargs):
-    return CmdRunner(
+    arg_formats = dict(
+        version=cmd_runner_fmt.as_fixed("--version"),
+        list_units=cmd_runner_fmt.as_fixed("list-units"),
+        no_pager=cmd_runner_fmt.as_fixed("--no-pager"),
+        typ=cmd_runner_fmt.as_fixed("--type"),
+        types=cmd_runner_fmt.as_func(lambda v: [] if not v else [",".join(v)]),
+        all=cmd_runner_fmt.as_fixed("--all"),
+        plain=cmd_runner_fmt.as_fixed("--plain"),
+        no_legend=cmd_runner_fmt.as_fixed("--no-legend"),
+        show=cmd_runner_fmt.as_fixed("show"),
+        p=cmd_runner_fmt.as_fixed("-p"),
+        props=cmd_runner_fmt.as_list(),
+        dashdash=cmd_runner_fmt.as_fixed("--"),
+        unit=cmd_runner_fmt.as_list(),
+    )
+
+    runner = CmdRunner(
         module,
         command=command,
-        arg_formats=systemd_info_arg_formats,
-        default_args_order=default_systemd_info_args_order,
+        arg_formats=arg_formats,
+        environ_update={'LC_ALL': 'C', 'LANG': 'C'},
         check_rc=True,
         **kwargs
     )
+    return runner

--- a/plugins/modules/systemd_info.py
+++ b/plugins/modules/systemd_info.py
@@ -217,17 +217,16 @@ def get_version(runner):
 
 
 def list_units(runner, types_value):
-    context = "list_units no_pager typ types all plain no_legend"
+    context = "list_units typ types all plain no_legend"
     with runner(context) as ctx:
         rc, stdout, stderr = ctx.run(types=types_value)
     return stdout.strip()
 
 
 def show_unit_properties(runner, prop_list, unit):
-    props_str = ",".join(prop_list)
-    context = "show p props dashdash unit"
+    context = "show props dashdash unit"
     with runner(context) as ctx:
-        rc, stdout, stderr = ctx.run(props=props_str, unit=unit)
+        rc, stdout, stderr = ctx.run(props=prop_list, unit=unit)
     return stdout.strip()
 
 

--- a/plugins/modules/systemd_info.py
+++ b/plugins/modules/systemd_info.py
@@ -286,6 +286,7 @@ def validate_unit_and_properties(runner, unit, extra_properties, units_info, pro
         module.fail_json(msg="Unit '{0}' does not exist or is inaccessible.".format(unit))
 
     category = determine_category(unit)
+
     if not category:
         module.fail_json(msg="Could not determine the category for unit '{0}'.".format(unit))
 
@@ -309,6 +310,7 @@ def validate_unit_and_properties(runner, unit, extra_properties, units_info, pro
 def process_wildcards(selected_units, all_units, module):
     resolved_units = {}
     non_matching_patterns = []
+
     for pattern in selected_units:
         matches = fnmatch.filter(all_units, pattern)
         if not matches:
@@ -316,6 +318,7 @@ def process_wildcards(selected_units, all_units, module):
         else:
             for match in matches:
                 resolved_units[match] = True
+
     if not resolved_units:
         module.fail_json(msg="No units match any of the provided patterns: {}".format(", ".join(non_matching_patterns)))
 

--- a/plugins/modules/systemd_info.py
+++ b/plugins/modules/systemd_info.py
@@ -217,7 +217,7 @@ def get_version(runner):
 
 
 def list_units(runner, types_value):
-    context = "list_units typ types all plain no_legend"
+    context = "list_units types all plain no_legend"
     with runner(context) as ctx:
         rc, stdout, stderr = ctx.run(types=types_value)
     return stdout.strip()

--- a/plugins/modules/systemd_info.py
+++ b/plugins/modules/systemd_info.py
@@ -28,7 +28,7 @@ options:
     description:
       - List of unit names to process.
       - It supports C(.service), C(.target), C(.socket), and C(.mount) units type.
-      - Each name must correspond to the full name of the C(systemd) unit or to a wildcard expression like C(ssh*), C(*.service).
+      - Each name must correspond to the full name of the C(systemd) unit or to a wildcard expression like V('ssh*') and V('*.service').
     type: list
     elements: str
     default: []

--- a/plugins/modules/systemd_info.py
+++ b/plugins/modules/systemd_info.py
@@ -207,10 +207,10 @@ units:
 
 import fnmatch
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.general.plugins.module_utils.systemd_info import systemd_info_runner
+from ansible_collections.community.general.plugins.module_utils.systemd import systemd_runner
 
 
-def run_version(runner):
+def get_version(runner):
     with runner("version") as ctx:
         rc, stdout, stderr = ctx.run()
     return stdout.strip()
@@ -358,9 +358,9 @@ def main():
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
     systemctl_bin = module.get_bin_path('systemctl', required=True)
 
-    base_runner = systemd_info_runner(module, systemctl_bin)
+    base_runner = systemd_runner(module, systemctl_bin)
 
-    run_version(base_runner)
+    get_version(base_runner)
 
     state_props = ['LoadState', 'ActiveState', 'SubState']
     results = {}

--- a/tests/integration/targets/systemd_info/tasks/tests.yml
+++ b/tests/integration/targets/systemd_info/tasks/tests.yml
@@ -105,3 +105,35 @@
       - journal_extra.units['systemd-journald.service'].description == journald_shell.Description
       - journal_extra.units['systemd-journald.service'].restart == journald_shell.Restart
     success_msg: "Success: Extra property values are correct."
+
+- name: Gather info using wildcard pattern for services
+  community.general.systemd_info:
+    unitname:
+      - '*.service'
+    extra_properties:
+      - Description
+  register: result_wildcards
+
+- name: Assert that at least one service unit was returned
+  ansible.builtin.assert:
+    that:
+      - result_wildcards.units | length > 0
+
+- name: Gather info using multiple wildcard patterns
+  community.general.systemd_info:
+    unitname:
+      - '*.service'
+      - 'ssh*'
+  register: result_multi
+
+- name: Debug multi-wildcard results
+  ansible.builtin.debug:
+    var: result_multi.units
+
+- name: Assert deduplication of units
+  ansible.builtin.assert:
+    that:
+      - unique_keys | length == all_keys | length
+  vars:
+    all_keys: "{{ result_multi.units | dict2items | map(attribute='key') | list }}"
+    unique_keys: "{{ all_keys | unique }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds support for wildcard expressions.

Examples:

```yaml
# Gather info using wildcards/expression
- name: Gather info of units that start with 'systemd-'
  community.general.systemd_info:
    unitname:
      - 'systemd-*'
  register: results
```

- Added new line in main description.
- Added new line in `unitname` description
- Added new example
- Added new integration tasks to test wildcard expressions and duplicates
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
systemd_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
