### PR TITLE
Redfish: implement obtaining PowerRestorePolicy (#9824)

### DIFF
--- a/changelogs/fragments/9824-redfish-implement-obtaining-powerrestorepolicy.yml
+++ b/changelogs/fragments/9824-redfish-implement-obtaining-powerrestorepolicy.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_info - add command ``GetPowerRestorePolicy`` to get the desired power state of the system when power is restored (https://github.com/ansible-collections/community.general/pull/9824).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -3970,3 +3970,16 @@ class RedfishUtils(object):
             'ret': True,
             'entries': response['data']
         }
+
+    def get_power_restore_policy(self, systems_uri):
+        # Retrieve System resource
+        response = self.get_request(self.root_uri + systems_uri)
+        if response['ret'] is False:
+            return response
+        return {
+            'ret': True,
+            'entries': response['data']['PowerRestorePolicy']
+        }
+
+    def get_multi_power_restore_policy(self):
+        return self.aggregate_systems(self.get_power_restore_policy)

--- a/plugins/modules/redfish_info.py
+++ b/plugins/modules/redfish_info.py
@@ -376,6 +376,14 @@ EXAMPLES = r"""
     username: "{{ username }}"
     password: "{{ password }}"
 
+- name: Get power restore policy
+  community.general.redfish_info:
+    category: Systems
+    command: GetPowerRestorePolicy
+    baseuri: "{{ baseuri }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+
 - name: Check the availability of the service with a timeout of 5 seconds
   community.general.redfish_info:
     category: Service
@@ -402,7 +410,8 @@ CATEGORY_COMMANDS_ALL = {
     "Systems": ["GetSystemInventory", "GetPsuInventory", "GetCpuInventory",
                 "GetMemoryInventory", "GetNicInventory", "GetHealthReport",
                 "GetStorageControllerInventory", "GetDiskInventory", "GetVolumeInventory",
-                "GetBiosAttributes", "GetBootOrder", "GetBootOverride", "GetVirtualMedia", "GetBiosRegistries"],
+                "GetBiosAttributes", "GetBootOrder", "GetBootOverride", "GetVirtualMedia", "GetBiosRegistries",
+                "GetPowerRestorePolicy"],
     "Chassis": ["GetFanInventory", "GetPsuInventory", "GetChassisPower",
                 "GetChassisThermals", "GetChassisInventory", "GetHealthReport", "GetHPEThermalConfig", "GetHPEFanPercentMin"],
     "Accounts": ["ListUsers", "GetAccountServiceConfig"],
@@ -544,6 +553,8 @@ def main():
                     result["virtual_media"] = rf_utils.get_multi_virtualmedia(category)
                 elif command == "GetBiosRegistries":
                     result["bios_registries"] = rf_utils.get_bios_registries()
+                elif command == "GetPowerRestorePolicy":
+                    result["power_restore_policy"] = rf_utils.get_multi_power_restore_policy()
 
         elif category == "Chassis":
             # execute only if we find Chassis resource


### PR DESCRIPTION
This property ("The desired power state of the system when power is restored after a power loss.") was added in ComputerSystem.v1_6_0 which became part of 2018.3 Redfish release.

Example result from querying OpenBMC's bmcweb Redfish server:
```
    entries:
    -   -   system_uri: /redfish/v1/Systems/system
        - AlwaysOff
    ret: true
```
