### PR TITLE
Adds option for http agent for user in slack callback

### DIFF
--- a/changelogs/fragments/9836-option-for-http-agent-for-user-to-callback-slack.yml
+++ b/changelogs/fragments/9836-option-for-http-agent-for-user-to-callback-slack.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - callback/slack - add ``http-agent`` option to enable the user to set a custom user agent for slack callback plugin (https://github.com/ansible-collections/community.general/pull/9836).
+  - slack callback plugin - add ``http_agent`` option to enable the user to set a custom user agent for slack callback plugin (https://github.com/ansible-collections/community.general/issues/9813, https://github.com/ansible-collections/community.general/pull/9836).

--- a/changelogs/fragments/9836-option-for-http-agent-for-user-to-callback-slack.yml
+++ b/changelogs/fragments/9836-option-for-http-agent-for-user-to-callback-slack.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - callback/slack - add ``http-agent`` option to enable the user to set a custom user agent for slack callback plugin (https://github.com/ansible-collections/community.general/pull/9836).

--- a/plugins/callback/slack.py
+++ b/plugins/callback/slack.py
@@ -18,6 +18,12 @@ short_description: Sends play events to a Slack channel
 description:
   - This is an ansible callback plugin that sends status updates to a Slack channel during playbook execution.
 options:
+  http_agent:
+    description:
+      - User-Agent to use in the request.
+    type: string
+    version_added: "10.5.0"
+    default: ansible-httpget
   webhook_url:
     required: true
     description: Slack Webhook URL.
@@ -106,7 +112,7 @@ class CallbackModule(CallbackBase):
         self.username = self.get_option('username')
         self.show_invocation = (self._display.verbosity > 1)
         self.validate_certs = self.get_option('validate_certs')
-
+        self.http_agent = self.get_option('http_agent')
         if self.webhook_url is None:
             self.disabled = True
             self._display.warning('Slack Webhook URL was not provided. The '
@@ -132,8 +138,13 @@ class CallbackModule(CallbackBase):
         self._display.debug(data)
         self._display.debug(self.webhook_url)
         try:
-            response = open_url(self.webhook_url, data=data, validate_certs=self.validate_certs,
-                                headers=headers)
+            response = open_url(
+                self.webhook_url,
+                data=data,
+                validate_certs=self.validate_certs,
+                headers=headers,
+                http_agent=self.http_agent,
+            )
             return response.read()
         except Exception as e:
             self._display.warning(f'Could not submit message to Slack: {e}')

--- a/plugins/callback/slack.py
+++ b/plugins/callback/slack.py
@@ -20,10 +20,9 @@ description:
 options:
   http_agent:
     description:
-      - User-Agent to use in the request.
+      - HTTP user agent to use requests to Slack.
     type: string
     version_added: "10.5.0"
-    default: ansible-httpget
   webhook_url:
     required: true
     description: Slack Webhook URL.

--- a/plugins/callback/slack.py
+++ b/plugins/callback/slack.py
@@ -20,7 +20,7 @@ description:
 options:
   http_agent:
     description:
-      - HTTP user agent to use requests to Slack.
+      - HTTP user agent to use for requests to Slack.
     type: string
     version_added: "10.5.0"
   webhook_url:


### PR DESCRIPTION
##### SUMMARY

Adding the option for http agent for user for the slack callback. This solves the existing issue [Callback slack is not using the default ansible http agent ](https://github.com/ansible-collections/community.general/issues/9813)

Fixes #9813

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
plugins/callback/slack.py

Edits as [Akasurde's](https://github.com/Akasurde) suggestion. 

```
