### PR TITLE
Redfish: implement setting PowerRestorePolicy

### DIFF
--- a/changelogs/fragments/9837-redfish-implement-setting-powerrestorepolicy.yml
+++ b/changelogs/fragments/9837-redfish-implement-setting-powerrestorepolicy.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_config - add command ``SetPowerRestorePolicy`` to set the desired power state of the system when power is restored (https://github.com/ansible-collections/community.general/pull/9837).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -3983,3 +3983,7 @@ class RedfishUtils(object):
 
     def get_multi_power_restore_policy(self):
         return self.aggregate_systems(self.get_power_restore_policy)
+
+    def set_power_restore_policy(self, policy):
+        body = {'PowerRestorePolicy': policy}
+        return self.patch_request(self.root_uri + self.systems_uri, body, check_pyld=True)


### PR DESCRIPTION
This property ("The desired power state of the system when power is restored after a power loss.") was added in ComputerSystem.v1_6_0 which became part of 2018.3 Redfish release.

Tested against an OpenBMC system running bmcweb Redfish server making sure the policy is updated only when needed and that errors and messages are propogated properly.
