### PR TITLE
homebrew_services: skip tests on macOS 13.2 and 14.3

### DIFF
--- a/tests/integration/targets/homebrew_services/aliases
+++ b/tests/integration/targets/homebrew_services/aliases
@@ -7,3 +7,5 @@ skip/aix
 skip/freebsd
 skip/rhel
 skip/docker
+skip/macos14.3
+skip/macos13.2


### PR DESCRIPTION
##### SUMMARY
For some reason, homebrew services no longer works on these OS versions in our CI.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
homebrew_services
