### PR TITLE
[stable-9] Unit tests: make set_module_args() a context manager, and remove copies of it in some tests

### DIFF
--- a/tests/unit/plugins/modules/test_alerta_customer.py
+++ b/tests/unit/plugins/modules/test_alerta_customer.py
@@ -82,169 +82,160 @@ class TestAlertaCustomerModule(ModuleTestCase):
     def test_without_parameters(self):
         """Failure if no parameters set"""
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            self.module.main()
+            with set_module_args({}):
+                self.module.main()
 
     def test_without_content(self):
         """Failure if customer and match are missing"""
-        set_module_args({
+        with set_module_args({
             'alerta_url': "http://localhost:8080",
             'api_username': "admin@example.com",
             'api_password': "password"
-        })
-        with self.assertRaises(AnsibleFailJson):
-            self.module.main()
+        }):
+            with self.assertRaises(AnsibleFailJson):
+                self.module.main()
 
     def test_successful_existing_customer_creation(self):
         """Test the customer creation (already exists)."""
-        set_module_args({
+        with set_module_args({
             'alerta_url': "http://localhost:8080",
             'api_username': "admin@example.com",
             'api_password': "password",
             'customer': 'Developer',
             'match': 'dev@example.com'
-        })
-
-        with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = customer_response_page1()
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
-            self.assertTrue(fetch_url_mock.call_count, 1)
+        }):
+            with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = customer_response_page1()
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
+                self.assertTrue(fetch_url_mock.call_count, 1)
 
     def test_successful_customer_creation(self):
         """Test the customer creation."""
-        set_module_args({
+        with set_module_args({
             'alerta_url': "http://localhost:8080",
             'api_username': "admin@example.com",
             'api_password': "password",
             'customer': 'Developer',
             'match': 'dev2@example.com'
-        })
+        }):
+            with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = customer_response_page1()
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
-        with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = customer_response_page1()
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
-
-            self.assertTrue(fetch_url_mock.call_count, 1)
-            call_data = json.loads(fetch_url_mock.call_args[1]['data'])
-            assert call_data['match'] == "dev2@example.com"
-            assert call_data['customer'] == "Developer"
+        self.assertTrue(fetch_url_mock.call_count, 1)
+        call_data = json.loads(fetch_url_mock.call_args[1]['data'])
+        assert call_data['match'] == "dev2@example.com"
+        assert call_data['customer'] == "Developer"
 
     def test_successful_customer_creation_key(self):
         """Test the customer creation using api_key."""
-        set_module_args({
+        with set_module_args({
             'alerta_url': "http://localhost:8080",
             'api_key': "demo-key",
             'customer': 'Developer',
             'match': 'dev2@example.com'
-        })
+        }):
+            with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = customer_response_page1()
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
-        with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = customer_response_page1()
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
-
-            self.assertTrue(fetch_url_mock.call_count, 1)
-            call_data = json.loads(fetch_url_mock.call_args[1]['data'])
-            assert call_data['match'] == "dev2@example.com"
-            assert call_data['customer'] == "Developer"
+        self.assertTrue(fetch_url_mock.call_count, 1)
+        call_data = json.loads(fetch_url_mock.call_args[1]['data'])
+        assert call_data['match'] == "dev2@example.com"
+        assert call_data['customer'] == "Developer"
 
     def test_failed_not_found(self):
         """Test failure with wrong URL."""
 
-        set_module_args({
+        with set_module_args({
             'alerta_url': "http://localhost:8080/s",
             'api_username': "admin@example.com",
             'api_password': "password",
             'customer': 'Developer',
             'match': 'dev@example.com'
-        })
-
-        with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = (None, {"status": 404, 'msg': 'Not found for request GET on http://localhost:8080/a/api/customers'})
-            with self.assertRaises(AnsibleFailJson):
-                self.module.main()
+        }):
+            with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 404, 'msg': 'Not found for request GET on http://localhost:8080/a/api/customers'})
+                with self.assertRaises(AnsibleFailJson):
+                    self.module.main()
 
     def test_failed_forbidden(self):
         """Test failure with wrong user."""
 
-        set_module_args({
+        with set_module_args({
             'alerta_url': "http://localhost:8080",
             'api_username': "dev@example.com",
             'api_password': "password",
             'customer': 'Developer',
             'match': 'dev@example.com'
-        })
-
-        with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = (None, {"status": 403, 'msg': 'Permission Denied for GET on http://localhost:8080/api/customers'})
-            with self.assertRaises(AnsibleFailJson):
-                self.module.main()
+        }):
+            with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 403, 'msg': 'Permission Denied for GET on http://localhost:8080/api/customers'})
+                with self.assertRaises(AnsibleFailJson):
+                    self.module.main()
 
     def test_failed_unauthorized(self):
         """Test failure with wrong username or password."""
 
-        set_module_args({
+        with set_module_args({
             'alerta_url': "http://localhost:8080",
             'api_username': "admin@example.com",
             'api_password': "password_wrong",
             'customer': 'Developer',
             'match': 'dev@example.com'
-        })
-
-        with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = (None, {"status": 401, 'msg': 'Unauthorized to request GET on http://localhost:8080/api/customers'})
-            with self.assertRaises(AnsibleFailJson):
-                self.module.main()
+        }):
+            with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 401, 'msg': 'Unauthorized to request GET on http://localhost:8080/api/customers'})
+                with self.assertRaises(AnsibleFailJson):
+                    self.module.main()
 
     def test_successful_customer_deletion(self):
         """Test the customer deletion."""
 
-        set_module_args({
+        with set_module_args({
             'alerta_url': "http://localhost:8080",
             'api_username': "admin@example.com",
             'api_password': "password",
             'customer': 'Developer',
             'match': 'dev@example.com',
             'state': 'absent'
-        })
-
-        with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = customer_response_page1()
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
+        }):
+            with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = customer_response_page1()
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
     def test_successful_customer_deletion_page2(self):
         """Test the customer deletion on the second page."""
 
-        set_module_args({
+        with set_module_args({
             'alerta_url': "http://localhost:8080",
             'api_username': "admin@example.com",
             'api_password': "password",
             'customer': 'Developer',
             'match': 'dev@example.com',
             'state': 'absent'
-        })
-
-        with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = customer_response_page2()
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
+        }):
+            with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = customer_response_page2()
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
     def test_successful_nonexisting_customer_deletion(self):
         """Test the customer deletion (non existing)."""
 
-        set_module_args({
+        with set_module_args({
             'alerta_url': "http://localhost:8080",
             'api_username': "admin@example.com",
             'api_password': "password",
             'customer': 'Billing',
             'match': 'dev@example.com',
             'state': 'absent'
-        })
-
-        with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = customer_response_page1()
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
+        }):
+            with patch.object(alerta_customer, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = customer_response_page1()
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()

--- a/tests/unit/plugins/modules/test_archive.py
+++ b/tests/unit/plugins/modules/test_archive.py
@@ -25,27 +25,26 @@ class TestArchive(ModuleTestCase):
         self.os_path_isdir = self.mock_os_path_isdir.stop()
 
     def test_archive_removal_safety(self):
-        set_module_args(
+        with set_module_args(
             dict(
                 path=['/foo', '/bar', '/baz'],
                 dest='/foo/destination.tgz',
                 remove=True
             )
-        )
-
-        module = AnsibleModule(
-            argument_spec=dict(
-                path=dict(type='list', elements='path', required=True),
-                format=dict(type='str', default='gz', choices=['bz2', 'gz', 'tar', 'xz', 'zip']),
-                dest=dict(type='path'),
-                exclude_path=dict(type='list', elements='path', default=[]),
-                exclusion_patterns=dict(type='list', elements='path'),
-                force_archive=dict(type='bool', default=False),
-                remove=dict(type='bool', default=False),
-            ),
-            add_file_common_args=True,
-            supports_check_mode=True,
-        )
+        ):
+            module = AnsibleModule(
+                argument_spec=dict(
+                    path=dict(type='list', elements='path', required=True),
+                    format=dict(type='str', default='gz', choices=['bz2', 'gz', 'tar', 'xz', 'zip']),
+                    dest=dict(type='path'),
+                    exclude_path=dict(type='list', elements='path', default=[]),
+                    exclusion_patterns=dict(type='list', elements='path'),
+                    force_archive=dict(type='bool', default=False),
+                    remove=dict(type='bool', default=False),
+                ),
+                add_file_common_args=True,
+                supports_check_mode=True,
+            )
 
         self.os_path_isdir.side_effect = [True, False, False, True]
 

--- a/tests/unit/plugins/modules/test_bitbucket_access_key.py
+++ b/tests/unit/plugins/modules/test_bitbucket_access_key.py
@@ -19,15 +19,15 @@ class TestBucketAccessKeyModule(ModuleTestCase):
 
     def test_missing_key_with_present_state(self):
         with self.assertRaises(AnsibleFailJson) as exec_info:
-            set_module_args({
+            with set_module_args({
                 'client_id': 'ABC',
                 'client_secret': 'XXX',
                 'workspace': 'name',
                 'repository': 'repo',
                 'label': 'key name',
                 'state': 'present',
-            })
-            self.module.main()
+            }):
+                self.module.main()
 
         self.assertEqual(exec_info.exception.args[0]['msg'], self.module.error_messages['required_key'])
 
@@ -35,7 +35,7 @@ class TestBucketAccessKeyModule(ModuleTestCase):
     def test_create_deploy_key(self, *args):
         with patch.object(self.module, 'create_deploy_key') as create_deploy_key_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'user': 'ABC',
                     'password': 'XXX',
                     'workspace': 'name',
@@ -43,8 +43,8 @@ class TestBucketAccessKeyModule(ModuleTestCase):
                     'key': 'public_key',
                     'label': 'key name',
                     'state': 'present',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(create_deploy_key_mock.call_count, 1)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -54,7 +54,7 @@ class TestBucketAccessKeyModule(ModuleTestCase):
     def test_create_deploy_key_check_mode(self, *args):
         with patch.object(self.module, 'create_deploy_key') as create_deploy_key_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
@@ -63,8 +63,8 @@ class TestBucketAccessKeyModule(ModuleTestCase):
                     'label': 'key name',
                     'state': 'present',
                     '_ansible_check_mode': True,
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(create_deploy_key_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -105,7 +105,7 @@ class TestBucketAccessKeyModule(ModuleTestCase):
         with patch.object(self.module, 'delete_deploy_key') as delete_deploy_key_mock:
             with patch.object(self.module, 'create_deploy_key') as create_deploy_key_mock:
                 with self.assertRaises(AnsibleExitJson) as exec_info:
-                    set_module_args({
+                    with set_module_args({
                         'client_id': 'ABC',
                         'client_secret': 'XXX',
                         'workspace': 'name',
@@ -113,8 +113,8 @@ class TestBucketAccessKeyModule(ModuleTestCase):
                         'key': 'new public key',
                         'label': 'mykey',
                         'state': 'present',
-                    })
-                    self.module.main()
+                    }):
+                        self.module.main()
 
                 self.assertEqual(delete_deploy_key_mock.call_count, 1)
                 self.assertEqual(create_deploy_key_mock.call_count, 1)
@@ -156,7 +156,7 @@ class TestBucketAccessKeyModule(ModuleTestCase):
         with patch.object(self.module, 'delete_deploy_key') as delete_deploy_key_mock:
             with patch.object(self.module, 'create_deploy_key') as create_deploy_key_mock:
                 with self.assertRaises(AnsibleExitJson) as exec_info:
-                    set_module_args({
+                    with set_module_args({
                         'client_id': 'ABC',
                         'client_secret': 'XXX',
                         'workspace': 'name',
@@ -164,8 +164,8 @@ class TestBucketAccessKeyModule(ModuleTestCase):
                         'key': 'new public key',
                         'label': 'mykey',
                         'state': 'present',
-                    })
-                    self.module.main()
+                    }):
+                        self.module.main()
 
                 self.assertEqual(delete_deploy_key_mock.call_count, 0)
                 self.assertEqual(create_deploy_key_mock.call_count, 0)
@@ -207,7 +207,7 @@ class TestBucketAccessKeyModule(ModuleTestCase):
         with patch.object(self.module, 'delete_deploy_key') as delete_deploy_key_mock:
             with patch.object(self.module, 'create_deploy_key') as create_deploy_key_mock:
                 with self.assertRaises(AnsibleExitJson) as exec_info:
-                    set_module_args({
+                    with set_module_args({
                         'client_id': 'ABC',
                         'client_secret': 'XXX',
                         'workspace': 'name',
@@ -216,8 +216,8 @@ class TestBucketAccessKeyModule(ModuleTestCase):
                         'label': 'mykey',
                         'state': 'present',
                         '_ansible_check_mode': True,
-                    })
-                    self.module.main()
+                    }):
+                        self.module.main()
 
                 self.assertEqual(delete_deploy_key_mock.call_count, 0)
                 self.assertEqual(create_deploy_key_mock.call_count, 0)
@@ -258,15 +258,15 @@ class TestBucketAccessKeyModule(ModuleTestCase):
     def test_delete_deploy_key(self, *args):
         with patch.object(self.module, 'delete_deploy_key') as delete_deploy_key_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
                     'repository': 'repo',
                     'label': 'mykey',
                     'state': 'absent',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(delete_deploy_key_mock.call_count, 1)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -276,15 +276,15 @@ class TestBucketAccessKeyModule(ModuleTestCase):
     def test_delete_absent_deploy_key(self, *args):
         with patch.object(self.module, 'delete_deploy_key') as delete_deploy_key_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
                     'repository': 'repo',
                     'label': 'mykey',
                     'state': 'absent',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(delete_deploy_key_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], False)
@@ -324,7 +324,7 @@ class TestBucketAccessKeyModule(ModuleTestCase):
     def test_delete_deploy_key_check_mode(self, *args):
         with patch.object(self.module, 'delete_deploy_key') as delete_deploy_key_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
@@ -332,8 +332,8 @@ class TestBucketAccessKeyModule(ModuleTestCase):
                     'label': 'mykey',
                     'state': 'absent',
                     '_ansible_check_mode': True,
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(delete_deploy_key_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)

--- a/tests/unit/plugins/modules/test_bitbucket_pipeline_key_pair.py
+++ b/tests/unit/plugins/modules/test_bitbucket_pipeline_key_pair.py
@@ -19,14 +19,14 @@ class TestBucketPipelineKeyPairModule(ModuleTestCase):
 
     def test_missing_keys_with_present_state(self):
         with self.assertRaises(AnsibleFailJson) as exec_info:
-            set_module_args({
+            with set_module_args({
                 'client_id': 'ABC',
                 'client_secret': 'XXX',
                 'workspace': 'name',
                 'repository': 'repo',
                 'state': 'present',
-            })
-            self.module.main()
+            }):
+                self.module.main()
 
         self.assertEqual(exec_info.exception.args[0]['msg'], self.module.error_messages['required_keys'])
 
@@ -34,7 +34,7 @@ class TestBucketPipelineKeyPairModule(ModuleTestCase):
     def test_create_keys(self, *args):
         with patch.object(self.module, 'update_ssh_key_pair') as update_ssh_key_pair_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'user': 'ABC',
                     'password': 'XXX',
                     'workspace': 'name',
@@ -42,8 +42,8 @@ class TestBucketPipelineKeyPairModule(ModuleTestCase):
                     'public_key': 'public',
                     'private_key': 'PRIVATE',
                     'state': 'present',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(update_ssh_key_pair_mock.call_count, 1)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -53,7 +53,7 @@ class TestBucketPipelineKeyPairModule(ModuleTestCase):
     def test_create_keys_check_mode(self, *args):
         with patch.object(self.module, 'update_ssh_key_pair') as update_ssh_key_pair_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
@@ -62,8 +62,8 @@ class TestBucketPipelineKeyPairModule(ModuleTestCase):
                     'private_key': 'PRIVATE',
                     'state': 'present',
                     '_ansible_check_mode': True,
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(update_ssh_key_pair_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -76,7 +76,7 @@ class TestBucketPipelineKeyPairModule(ModuleTestCase):
     def test_update_keys(self, *args):
         with patch.object(self.module, 'update_ssh_key_pair') as update_ssh_key_pair_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
@@ -84,8 +84,8 @@ class TestBucketPipelineKeyPairModule(ModuleTestCase):
                     'public_key': 'public',
                     'private_key': 'PRIVATE',
                     'state': 'present',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(update_ssh_key_pair_mock.call_count, 1)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -98,7 +98,7 @@ class TestBucketPipelineKeyPairModule(ModuleTestCase):
     def test_dont_update_same_key(self, *args):
         with patch.object(self.module, 'update_ssh_key_pair') as update_ssh_key_pair_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
@@ -106,8 +106,8 @@ class TestBucketPipelineKeyPairModule(ModuleTestCase):
                     'public_key': 'public',
                     'private_key': 'PRIVATE',
                     'state': 'present',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(update_ssh_key_pair_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], False)
@@ -120,7 +120,7 @@ class TestBucketPipelineKeyPairModule(ModuleTestCase):
     def test_update_keys_check_mode(self, *args):
         with patch.object(self.module, 'update_ssh_key_pair') as update_ssh_key_pair_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
@@ -129,8 +129,8 @@ class TestBucketPipelineKeyPairModule(ModuleTestCase):
                     'private_key': 'PRIVATE',
                     'state': 'present',
                     '_ansible_check_mode': True,
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(update_ssh_key_pair_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -143,14 +143,14 @@ class TestBucketPipelineKeyPairModule(ModuleTestCase):
     def test_delete_keys(self, *args):
         with patch.object(self.module, 'delete_ssh_key_pair') as delete_ssh_key_pair_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
                     'repository': 'repo',
                     'state': 'absent',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(delete_ssh_key_pair_mock.call_count, 1)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -160,14 +160,14 @@ class TestBucketPipelineKeyPairModule(ModuleTestCase):
     def test_delete_absent_keys(self, *args):
         with patch.object(self.module, 'delete_ssh_key_pair') as delete_ssh_key_pair_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
                     'repository': 'repo',
                     'state': 'absent',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(delete_ssh_key_pair_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], False)
@@ -180,15 +180,15 @@ class TestBucketPipelineKeyPairModule(ModuleTestCase):
     def test_delete_keys_check_mode(self, *args):
         with patch.object(self.module, 'delete_ssh_key_pair') as delete_ssh_key_pair_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
                     'repository': 'repo',
                     'state': 'absent',
                     '_ansible_check_mode': True,
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(delete_ssh_key_pair_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)

--- a/tests/unit/plugins/modules/test_bitbucket_pipeline_known_host.py
+++ b/tests/unit/plugins/modules/test_bitbucket_pipeline_known_host.py
@@ -26,15 +26,15 @@ class TestBucketPipelineKnownHostModule(ModuleTestCase):
     def test_create_known_host(self, *args):
         with patch.object(self.module, 'create_known_host') as create_known_host_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
                     'repository': 'repo',
                     'name': 'bitbucket.org',
                     'state': 'present',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(create_known_host_mock.call_count, 1)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -44,7 +44,7 @@ class TestBucketPipelineKnownHostModule(ModuleTestCase):
     def test_create_known_host_with_key(self, *args):
         with patch.object(self.module, 'get_host_key') as get_host_key_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'user': 'ABC',
                     'password': 'XXX',
                     'workspace': 'name',
@@ -52,8 +52,8 @@ class TestBucketPipelineKnownHostModule(ModuleTestCase):
                     'name': 'bitbucket.org',
                     'key': 'ssh-rsa public',
                     'state': 'present',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(get_host_key_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -75,15 +75,15 @@ class TestBucketPipelineKnownHostModule(ModuleTestCase):
     def test_dont_create_same_value(self, *args):
         with patch.object(self.module, 'create_known_host') as create_known_host_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
                     'repository': 'repo',
                     'name': 'bitbucket.org',
                     'state': 'present',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(create_known_host_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], False)
@@ -94,7 +94,7 @@ class TestBucketPipelineKnownHostModule(ModuleTestCase):
     def test_create_known_host_check_mode(self, *args):
         with patch.object(self.module, 'create_known_host') as create_known_host_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
@@ -102,8 +102,8 @@ class TestBucketPipelineKnownHostModule(ModuleTestCase):
                     'name': 'bitbucket.org',
                     'state': 'present',
                     '_ansible_check_mode': True,
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(create_known_host_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -125,15 +125,15 @@ class TestBucketPipelineKnownHostModule(ModuleTestCase):
     def test_delete_known_host(self, *args):
         with patch.object(self.module, 'delete_known_host') as delete_known_host_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
                     'repository': 'repo',
                     'name': 'bitbucket.org',
                     'state': 'absent',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(delete_known_host_mock.call_count, 1)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -144,15 +144,15 @@ class TestBucketPipelineKnownHostModule(ModuleTestCase):
     def test_delete_absent_known_host(self, *args):
         with patch.object(self.module, 'delete_known_host') as delete_known_host_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
                     'repository': 'repo',
                     'name': 'bitbucket.org',
                     'state': 'absent',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(delete_known_host_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], False)
@@ -174,7 +174,7 @@ class TestBucketPipelineKnownHostModule(ModuleTestCase):
     def test_delete_known_host_check_mode(self, *args):
         with patch.object(self.module, 'delete_known_host') as delete_known_host_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
@@ -182,8 +182,8 @@ class TestBucketPipelineKnownHostModule(ModuleTestCase):
                     'name': 'bitbucket.org',
                     'state': 'absent',
                     '_ansible_check_mode': True,
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(delete_known_host_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)

--- a/tests/unit/plugins/modules/test_bitbucket_pipeline_variable.py
+++ b/tests/unit/plugins/modules/test_bitbucket_pipeline_variable.py
@@ -19,27 +19,27 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
 
     def test_without_required_parameters(self):
         with self.assertRaises(AnsibleFailJson) as exec_info:
-            set_module_args({
+            with set_module_args({
                 'workspace': 'name',
                 'repository': 'repo',
                 'name': 'PIPELINE_VAR_NAME',
                 'state': 'absent',
-            })
-            self.module.main()
+            }):
+                self.module.main()
 
         self.assertEqual(exec_info.exception.args[0]['failed'], True)
 
     def test_missing_value_with_present_state(self):
         with self.assertRaises(AnsibleFailJson) as exec_info:
-            set_module_args({
+            with set_module_args({
                 'client_id': 'ABC',
                 'client_secret': 'XXX',
                 'workspace': 'name',
                 'repository': 'repo',
                 'name': 'PIPELINE_VAR_NAME',
                 'state': 'present',
-            })
-            self.module.main()
+            }):
+                self.module.main()
 
         self.assertEqual(exec_info.exception.args[0]['msg'], self.module.error_messages['required_value'])
 
@@ -51,13 +51,13 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
     @patch.object(bitbucket_pipeline_variable, 'get_existing_pipeline_variable', return_value=None)
     def test_oauth_env_vars_params(self, *args):
         with self.assertRaises(AnsibleExitJson):
-            set_module_args({
+            with set_module_args({
                 'workspace': 'name',
                 'repository': 'repo',
                 'name': 'PIPELINE_VAR_NAME',
                 'state': 'absent',
-            })
-            self.module.main()
+            }):
+                self.module.main()
 
     @patch.dict('os.environ', {
         'BITBUCKET_USERNAME': 'ABC',
@@ -66,19 +66,19 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
     @patch.object(bitbucket_pipeline_variable, 'get_existing_pipeline_variable', return_value=None)
     def test_basic_auth_env_vars_params(self, *args):
         with self.assertRaises(AnsibleExitJson):
-            set_module_args({
+            with set_module_args({
                 'workspace': 'name',
                 'repository': 'repo',
                 'name': 'PIPELINE_VAR_NAME',
                 'state': 'absent',
-            })
-            self.module.main()
+            }):
+                self.module.main()
 
     @patch.object(bitbucket_pipeline_variable, 'get_existing_pipeline_variable', return_value=None)
     def test_create_variable(self, *args):
         with patch.object(self.module, 'create_pipeline_variable') as create_pipeline_variable_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'user': 'ABC',
                     'password': 'XXX',
                     'workspace': 'name',
@@ -86,8 +86,8 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
                     'name': 'PIPELINE_VAR_NAME',
                     'value': '42',
                     'state': 'present',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(create_pipeline_variable_mock.call_count, 1)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -97,7 +97,7 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
     def test_create_variable_check_mode(self, *args):
         with patch.object(self.module, 'create_pipeline_variable') as create_pipeline_variable_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
@@ -106,8 +106,8 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
                     'value': '42',
                     'state': 'present',
                     '_ansible_check_mode': True,
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(create_pipeline_variable_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -123,7 +123,7 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
     def test_update_variable(self, *args):
         with patch.object(self.module, 'update_pipeline_variable') as update_pipeline_variable_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
@@ -131,8 +131,8 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
                     'name': 'PIPELINE_VAR_NAME',
                     'value': '42',
                     'state': 'present',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(update_pipeline_variable_mock.call_count, 1)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -147,7 +147,7 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
     def test_update_secured_variable(self, *args):
         with patch.object(self.module, 'update_pipeline_variable') as update_pipeline_variable_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
@@ -156,8 +156,8 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
                     'value': '42',
                     'secured': True,
                     'state': 'present',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(update_pipeline_variable_mock.call_count, 1)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -173,7 +173,7 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
     def test_update_secured_state(self, *args):
         with patch.object(self.module, 'update_pipeline_variable') as update_pipeline_variable_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
@@ -182,8 +182,8 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
                     'value': '42',
                     'secured': True,
                     'state': 'present',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(update_pipeline_variable_mock.call_count, 1)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -199,7 +199,7 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
     def test_dont_update_same_value(self, *args):
         with patch.object(self.module, 'update_pipeline_variable') as update_pipeline_variable_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
@@ -207,8 +207,8 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
                     'name': 'PIPELINE_VAR_NAME',
                     'value': '42',
                     'state': 'present',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(update_pipeline_variable_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], False)
@@ -224,7 +224,7 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
     def test_update_variable_check_mode(self, *args):
         with patch.object(self.module, 'update_pipeline_variable') as update_pipeline_variable_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
@@ -233,8 +233,8 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
                     'value': '42',
                     'state': 'present',
                     '_ansible_check_mode': True,
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(update_pipeline_variable_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -250,15 +250,15 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
     def test_delete_variable(self, *args):
         with patch.object(self.module, 'delete_pipeline_variable') as delete_pipeline_variable_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
                     'repository': 'repo',
                     'name': 'PIPELINE_VAR_NAME',
                     'state': 'absent',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(delete_pipeline_variable_mock.call_count, 1)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
@@ -268,15 +268,15 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
     def test_delete_absent_variable(self, *args):
         with patch.object(self.module, 'delete_pipeline_variable') as delete_pipeline_variable_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
                     'repository': 'repo',
                     'name': 'PIPELINE_VAR_NAME',
                     'state': 'absent',
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(delete_pipeline_variable_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], False)
@@ -292,7 +292,7 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
     def test_delete_variable_check_mode(self, *args):
         with patch.object(self.module, 'delete_pipeline_variable') as delete_pipeline_variable_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
-                set_module_args({
+                with set_module_args({
                     'client_id': 'ABC',
                     'client_secret': 'XXX',
                     'workspace': 'name',
@@ -300,8 +300,8 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
                     'name': 'PIPELINE_VAR_NAME',
                     'state': 'absent',
                     '_ansible_check_mode': True,
-                })
-                self.module.main()
+                }):
+                    self.module.main()
 
             self.assertEqual(delete_pipeline_variable_mock.call_count, 0)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)

--- a/tests/unit/plugins/modules/test_bootc_manage.py
+++ b/tests/unit/plugins/modules/test_bootc_manage.py
@@ -21,52 +21,52 @@ class TestBootcManageModule(ModuleTestCase):
 
     def test_switch_without_image(self):
         """Failure if state is 'switch' but no image provided"""
-        set_module_args({'state': 'switch'})
-        with self.assertRaises(AnsibleFailJson) as result:
-            self.module.main()
+        with set_module_args({'state': 'switch'}):
+            with self.assertRaises(AnsibleFailJson) as result:
+                self.module.main()
         self.assertEqual(result.exception.args[0]['msg'], "state is switch but all of the following are missing: image")
 
     def test_switch_with_image(self):
         """Test successful switch with image provided"""
-        set_module_args({'state': 'switch', 'image': 'example.com/image:latest'})
-        with patch('ansible.module_utils.basic.AnsibleModule.run_command') as run_command_mock:
-            run_command_mock.return_value = (0, 'Queued for next boot: ', '')
-            with self.assertRaises(AnsibleExitJson) as result:
-                self.module.main()
+        with set_module_args({'state': 'switch', 'image': 'example.com/image:latest'}):
+            with patch('ansible.module_utils.basic.AnsibleModule.run_command') as run_command_mock:
+                run_command_mock.return_value = (0, 'Queued for next boot: ', '')
+                with self.assertRaises(AnsibleExitJson) as result:
+                    self.module.main()
             self.assertTrue(result.exception.args[0]['changed'])
 
     def test_latest_state(self):
         """Test successful upgrade to the latest state"""
-        set_module_args({'state': 'latest'})
-        with patch('ansible.module_utils.basic.AnsibleModule.run_command') as run_command_mock:
-            run_command_mock.return_value = (0, 'Queued for next boot: ', '')
-            with self.assertRaises(AnsibleExitJson) as result:
-                self.module.main()
+        with set_module_args({'state': 'latest'}):
+            with patch('ansible.module_utils.basic.AnsibleModule.run_command') as run_command_mock:
+                run_command_mock.return_value = (0, 'Queued for next boot: ', '')
+                with self.assertRaises(AnsibleExitJson) as result:
+                    self.module.main()
             self.assertTrue(result.exception.args[0]['changed'])
 
     def test_latest_state_no_change(self):
         """Test no change for latest state"""
-        set_module_args({'state': 'latest'})
-        with patch('ansible.module_utils.basic.AnsibleModule.run_command') as run_command_mock:
-            run_command_mock.return_value = (0, 'No changes in ', '')
-            with self.assertRaises(AnsibleExitJson) as result:
-                self.module.main()
+        with set_module_args({'state': 'latest'}):
+            with patch('ansible.module_utils.basic.AnsibleModule.run_command') as run_command_mock:
+                run_command_mock.return_value = (0, 'No changes in ', '')
+                with self.assertRaises(AnsibleExitJson) as result:
+                    self.module.main()
             self.assertFalse(result.exception.args[0]['changed'])
 
     def test_switch_image_failure(self):
         """Test failure during image switch"""
-        set_module_args({'state': 'switch', 'image': 'example.com/image:latest'})
-        with patch('ansible.module_utils.basic.AnsibleModule.run_command') as run_command_mock:
-            run_command_mock.return_value = (1, '', 'ERROR')
-            with self.assertRaises(AnsibleFailJson) as result:
-                self.module.main()
+        with set_module_args({'state': 'switch', 'image': 'example.com/image:latest'}):
+            with patch('ansible.module_utils.basic.AnsibleModule.run_command') as run_command_mock:
+                run_command_mock.return_value = (1, '', 'ERROR')
+                with self.assertRaises(AnsibleFailJson) as result:
+                    self.module.main()
             self.assertEqual(result.exception.args[0]['msg'], 'ERROR: Command execution failed.')
 
     def test_latest_state_failure(self):
         """Test failure during upgrade"""
-        set_module_args({'state': 'latest'})
-        with patch('ansible.module_utils.basic.AnsibleModule.run_command') as run_command_mock:
-            run_command_mock.return_value = (1, '', 'ERROR')
-            with self.assertRaises(AnsibleFailJson) as result:
-                self.module.main()
+        with set_module_args({'state': 'latest'}):
+            with patch('ansible.module_utils.basic.AnsibleModule.run_command') as run_command_mock:
+                run_command_mock.return_value = (1, '', 'ERROR')
+                with self.assertRaises(AnsibleFailJson) as result:
+                    self.module.main()
             self.assertEqual(result.exception.args[0]['msg'], 'ERROR: Command execution failed.')

--- a/tests/unit/plugins/modules/test_campfire.py
+++ b/tests/unit/plugins/modules/test_campfire.py
@@ -27,70 +27,67 @@ class TestCampfireModule(ModuleTestCase):
     def test_without_required_parameters(self):
         """Failure must occurs when all parameters are missing"""
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            self.module.main()
+            with set_module_args({}):
+                self.module.main()
 
     def test_successful_message(self):
         """Test failure message"""
-        set_module_args({
+        with set_module_args({
             'subscription': 'test',
             'token': 'abc',
             'room': 'test',
             'msg': 'test'
-        })
+        }):
+            with patch.object(campfire, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 200})
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
-        with patch.object(campfire, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = (None, {"status": 200})
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
+        assert fetch_url_mock.call_count == 1
+        url = fetch_url_mock.call_args[0][1]
+        data = fetch_url_mock.call_args[1]['data']
 
-            assert fetch_url_mock.call_count == 1
-            url = fetch_url_mock.call_args[0][1]
-            data = fetch_url_mock.call_args[1]['data']
-
-            assert url == 'https://test.campfirenow.com/room/test/speak.xml'
-            assert data == '<message><body>test</body></message>'
+        assert url == 'https://test.campfirenow.com/room/test/speak.xml'
+        assert data == '<message><body>test</body></message>'
 
     def test_successful_message_with_notify(self):
         """Test failure message"""
-        set_module_args({
+        with set_module_args({
             'subscription': 'test',
             'token': 'abc',
             'room': 'test',
             'msg': 'test',
             'notify': 'bell'
-        })
+        }):
+            with patch.object(campfire, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 200})
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
-        with patch.object(campfire, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = (None, {"status": 200})
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
+        assert fetch_url_mock.call_count == 2
+        notify_call = fetch_url_mock.mock_calls[0]
+        url = notify_call[1][1]
+        data = notify_call[2]['data']
 
-            assert fetch_url_mock.call_count == 2
-            notify_call = fetch_url_mock.mock_calls[0]
-            url = notify_call[1][1]
-            data = notify_call[2]['data']
+        assert url == 'https://test.campfirenow.com/room/test/speak.xml'
+        assert data == '<message><type>SoundMessage</type><body>bell</body></message>'
 
-            assert url == 'https://test.campfirenow.com/room/test/speak.xml'
-            assert data == '<message><type>SoundMessage</type><body>bell</body></message>'
+        message_call = fetch_url_mock.mock_calls[1]
+        url = message_call[1][1]
+        data = message_call[2]['data']
 
-            message_call = fetch_url_mock.mock_calls[1]
-            url = message_call[1][1]
-            data = message_call[2]['data']
-
-            assert url == 'https://test.campfirenow.com/room/test/speak.xml'
-            assert data == '<message><body>test</body></message>'
+        assert url == 'https://test.campfirenow.com/room/test/speak.xml'
+        assert data == '<message><body>test</body></message>'
 
     def test_failure_message(self):
         """Test failure message"""
-        set_module_args({
+        with set_module_args({
             'subscription': 'test',
             'token': 'abc',
             'room': 'test',
             'msg': 'test'
-        })
-
-        with patch.object(campfire, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = (None, {"status": 403})
-            with self.assertRaises(AnsibleFailJson):
-                self.module.main()
+        }):
+            with patch.object(campfire, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 403})
+                with self.assertRaises(AnsibleFailJson):
+                    self.module.main()

--- a/tests/unit/plugins/modules/test_circonus_annotation.py
+++ b/tests/unit/plugins/modules/test_circonus_annotation.py
@@ -30,45 +30,46 @@ class TestCirconusAnnotation(ModuleTestCase):
     def test_without_required_parameters(self):
         """Failure must occurs when all parameters are missing"""
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            self.module.main()
+            with set_module_args({}):
+                self.module.main()
 
     def test_add_annotation(self):
         """Check that result is changed"""
-        set_module_args({
+        with set_module_args({
             'category': 'test category',
             'description': 'test description',
             'title': 'test title',
             'api_key': str(uuid.uuid4()),
-        })
+        }):
 
-        cid = '/annotation/100000'
+            cid = '/annotation/100000'
 
-        def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):
-            data = {
-                '_cid': cid,
-                '_created': 1502146995,
-                '_last_modified': 1502146995,
-                '_last_modified_by': '/user/1000',
-                'category': 'test category',
-                'description': 'test description',
-                'rel_metrics': [],
-                'start': 1502145480,
-                'stop': None,
-                'title': 'test title',
-            }
-            raw = to_bytes(json.dumps(data))
-            resp = HTTPResponse(body=io.BytesIO(raw), preload_content=False)
-            resp.status = 200
-            resp.reason = 'OK'
-            resp.headers = {'X-Circonus-API-Version': '2.00'}
-            return self.build_response(request, resp)
+            def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):
+                data = {
+                    '_cid': cid,
+                    '_created': 1502146995,
+                    '_last_modified': 1502146995,
+                    '_last_modified_by': '/user/1000',
+                    'category': 'test category',
+                    'description': 'test description',
+                    'rel_metrics': [],
+                    'start': 1502145480,
+                    'stop': None,
+                    'title': 'test title',
+                }
+                raw = to_bytes(json.dumps(data))
+                resp = HTTPResponse(body=io.BytesIO(raw), preload_content=False)
+                resp.status = 200
+                resp.reason = 'OK'
+                resp.headers = {'X-Circonus-API-Version': '2.00'}
+                return self.build_response(request, resp)
 
-        with patch('requests.adapters.HTTPAdapter.send', autospec=True, side_effect=send) as send:
-            with self.assertRaises(AnsibleExitJson) as result:
-                self.module.main()
-            self.assertTrue(result.exception.args[0]['changed'])
-            self.assertEqual(result.exception.args[0]['annotation']['_cid'], cid)
+            with patch('requests.adapters.HTTPAdapter.send', autospec=True, side_effect=send) as send:
+                with self.assertRaises(AnsibleExitJson) as result:
+                    self.module.main()
+
+        self.assertTrue(result.exception.args[0]['changed'])
+        self.assertEqual(result.exception.args[0]['annotation']['_cid'], cid)
         self.assertEqual(send.call_count, 1)
 
     def test_add_annotation_unicode(self):
@@ -76,78 +77,80 @@ class TestCirconusAnnotation(ModuleTestCase):
            Note: it seems there is a bug which prevent to create an annotation
            with a non-ASCII category if this category already exists, in such
            case an Internal Server Error (500) occurs."""
-        set_module_args({
+        with set_module_args({
             'category': 'new catégorÿ',
             'description': 'test description',
             'title': 'test title',
             'api_key': str(uuid.uuid4()),
-        })
+        }):
 
-        cid = '/annotation/100000'
+            cid = '/annotation/100000'
 
-        def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):
-            data = {
-                '_cid': '/annotation/100000',
-                '_created': 1502236928,
-                '_last_modified': 1502236928,
-                '_last_modified_by': '/user/1000',
-                # use res['annotation']['category'].encode('latin1').decode('utf8')
-                'category': u'new cat\xc3\xa9gor\xc3\xbf',
-                'description': 'test description',
-                'rel_metrics': [],
-                'start': 1502236927,
-                'stop': 1502236927,
-                'title': 'test title',
-            }
+            def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):
+                data = {
+                    '_cid': '/annotation/100000',
+                    '_created': 1502236928,
+                    '_last_modified': 1502236928,
+                    '_last_modified_by': '/user/1000',
+                    # use res['annotation']['category'].encode('latin1').decode('utf8')
+                    'category': u'new cat\xc3\xa9gor\xc3\xbf',
+                    'description': 'test description',
+                    'rel_metrics': [],
+                    'start': 1502236927,
+                    'stop': 1502236927,
+                    'title': 'test title',
+                }
 
-            raw = to_bytes(json.dumps(data), encoding='latin1')
-            resp = HTTPResponse(body=io.BytesIO(raw), preload_content=False)
-            resp.status = 200
-            resp.reason = 'OK'
-            resp.headers = {'X-Circonus-API-Version': '2.00'}
-            return self.build_response(request, resp)
+                raw = to_bytes(json.dumps(data), encoding='latin1')
+                resp = HTTPResponse(body=io.BytesIO(raw), preload_content=False)
+                resp.status = 200
+                resp.reason = 'OK'
+                resp.headers = {'X-Circonus-API-Version': '2.00'}
+                return self.build_response(request, resp)
 
-        with patch('requests.adapters.HTTPAdapter.send', autospec=True, side_effect=send) as send:
-            with self.assertRaises(AnsibleExitJson) as result:
-                self.module.main()
-            self.assertTrue(result.exception.args[0]['changed'])
-            self.assertEqual(result.exception.args[0]['annotation']['_cid'], cid)
+            with patch('requests.adapters.HTTPAdapter.send', autospec=True, side_effect=send) as send:
+                with self.assertRaises(AnsibleExitJson) as result:
+                    self.module.main()
+
+        self.assertTrue(result.exception.args[0]['changed'])
+        self.assertEqual(result.exception.args[0]['annotation']['_cid'], cid)
         self.assertEqual(send.call_count, 1)
 
     def test_auth_failure(self):
         """Check that an error is raised when authentication failed"""
-        set_module_args({
+        with set_module_args({
             'category': 'test category',
             'description': 'test description',
             'title': 'test title',
             'api_key': str(uuid.uuid4()),
-        })
+        }):
 
-        cid = '/annotation/100000'
+            cid = '/annotation/100000'
 
-        def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):
-            data = {
-                '_cid': cid,
-                '_created': 1502146995,
-                '_last_modified': 1502146995,
-                '_last_modified_by': '/user/1000',
-                'category': 'test category',
-                'description': 'test description',
-                'rel_metrics': [],
-                'start': 1502145480,
-                'stop': None,
-                'title': 'test title',
-            }
-            raw = to_bytes(json.dumps(data))
-            resp = HTTPResponse(body=io.BytesIO(raw), preload_content=False)
-            resp.status = 403
-            resp.reason = 'Forbidden'
-            resp.headers = {'X-Circonus-API-Version': '2.00'}
-            return self.build_response(request, resp)
+            def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):
+                data = {
+                    '_cid': cid,
+                    '_created': 1502146995,
+                    '_last_modified': 1502146995,
+                    '_last_modified_by': '/user/1000',
+                    'category': 'test category',
+                    'description': 'test description',
+                    'rel_metrics': [],
+                    'start': 1502145480,
+                    'stop': None,
+                    'title': 'test title',
+                }
+                raw = to_bytes(json.dumps(data))
+                resp = HTTPResponse(body=io.BytesIO(raw), preload_content=False)
+                resp.status = 403
+                resp.reason = 'Forbidden'
+                resp.headers = {'X-Circonus-API-Version': '2.00'}
+                return self.build_response(request, resp)
 
-        with patch('requests.adapters.HTTPAdapter.send', autospec=True, side_effect=send) as send:
-            with self.assertRaises(AnsibleFailJson) as result:
-                self.module.main()
-            self.assertTrue(result.exception.args[0]['failed'])
-            self.assertTrue(re.match(r'\b403\b', result.exception.args[0]['reason']))
+            with patch('requests.adapters.HTTPAdapter.send', autospec=True, side_effect=send) as send:
+                with self.assertRaises(AnsibleFailJson) as result:
+                    self.module.main()
+
+        self.assertTrue(result.exception.args[0]['failed'])
+        self.assertTrue(re.match(r'\b403\b', result.exception.args[0]['reason']))
         self.assertEqual(send.call_count, 1)

--- a/tests/unit/plugins/modules/test_datadog_downtime.py
+++ b/tests/unit/plugins/modules/test_datadog_downtime.py
@@ -33,12 +33,12 @@ class TestDatadogDowntime(ModuleTestCase):
     def test_without_required_parameters(self):
         """Failure must occurs when all parameters are missing"""
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            self.module.main()
+            with set_module_args({}):
+                self.module.main()
 
     @patch("ansible_collections.community.general.plugins.modules.datadog_downtime.DowntimesApi")
     def test_create_downtime_when_no_id(self, downtimes_api_mock):
-        set_module_args({
+        with set_module_args({
             "monitor_tags": ["foo:bar"],
             "scope": ["*"],
             "monitor_id": 12345,
@@ -49,32 +49,32 @@ class TestDatadogDowntime(ModuleTestCase):
             "rrule": "rrule",
             "api_key": "an_api_key",
             "app_key": "an_app_key",
-        })
+        }):
+            downtime = Downtime()
+            downtime.monitor_tags = ["foo:bar"]
+            downtime.scope = ["*"]
+            downtime.monitor_id = 12345
+            downtime.message = "Message"
+            downtime.start = 1111
+            downtime.end = 2222
+            downtime.timezone = "UTC"
+            downtime.recurrence = DowntimeRecurrence(
+                rrule="rrule",
+                type="rrule"
+            )
 
-        downtime = Downtime()
-        downtime.monitor_tags = ["foo:bar"]
-        downtime.scope = ["*"]
-        downtime.monitor_id = 12345
-        downtime.message = "Message"
-        downtime.start = 1111
-        downtime.end = 2222
-        downtime.timezone = "UTC"
-        downtime.recurrence = DowntimeRecurrence(
-            rrule="rrule",
-            type="rrule"
-        )
+            create_downtime_mock = MagicMock(return_value=self.__downtime_with_id(12345))
+            downtimes_api_mock.return_value = MagicMock(create_downtime=create_downtime_mock)
+            with self.assertRaises(AnsibleExitJson) as result:
+                self.module.main()
 
-        create_downtime_mock = MagicMock(return_value=self.__downtime_with_id(12345))
-        downtimes_api_mock.return_value = MagicMock(create_downtime=create_downtime_mock)
-        with self.assertRaises(AnsibleExitJson) as result:
-            self.module.main()
         self.assertTrue(result.exception.args[0]['changed'])
         self.assertEqual(result.exception.args[0]['downtime']['id'], 12345)
         create_downtime_mock.assert_called_once_with(downtime)
 
     @patch("ansible_collections.community.general.plugins.modules.datadog_downtime.DowntimesApi")
     def test_create_downtime_when_id_and_disabled(self, downtimes_api_mock):
-        set_module_args({
+        with set_module_args({
             "id": 1212,
             "monitor_tags": ["foo:bar"],
             "scope": ["*"],
@@ -86,32 +86,32 @@ class TestDatadogDowntime(ModuleTestCase):
             "rrule": "rrule",
             "api_key": "an_api_key",
             "app_key": "an_app_key",
-        })
+        }):
+            downtime = Downtime()
+            downtime.monitor_tags = ["foo:bar"]
+            downtime.scope = ["*"]
+            downtime.monitor_id = 12345
+            downtime.message = "Message"
+            downtime.start = 1111
+            downtime.end = 2222
+            downtime.timezone = "UTC"
+            downtime.recurrence = DowntimeRecurrence(
+                rrule="rrule",
+                type="rrule"
+            )
 
-        downtime = Downtime()
-        downtime.monitor_tags = ["foo:bar"]
-        downtime.scope = ["*"]
-        downtime.monitor_id = 12345
-        downtime.message = "Message"
-        downtime.start = 1111
-        downtime.end = 2222
-        downtime.timezone = "UTC"
-        downtime.recurrence = DowntimeRecurrence(
-            rrule="rrule",
-            type="rrule"
-        )
+            disabled_downtime = Downtime()
+            disabled_downtime.disabled = True
+            disabled_downtime.id = 1212
 
-        disabled_downtime = Downtime()
-        disabled_downtime.disabled = True
-        disabled_downtime.id = 1212
+            create_downtime_mock = MagicMock(return_value=self.__downtime_with_id(12345))
+            get_downtime_mock = MagicMock(return_value=disabled_downtime)
+            downtimes_api_mock.return_value = MagicMock(
+                create_downtime=create_downtime_mock, get_downtime=get_downtime_mock
+            )
+            with self.assertRaises(AnsibleExitJson) as result:
+                self.module.main()
 
-        create_downtime_mock = MagicMock(return_value=self.__downtime_with_id(12345))
-        get_downtime_mock = MagicMock(return_value=disabled_downtime)
-        downtimes_api_mock.return_value = MagicMock(
-            create_downtime=create_downtime_mock, get_downtime=get_downtime_mock
-        )
-        with self.assertRaises(AnsibleExitJson) as result:
-            self.module.main()
         self.assertTrue(result.exception.args[0]['changed'])
         self.assertEqual(result.exception.args[0]['downtime']['id'], 12345)
         create_downtime_mock.assert_called_once_with(downtime)
@@ -119,7 +119,7 @@ class TestDatadogDowntime(ModuleTestCase):
 
     @patch("ansible_collections.community.general.plugins.modules.datadog_downtime.DowntimesApi")
     def test_update_downtime_when_not_disabled(self, downtimes_api_mock):
-        set_module_args({
+        with set_module_args({
             "id": 1212,
             "monitor_tags": ["foo:bar"],
             "scope": ["*"],
@@ -131,32 +131,32 @@ class TestDatadogDowntime(ModuleTestCase):
             "rrule": "rrule",
             "api_key": "an_api_key",
             "app_key": "an_app_key",
-        })
+        }):
+            downtime = Downtime()
+            downtime.monitor_tags = ["foo:bar"]
+            downtime.scope = ["*"]
+            downtime.monitor_id = 12345
+            downtime.message = "Message"
+            downtime.start = 1111
+            downtime.end = 2222
+            downtime.timezone = "UTC"
+            downtime.recurrence = DowntimeRecurrence(
+                rrule="rrule",
+                type="rrule"
+            )
 
-        downtime = Downtime()
-        downtime.monitor_tags = ["foo:bar"]
-        downtime.scope = ["*"]
-        downtime.monitor_id = 12345
-        downtime.message = "Message"
-        downtime.start = 1111
-        downtime.end = 2222
-        downtime.timezone = "UTC"
-        downtime.recurrence = DowntimeRecurrence(
-            rrule="rrule",
-            type="rrule"
-        )
+            enabled_downtime = Downtime()
+            enabled_downtime.disabled = False
+            enabled_downtime.id = 1212
 
-        enabled_downtime = Downtime()
-        enabled_downtime.disabled = False
-        enabled_downtime.id = 1212
+            update_downtime_mock = MagicMock(return_value=self.__downtime_with_id(1212))
+            get_downtime_mock = MagicMock(return_value=enabled_downtime)
+            downtimes_api_mock.return_value = MagicMock(
+                update_downtime=update_downtime_mock, get_downtime=get_downtime_mock
+            )
+            with self.assertRaises(AnsibleExitJson) as result:
+                self.module.main()
 
-        update_downtime_mock = MagicMock(return_value=self.__downtime_with_id(1212))
-        get_downtime_mock = MagicMock(return_value=enabled_downtime)
-        downtimes_api_mock.return_value = MagicMock(
-            update_downtime=update_downtime_mock, get_downtime=get_downtime_mock
-        )
-        with self.assertRaises(AnsibleExitJson) as result:
-            self.module.main()
         self.assertTrue(result.exception.args[0]['changed'])
         self.assertEqual(result.exception.args[0]['downtime']['id'], 1212)
         update_downtime_mock.assert_called_once_with(1212, downtime)
@@ -164,7 +164,7 @@ class TestDatadogDowntime(ModuleTestCase):
 
     @patch("ansible_collections.community.general.plugins.modules.datadog_downtime.DowntimesApi")
     def test_update_downtime_no_change(self, downtimes_api_mock):
-        set_module_args({
+        with set_module_args({
             "id": 1212,
             "monitor_tags": ["foo:bar"],
             "scope": ["*"],
@@ -176,42 +176,42 @@ class TestDatadogDowntime(ModuleTestCase):
             "rrule": "rrule",
             "api_key": "an_api_key",
             "app_key": "an_app_key",
-        })
+        }):
+            downtime = Downtime()
+            downtime.monitor_tags = ["foo:bar"]
+            downtime.scope = ["*"]
+            downtime.monitor_id = 12345
+            downtime.message = "Message"
+            downtime.start = 1111
+            downtime.end = 2222
+            downtime.timezone = "UTC"
+            downtime.recurrence = DowntimeRecurrence(
+                rrule="rrule",
+                type="rrule"
+            )
 
-        downtime = Downtime()
-        downtime.monitor_tags = ["foo:bar"]
-        downtime.scope = ["*"]
-        downtime.monitor_id = 12345
-        downtime.message = "Message"
-        downtime.start = 1111
-        downtime.end = 2222
-        downtime.timezone = "UTC"
-        downtime.recurrence = DowntimeRecurrence(
-            rrule="rrule",
-            type="rrule"
-        )
+            downtime_get = Downtime()
+            downtime_get.id = 1212
+            downtime_get.disabled = False
+            downtime_get.monitor_tags = ["foo:bar"]
+            downtime_get.scope = ["*"]
+            downtime_get.monitor_id = 12345
+            downtime_get.message = "Message"
+            downtime_get.start = 1111
+            downtime_get.end = 2222
+            downtime_get.timezone = "UTC"
+            downtime_get.recurrence = DowntimeRecurrence(
+                rrule="rrule"
+            )
 
-        downtime_get = Downtime()
-        downtime_get.id = 1212
-        downtime_get.disabled = False
-        downtime_get.monitor_tags = ["foo:bar"]
-        downtime_get.scope = ["*"]
-        downtime_get.monitor_id = 12345
-        downtime_get.message = "Message"
-        downtime_get.start = 1111
-        downtime_get.end = 2222
-        downtime_get.timezone = "UTC"
-        downtime_get.recurrence = DowntimeRecurrence(
-            rrule="rrule"
-        )
+            update_downtime_mock = MagicMock(return_value=downtime_get)
+            get_downtime_mock = MagicMock(return_value=downtime_get)
+            downtimes_api_mock.return_value = MagicMock(
+                update_downtime=update_downtime_mock, get_downtime=get_downtime_mock
+            )
+            with self.assertRaises(AnsibleExitJson) as result:
+                self.module.main()
 
-        update_downtime_mock = MagicMock(return_value=downtime_get)
-        get_downtime_mock = MagicMock(return_value=downtime_get)
-        downtimes_api_mock.return_value = MagicMock(
-            update_downtime=update_downtime_mock, get_downtime=get_downtime_mock
-        )
-        with self.assertRaises(AnsibleExitJson) as result:
-            self.module.main()
         self.assertFalse(result.exception.args[0]['changed'])
         self.assertEqual(result.exception.args[0]['downtime']['id'], 1212)
         update_downtime_mock.assert_called_once_with(1212, downtime)
@@ -219,20 +219,20 @@ class TestDatadogDowntime(ModuleTestCase):
 
     @patch("ansible_collections.community.general.plugins.modules.datadog_downtime.DowntimesApi")
     def test_delete_downtime(self, downtimes_api_mock):
-        set_module_args({
+        with set_module_args({
             "id": 1212,
             "state": "absent",
             "api_key": "an_api_key",
             "app_key": "an_app_key",
-        })
+        }):
+            cancel_downtime_mock = MagicMock()
+            downtimes_api_mock.return_value = MagicMock(
+                get_downtime=self.__downtime_with_id,
+                cancel_downtime=cancel_downtime_mock
+            )
+            with self.assertRaises(AnsibleExitJson) as result:
+                self.module.main()
 
-        cancel_downtime_mock = MagicMock()
-        downtimes_api_mock.return_value = MagicMock(
-            get_downtime=self.__downtime_with_id,
-            cancel_downtime=cancel_downtime_mock
-        )
-        with self.assertRaises(AnsibleExitJson) as result:
-            self.module.main()
         self.assertTrue(result.exception.args[0]['changed'])
         cancel_downtime_mock.assert_called_once_with(1212)
 

--- a/tests/unit/plugins/modules/test_discord.py
+++ b/tests/unit/plugins/modules/test_discord.py
@@ -28,30 +28,30 @@ class TestDiscordModule(ModuleTestCase):
     def test_without_parameters(self):
         """Failure if no parameters set"""
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            self.module.main()
+            with set_module_args({}):
+                self.module.main()
 
     def test_without_content(self):
         """Failure if content and embeds both are missing"""
-        set_module_args({
+        with set_module_args({
             'webhook_id': 'xxx',
             'webhook_token': 'xxx'
-        })
-        with self.assertRaises(AnsibleFailJson):
-            self.module.main()
+        }):
+            with self.assertRaises(AnsibleFailJson):
+                self.module.main()
 
     def test_successful_message(self):
         """Test a basic message successfully."""
-        set_module_args({
+        with set_module_args({
             'webhook_id': 'xxx',
             'webhook_token': 'xxx',
             'content': 'test'
-        })
+        }):
 
-        with patch.object(discord, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = (None, {"status": 204, 'msg': 'OK (0 bytes)'})
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
+            with patch.object(discord, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 204, 'msg': 'OK (0 bytes)'})
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
             self.assertTrue(fetch_url_mock.call_count, 1)
             call_data = json.loads(fetch_url_mock.call_args[1]['data'])
@@ -59,17 +59,17 @@ class TestDiscordModule(ModuleTestCase):
 
     def test_message_with_username(self):
         """Test a message with username set successfully."""
-        set_module_args({
+        with set_module_args({
             'webhook_id': 'xxx',
             'webhook_token': 'xxx',
             'content': 'test',
             'username': 'Ansible Bot'
-        })
+        }):
 
-        with patch.object(discord, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = (None, {"status": 204, 'msg': 'OK (0 bytes)'})
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
+            with patch.object(discord, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 204, 'msg': 'OK (0 bytes)'})
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
             self.assertTrue(fetch_url_mock.call_count, 1)
             call_data = json.loads(fetch_url_mock.call_args[1]['data'])
@@ -79,27 +79,30 @@ class TestDiscordModule(ModuleTestCase):
     def test_failed_message(self):
         """Test failure because webhook id is wrong."""
 
-        set_module_args({
+        with set_module_args({
             'webhook_id': 'wrong',
             'webhook_token': 'xxx',
             'content': 'test'
-        })
+        }):
 
-        with patch.object(discord, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = (None, {"status": 404, 'msg': 'HTTP Error 404: Not Found', 'body': '{"message": "Unknown Webhook", "code": 10015}'})
-            with self.assertRaises(AnsibleFailJson):
-                self.module.main()
+            with patch.object(discord, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (
+                    None,
+                    {"status": 404, 'msg': 'HTTP Error 404: Not Found', 'body': '{"message": "Unknown Webhook", "code": 10015}'},
+                )
+                with self.assertRaises(AnsibleFailJson):
+                    self.module.main()
 
     def test_failed_message_without_body(self):
         """Test failure with empty response body."""
 
-        set_module_args({
+        with set_module_args({
             'webhook_id': 'wrong',
             'webhook_token': 'xxx',
             'content': 'test'
-        })
+        }):
 
-        with patch.object(discord, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = (None, {"status": 404, 'msg': 'HTTP Error 404: Not Found'})
-            with self.assertRaises(AnsibleFailJson):
-                self.module.main()
+            with patch.object(discord, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 404, 'msg': 'HTTP Error 404: Not Found'})
+                with self.assertRaises(AnsibleFailJson):
+                    self.module.main()

--- a/tests/unit/plugins/modules/test_dnf_config_manager.py
+++ b/tests/unit/plugins/modules/test_dnf_config_manager.py
@@ -305,22 +305,22 @@ class TestDNFConfigManager(ModuleTestCase):
         return result
 
     def test_get_repo_states(self):
-        set_module_args({})
-        self.set_command_mock(execute_return=(0, mock_repolist_crb_enabled, ''))
-        result = self.execute_module(changed=False)
+        with set_module_args({}):
+            self.set_command_mock(execute_return=(0, mock_repolist_crb_enabled, ''))
+            result = self.execute_module(changed=False)
         self.assertEqual(result['repo_states_pre'], expected_repo_states_crb_enabled)
         self.assertEqual(result['repo_states_post'], expected_repo_states_crb_enabled)
         self.assertEqual(result['changed_repos'], [])
         self.run_command.assert_has_calls(calls=[call_get_repo_states, call_get_repo_states], any_order=False)
 
     def test_enable_disabled_repo(self):
-        set_module_args({
+        with set_module_args({
             'name': ['crb'],
             'state': 'enabled'
-        })
-        side_effects = [(0, mock_repolist_crb_disabled, ''), (0, '', ''), (0, mock_repolist_crb_enabled, '')]
-        self.set_command_mock(execute_side_effect=side_effects)
-        result = self.execute_module(changed=True)
+        }):
+            side_effects = [(0, mock_repolist_crb_disabled, ''), (0, '', ''), (0, mock_repolist_crb_enabled, '')]
+            self.set_command_mock(execute_side_effect=side_effects)
+            result = self.execute_module(changed=True)
         self.assertEqual(result['repo_states_pre'], expected_repo_states_crb_disabled)
         self.assertEqual(result['repo_states_post'], expected_repo_states_crb_enabled)
         self.assertEqual(result['changed_repos'], ['crb'])
@@ -328,25 +328,25 @@ class TestDNFConfigManager(ModuleTestCase):
         self.run_command.assert_has_calls(calls=expected_calls, any_order=False)
 
     def test_enable_disabled_repo_check_mode(self):
-        set_module_args({
+        with set_module_args({
             'name': ['crb'],
             'state': 'enabled',
             '_ansible_check_mode': True
-        })
-        side_effects = [(0, mock_repolist_crb_disabled, ''), (0, mock_repolist_crb_disabled, '')]
-        self.set_command_mock(execute_side_effect=side_effects)
-        result = self.execute_module(changed=True)
+        }):
+            side_effects = [(0, mock_repolist_crb_disabled, ''), (0, mock_repolist_crb_disabled, '')]
+            self.set_command_mock(execute_side_effect=side_effects)
+            result = self.execute_module(changed=True)
         self.assertEqual(result['changed_repos'], ['crb'])
         self.run_command.assert_has_calls(calls=[call_get_repo_states], any_order=False)
 
     def test_disable_enabled_repo(self):
-        set_module_args({
+        with set_module_args({
             'name': ['crb'],
             'state': 'disabled'
-        })
-        side_effects = [(0, mock_repolist_crb_enabled, ''), (0, '', ''), (0, mock_repolist_crb_disabled, '')]
-        self.set_command_mock(execute_side_effect=side_effects)
-        result = self.execute_module(changed=True)
+        }):
+            side_effects = [(0, mock_repolist_crb_enabled, ''), (0, '', ''), (0, mock_repolist_crb_disabled, '')]
+            self.set_command_mock(execute_side_effect=side_effects)
+            result = self.execute_module(changed=True)
         self.assertEqual(result['repo_states_pre'], expected_repo_states_crb_enabled)
         self.assertEqual(result['repo_states_post'], expected_repo_states_crb_disabled)
         self.assertEqual(result['changed_repos'], ['crb'])
@@ -354,49 +354,49 @@ class TestDNFConfigManager(ModuleTestCase):
         self.run_command.assert_has_calls(calls=expected_calls, any_order=False)
 
     def test_crb_already_enabled(self):
-        set_module_args({
+        with set_module_args({
             'name': ['crb'],
             'state': 'enabled'
-        })
-        side_effects = [(0, mock_repolist_crb_enabled, ''), (0, mock_repolist_crb_enabled, '')]
-        self.set_command_mock(execute_side_effect=side_effects)
-        result = self.execute_module(changed=False)
+        }):
+            side_effects = [(0, mock_repolist_crb_enabled, ''), (0, mock_repolist_crb_enabled, '')]
+            self.set_command_mock(execute_side_effect=side_effects)
+            result = self.execute_module(changed=False)
         self.assertEqual(result['repo_states_pre'], expected_repo_states_crb_enabled)
         self.assertEqual(result['repo_states_post'], expected_repo_states_crb_enabled)
         self.assertEqual(result['changed_repos'], [])
         self.run_command.assert_has_calls(calls=[call_get_repo_states, call_get_repo_states], any_order=False)
 
     def test_get_repo_states_fail_no_status(self):
-        set_module_args({})
-        self.set_command_mock(execute_return=(0, mock_repolist_no_status, ''))
-        result = self.execute_module(failed=True)
+        with set_module_args({}):
+            self.set_command_mock(execute_return=(0, mock_repolist_no_status, ''))
+            result = self.execute_module(failed=True)
         self.assertEqual(result['msg'], 'dnf repolist parse failure: parsed another repo id before next status')
         self.run_command.assert_has_calls(calls=[call_get_repo_states], any_order=False)
 
     def test_get_repo_states_fail_status_before_id(self):
-        set_module_args({})
-        self.set_command_mock(execute_return=(0, mock_repolist_status_before_id, ''))
-        result = self.execute_module(failed=True)
+        with set_module_args({}):
+            self.set_command_mock(execute_return=(0, mock_repolist_status_before_id, ''))
+            result = self.execute_module(failed=True)
         self.assertEqual(result['msg'], 'dnf repolist parse failure: parsed status before repo id')
         self.run_command.assert_has_calls(calls=[call_get_repo_states], any_order=False)
 
     def test_failed__unknown_repo_id(self):
-        set_module_args({
+        with set_module_args({
             'name': ['fake']
-        })
-        self.set_command_mock(execute_return=(0, mock_repolist_crb_disabled, ''))
-        result = self.execute_module(failed=True)
+        }):
+            self.set_command_mock(execute_return=(0, mock_repolist_crb_disabled, ''))
+            result = self.execute_module(failed=True)
         self.assertEqual(result['msg'], "did not find repo with ID 'fake' in dnf repolist --all --verbose")
         self.run_command.assert_has_calls(calls=[call_get_repo_states], any_order=False)
 
     def test_failed_state_change_ineffective(self):
-        set_module_args({
+        with set_module_args({
             'name': ['crb'],
             'state': 'enabled'
-        })
-        side_effects = [(0, mock_repolist_crb_disabled, ''), (0, '', ''), (0, mock_repolist_crb_disabled, '')]
-        self.set_command_mock(execute_side_effect=side_effects)
-        result = self.execute_module(failed=True)
+        }):
+            side_effects = [(0, mock_repolist_crb_disabled, ''), (0, '', ''), (0, mock_repolist_crb_disabled, '')]
+            self.set_command_mock(execute_side_effect=side_effects)
+            result = self.execute_module(failed=True)
         self.assertEqual(result['msg'], "dnf config-manager failed to make 'crb' enabled")
         expected_calls = [call_get_repo_states, call_enable_crb, call_get_repo_states]
         self.run_command.assert_has_calls(calls=expected_calls, any_order=False)

--- a/tests/unit/plugins/modules/test_dnsimple.py
+++ b/tests/unit/plugins/modules/test_dnsimple.py
@@ -38,8 +38,8 @@ class TestDNSimple(ModuleTestCase):
     def test_without_required_parameters(self):
         """Failure must occurs when all parameters are missing"""
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            self.module.main()
+            with set_module_args({}):
+                self.module.main()
 
     @patch('dnsimple.service.Identity.whoami')
     def test_account_token(self, mock_whoami):

--- a/tests/unit/plugins/modules/test_dnsimple_info.py
+++ b/tests/unit/plugins/modules/test_dnsimple_info.py
@@ -56,19 +56,19 @@ class TestDNSimple_Info(ModuleTestCase):
     def test_with_no_parameters(self):
         """Failure must occurs when all parameters are missing"""
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            self.module.main()
+            with set_module_args({}):
+                self.module.main()
 
     @with_httmock(zones_resp)
     def test_only_key_and_account(self):
         """key and account will pass, returns domains"""
         account_id = "1234"
         with self.assertRaises(AnsibleExitJson) as exc_info:
-            set_module_args({
+            with set_module_args({
                 "api_key": "abcd1324",
                 "account_id": account_id
-            })
-            self.module.main()
+            }):
+                self.module.main()
         result = exc_info.exception.args[0]
         # nothing should change
         self.assertFalse(result['changed'])
@@ -80,12 +80,12 @@ class TestDNSimple_Info(ModuleTestCase):
         """name and no record should not fail, returns the record"""
         name = "example.com"
         with self.assertRaises(AnsibleExitJson) as exc_info:
-            set_module_args({
+            with set_module_args({
                 "api_key": "abcd1324",
                 "name": "example.com",
                 "account_id": "1234"
-            })
-            self.module.main()
+            }):
+                self.module.main()
         result = exc_info.exception.args[0]
         # nothing should change
         self.assertFalse(result['changed'])
@@ -97,13 +97,13 @@ class TestDNSimple_Info(ModuleTestCase):
         """name and record should not fail, returns the record"""
         record = "example"
         with self.assertRaises(AnsibleExitJson) as exc_info:
-            set_module_args({
+            with set_module_args({
                 "api_key": "abcd1324",
                 "account_id": "1234",
                 "name": "example.com",
                 "record": "example"
-            })
-            self.module.main()
+            }):
+                self.module.main()
         result = exc_info.exception.args[0]
         # nothing should change
         self.assertFalse(result['changed'])

--- a/tests/unit/plugins/modules/test_gem.py
+++ b/tests/unit/plugins/modules/test_gem.py
@@ -55,14 +55,13 @@ class TestGem(ModuleTestCase):
         return self.mocker.patch(target)
 
     def test_fails_when_user_install_and_install_dir_are_combined(self):
-        set_module_args({
+        with set_module_args({
             'name': 'dummy',
             'user_install': True,
             'install_dir': '/opt/dummy',
-        })
-
-        with pytest.raises(AnsibleFailJson) as exc:
-            gem.main()
+        }):
+            with pytest.raises(AnsibleFailJson) as exc:
+                gem.main()
 
         result = exc.value.args[0]
         assert result['failed']
@@ -75,18 +74,17 @@ class TestGem(ModuleTestCase):
         #      test mocks. The only thing that matters is the assertion that this 'gem install' is
         #      invoked with '--install-dir'.
 
-        set_module_args({
+        with set_module_args({
             'name': 'dummy',
             'user_install': False,
             'install_dir': '/opt/dummy',
-        })
+        }):
+            self.patch_rubygems_version()
+            self.patch_installed_versions([])
+            run_command = self.patch_run_command()
 
-        self.patch_rubygems_version()
-        self.patch_installed_versions([])
-        run_command = self.patch_run_command()
-
-        with pytest.raises(AnsibleExitJson) as exc:
-            gem.main()
+            with pytest.raises(AnsibleExitJson) as exc:
+                gem.main()
 
         result = exc.value.args[0]
         assert result['changed']
@@ -98,20 +96,19 @@ class TestGem(ModuleTestCase):
         # XXX: This test is also extremely fragile because of mocking.
         #      If this breaks, the only that matters is to check whether '--install-dir' is
         #      in the run command, and that GEM_HOME is passed to the command.
-        set_module_args({
+        with set_module_args({
             'name': 'dummy',
             'user_install': False,
             'install_dir': '/opt/dummy',
             'state': 'absent',
-        })
+        }):
+            self.patch_rubygems_version()
+            self.patch_installed_versions(['1.0.0'])
 
-        self.patch_rubygems_version()
-        self.patch_installed_versions(['1.0.0'])
+            run_command = self.patch_run_command()
 
-        run_command = self.patch_run_command()
-
-        with pytest.raises(AnsibleExitJson) as exc:
-            gem.main()
+            with pytest.raises(AnsibleExitJson) as exc:
+                gem.main()
 
         result = exc.value.args[0]
 
@@ -124,17 +121,16 @@ class TestGem(ModuleTestCase):
         assert update_environ.get('GEM_HOME') == '/opt/dummy'
 
     def test_passes_add_force_option(self):
-        set_module_args({
+        with set_module_args({
             'name': 'dummy',
             'force': True,
-        })
+        }):
+            self.patch_rubygems_version()
+            self.patch_installed_versions([])
+            run_command = self.patch_run_command()
 
-        self.patch_rubygems_version()
-        self.patch_installed_versions([])
-        run_command = self.patch_run_command()
-
-        with pytest.raises(AnsibleExitJson) as exc:
-            gem.main()
+            with pytest.raises(AnsibleExitJson) as exc:
+                gem.main()
 
         result = exc.value.args[0]
         assert result['changed']

--- a/tests/unit/plugins/modules/test_icinga2_feature.py
+++ b/tests/unit/plugins/modules/test_icinga2_feature.py
@@ -38,63 +38,63 @@ class TestIcinga2Feature(ModuleTestCase):
     def test_without_required_parameters(self):
         """Failure must occurs when all parameters are missing."""
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            self.module.main()
+            with set_module_args({}):
+                self.module.main()
 
     def test_enable_feature(self):
         """Check that result is changed."""
-        set_module_args({
+        with set_module_args({
             'name': 'api',
-        })
-        with patch.object(basic.AnsibleModule, 'run_command') as run_command:
-            run_command.return_value = 0, '', ''  # successful execution, no output
-            with self.assertRaises(AnsibleExitJson) as result:
-                icinga2_feature.main()
-                self.assertTrue(result.exception.args[0]['changed'])
+        }):
+            with patch.object(basic.AnsibleModule, 'run_command') as run_command:
+                run_command.return_value = 0, '', ''  # successful execution, no output
+                with self.assertRaises(AnsibleExitJson) as result:
+                    icinga2_feature.main()
+                    self.assertTrue(result.exception.args[0]['changed'])
 
         self.assertEqual(run_command.call_count, 2)
         self.assertEqual(run_command.call_args[0][0][-1], 'api')
 
     def test_enable_feature_with_check_mode(self):
         """Check that result is changed in check mode."""
-        set_module_args({
+        with set_module_args({
             'name': 'api',
             '_ansible_check_mode': True,
-        })
-        with patch.object(basic.AnsibleModule, 'run_command') as run_command:
-            run_command.return_value = 0, '', ''  # successful execution, no output
-            with self.assertRaises(AnsibleExitJson) as result:
-                icinga2_feature.main()
-                self.assertTrue(result.exception.args[0]['changed'])
+        }):
+            with patch.object(basic.AnsibleModule, 'run_command') as run_command:
+                run_command.return_value = 0, '', ''  # successful execution, no output
+                with self.assertRaises(AnsibleExitJson) as result:
+                    icinga2_feature.main()
+                    self.assertTrue(result.exception.args[0]['changed'])
 
         self.assertEqual(run_command.call_count, 1)
 
     def test_disable_feature(self):
         """Check that result is changed."""
-        set_module_args({
+        with set_module_args({
             'name': 'api',
             'state': 'absent'
-        })
-        with patch.object(basic.AnsibleModule, 'run_command') as run_command:
-            run_command.return_value = 0, '', ''  # successful execution, no output
-            with self.assertRaises(AnsibleExitJson) as result:
-                icinga2_feature.main()
-                self.assertTrue(result.exception.args[0]['changed'])
+        }):
+            with patch.object(basic.AnsibleModule, 'run_command') as run_command:
+                run_command.return_value = 0, '', ''  # successful execution, no output
+                with self.assertRaises(AnsibleExitJson) as result:
+                    icinga2_feature.main()
+                    self.assertTrue(result.exception.args[0]['changed'])
 
         self.assertEqual(run_command.call_count, 2)
         self.assertEqual(run_command.call_args[0][0][-1], 'api')
 
     def test_disable_feature_with_check_mode(self):
         """Check that result is changed in check mode."""
-        set_module_args({
+        with set_module_args({
             'name': 'api',
             'state': 'absent',
             '_ansible_check_mode': True,
-        })
-        with patch.object(basic.AnsibleModule, 'run_command') as run_command:
-            run_command.return_value = 0, '', ''  # successful execution, no output
-            with self.assertRaises(AnsibleExitJson) as result:
-                icinga2_feature.main()
-                self.assertTrue(result.exception.args[0]['changed'])
+        }):
+            with patch.object(basic.AnsibleModule, 'run_command') as run_command:
+                run_command.return_value = 0, '', ''  # successful execution, no output
+                with self.assertRaises(AnsibleExitJson) as result:
+                    icinga2_feature.main()
+                    self.assertTrue(result.exception.args[0]['changed'])
 
         self.assertEqual(run_command.call_count, 1)

--- a/tests/unit/plugins/modules/test_ipa_getkeytab.py
+++ b/tests/unit/plugins/modules/test_ipa_getkeytab.py
@@ -34,18 +34,17 @@ class IPAKeytabModuleTestCase(ModuleTestCase):
         return exc.exception.args[0]
 
     def test_present(self):
-        set_module_args({
+        with set_module_args({
             'path': '/tmp/test.keytab',
             'principal': 'HTTP/freeipa-dc02.ipa.test',
             'ipa_host': 'freeipa-dc01.ipa.test',
             'state': 'present'
-        })
+        }):
+            self.module_main_command.side_effect = [
+                (0, '{}', ''),
+            ]
 
-        self.module_main_command.side_effect = [
-            (0, '{}', ''),
-        ]
-
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertTrue(result['changed'])
         self.module_main_command.assert_has_calls([

--- a/tests/unit/plugins/modules/test_ipa_otpconfig.py
+++ b/tests/unit/plugins/modules/test_ipa_otpconfig.py
@@ -61,12 +61,12 @@ class TestIPAOTPConfig(ModuleTestCase):
         changed (bool):
             Whether or not the module is supposed to be marked as changed
         """
-        set_module_args(module_args)
 
         # Run the module
-        with patch_ipa(return_value=return_value) as (mock_login, mock_post):
-            with self.assertRaises(AnsibleExitJson) as exec_info:
-                self.module.main()
+        with set_module_args(module_args):
+            with patch_ipa(return_value=return_value) as (mock_login, mock_post):
+                with self.assertRaises(AnsibleExitJson) as exec_info:
+                    self.module.main()
 
         # Verify that the calls to _post_json match what is expected
         expected_call_count = len(mock_calls)
@@ -389,16 +389,15 @@ class TestIPAOTPConfig(ModuleTestCase):
 
     def test_fail_post(self):
         """Fail due to an exception raised from _post_json"""
-        set_module_args({
+        with set_module_args({
             'ipatokentotpauthwindow': 11,
             'ipatokentotpsyncwindow': 12,
             'ipatokenhotpauthwindow': 13,
             'ipatokenhotpsyncwindow': 14
-        })
-
-        with patch_ipa(side_effect=Exception('ERROR MESSAGE')) as (mock_login, mock_post):
-            with self.assertRaises(AnsibleFailJson) as exec_info:
-                self.module.main()
+        }):
+            with patch_ipa(side_effect=Exception('ERROR MESSAGE')) as (mock_login, mock_post):
+                with self.assertRaises(AnsibleFailJson) as exec_info:
+                    self.module.main()
 
         self.assertEqual(exec_info.exception.args[0]['msg'], 'ERROR MESSAGE')
 

--- a/tests/unit/plugins/modules/test_ipa_otptoken.py
+++ b/tests/unit/plugins/modules/test_ipa_otptoken.py
@@ -61,12 +61,11 @@ class TestIPAOTPToken(ModuleTestCase):
         changed (bool):
             Whether or not the module is supposed to be marked as changed
         """
-        set_module_args(module_args)
-
-        # Run the module
-        with patch_ipa(return_value=return_value) as (mock_login, mock_post):
-            with self.assertRaises(AnsibleExitJson) as exec_info:
-                self.module.main()
+        with set_module_args(module_args):
+            # Run the module
+            with patch_ipa(return_value=return_value) as (mock_login, mock_post):
+                with self.assertRaises(AnsibleExitJson) as exec_info:
+                    self.module.main()
 
         # Verify that the calls to _post_json match what is expected
         expected_call_count = len(mock_calls)
@@ -481,13 +480,12 @@ class TestIPAOTPToken(ModuleTestCase):
 
     def test_fail_post(self):
         """Fail due to an exception raised from _post_json"""
-        set_module_args({
+        with set_module_args({
             'uniqueid': 'NewToken1'
-        })
-
-        with patch_ipa(side_effect=Exception('ERROR MESSAGE')) as (mock_login, mock_post):
-            with self.assertRaises(AnsibleFailJson) as exec_info:
-                self.module.main()
+        }):
+            with patch_ipa(side_effect=Exception('ERROR MESSAGE')) as (mock_login, mock_post):
+                with self.assertRaises(AnsibleFailJson) as exec_info:
+                    self.module.main()
 
         self.assertEqual(exec_info.exception.args[0]['msg'], 'ERROR MESSAGE')
 

--- a/tests/unit/plugins/modules/test_ipa_pwpolicy.py
+++ b/tests/unit/plugins/modules/test_ipa_pwpolicy.py
@@ -62,12 +62,11 @@ class TestIPAPwPolicy(ModuleTestCase):
         changed (bool):
             Whether or not the module is supposed to be marked as changed
         """
-        set_module_args(module_args)
-
-        # Run the module
-        with patch_ipa(return_value=return_value) as (mock_login, mock_post):
-            with self.assertRaises(AnsibleExitJson) as exec_info:
-                self.module.main()
+        with set_module_args(module_args):
+            # Run the module
+            with patch_ipa(return_value=return_value) as (mock_login, mock_post):
+                with self.assertRaises(AnsibleExitJson) as exec_info:
+                    self.module.main()
 
         # Verify that the calls to _post_json match what is expected
         expected_call_count = len(mock_calls)
@@ -693,14 +692,13 @@ class TestIPAPwPolicy(ModuleTestCase):
 
     def test_fail_post(self):
         """Fail due to an exception raised from _post_json"""
-        set_module_args({
+        with set_module_args({
             'group': 'admins',
             'state': 'absent'
-        })
-
-        with patch_ipa(side_effect=Exception('ERROR MESSAGE')) as (mock_login, mock_post):
-            with self.assertRaises(AnsibleFailJson) as exec_info:
-                self.module.main()
+        }):
+            with patch_ipa(side_effect=Exception('ERROR MESSAGE')) as (mock_login, mock_post):
+                with self.assertRaises(AnsibleFailJson) as exec_info:
+                    self.module.main()
 
         self.assertEqual(exec_info.exception.args[0]['msg'], 'ERROR MESSAGE')
 

--- a/tests/unit/plugins/modules/test_java_keystore.py
+++ b/tests/unit/plugins/modules/test_java_keystore.py
@@ -83,20 +83,20 @@ class TestCreateJavaKeystore(ModuleTestCase):
         self.mock_os_path_exists.stop()
 
     def test_create_jks_success(self):
-        set_module_args(dict(
+        with set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
             dest='/path/to/keystore.jks',
             name='test',
             password='changeit'
-        ))
+        )):
 
-        module = AnsibleModule(
-            argument_spec=module_argument_spec,
-            supports_check_mode=module_supports_check_mode,
-            mutually_exclusive=module_choose_between,
-            required_one_of=module_choose_between
-        )
+            module = AnsibleModule(
+                argument_spec=module_argument_spec,
+                supports_check_mode=module_supports_check_mode,
+                mutually_exclusive=module_choose_between,
+                required_one_of=module_choose_between
+            )
 
         with patch('os.remove', return_value=True):
             self.create_path.side_effect = ['/tmp/tmpgrzm2ah7']
@@ -115,21 +115,21 @@ class TestCreateJavaKeystore(ModuleTestCase):
             }
 
     def test_create_jks_keypass_fail_export_pkcs12(self):
-        set_module_args(dict(
+        with set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
             private_key_passphrase='passphrase-foo',
             dest='/path/to/keystore.jks',
             name='test',
             password='changeit'
-        ))
+        )):
 
-        module = AnsibleModule(
-            argument_spec=module_argument_spec,
-            supports_check_mode=module_supports_check_mode,
-            mutually_exclusive=module_choose_between,
-            required_one_of=module_choose_between
-        )
+            module = AnsibleModule(
+                argument_spec=module_argument_spec,
+                supports_check_mode=module_supports_check_mode,
+                mutually_exclusive=module_choose_between,
+                required_one_of=module_choose_between
+            )
 
         module.exit_json = Mock()
         module.fail_json = Mock()
@@ -154,20 +154,20 @@ class TestCreateJavaKeystore(ModuleTestCase):
             )
 
     def test_create_jks_fail_export_pkcs12(self):
-        set_module_args(dict(
+        with set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
             dest='/path/to/keystore.jks',
             name='test',
             password='changeit'
-        ))
+        )):
 
-        module = AnsibleModule(
-            argument_spec=module_argument_spec,
-            supports_check_mode=module_supports_check_mode,
-            mutually_exclusive=module_choose_between,
-            required_one_of=module_choose_between
-        )
+            module = AnsibleModule(
+                argument_spec=module_argument_spec,
+                supports_check_mode=module_supports_check_mode,
+                mutually_exclusive=module_choose_between,
+                required_one_of=module_choose_between
+            )
 
         module.exit_json = Mock()
         module.fail_json = Mock()
@@ -191,20 +191,20 @@ class TestCreateJavaKeystore(ModuleTestCase):
             )
 
     def test_create_jks_fail_import_key(self):
-        set_module_args(dict(
+        with set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
             dest='/path/to/keystore.jks',
             name='test',
             password='changeit'
-        ))
+        )):
 
-        module = AnsibleModule(
-            argument_spec=module_argument_spec,
-            supports_check_mode=module_supports_check_mode,
-            mutually_exclusive=module_choose_between,
-            required_one_of=module_choose_between
-        )
+            module = AnsibleModule(
+                argument_spec=module_argument_spec,
+                supports_check_mode=module_supports_check_mode,
+                mutually_exclusive=module_choose_between,
+                required_one_of=module_choose_between
+            )
 
         module.exit_json = Mock()
         module.fail_json = Mock()
@@ -257,20 +257,20 @@ class TestCertChanged(ModuleTestCase):
         self.mock_atomic_move.stop()
 
     def test_cert_unchanged_same_fingerprint(self):
-        set_module_args(dict(
+        with set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
             dest='/path/to/keystore.jks',
             name='foo',
             password='changeit'
-        ))
+        )):
 
-        module = AnsibleModule(
-            argument_spec=module_argument_spec,
-            supports_check_mode=module_supports_check_mode,
-            mutually_exclusive=module_choose_between,
-            required_one_of=module_choose_between
-        )
+            module = AnsibleModule(
+                argument_spec=module_argument_spec,
+                supports_check_mode=module_supports_check_mode,
+                mutually_exclusive=module_choose_between,
+                required_one_of=module_choose_between
+            )
 
         with patch('os.remove', return_value=True):
             self.create_file.side_effect = ['/tmp/placeholder', '']
@@ -282,20 +282,20 @@ class TestCertChanged(ModuleTestCase):
             self.assertFalse(result, 'Fingerprint is identical')
 
     def test_cert_changed_fingerprint_mismatch(self):
-        set_module_args(dict(
+        with set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
             dest='/path/to/keystore.jks',
             name='foo',
             password='changeit'
-        ))
+        )):
 
-        module = AnsibleModule(
-            argument_spec=module_argument_spec,
-            supports_check_mode=module_supports_check_mode,
-            mutually_exclusive=module_choose_between,
-            required_one_of=module_choose_between
-        )
+            module = AnsibleModule(
+                argument_spec=module_argument_spec,
+                supports_check_mode=module_supports_check_mode,
+                mutually_exclusive=module_choose_between,
+                required_one_of=module_choose_between
+            )
 
         with patch('os.remove', return_value=True):
             self.create_file.side_effect = ['/tmp/placeholder', '']
@@ -307,20 +307,20 @@ class TestCertChanged(ModuleTestCase):
             self.assertTrue(result, 'Fingerprint mismatch')
 
     def test_cert_changed_alias_does_not_exist(self):
-        set_module_args(dict(
+        with set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
             dest='/path/to/keystore.jks',
             name='foo',
             password='changeit'
-        ))
+        )):
 
-        module = AnsibleModule(
-            argument_spec=module_argument_spec,
-            supports_check_mode=module_supports_check_mode,
-            mutually_exclusive=module_choose_between,
-            required_one_of=module_choose_between
-        )
+            module = AnsibleModule(
+                argument_spec=module_argument_spec,
+                supports_check_mode=module_supports_check_mode,
+                mutually_exclusive=module_choose_between,
+                required_one_of=module_choose_between
+            )
 
         with patch('os.remove', return_value=True):
             self.create_file.side_effect = ['/tmp/placeholder', '']
@@ -332,20 +332,20 @@ class TestCertChanged(ModuleTestCase):
             self.assertTrue(result, 'Alias mismatch detected')
 
     def test_cert_changed_password_mismatch(self):
-        set_module_args(dict(
+        with set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
             dest='/path/to/keystore.jks',
             name='foo',
             password='changeit'
-        ))
+        )):
 
-        module = AnsibleModule(
-            argument_spec=module_argument_spec,
-            supports_check_mode=module_supports_check_mode,
-            mutually_exclusive=module_choose_between,
-            required_one_of=module_choose_between
-        )
+            module = AnsibleModule(
+                argument_spec=module_argument_spec,
+                supports_check_mode=module_supports_check_mode,
+                mutually_exclusive=module_choose_between,
+                required_one_of=module_choose_between
+            )
 
         with patch('os.remove', return_value=True):
             self.create_file.side_effect = ['/tmp/placeholder', '']
@@ -357,20 +357,20 @@ class TestCertChanged(ModuleTestCase):
             self.assertTrue(result, 'Password mismatch detected')
 
     def test_cert_changed_fail_read_cert(self):
-        set_module_args(dict(
+        with set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
             dest='/path/to/keystore.jks',
             name='foo',
             password='changeit'
-        ))
+        )):
 
-        module = AnsibleModule(
-            argument_spec=module_argument_spec,
-            supports_check_mode=module_supports_check_mode,
-            mutually_exclusive=module_choose_between,
-            required_one_of=module_choose_between
-        )
+            module = AnsibleModule(
+                argument_spec=module_argument_spec,
+                supports_check_mode=module_supports_check_mode,
+                mutually_exclusive=module_choose_between,
+                required_one_of=module_choose_between
+            )
 
         module.exit_json = Mock()
         module.fail_json = Mock()
@@ -390,20 +390,20 @@ class TestCertChanged(ModuleTestCase):
             )
 
     def test_cert_changed_fail_read_keystore(self):
-        set_module_args(dict(
+        with set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
             dest='/path/to/keystore.jks',
             name='foo',
             password='changeit'
-        ))
+        )):
 
-        module = AnsibleModule(
-            argument_spec=module_argument_spec,
-            supports_check_mode=module_supports_check_mode,
-            mutually_exclusive=module_choose_between,
-            required_one_of=module_choose_between
-        )
+            module = AnsibleModule(
+                argument_spec=module_argument_spec,
+                supports_check_mode=module_supports_check_mode,
+                mutually_exclusive=module_choose_between,
+                required_one_of=module_choose_between
+            )
 
         module.exit_json = Mock()
         module.fail_json = Mock(return_value=True)

--- a/tests/unit/plugins/modules/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/test_jenkins_build.py
@@ -8,39 +8,8 @@ __metaclass__ = type
 from ansible_collections.community.general.tests.unit.compat import unittest
 from ansible_collections.community.general.tests.unit.compat.mock import patch
 from ansible.module_utils import basic
-from ansible.module_utils.common.text.converters import to_bytes
 from ansible_collections.community.general.plugins.modules import jenkins_build
-
-import json
-
-
-def set_module_args(args):
-    """prepare arguments so that they will be picked up during module creation"""
-    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
-    basic._ANSIBLE_ARGS = to_bytes(args)
-
-
-class AnsibleExitJson(Exception):
-    """Exception class to be raised by module.exit_json and caught by the test case"""
-    pass
-
-
-class AnsibleFailJson(Exception):
-    """Exception class to be raised by module.fail_json and caught by the test case"""
-    pass
-
-
-def exit_json(*args, **kwargs):
-    """function to patch over exit_json; package return data into an exception"""
-    if 'changed' not in kwargs:
-        kwargs['changed'] = False
-    raise AnsibleExitJson(kwargs)
-
-
-def fail_json(*args, **kwargs):
-    """function to patch over fail_json; package return data into an exception"""
-    kwargs['failed'] = True
-    raise AnsibleFailJson(kwargs)
+from ansible_collections.community.general.tests.unit.plugins.modules.utils import AnsibleExitJson, AnsibleFailJson, set_module_args, exit_json, fail_json
 
 
 class jenkins:
@@ -131,18 +100,18 @@ class TestJenkinsBuild(unittest.TestCase):
     def test_module_fail_when_required_args_missing(self, test_deps):
         test_deps.return_value = None
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            jenkins_build.main()
+            with set_module_args({}):
+                jenkins_build.main()
 
     @patch('ansible_collections.community.general.plugins.modules.jenkins_build.test_dependencies')
     def test_module_fail_when_missing_build_number(self, test_deps):
         test_deps.return_value = None
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 "name": "required-if",
                 "state": "stopped"
-            })
-            jenkins_build.main()
+            }):
+                jenkins_build.main()
 
     @patch('ansible_collections.community.general.plugins.modules.jenkins_build.test_dependencies')
     @patch('ansible_collections.community.general.plugins.modules.jenkins_build.JenkinsBuild.get_jenkins_connection')
@@ -151,12 +120,12 @@ class TestJenkinsBuild(unittest.TestCase):
         jenkins_connection.return_value = JenkinsMock()
 
         with self.assertRaises(AnsibleExitJson):
-            set_module_args({
+            with set_module_args({
                 "name": "host-check",
                 "user": "abc",
                 "token": "xyz"
-            })
-            jenkins_build.main()
+            }):
+                jenkins_build.main()
 
     @patch('ansible_collections.community.general.plugins.modules.jenkins_build.test_dependencies')
     @patch('ansible_collections.community.general.plugins.modules.jenkins_build.JenkinsBuild.get_jenkins_connection')
@@ -165,14 +134,14 @@ class TestJenkinsBuild(unittest.TestCase):
         jenkins_connection.return_value = JenkinsMock()
 
         with self.assertRaises(AnsibleExitJson) as return_json:
-            set_module_args({
+            with set_module_args({
                 "name": "host-check",
                 "build_number": "1234",
                 "state": "stopped",
                 "user": "abc",
                 "token": "xyz"
-            })
-            jenkins_build.main()
+            }):
+                jenkins_build.main()
 
         self.assertTrue(return_json.exception.args[0]['changed'])
 
@@ -183,14 +152,14 @@ class TestJenkinsBuild(unittest.TestCase):
         jenkins_connection.return_value = JenkinsMockIdempotent()
 
         with self.assertRaises(AnsibleExitJson) as return_json:
-            set_module_args({
+            with set_module_args({
                 "name": "host-check",
                 "build_number": "1234",
                 "state": "stopped",
                 "user": "abc",
                 "password": "xyz"
-            })
-            jenkins_build.main()
+            }):
+                jenkins_build.main()
 
         self.assertFalse(return_json.exception.args[0]['changed'])
 
@@ -203,14 +172,14 @@ class TestJenkinsBuild(unittest.TestCase):
         build_status.return_value = JenkinsBuildMock().get_build_status()
 
         with self.assertRaises(AnsibleExitJson):
-            set_module_args({
+            with set_module_args({
                 "name": "host-delete",
                 "build_number": "1234",
                 "state": "absent",
                 "user": "abc",
                 "token": "xyz"
-            })
-            jenkins_build.main()
+            }):
+                jenkins_build.main()
 
     @patch('ansible_collections.community.general.plugins.modules.jenkins_build.test_dependencies')
     @patch('ansible_collections.community.general.plugins.modules.jenkins_build.JenkinsBuild.get_jenkins_connection')
@@ -219,14 +188,14 @@ class TestJenkinsBuild(unittest.TestCase):
         jenkins_connection.return_value = JenkinsMockIdempotent()
 
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 "name": "host-delete",
                 "build_number": "1234",
                 "state": "absent",
                 "user": "abc",
                 "token": "xyz"
-            })
-            jenkins_build.main()
+            }):
+                jenkins_build.main()
 
     @patch('ansible_collections.community.general.plugins.modules.jenkins_build.test_dependencies')
     @patch('ansible_collections.community.general.plugins.modules.jenkins_build.JenkinsBuild.get_jenkins_connection')
@@ -237,12 +206,12 @@ class TestJenkinsBuild(unittest.TestCase):
         build_status.return_value = JenkinsBuildMock().get_build_status()
 
         with self.assertRaises(AnsibleExitJson) as return_json:
-            set_module_args({
+            with set_module_args({
                 "name": "create-detached",
                 "user": "abc",
                 "token": "xyz"
-            })
-            jenkins_build.main()
+            }):
+                jenkins_build.main()
 
         self.assertFalse(return_json.exception.args[0]['changed'])
 
@@ -253,12 +222,12 @@ class TestJenkinsBuild(unittest.TestCase):
         jenkins_connection.return_value = JenkinsMock()
 
         with self.assertRaises(AnsibleExitJson) as return_json:
-            set_module_args({
+            with set_module_args({
                 "name": "create-detached",
                 "user": "abc",
                 "token": "xyz",
                 "detach": True
-            })
-            jenkins_build.main()
+            }):
+                jenkins_build.main()
 
         self.assertTrue(return_json.exception.args[0]['changed'])

--- a/tests/unit/plugins/modules/test_keycloak_authentication.py
+++ b/tests/unit/plugins/modules/test_keycloak_authentication.py
@@ -163,17 +163,16 @@ class TestKeycloakAuthentication(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before, copy_auth_flow=return_value_copied,
-                                    get_executions_representation=return_value_executions_after) \
-                    as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
-                        mock_get_executions_representation, mock_delete_authentication_flow_by_id):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before, copy_auth_flow=return_value_copied,
+                                        get_executions_representation=return_value_executions_after) \
+                        as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
+                            mock_get_executions_representation, mock_delete_authentication_flow_by_id):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
@@ -256,17 +255,16 @@ class TestKeycloakAuthentication(ModuleTestCase):
         ]
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before,
-                                    get_executions_representation=return_value_executions_after) \
-                    as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
-                        mock_get_executions_representation, mock_delete_authentication_flow_by_id):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before,
+                                        get_executions_representation=return_value_executions_after) \
+                        as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
+                            mock_get_executions_representation, mock_delete_authentication_flow_by_id):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
@@ -328,17 +326,16 @@ class TestKeycloakAuthentication(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before,
-                                    get_executions_representation=return_value_executions_after, create_empty_auth_flow=return_value_created_empty_flow) \
-                    as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
-                        mock_get_executions_representation, mock_delete_authentication_flow_by_id):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before,
+                                        get_executions_representation=return_value_executions_after, create_empty_auth_flow=return_value_created_empty_flow) \
+                        as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
+                            mock_get_executions_representation, mock_delete_authentication_flow_by_id):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
@@ -419,17 +416,16 @@ class TestKeycloakAuthentication(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before,
-                                    get_executions_representation=return_value_executions_after) \
-                    as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
-                        mock_get_executions_representation, mock_delete_authentication_flow_by_id):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before,
+                                        get_executions_representation=return_value_executions_after) \
+                        as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
+                            mock_get_executions_representation, mock_delete_authentication_flow_by_id):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
@@ -472,16 +468,15 @@ class TestKeycloakAuthentication(ModuleTestCase):
         }]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before) \
-                    as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
-                        mock_get_executions_representation, mock_delete_authentication_flow_by_id):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before) \
+                        as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
+                            mock_get_executions_representation, mock_delete_authentication_flow_by_id):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
@@ -508,16 +503,15 @@ class TestKeycloakAuthentication(ModuleTestCase):
         return_value_auth_flow_before = [{}]
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before) \
-                    as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
-                        mock_get_executions_representation, mock_delete_authentication_flow_by_id):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before) \
+                        as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
+                            mock_get_executions_representation, mock_delete_authentication_flow_by_id):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
@@ -596,17 +590,16 @@ class TestKeycloakAuthentication(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before,
-                                    get_executions_representation=return_value_executions_after, create_empty_auth_flow=return_value_created_empty_flow) \
-                    as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
-                        mock_get_executions_representation, mock_delete_authentication_flow_by_id):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before,
+                                        get_executions_representation=return_value_executions_after, create_empty_auth_flow=return_value_created_empty_flow) \
+                        as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
+                            mock_get_executions_representation, mock_delete_authentication_flow_by_id):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)

--- a/tests/unit/plugins/modules/test_keycloak_authentication_required_actions.py
+++ b/tests/unit/plugins/modules/test_keycloak_authentication_required_actions.py
@@ -235,20 +235,19 @@ class TestKeycloakAuthentication(ModuleTestCase):
 
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
-        with mock_good_connection():
-            with patch_keycloak_api(
-                get_required_actions=return_value_required_actions,
-            ) as (
-                mock_get_required_actions,
-                mock_register_required_action,
-                mock_update_required_action,
-                mock_delete_required_action,
-            ):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(
+                    get_required_actions=return_value_required_actions,
+                ) as (
+                    mock_get_required_actions,
+                    mock_register_required_action,
+                    mock_update_required_action,
+                    mock_delete_required_action,
+                ):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(len(mock_get_required_actions.mock_calls), 1)
@@ -386,20 +385,19 @@ class TestKeycloakAuthentication(ModuleTestCase):
 
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
-        with mock_good_connection():
-            with patch_keycloak_api(
-                get_required_actions=return_value_required_actions,
-            ) as (
-                mock_get_required_actions,
-                mock_register_required_action,
-                mock_update_required_action,
-                mock_delete_required_action,
-            ):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(
+                    get_required_actions=return_value_required_actions,
+                ) as (
+                    mock_get_required_actions,
+                    mock_register_required_action,
+                    mock_update_required_action,
+                    mock_delete_required_action,
+                ):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(len(mock_get_required_actions.mock_calls), 1)
@@ -537,20 +535,19 @@ class TestKeycloakAuthentication(ModuleTestCase):
 
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
-        with mock_good_connection():
-            with patch_keycloak_api(
-                get_required_actions=return_value_required_actions,
-            ) as (
-                mock_get_required_actions,
-                mock_register_required_action,
-                mock_update_required_action,
-                mock_delete_required_action,
-            ):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(
+                    get_required_actions=return_value_required_actions,
+                ) as (
+                    mock_get_required_actions,
+                    mock_register_required_action,
+                    mock_update_required_action,
+                    mock_delete_required_action,
+                ):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(len(mock_get_required_actions.mock_calls), 1)
@@ -676,20 +673,19 @@ class TestKeycloakAuthentication(ModuleTestCase):
 
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
-        with mock_good_connection():
-            with patch_keycloak_api(
-                get_required_actions=return_value_required_actions,
-            ) as (
-                mock_get_required_actions,
-                mock_register_required_action,
-                mock_update_required_action,
-                mock_delete_required_action,
-            ):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(
+                    get_required_actions=return_value_required_actions,
+                ) as (
+                    mock_get_required_actions,
+                    mock_register_required_action,
+                    mock_update_required_action,
+                    mock_delete_required_action,
+                ):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(len(mock_get_required_actions.mock_calls), 1)
@@ -806,20 +802,19 @@ class TestKeycloakAuthentication(ModuleTestCase):
 
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
-        with mock_good_connection():
-            with patch_keycloak_api(
-                get_required_actions=return_value_required_actions,
-            ) as (
-                mock_get_required_actions,
-                mock_register_required_action,
-                mock_update_required_action,
-                mock_delete_required_action,
-            ):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(
+                    get_required_actions=return_value_required_actions,
+                ) as (
+                    mock_get_required_actions,
+                    mock_register_required_action,
+                    mock_update_required_action,
+                    mock_delete_required_action,
+                ):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(len(mock_get_required_actions.mock_calls), 1)

--- a/tests/unit/plugins/modules/test_keycloak_client.py
+++ b/tests/unit/plugins/modules/test_keycloak_client.py
@@ -126,15 +126,14 @@ class TestKeycloakRealm(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_client_by_clientid=return_value_get_client_by_clientid) \
-                    as (mock_get_client_by_clientid, mock_get_client_by_id, mock_create_client, mock_update_client, mock_delete_client):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_client_by_clientid=return_value_get_client_by_clientid) \
+                        as (mock_get_client_by_clientid, mock_get_client_by_id, mock_create_client, mock_update_client, mock_delete_client):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(mock_get_client_by_clientid.call_count, 2)
         self.assertEqual(mock_get_client_by_id.call_count, 0)

--- a/tests/unit/plugins/modules/test_keycloak_client_rolemapping.py
+++ b/tests/unit/plugins/modules/test_keycloak_client_rolemapping.py
@@ -188,20 +188,19 @@ class TestKeycloakRealm(ModuleTestCase):
 
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
-                                    get_client_role_id_by_name=return_value_get_client_role_id_by_name,
-                                    get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
-                                    get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
-                    as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping,
-                        mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
-                        mock_delete_group_rolemapping):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
+                                        get_client_role_id_by_name=return_value_get_client_role_id_by_name,
+                                        get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
+                                        get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
+                        as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping,
+                            mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
+                            mock_delete_group_rolemapping):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(mock_get_group_by_name.call_count, 1)
         self.assertEqual(mock_get_client_id.call_count, 1)
@@ -272,20 +271,19 @@ class TestKeycloakRealm(ModuleTestCase):
 
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
-                                    get_client_role_id_by_name=return_value_get_client_role_id_by_name,
-                                    get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
-                                    get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
-                    as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping,
-                        mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
-                        mock_delete_group_rolemapping):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
+                                        get_client_role_id_by_name=return_value_get_client_role_id_by_name,
+                                        get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
+                                        get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
+                        as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping,
+                            mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
+                            mock_delete_group_rolemapping):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(mock_get_group_by_name.call_count, 1)
         self.assertEqual(mock_get_client_id.call_count, 1)
@@ -374,20 +372,19 @@ class TestKeycloakRealm(ModuleTestCase):
 
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
-                                    get_client_role_id_by_name=return_value_get_client_role_id_by_name,
-                                    get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
-                                    get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
-                    as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping,
-                        mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
-                        mock_delete_group_rolemapping):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
+                                        get_client_role_id_by_name=return_value_get_client_role_id_by_name,
+                                        get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
+                                        get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
+                        as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping,
+                            mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
+                            mock_delete_group_rolemapping):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(mock_get_group_by_name.call_count, 0)
         self.assertEqual(mock_get_client_id.call_count, 0)
@@ -461,20 +458,19 @@ class TestKeycloakRealm(ModuleTestCase):
 
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
-                                    get_client_role_id_by_name=return_value_get_client_role_id_by_name,
-                                    get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
-                                    get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
-                    as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping,
-                        mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
-                        mock_delete_group_rolemapping):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
+                                        get_client_role_id_by_name=return_value_get_client_role_id_by_name,
+                                        get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
+                                        get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
+                        as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping,
+                            mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
+                            mock_delete_group_rolemapping):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(mock_get_group_by_name.call_count, 1)
         self.assertEqual(mock_get_client_id.call_count, 1)
@@ -547,20 +543,19 @@ class TestKeycloakRealm(ModuleTestCase):
 
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
-                                    get_client_role_id_by_name=return_value_get_client_role_id_by_name,
-                                    get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
-                                    get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
-                    as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping,
-                        mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
-                        mock_delete_group_rolemapping):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
+                                        get_client_role_id_by_name=return_value_get_client_role_id_by_name,
+                                        get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
+                                        get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
+                        as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping,
+                            mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
+                            mock_delete_group_rolemapping):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(mock_get_group_by_name.call_count, 1)
         self.assertEqual(mock_get_client_id.call_count, 1)

--- a/tests/unit/plugins/modules/test_keycloak_clientscope.py
+++ b/tests/unit/plugins/modules/test_keycloak_clientscope.py
@@ -142,18 +142,17 @@ class TestKeycloakAuthentication(ModuleTestCase):
 
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_clientscope_by_name=return_value_get_clientscope_by_name) \
-                    as (mock_get_clientscope_by_name, mock_get_clientscope_by_clientscopeid, mock_create_clientscope,
-                        mock_update_clientscope, mock_get_clientscope_protocolmapper_by_name,
-                        mock_update_clientscope_protocolmappers,
-                        mock_create_clientscope_protocolmapper, mock_delete_clientscope):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_clientscope_by_name=return_value_get_clientscope_by_name) \
+                        as (mock_get_clientscope_by_name, mock_get_clientscope_by_clientscopeid, mock_create_clientscope,
+                            mock_update_clientscope, mock_get_clientscope_protocolmapper_by_name,
+                            mock_update_clientscope_protocolmappers,
+                            mock_create_clientscope_protocolmapper, mock_delete_clientscope):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(mock_get_clientscope_by_name.call_count, 2)
@@ -188,18 +187,17 @@ class TestKeycloakAuthentication(ModuleTestCase):
 
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_clientscope_by_name=return_value_get_clientscope_by_name) \
-                    as (mock_get_clientscope_by_name, mock_get_clientscope_by_clientscopeid, mock_create_clientscope,
-                        mock_update_clientscope, mock_get_clientscope_protocolmapper_by_name,
-                        mock_update_clientscope_protocolmappers,
-                        mock_create_clientscope_protocolmapper, mock_delete_clientscope):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_clientscope_by_name=return_value_get_clientscope_by_name) \
+                        as (mock_get_clientscope_by_name, mock_get_clientscope_by_clientscopeid, mock_create_clientscope,
+                            mock_update_clientscope, mock_get_clientscope_protocolmapper_by_name,
+                            mock_update_clientscope_protocolmappers,
+                            mock_create_clientscope_protocolmapper, mock_delete_clientscope):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(mock_get_clientscope_by_name.call_count, 1)
@@ -234,18 +232,17 @@ class TestKeycloakAuthentication(ModuleTestCase):
 
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_clientscope_by_name=return_value_get_clientscope_by_name) \
-                    as (mock_get_clientscope_by_name, mock_get_clientscope_by_clientscopeid, mock_create_clientscope,
-                        mock_update_clientscope, mock_get_clientscope_protocolmapper_by_name,
-                        mock_update_clientscope_protocolmappers,
-                        mock_create_clientscope_protocolmapper, mock_delete_clientscope):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_clientscope_by_name=return_value_get_clientscope_by_name) \
+                        as (mock_get_clientscope_by_name, mock_get_clientscope_by_clientscopeid, mock_create_clientscope,
+                            mock_update_clientscope, mock_get_clientscope_protocolmapper_by_name,
+                            mock_update_clientscope_protocolmappers,
+                            mock_create_clientscope_protocolmapper, mock_delete_clientscope):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(mock_get_clientscope_by_name.call_count, 1)
@@ -276,18 +273,17 @@ class TestKeycloakAuthentication(ModuleTestCase):
 
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_clientscope_by_name=return_value_get_clientscope_by_name) \
-                    as (mock_get_clientscope_by_name, mock_get_clientscope_by_clientscopeid, mock_create_clientscope,
-                        mock_update_clientscope, mock_get_clientscope_protocolmapper_by_name,
-                        mock_update_clientscope_protocolmappers,
-                        mock_create_clientscope_protocolmapper, mock_delete_clientscope):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_clientscope_by_name=return_value_get_clientscope_by_name) \
+                        as (mock_get_clientscope_by_name, mock_get_clientscope_by_clientscopeid, mock_create_clientscope,
+                            mock_update_clientscope, mock_get_clientscope_protocolmapper_by_name,
+                            mock_update_clientscope_protocolmappers,
+                            mock_create_clientscope_protocolmapper, mock_delete_clientscope):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(mock_get_clientscope_by_name.call_count, 1)
@@ -405,18 +401,17 @@ class TestKeycloakAuthentication(ModuleTestCase):
 
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_clientscope_by_name=return_value_get_clientscope_by_name) \
-                    as (mock_get_clientscope_by_name, mock_get_clientscope_by_clientscopeid, mock_create_clientscope,
-                        mock_update_clientscope, mock_get_clientscope_protocolmapper_by_name,
-                        mock_update_clientscope_protocolmappers,
-                        mock_create_clientscope_protocolmapper, mock_delete_clientscope):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_clientscope_by_name=return_value_get_clientscope_by_name) \
+                        as (mock_get_clientscope_by_name, mock_get_clientscope_by_clientscopeid, mock_create_clientscope,
+                            mock_update_clientscope, mock_get_clientscope_protocolmapper_by_name,
+                            mock_update_clientscope_protocolmappers,
+                            mock_create_clientscope_protocolmapper, mock_delete_clientscope):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(mock_get_clientscope_by_name.call_count, 2)
@@ -582,19 +577,18 @@ class TestKeycloakAuthentication(ModuleTestCase):
 
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_clientscope_by_name=return_value_get_clientscope_by_name,
-                                    get_clientscope_by_clientscopeid=return_value_get_clientscope_by_clientscopeid) \
-                    as (mock_get_clientscope_by_name, mock_get_clientscope_by_clientscopeid, mock_create_clientscope,
-                        mock_update_clientscope, mock_get_clientscope_protocolmapper_by_name,
-                        mock_update_clientscope_protocolmappers,
-                        mock_create_clientscope_protocolmapper, mock_delete_clientscope):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_clientscope_by_name=return_value_get_clientscope_by_name,
+                                        get_clientscope_by_clientscopeid=return_value_get_clientscope_by_clientscopeid) \
+                        as (mock_get_clientscope_by_name, mock_get_clientscope_by_clientscopeid, mock_create_clientscope,
+                            mock_update_clientscope, mock_get_clientscope_protocolmapper_by_name,
+                            mock_update_clientscope_protocolmappers,
+                            mock_create_clientscope_protocolmapper, mock_delete_clientscope):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(mock_get_clientscope_by_name.call_count, 1)

--- a/tests/unit/plugins/modules/test_keycloak_identity_provider.py
+++ b/tests/unit/plugins/modules/test_keycloak_identity_provider.py
@@ -238,19 +238,18 @@ class TestKeycloakIdentityProvider(ModuleTestCase):
         return_value_mapper_created = [None, None]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_identity_provider=return_value_idp_get, get_identity_provider_mappers=return_value_mappers_get,
-                                    create_identity_provider=return_value_idp_created, create_identity_provider_mapper=return_value_mapper_created,
-                                    get_realm_by_id=return_value_realm_get) \
-                    as (mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, mock_delete_identity_provider,
-                        mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, mock_update_identity_provider_mapper,
-                        mock_delete_identity_provider_mapper, mock_get_realm_by_id):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_identity_provider=return_value_idp_get, get_identity_provider_mappers=return_value_mappers_get,
+                                        create_identity_provider=return_value_idp_created, create_identity_provider_mapper=return_value_mapper_created,
+                                        get_realm_by_id=return_value_realm_get) \
+                        as (mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, mock_delete_identity_provider,
+                            mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, mock_update_identity_provider_mapper,
+                            mock_delete_identity_provider_mapper, mock_get_realm_by_id):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_identity_provider.mock_calls), 2)
         self.assertEqual(len(mock_get_identity_provider_mappers.mock_calls), 1)
@@ -547,19 +546,18 @@ class TestKeycloakIdentityProvider(ModuleTestCase):
         return_value_mapper_created = [None]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_identity_provider=return_value_idp_get, get_identity_provider_mappers=return_value_mappers_get,
-                                    update_identity_provider=return_value_idp_updated, update_identity_provider_mapper=return_value_mapper_updated,
-                                    create_identity_provider_mapper=return_value_mapper_created, get_realm_by_id=return_value_realm_get) \
-                    as (mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, mock_delete_identity_provider,
-                        mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, mock_update_identity_provider_mapper,
-                        mock_delete_identity_provider_mapper, mock_get_realm_by_id):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_identity_provider=return_value_idp_get, get_identity_provider_mappers=return_value_mappers_get,
+                                        update_identity_provider=return_value_idp_updated, update_identity_provider_mapper=return_value_mapper_updated,
+                                        create_identity_provider_mapper=return_value_mapper_created, get_realm_by_id=return_value_realm_get) \
+                        as (mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, mock_delete_identity_provider,
+                            mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, mock_update_identity_provider_mapper,
+                            mock_delete_identity_provider_mapper, mock_get_realm_by_id):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_identity_provider.mock_calls), 2)
         self.assertEqual(len(mock_get_identity_provider_mappers.mock_calls), 5)
@@ -697,19 +695,18 @@ class TestKeycloakIdentityProvider(ModuleTestCase):
         return_value_mapper_created = [None]
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_identity_provider=return_value_idp_get, get_identity_provider_mappers=return_value_mappers_get,
-                                    update_identity_provider=return_value_idp_updated, update_identity_provider_mapper=return_value_mapper_updated,
-                                    create_identity_provider_mapper=return_value_mapper_created, get_realm_by_id=return_value_realm_get) \
-                    as (mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, mock_delete_identity_provider,
-                        mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, mock_update_identity_provider_mapper,
-                        mock_delete_identity_provider_mapper, mock_get_realm_by_id):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_identity_provider=return_value_idp_get, get_identity_provider_mappers=return_value_mappers_get,
+                                        update_identity_provider=return_value_idp_updated, update_identity_provider_mapper=return_value_mapper_updated,
+                                        create_identity_provider_mapper=return_value_mapper_created, get_realm_by_id=return_value_realm_get) \
+                        as (mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, mock_delete_identity_provider,
+                            mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, mock_update_identity_provider_mapper,
+                            mock_delete_identity_provider_mapper, mock_get_realm_by_id):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_identity_provider.mock_calls), 1)
         self.assertEqual(len(mock_get_identity_provider_mappers.mock_calls), 2)
@@ -738,17 +735,16 @@ class TestKeycloakIdentityProvider(ModuleTestCase):
         return_value_idp_get = [None]
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_identity_provider=return_value_idp_get) \
-                    as (mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, mock_delete_identity_provider,
-                        mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, mock_update_identity_provider_mapper,
-                        mock_delete_identity_provider_mapper, mock_get_realm_by_id):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_identity_provider=return_value_idp_get) \
+                        as (mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, mock_delete_identity_provider,
+                            mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, mock_update_identity_provider_mapper,
+                            mock_delete_identity_provider_mapper, mock_get_realm_by_id):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_identity_provider.mock_calls), 1)
         self.assertEqual(len(mock_delete_identity_provider.mock_calls), 0)
@@ -844,18 +840,17 @@ class TestKeycloakIdentityProvider(ModuleTestCase):
         return_value_idp_deleted = [None]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_identity_provider=return_value_idp_get, get_identity_provider_mappers=return_value_mappers_get,
-                                    delete_identity_provider=return_value_idp_deleted, get_realm_by_id=return_value_realm_get) \
-                    as (mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, mock_delete_identity_provider,
-                        mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, mock_update_identity_provider_mapper,
-                        mock_delete_identity_provider_mapper, mock_get_realm_by_id):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_identity_provider=return_value_idp_get, get_identity_provider_mappers=return_value_mappers_get,
+                                        delete_identity_provider=return_value_idp_deleted, get_realm_by_id=return_value_realm_get) \
+                        as (mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, mock_delete_identity_provider,
+                            mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, mock_update_identity_provider_mapper,
+                            mock_delete_identity_provider_mapper, mock_get_realm_by_id):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_identity_provider.mock_calls), 1)
         self.assertEqual(len(mock_get_identity_provider_mappers.mock_calls), 1)

--- a/tests/unit/plugins/modules/test_keycloak_realm.py
+++ b/tests/unit/plugins/modules/test_keycloak_realm.py
@@ -113,15 +113,14 @@ class TestKeycloakRealm(ModuleTestCase):
         }]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_realm_by_id=return_value_absent, create_realm=return_value_created) \
-                    as (mock_get_realm_by_id, mock_create_realm, mock_update_realm, mock_delete_realm):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_realm_by_id=return_value_absent, create_realm=return_value_created) \
+                        as (mock_get_realm_by_id, mock_create_realm, mock_update_realm, mock_delete_realm):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_realm_by_id.mock_calls), 2)
         self.assertEqual(len(mock_create_realm.mock_calls), 1)
@@ -164,15 +163,14 @@ class TestKeycloakRealm(ModuleTestCase):
         }]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_realm_by_id=return_value_absent, update_realm=return_value_updated) \
-                    as (mock_get_realm_by_id, mock_create_realm, mock_update_realm, mock_delete_realm):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_realm_by_id=return_value_absent, update_realm=return_value_updated) \
+                        as (mock_get_realm_by_id, mock_create_realm, mock_update_realm, mock_delete_realm):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_realm_by_id.mock_calls), 2)
         self.assertEqual(len(mock_create_realm.mock_calls), 0)
@@ -215,15 +213,14 @@ class TestKeycloakRealm(ModuleTestCase):
         }]
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_realm_by_id=return_value_absent, update_realm=return_value_updated) \
-                    as (mock_get_realm_by_id, mock_create_realm, mock_update_realm, mock_delete_realm):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_realm_by_id=return_value_absent, update_realm=return_value_updated) \
+                        as (mock_get_realm_by_id, mock_create_realm, mock_update_realm, mock_delete_realm):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_realm_by_id.mock_calls), 2)
         self.assertEqual(len(mock_create_realm.mock_calls), 0)
@@ -251,15 +248,14 @@ class TestKeycloakRealm(ModuleTestCase):
         return_value_deleted = [None]
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_realm_by_id=return_value_absent, delete_realm=return_value_deleted) \
-                    as (mock_get_realm_by_id, mock_create_realm, mock_update_realm, mock_delete_realm):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_realm_by_id=return_value_absent, delete_realm=return_value_deleted) \
+                        as (mock_get_realm_by_id, mock_create_realm, mock_update_realm, mock_delete_realm):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_realm_by_id.mock_calls), 1)
         self.assertEqual(len(mock_delete_realm.mock_calls), 0)
@@ -290,15 +286,14 @@ class TestKeycloakRealm(ModuleTestCase):
         return_value_deleted = [None]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_realm_by_id=return_value_absent, delete_realm=return_value_deleted) \
-                    as (mock_get_realm_by_id, mock_create_realm, mock_update_realm, mock_delete_realm):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_realm_by_id=return_value_absent, delete_realm=return_value_deleted) \
+                        as (mock_get_realm_by_id, mock_create_realm, mock_update_realm, mock_delete_realm):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_realm_by_id.mock_calls), 1)
         self.assertEqual(len(mock_delete_realm.mock_calls), 1)

--- a/tests/unit/plugins/modules/test_keycloak_realm_info.py
+++ b/tests/unit/plugins/modules/test_keycloak_realm_info.py
@@ -105,15 +105,14 @@ class TestKeycloakRealmRole(ModuleTestCase):
             }
         ]
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_realm_info_by_id=return_value) \
-                    as (mock_get_realm_info_by_id):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_realm_info_by_id=return_value) \
+                        as (mock_get_realm_info_by_id):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_realm_info_by_id.mock_calls), 1)
 

--- a/tests/unit/plugins/modules/test_keycloak_realm_keys.py
+++ b/tests/unit/plugins/modules/test_keycloak_realm_keys.py
@@ -139,15 +139,14 @@ class TestKeycloakRealmKeys(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_components=return_value_components_get, create_component=return_value_component_create) \
-                    as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_components=return_value_components_get, create_component=return_value_component_create) \
+                        as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_components.mock_calls), 1)
         self.assertEqual(len(mock_get_component.mock_calls), 0)
@@ -232,16 +231,15 @@ class TestKeycloakRealmKeys(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_components=return_value_components_get,
-                                    update_component=return_value_component_update) \
-                    as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_components=return_value_components_get,
+                                        update_component=return_value_component_update) \
+                        as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_components.mock_calls), 1)
         self.assertEqual(len(mock_get_component.mock_calls), 0)
@@ -277,15 +275,14 @@ class TestKeycloakRealmKeys(ModuleTestCase):
         ]
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_components=return_value_components_get) \
-                    as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_components=return_value_components_get) \
+                        as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_components.mock_calls), 1)
         self.assertEqual(len(mock_get_component.mock_calls), 0)
@@ -356,15 +353,14 @@ class TestKeycloakRealmKeys(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_components=return_value_components_get, delete_component=return_value_component_delete) \
-                    as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_components=return_value_components_get, delete_component=return_value_component_delete) \
+                        as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_components.mock_calls), 1)
         self.assertEqual(len(mock_get_component.mock_calls), 0)

--- a/tests/unit/plugins/modules/test_keycloak_realm_keys_metadata_info.py
+++ b/tests/unit/plugins/modules/test_keycloak_realm_keys_metadata_info.py
@@ -158,23 +158,22 @@ class TestKeycloakRealmRole(ModuleTestCase):
             }
         ]
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(side_effect=return_value) as (
-                mock_get_realm_keys_metadata_by_id
-            ):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(side_effect=return_value) as (
+                    mock_get_realm_keys_metadata_by_id
+                ):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
-                result = exec_info.exception.args[0]
-                self.assertIs(result["changed"], False)
-                self.assertEqual(
-                    result["msg"], "Get realm keys metadata successful for ID my-realm"
-                )
-                self.assertEqual(result["keys_metadata"], return_value[0])
+        result = exec_info.exception.args[0]
+        self.assertIs(result["changed"], False)
+        self.assertEqual(
+            result["msg"], "Get realm keys metadata successful for ID my-realm"
+        )
+        self.assertEqual(result["keys_metadata"], return_value[0])
 
         self.assertEqual(len(mock_get_realm_keys_metadata_by_id.mock_calls), 1)
 

--- a/tests/unit/plugins/modules/test_keycloak_role.py
+++ b/tests/unit/plugins/modules/test_keycloak_role.py
@@ -129,17 +129,16 @@ class TestKeycloakRealmRole(ModuleTestCase):
         return_value_created = [None]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_realm_role=return_value_absent, create_realm_role=return_value_created) \
-                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
-                        mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
-                        mock_get_client_by_client_id, mock_get_role_composites):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_realm_role=return_value_absent, create_realm_role=return_value_created) \
+                        as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
+                            mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
+                            mock_get_client_by_client_id, mock_get_role_composites):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_realm_role.mock_calls), 2)
         self.assertEqual(len(mock_create_realm_role.mock_calls), 1)
@@ -185,17 +184,16 @@ class TestKeycloakRealmRole(ModuleTestCase):
         return_value_updated = [None]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_realm_role=return_value_present, update_realm_role=return_value_updated) \
-                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
-                        mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
-                        mock_get_client_by_client_id, mock_get_role_composites):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_realm_role=return_value_present, update_realm_role=return_value_updated) \
+                        as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
+                            mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
+                            mock_get_client_by_client_id, mock_get_role_composites):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_realm_role.mock_calls), 2)
         self.assertEqual(len(mock_create_realm_role.mock_calls), 0)
@@ -241,17 +239,16 @@ class TestKeycloakRealmRole(ModuleTestCase):
         return_value_updated = [None]
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_realm_role=return_value_present, update_realm_role=return_value_updated) \
-                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
-                        mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
-                        mock_get_client_by_client_id, mock_get_role_composites):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_realm_role=return_value_present, update_realm_role=return_value_updated) \
+                        as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
+                            mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
+                            mock_get_client_by_client_id, mock_get_role_composites):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_realm_role.mock_calls), 1)
         self.assertEqual(len(mock_create_realm_role.mock_calls), 0)
@@ -371,19 +368,18 @@ class TestKeycloakRealmRole(ModuleTestCase):
 
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_realm_role=return_value_present, update_realm_role=return_value_updated,
-                                    get_client_by_id=return_get_client_by_client_id,
-                                    get_role_composites=return_get_role_composites) \
-                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
-                        mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
-                        mock_get_client_by_client_id, mock_get_role_composites):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_realm_role=return_value_present, update_realm_role=return_value_updated,
+                                        get_client_by_id=return_get_client_by_client_id,
+                                        get_role_composites=return_get_role_composites) \
+                        as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
+                            mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
+                            mock_get_client_by_client_id, mock_get_role_composites):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_realm_role.mock_calls), 1)
         self.assertEqual(len(mock_create_realm_role.mock_calls), 0)
@@ -412,17 +408,16 @@ class TestKeycloakRealmRole(ModuleTestCase):
         return_value_deleted = [None]
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_realm_role=return_value_absent, delete_realm_role=return_value_deleted) \
-                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
-                        mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
-                        mock_get_client_by_client_id, mock_get_role_composites):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_realm_role=return_value_absent, delete_realm_role=return_value_deleted) \
+                        as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
+                            mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
+                            mock_get_client_by_client_id, mock_get_role_composites):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_realm_role.mock_calls), 1)
         self.assertEqual(len(mock_delete_realm_role.mock_calls), 0)
@@ -458,17 +453,16 @@ class TestKeycloakRealmRole(ModuleTestCase):
         return_value_deleted = [None]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_realm_role=return_value_absent, delete_realm_role=return_value_deleted) \
-                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
-                        mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
-                        mock_get_client_by_client_id, mock_get_role_composites):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_realm_role=return_value_absent, delete_realm_role=return_value_deleted) \
+                        as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
+                            mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
+                            mock_get_client_by_client_id, mock_get_role_composites):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_realm_role.mock_calls), 1)
         self.assertEqual(len(mock_delete_realm_role.mock_calls), 1)
@@ -531,17 +525,16 @@ class TestKeycloakClientRole(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_client_role=return_get_client_role) \
-                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
-                        mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
-                        mock_get_client_by_client_id, mock_get_role_composites):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_client_role=return_get_client_role) \
+                        as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
+                            mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
+                            mock_get_client_by_client_id, mock_get_role_composites):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_realm_role.mock_calls), 0)
         self.assertEqual(len(mock_create_realm_role.mock_calls), 0)
@@ -653,18 +646,17 @@ class TestKeycloakClientRole(ModuleTestCase):
         ]
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_client_role=return_get_client_role, get_client_by_id=return_get_client_by_client_id,
-                                    get_role_composites=return_get_role_composites) \
-                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
-                        mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
-                        mock_get_client_by_client_id, mock_get_role_composites):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_client_role=return_get_client_role, get_client_by_id=return_get_client_by_client_id,
+                                        get_role_composites=return_get_role_composites) \
+                        as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
+                            mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
+                            mock_get_client_by_client_id, mock_get_role_composites):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_realm_role.mock_calls), 0)
         self.assertEqual(len(mock_create_realm_role.mock_calls), 0)

--- a/tests/unit/plugins/modules/test_keycloak_user.py
+++ b/tests/unit/plugins/modules/test_keycloak_user.py
@@ -114,25 +114,24 @@ class TestKeycloakUser(ModuleTestCase):
         return_update_user = None
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_user_by_username=return_value_get_user_by_username,
-                                    create_user=return_create_user,
-                                    update_user_groups_membership=return_value_update_user_groups_membership,
-                                    get_user_groups=return_get_user_groups,
-                                    update_user=return_update_user,
-                                    delete_user=return_delete_user) \
-                    as (mock_get_user_by_username,
-                        mock_create_user,
-                        mock_update_user_groups_membership,
-                        mock_get_user_groups,
-                        mock_delete_user,
-                        mock_update_user):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_user_by_username=return_value_get_user_by_username,
+                                        create_user=return_create_user,
+                                        update_user_groups_membership=return_value_update_user_groups_membership,
+                                        get_user_groups=return_get_user_groups,
+                                        update_user=return_update_user,
+                                        delete_user=return_delete_user) \
+                        as (mock_get_user_by_username,
+                            mock_create_user,
+                            mock_update_user_groups_membership,
+                            mock_get_user_groups,
+                            mock_delete_user,
+                            mock_update_user):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(mock_get_user_by_username.call_count, 1)
         self.assertEqual(mock_create_user.call_count, 1)
@@ -176,25 +175,24 @@ class TestKeycloakUser(ModuleTestCase):
         return_update_user = None
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_user_by_username=return_value_get_user_by_username,
-                                    create_user=return_create_user,
-                                    update_user_groups_membership=return_value_update_user_groups_membership,
-                                    get_user_groups=return_get_user_groups,
-                                    update_user=return_update_user,
-                                    delete_user=return_delete_user) \
-                    as (mock_get_user_by_username,
-                        mock_create_user,
-                        mock_update_user_groups_membership,
-                        mock_get_user_groups,
-                        mock_delete_user,
-                        mock_update_user):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_user_by_username=return_value_get_user_by_username,
+                                        create_user=return_create_user,
+                                        update_user_groups_membership=return_value_update_user_groups_membership,
+                                        get_user_groups=return_get_user_groups,
+                                        update_user=return_update_user,
+                                        delete_user=return_delete_user) \
+                        as (mock_get_user_by_username,
+                            mock_create_user,
+                            mock_update_user_groups_membership,
+                            mock_get_user_groups,
+                            mock_delete_user,
+                            mock_update_user):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(mock_get_user_by_username.call_count, 1)
         self.assertEqual(mock_create_user.call_count, 0)
@@ -257,25 +255,24 @@ class TestKeycloakUser(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_user_by_username=return_value_get_user_by_username,
-                                    create_user=return_create_user,
-                                    update_user_groups_membership=return_value_update_user_groups_membership,
-                                    get_user_groups=return_get_user_groups,
-                                    update_user=return_update_user,
-                                    delete_user=return_delete_user) \
-                    as (mock_get_user_by_username,
-                        mock_create_user,
-                        mock_update_user_groups_membership,
-                        mock_get_user_groups,
-                        mock_delete_user,
-                        mock_update_user):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_user_by_username=return_value_get_user_by_username,
+                                        create_user=return_create_user,
+                                        update_user_groups_membership=return_value_update_user_groups_membership,
+                                        get_user_groups=return_get_user_groups,
+                                        update_user=return_update_user,
+                                        delete_user=return_delete_user) \
+                        as (mock_get_user_by_username,
+                            mock_create_user,
+                            mock_update_user_groups_membership,
+                            mock_get_user_groups,
+                            mock_delete_user,
+                            mock_update_user):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(mock_get_user_by_username.call_count, 1)
         self.assertEqual(mock_create_user.call_count, 0)
@@ -319,25 +316,24 @@ class TestKeycloakUser(ModuleTestCase):
         return_update_user = None
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_user_by_username=return_value_get_user_by_username,
-                                    create_user=return_create_user,
-                                    update_user_groups_membership=return_value_update_user_groups_membership,
-                                    get_user_groups=return_get_user_groups,
-                                    update_user=return_update_user,
-                                    delete_user=return_delete_user) \
-                    as (mock_get_user_by_username,
-                        mock_create_user,
-                        mock_update_user_groups_membership,
-                        mock_get_user_groups,
-                        mock_delete_user,
-                        mock_update_user):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_user_by_username=return_value_get_user_by_username,
+                                        create_user=return_create_user,
+                                        update_user_groups_membership=return_value_update_user_groups_membership,
+                                        get_user_groups=return_get_user_groups,
+                                        update_user=return_update_user,
+                                        delete_user=return_delete_user) \
+                        as (mock_get_user_by_username,
+                            mock_create_user,
+                            mock_update_user_groups_membership,
+                            mock_get_user_groups,
+                            mock_delete_user,
+                            mock_update_user):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(mock_get_user_by_username.call_count, 1)
         self.assertEqual(mock_create_user.call_count, 0)

--- a/tests/unit/plugins/modules/test_keycloak_user_federation.py
+++ b/tests/unit/plugins/modules/test_keycloak_user_federation.py
@@ -150,15 +150,14 @@ class TestKeycloakUserFederation(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_components=return_value_components_get, create_component=return_value_component_create) \
-                    as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_components=return_value_components_get, create_component=return_value_component_create) \
+                        as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_components.mock_calls), 3)
         self.assertEqual(len(mock_get_component.mock_calls), 0)
@@ -272,16 +271,15 @@ class TestKeycloakUserFederation(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_components=return_value_components_get, get_component=return_value_component_get,
-                                    update_component=return_value_component_update) \
-                    as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_components=return_value_components_get, get_component=return_value_component_get,
+                                        update_component=return_value_component_update) \
+                        as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_components.mock_calls), 3)
         self.assertEqual(len(mock_get_component.mock_calls), 1)
@@ -494,15 +492,14 @@ class TestKeycloakUserFederation(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_components=return_value_components_get, create_component=return_value_component_create) \
-                    as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_components=return_value_components_get, create_component=return_value_component_create) \
+                        as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_components.mock_calls), 3)
         self.assertEqual(len(mock_get_component.mock_calls), 0)
@@ -530,15 +527,14 @@ class TestKeycloakUserFederation(ModuleTestCase):
         ]
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_components=return_value_components_get) \
-                    as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_components=return_value_components_get) \
+                        as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_components.mock_calls), 1)
         self.assertEqual(len(mock_get_component.mock_calls), 0)
@@ -604,15 +600,14 @@ class TestKeycloakUserFederation(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_components=return_value_components_get, delete_component=return_value_component_delete) \
-                    as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_components=return_value_components_get, delete_component=return_value_component_delete) \
+                        as (mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_components.mock_calls), 2)
         self.assertEqual(len(mock_get_component.mock_calls), 0)

--- a/tests/unit/plugins/modules/test_keycloak_userprofile.py
+++ b/tests/unit/plugins/modules/test_keycloak_userprofile.py
@@ -350,15 +350,14 @@ class TestKeycloakUserprofile(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_components=return_value_get_components_get, create_component=return_value_component_create) as (
-                    mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_components=return_value_get_components_get, create_component=return_value_component_create) as (
+                        mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_components.mock_calls), 1)
         self.assertEqual(len(mock_get_component.mock_calls), 0)
@@ -639,16 +638,15 @@ class TestKeycloakUserprofile(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_components=return_value_get_components_get,
-                                    update_component=return_value_component_update) as (
-                    mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_components=return_value_get_components_get,
+                                        update_component=return_value_component_update) as (
+                        mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_components.mock_calls), 1)
         self.assertEqual(len(mock_get_component.mock_calls), 0)
@@ -676,15 +674,14 @@ class TestKeycloakUserprofile(ModuleTestCase):
         ]
         changed = False
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_components=return_value_get_components_get) as (
-                    mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_components=return_value_get_components_get) as (
+                        mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_components.mock_calls), 1)
         self.assertEqual(len(mock_get_component.mock_calls), 0)
@@ -844,15 +841,14 @@ class TestKeycloakUserprofile(ModuleTestCase):
         ]
         changed = True
 
-        set_module_args(module_args)
-
         # Run the module
 
-        with mock_good_connection():
-            with patch_keycloak_api(get_components=return_value_get_components_get, delete_component=return_value_component_delete) as (
-                    mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
+        with set_module_args(module_args):
+            with mock_good_connection():
+                with patch_keycloak_api(get_components=return_value_get_components_get, delete_component=return_value_component_delete) as (
+                        mock_get_components, mock_get_component, mock_create_component, mock_update_component, mock_delete_component):
+                    with self.assertRaises(AnsibleExitJson) as exec_info:
+                        self.module.main()
 
         self.assertEqual(len(mock_get_components.mock_calls), 1)
         self.assertEqual(len(mock_get_component.mock_calls), 0)

--- a/tests/unit/plugins/modules/test_linode.py
+++ b/tests/unit/plugins/modules/test_linode.py
@@ -18,5 +18,5 @@ if not linode.HAS_LINODE:
 
 def test_name_is_a_required_parameter(api_key, auth):
     with pytest.raises(SystemExit):
-        set_module_args({})
-        linode.main()
+        with set_module_args({}):
+            linode.main()

--- a/tests/unit/plugins/modules/test_linode_v4.py
+++ b/tests/unit/plugins/modules/test_linode_v4.py
@@ -30,8 +30,8 @@ from .linode_conftest import access_token, no_access_token_in_env, default_args,
 
 def test_mandatory_state_is_validated(capfd):
     with pytest.raises(SystemExit):
-        set_module_args({'label': 'foo'})
-        linode_v4.initialise_module()
+        with set_module_args({'label': 'foo'}):
+            linode_v4.initialise_module()
 
     out, err = capfd.readouterr()
     results = json.loads(out)
@@ -42,8 +42,8 @@ def test_mandatory_state_is_validated(capfd):
 
 def test_mandatory_label_is_validated(capfd):
     with pytest.raises(SystemExit):
-        set_module_args({'state': 'present'})
-        linode_v4.initialise_module()
+        with set_module_args({'state': 'present'}):
+            linode_v4.initialise_module()
 
     out, err = capfd.readouterr()
     results = json.loads(out)
@@ -56,8 +56,8 @@ def test_mandatory_access_token_is_validated(default_args,
                                              no_access_token_in_env,
                                              capfd):
     with pytest.raises(SystemExit):
-        set_module_args(default_args)
-        linode_v4.initialise_module()
+        with set_module_args(default_args):
+            linode_v4.initialise_module()
 
     out, err = capfd.readouterr()
     results = json.loads(out)
@@ -72,12 +72,12 @@ def test_mandatory_access_token_is_validated(default_args,
 
 def test_mandatory_access_token_passed_in_env(default_args,
                                               access_token):
-    set_module_args(default_args)
+    with set_module_args(default_args):
 
-    try:
-        module = linode_v4.initialise_module()
-    except SystemExit:
-        pytest.fail("'access_token' is passed in environment")
+        try:
+            module = linode_v4.initialise_module()
+        except SystemExit:
+            pytest.fail("'access_token' is passed in environment")
 
     now_set_token = module.params['access_token']
     assert now_set_token == os.environ['LINODE_ACCESS_TOKEN']
@@ -86,26 +86,26 @@ def test_mandatory_access_token_passed_in_env(default_args,
 def test_mandatory_access_token_passed_in_as_parameter(default_args,
                                                        no_access_token_in_env):
     default_args.update({'access_token': 'foo'})
-    set_module_args(default_args)
+    with set_module_args(default_args):
 
-    try:
-        module = linode_v4.initialise_module()
-    except SystemExit:
-        pytest.fail("'access_token' is passed in as parameter")
+        try:
+            module = linode_v4.initialise_module()
+        except SystemExit:
+            pytest.fail("'access_token' is passed in as parameter")
 
     assert module.params['access_token'] == 'foo'
 
 
 def test_instance_by_label_cannot_authenticate(capfd, access_token,
                                                default_args):
-    set_module_args(default_args)
-    module = linode_v4.initialise_module()
-    client = LinodeClient(module.params['access_token'])
+    with set_module_args(default_args):
+        module = linode_v4.initialise_module()
+        client = LinodeClient(module.params['access_token'])
 
-    target = 'linode_api4.linode_client.LinodeGroup.instances'
-    with mock.patch(target, side_effect=LinodeApiError('foo')):
-        with pytest.raises(SystemExit):
-            linode_v4.maybe_instance_from_label(module, client)
+        target = 'linode_api4.linode_client.LinodeGroup.instances'
+        with mock.patch(target, side_effect=LinodeApiError('foo')):
+            with pytest.raises(SystemExit):
+                linode_v4.maybe_instance_from_label(module, client)
 
     out, err = capfd.readouterr()
     results = json.loads(out)
@@ -116,23 +116,23 @@ def test_instance_by_label_cannot_authenticate(capfd, access_token,
 
 def test_no_instances_found_with_label_gives_none(default_args,
                                                   access_token):
-    set_module_args(default_args)
-    module = linode_v4.initialise_module()
-    client = LinodeClient(module.params['access_token'])
+    with set_module_args(default_args):
+        module = linode_v4.initialise_module()
+        client = LinodeClient(module.params['access_token'])
 
-    target = 'linode_api4.linode_client.LinodeGroup.instances'
-    with mock.patch(target, return_value=[]):
-        result = linode_v4.maybe_instance_from_label(module, client)
+        target = 'linode_api4.linode_client.LinodeGroup.instances'
+        with mock.patch(target, return_value=[]):
+            result = linode_v4.maybe_instance_from_label(module, client)
 
     assert result is None
 
 
 def test_optional_region_is_validated(default_args, capfd, access_token):
     default_args.update({'type': 'foo', 'image': 'bar'})
-    set_module_args(default_args)
+    with set_module_args(default_args):
 
-    with pytest.raises(SystemExit):
-        linode_v4.initialise_module()
+        with pytest.raises(SystemExit):
+            linode_v4.initialise_module()
 
     out, err = capfd.readouterr()
     results = json.loads(out)
@@ -147,10 +147,10 @@ def test_optional_region_is_validated(default_args, capfd, access_token):
 
 def test_optional_type_is_validated(default_args, capfd, access_token):
     default_args.update({'region': 'foo', 'image': 'bar'})
-    set_module_args(default_args)
+    with set_module_args(default_args):
 
-    with pytest.raises(SystemExit):
-        linode_v4.initialise_module()
+        with pytest.raises(SystemExit):
+            linode_v4.initialise_module()
 
     out, err = capfd.readouterr()
     results = json.loads(out)
@@ -165,10 +165,10 @@ def test_optional_type_is_validated(default_args, capfd, access_token):
 
 def test_optional_image_is_validated(default_args, capfd, access_token):
     default_args.update({'type': 'foo', 'region': 'bar'})
-    set_module_args(default_args)
+    with set_module_args(default_args):
 
-    with pytest.raises(SystemExit):
-        linode_v4.initialise_module()
+        with pytest.raises(SystemExit):
+            linode_v4.initialise_module()
 
     out, err = capfd.readouterr()
     results = json.loads(out)
@@ -184,9 +184,9 @@ def test_optional_image_is_validated(default_args, capfd, access_token):
 @pytest.mark.parametrize('value', [True, False])
 def test_private_ip_valid_values(default_args, access_token, value):
     default_args.update({'private_ip': value})
-    set_module_args(default_args)
+    with set_module_args(default_args):
 
-    module = linode_v4.initialise_module()
+        module = linode_v4.initialise_module()
 
     assert module.params['private_ip'] is value
 
@@ -194,10 +194,10 @@ def test_private_ip_valid_values(default_args, access_token, value):
 @pytest.mark.parametrize('value', ['not-a-bool', 42])
 def test_private_ip_invalid_values(default_args, capfd, access_token, value):
     default_args.update({'private_ip': value})
-    set_module_args(default_args)
+    with set_module_args(default_args):
 
-    with pytest.raises(SystemExit):
-        linode_v4.initialise_module()
+        with pytest.raises(SystemExit):
+            linode_v4.initialise_module()
 
     out, err = capfd.readouterr()
     results = json.loads(out)
@@ -208,23 +208,23 @@ def test_private_ip_invalid_values(default_args, capfd, access_token, value):
 
 def test_private_ip_default_value(default_args, access_token):
     default_args.pop('private_ip', None)
-    set_module_args(default_args)
+    with set_module_args(default_args):
 
-    module = linode_v4.initialise_module()
+        module = linode_v4.initialise_module()
 
     assert module.params['private_ip'] is False
 
 
 def test_private_ip_is_forwarded_to_linode(default_args, mock_linode, access_token):
     default_args.update({'private_ip': True})
-    set_module_args(default_args)
+    with set_module_args(default_args):
 
-    target = 'linode_api4.linode_client.LinodeGroup.instances'
-    with mock.patch(target, return_value=[]):
-        with pytest.raises(SystemExit):
-            target = 'linode_api4.linode_client.LinodeGroup.instance_create'
-            with mock.patch(target, return_value=(mock_linode, 'passw0rd')) as instance_create_mock:
-                linode_v4.main()
+        target = 'linode_api4.linode_client.LinodeGroup.instances'
+        with mock.patch(target, return_value=[]):
+            with pytest.raises(SystemExit):
+                target = 'linode_api4.linode_client.LinodeGroup.instance_create'
+                with mock.patch(target, return_value=(mock_linode, 'passw0rd')) as instance_create_mock:
+                    linode_v4.main()
 
     args, kwargs = instance_create_mock.call_args
     assert kwargs['private_ip'] is True
@@ -239,12 +239,12 @@ def test_instance_already_created(default_args,
         'region': 'bar',
         'image': 'baz'
     })
-    set_module_args(default_args)
+    with set_module_args(default_args):
 
-    target = 'linode_api4.linode_client.LinodeGroup.instances'
-    with mock.patch(target, return_value=[mock_linode]):
-        with pytest.raises(SystemExit) as sys_exit_exc:
-            linode_v4.main()
+        target = 'linode_api4.linode_client.LinodeGroup.instances'
+        with mock.patch(target, return_value=[mock_linode]):
+            with pytest.raises(SystemExit) as sys_exit_exc:
+                linode_v4.main()
 
     assert sys_exit_exc.value.code == 0
 
@@ -268,14 +268,14 @@ def test_instance_to_be_created_without_root_pass(default_args,
         'region': 'bar',
         'image': 'baz'
     })
-    set_module_args(default_args)
+    with set_module_args(default_args):
 
-    target = 'linode_api4.linode_client.LinodeGroup.instances'
-    with mock.patch(target, return_value=[]):
-        with pytest.raises(SystemExit) as sys_exit_exc:
-            target = 'linode_api4.linode_client.LinodeGroup.instance_create'
-            with mock.patch(target, return_value=(mock_linode, 'passw0rd')):
-                linode_v4.main()
+        target = 'linode_api4.linode_client.LinodeGroup.instances'
+        with mock.patch(target, return_value=[]):
+            with pytest.raises(SystemExit) as sys_exit_exc:
+                target = 'linode_api4.linode_client.LinodeGroup.instance_create'
+                with mock.patch(target, return_value=(mock_linode, 'passw0rd')):
+                    linode_v4.main()
 
     assert sys_exit_exc.value.code == 0
 
@@ -300,14 +300,14 @@ def test_instance_to_be_created_with_root_pass(default_args,
         'image': 'baz',
         'root_pass': 'passw0rd',
     })
-    set_module_args(default_args)
+    with set_module_args(default_args):
 
-    target = 'linode_api4.linode_client.LinodeGroup.instances'
-    with mock.patch(target, return_value=[]):
-        with pytest.raises(SystemExit) as sys_exit_exc:
-            target = 'linode_api4.linode_client.LinodeGroup.instance_create'
-            with mock.patch(target, return_value=mock_linode):
-                linode_v4.main()
+        target = 'linode_api4.linode_client.LinodeGroup.instances'
+        with mock.patch(target, return_value=[]):
+            with pytest.raises(SystemExit) as sys_exit_exc:
+                target = 'linode_api4.linode_client.LinodeGroup.instance_create'
+                with mock.patch(target, return_value=mock_linode):
+                    linode_v4.main()
 
     assert sys_exit_exc.value.code == 0
 
@@ -327,12 +327,12 @@ def test_instance_to_be_deleted(default_args,
                                 capfd,
                                 access_token):
     default_args.update({'state': 'absent'})
-    set_module_args(default_args)
+    with set_module_args(default_args):
 
-    target = 'linode_api4.linode_client.LinodeGroup.instances'
-    with mock.patch(target, return_value=[mock_linode]):
-        with pytest.raises(SystemExit) as sys_exit_exc:
-            linode_v4.main()
+        target = 'linode_api4.linode_client.LinodeGroup.instances'
+        with mock.patch(target, return_value=[mock_linode]):
+            with pytest.raises(SystemExit) as sys_exit_exc:
+                linode_v4.main()
 
     assert sys_exit_exc.value.code == 0
 
@@ -351,12 +351,12 @@ def test_instance_already_deleted_no_change(default_args,
                                             capfd,
                                             access_token):
     default_args.update({'state': 'absent'})
-    set_module_args(default_args)
+    with set_module_args(default_args):
 
-    target = 'linode_api4.linode_client.LinodeGroup.instances'
-    with mock.patch(target, return_value=[]):
-        with pytest.raises(SystemExit) as sys_exit_exc:
-            linode_v4.main()
+        target = 'linode_api4.linode_client.LinodeGroup.instances'
+        with mock.patch(target, return_value=[]):
+            with pytest.raises(SystemExit) as sys_exit_exc:
+                linode_v4.main()
 
     assert sys_exit_exc.value.code == 0
 

--- a/tests/unit/plugins/modules/test_lvg_rename.py
+++ b/tests/unit/plugins/modules/test_lvg_rename.py
@@ -48,10 +48,10 @@ class TestLvgRename(ModuleTestCase):
             'vg': 'vg_missing',
             'vg_new': 'vg_data_testhost2',
         }
-        set_module_args(args=module_args)
+        with set_module_args(args=module_args):
 
-        with self.assertRaises(AnsibleFailJson) as result:
-            self.module.main()
+            with self.assertRaises(AnsibleFailJson) as result:
+                self.module.main()
 
         self.assertEqual(len(self.mock_module_run_command.mock_calls), 1)
         self.assertIs(result.exception.args[0]['failed'], failed)
@@ -67,10 +67,10 @@ class TestLvgRename(ModuleTestCase):
             'vg': 'Yfj4YG-c8nI-z7w5-B7Fw-i2eM-HqlF-ApFVp0',
             'vg_new': 'vg_data_testhost2',
         }
-        set_module_args(args=module_args)
+        with set_module_args(args=module_args):
 
-        with self.assertRaises(AnsibleFailJson) as result:
-            self.module.main()
+            with self.assertRaises(AnsibleFailJson) as result:
+                self.module.main()
 
         self.assertEqual(len(self.mock_module_run_command.mock_calls), 1)
         self.assertIs(result.exception.args[0]['failed'], failed)
@@ -86,10 +86,10 @@ class TestLvgRename(ModuleTestCase):
             'vg': 'vg_data_testhost1',
             'vg_new': 'vg_sys_testhost2',
         }
-        set_module_args(args=module_args)
+        with set_module_args(args=module_args):
 
-        with self.assertRaises(AnsibleFailJson) as result:
-            self.module.main()
+            with self.assertRaises(AnsibleFailJson) as result:
+                self.module.main()
 
         self.assertEqual(len(self.mock_module_run_command.mock_calls), 1)
         self.assertIs(result.exception.args[0]['failed'], failed)
@@ -109,10 +109,10 @@ class TestLvgRename(ModuleTestCase):
             'vg': '/dev/vg_data_testhost1',
             'vg_new': 'vg_data_testhost2',
         }
-        set_module_args(args=module_args)
+        with set_module_args(args=module_args):
 
-        with self.assertRaises(AnsibleExitJson) as result:
-            self.module.main()
+            with self.assertRaises(AnsibleExitJson) as result:
+                self.module.main()
 
         self.assertEqual(len(self.mock_module_run_command.mock_calls), 2)
         self.assertIs(result.exception.args[0]['changed'], changed)
@@ -130,10 +130,10 @@ class TestLvgRename(ModuleTestCase):
             'vg_new': 'vg_data_testhost2',
             '_ansible_check_mode': True,
         }
-        set_module_args(args=module_args)
+        with set_module_args(args=module_args):
 
-        with self.assertRaises(AnsibleExitJson) as result:
-            self.module.main()
+            with self.assertRaises(AnsibleExitJson) as result:
+                self.module.main()
 
         self.assertEqual(len(self.mock_module_run_command.mock_calls), 1)
         self.assertIs(result.exception.args[0]['changed'], changed)
@@ -150,10 +150,10 @@ class TestLvgRename(ModuleTestCase):
             'vg': 'vg_data_testhostX',
             'vg_new': 'vg_data_testhost1',
         }
-        set_module_args(args=module_args)
+        with set_module_args(args=module_args):
 
-        with self.assertRaises(AnsibleExitJson) as result:
-            self.module.main()
+            with self.assertRaises(AnsibleExitJson) as result:
+                self.module.main()
 
         self.assertEqual(len(self.mock_module_run_command.mock_calls), 1)
         self.assertIs(result.exception.args[0]['changed'], changed)

--- a/tests/unit/plugins/modules/test_modprobe.py
+++ b/tests/unit/plugins/modules/test_modprobe.py
@@ -36,19 +36,18 @@ class TestLoadModule(ModuleTestCase):
         self.mock_get_bin_path.stop()
 
     def test_load_module_success(self):
-        set_module_args(dict(
+        with set_module_args(dict(
             name='test',
             state='present',
-        ))
+        )):
+            module = build_module()
 
-        module = build_module()
+            self.get_bin_path.side_effect = ['modprobe']
+            self.module_loaded.side_effect = [True]
+            self.run_command.side_effect = [(0, '', '')]
 
-        self.get_bin_path.side_effect = ['modprobe']
-        self.module_loaded.side_effect = [True]
-        self.run_command.side_effect = [(0, '', '')]
-
-        modprobe = Modprobe(module)
-        modprobe.load_module()
+            modprobe = Modprobe(module)
+            modprobe.load_module()
 
         assert modprobe.result == {
             'changed': True,
@@ -58,21 +57,20 @@ class TestLoadModule(ModuleTestCase):
         }
 
     def test_load_module_unchanged(self):
-        set_module_args(dict(
+        with set_module_args(dict(
             name='test',
             state='present',
-        ))
+        )):
+            module = build_module()
 
-        module = build_module()
+            module.warn = Mock()
 
-        module.warn = Mock()
+            self.get_bin_path.side_effect = ['modprobe']
+            self.module_loaded.side_effect = [False]
+            self.run_command.side_effect = [(0, '', ''), (1, '', '')]
 
-        self.get_bin_path.side_effect = ['modprobe']
-        self.module_loaded.side_effect = [False]
-        self.run_command.side_effect = [(0, '', ''), (1, '', '')]
-
-        modprobe = Modprobe(module)
-        modprobe.load_module()
+            modprobe = Modprobe(module)
+            modprobe.load_module()
 
         module.warn.assert_called_once_with('')
 
@@ -99,19 +97,18 @@ class TestUnloadModule(ModuleTestCase):
         self.mock_get_bin_path.stop()
 
     def test_unload_module_success(self):
-        set_module_args(dict(
+        with set_module_args(dict(
             name='test',
             state='absent',
-        ))
+        )):
+            module = build_module()
 
-        module = build_module()
+            self.get_bin_path.side_effect = ['modprobe']
+            self.module_loaded.side_effect = [False]
+            self.run_command.side_effect = [(0, '', '')]
 
-        self.get_bin_path.side_effect = ['modprobe']
-        self.module_loaded.side_effect = [False]
-        self.run_command.side_effect = [(0, '', '')]
-
-        modprobe = Modprobe(module)
-        modprobe.unload_module()
+            modprobe = Modprobe(module)
+            modprobe.unload_module()
 
         assert modprobe.result == {
             'changed': True,
@@ -121,21 +118,20 @@ class TestUnloadModule(ModuleTestCase):
         }
 
     def test_unload_module_failure(self):
-        set_module_args(dict(
+        with set_module_args(dict(
             name='test',
             state='absent',
-        ))
+        )):
+            module = build_module()
 
-        module = build_module()
+            module.fail_json = Mock()
 
-        module.fail_json = Mock()
+            self.get_bin_path.side_effect = ['modprobe']
+            self.module_loaded.side_effect = [True]
+            self.run_command.side_effect = [(1, '', '')]
 
-        self.get_bin_path.side_effect = ['modprobe']
-        self.module_loaded.side_effect = [True]
-        self.run_command.side_effect = [(1, '', '')]
-
-        modprobe = Modprobe(module)
-        modprobe.unload_module()
+            modprobe = Modprobe(module)
+            modprobe.unload_module()
 
         dummy_result = {
             'changed': False,
@@ -168,63 +164,60 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
 
     def test_module_is_loaded(self):
 
-        set_module_args(dict(
+        with set_module_args(dict(
             name='dummy',
             state='present',
             persistent='present'
-        ))
+        )):
+            module = build_module()
 
-        module = build_module()
+            self.get_bin_path.side_effect = ['modprobe']
 
-        self.get_bin_path.side_effect = ['modprobe']
+            modprobe = Modprobe(module)
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data='dummy')) as mocked_file:
+                with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modules_files'):
+                    modprobe.modules_files = ['/etc/modules-load.d/dummy.conf']
 
-        modprobe = Modprobe(module)
-        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data='dummy')) as mocked_file:
-            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modules_files'):
-                modprobe.modules_files = ['/etc/modules-load.d/dummy.conf']
-
-                assert modprobe.module_is_loaded_persistently
+                    assert modprobe.module_is_loaded_persistently
 
         mocked_file.assert_called_once_with('/etc/modules-load.d/dummy.conf')
 
     def test_module_is_not_loaded_empty_file(self):
 
-        set_module_args(dict(
+        with set_module_args(dict(
             name='dummy',
             state='present',
             persistent='present'
-        ))
+        )):
+            module = build_module()
 
-        module = build_module()
+            self.get_bin_path.side_effect = ['modprobe']
 
-        self.get_bin_path.side_effect = ['modprobe']
+            modprobe = Modprobe(module)
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data='')) as mocked_file:
+                with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modules_files'):
+                    modprobe.modules_files = ['/etc/modules-load.d/dummy.conf']
 
-        modprobe = Modprobe(module)
-        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data='')) as mocked_file:
-            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modules_files'):
-                modprobe.modules_files = ['/etc/modules-load.d/dummy.conf']
-
-                assert not modprobe.module_is_loaded_persistently
+                    assert not modprobe.module_is_loaded_persistently
 
         mocked_file.assert_called_once_with('/etc/modules-load.d/dummy.conf')
 
     def test_module_is_not_loaded_no_files(self):
 
-        set_module_args(dict(
+        with set_module_args(dict(
             name='dummy',
             state='present',
             persistent='present'
-        ))
+        )):
+            module = build_module()
 
-        module = build_module()
+            self.get_bin_path.side_effect = ['modprobe']
 
-        self.get_bin_path.side_effect = ['modprobe']
+            modprobe = Modprobe(module)
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modules_files'):
+                modprobe.modules_files = []
 
-        modprobe = Modprobe(module)
-        with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modules_files'):
-            modprobe.modules_files = []
-
-            assert not modprobe.module_is_loaded_persistently
+                assert not modprobe.module_is_loaded_persistently
 
 
 class TestPermanentParams(ModuleTestCase):
@@ -251,24 +244,23 @@ class TestPermanentParams(ModuleTestCase):
         ]
         mock_files_content = [mock_open(read_data=content).return_value for content in files_content]
 
-        set_module_args(dict(
+        with set_module_args(dict(
             name='dummy',
             state='present',
             persistent='present'
-        ))
+        )):
+            module = build_module()
 
-        module = build_module()
+            self.get_bin_path.side_effect = ['modprobe']
 
-        self.get_bin_path.side_effect = ['modprobe']
+            modprobe = Modprobe(module)
 
-        modprobe = Modprobe(module)
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open()) as mocked_file:
+                mocked_file.side_effect = mock_files_content
+                with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modprobe_files'):
+                    modprobe.modprobe_files = ['/etc/modprobe.d/dummy1.conf', '/etc/modprobe.d/dummy2.conf']
 
-        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open()) as mocked_file:
-            mocked_file.side_effect = mock_files_content
-            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modprobe_files'):
-                modprobe.modprobe_files = ['/etc/modprobe.d/dummy1.conf', '/etc/modprobe.d/dummy2.conf']
-
-                assert modprobe.permanent_params == set(['numdummies=4', 'dummy_parameter1=6', 'dummy_parameter2=5'])
+                    assert modprobe.permanent_params == set(['numdummies=4', 'dummy_parameter1=6', 'dummy_parameter2=5'])
 
     def test_module_permanent_params_empty(self):
 
@@ -278,24 +270,23 @@ class TestPermanentParams(ModuleTestCase):
         ]
         mock_files_content = [mock_open(read_data=content).return_value for content in files_content]
 
-        set_module_args(dict(
+        with set_module_args(dict(
             name='dummy',
             state='present',
             persistent='present'
-        ))
+        )):
+            module = build_module()
 
-        module = build_module()
+            self.get_bin_path.side_effect = ['modprobe']
 
-        self.get_bin_path.side_effect = ['modprobe']
+            modprobe = Modprobe(module)
 
-        modprobe = Modprobe(module)
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data='')) as mocked_file:
+                mocked_file.side_effect = mock_files_content
+                with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modprobe_files'):
+                    modprobe.modprobe_files = ['/etc/modprobe.d/dummy1.conf', '/etc/modprobe.d/dummy2.conf']
 
-        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data='')) as mocked_file:
-            mocked_file.side_effect = mock_files_content
-            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modprobe_files'):
-                modprobe.modprobe_files = ['/etc/modprobe.d/dummy1.conf', '/etc/modprobe.d/dummy2.conf']
-
-                assert modprobe.permanent_params == set()
+                    assert modprobe.permanent_params == set()
 
 
 class TestCreateModuleFIle(ModuleTestCase):
@@ -314,22 +305,21 @@ class TestCreateModuleFIle(ModuleTestCase):
 
     def test_create_file(self):
 
-        set_module_args(dict(
+        with set_module_args(dict(
             name='dummy',
             state='present',
             persistent='present'
-        ))
+        )):
+            module = build_module()
 
-        module = build_module()
+            self.get_bin_path.side_effect = ['modprobe']
 
-        self.get_bin_path.side_effect = ['modprobe']
+            modprobe = Modprobe(module)
 
-        modprobe = Modprobe(module)
-
-        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open()) as mocked_file:
-            modprobe.create_module_file()
-            mocked_file.assert_called_once_with('/etc/modules-load.d/dummy.conf', 'w')
-            mocked_file().write.assert_called_once_with('dummy\n')
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open()) as mocked_file:
+                modprobe.create_module_file()
+                mocked_file.assert_called_once_with('/etc/modules-load.d/dummy.conf', 'w')
+                mocked_file().write.assert_called_once_with('dummy\n')
 
 
 class TestCreateModuleOptionsFIle(ModuleTestCase):
@@ -348,23 +338,22 @@ class TestCreateModuleOptionsFIle(ModuleTestCase):
 
     def test_create_file(self):
 
-        set_module_args(dict(
+        with set_module_args(dict(
             name='dummy',
             state='present',
             params='numdummies=4',
             persistent='present'
-        ))
+        )):
+            module = build_module()
 
-        module = build_module()
+            self.get_bin_path.side_effect = ['modprobe']
 
-        self.get_bin_path.side_effect = ['modprobe']
+            modprobe = Modprobe(module)
 
-        modprobe = Modprobe(module)
-
-        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open()) as mocked_file:
-            modprobe.create_module_options_file()
-            mocked_file.assert_called_once_with('/etc/modprobe.d/dummy.conf', 'w')
-            mocked_file().write.assert_called_once_with('options dummy numdummies=4\n')
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open()) as mocked_file:
+                modprobe.create_module_options_file()
+                mocked_file.assert_called_once_with('/etc/modprobe.d/dummy.conf', 'w')
+                mocked_file().write.assert_called_once_with('options dummy numdummies=4\n')
 
 
 class TestDisableOldParams(ModuleTestCase):
@@ -384,47 +373,45 @@ class TestDisableOldParams(ModuleTestCase):
     def test_disable_old_params_file_changed(self):
         mock_data = 'options dummy numdummies=4'
 
-        set_module_args(dict(
+        with set_module_args(dict(
             name='dummy',
             state='present',
             params='numdummies=4',
             persistent='present'
-        ))
+        )):
+            module = build_module()
 
-        module = build_module()
+            self.get_bin_path.side_effect = ['modprobe']
 
-        self.get_bin_path.side_effect = ['modprobe']
+            modprobe = Modprobe(module)
 
-        modprobe = Modprobe(module)
-
-        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data=mock_data)) as mocked_file:
-            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modprobe_files'):
-                modprobe.modprobe_files = ['/etc/modprobe.d/dummy1.conf']
-                modprobe.disable_old_params()
-                mocked_file.assert_called_with('/etc/modprobe.d/dummy1.conf', 'w')
-                mocked_file().write.assert_called_once_with('#options dummy numdummies=4')
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data=mock_data)) as mocked_file:
+                with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modprobe_files'):
+                    modprobe.modprobe_files = ['/etc/modprobe.d/dummy1.conf']
+                    modprobe.disable_old_params()
+                    mocked_file.assert_called_with('/etc/modprobe.d/dummy1.conf', 'w')
+                    mocked_file().write.assert_called_once_with('#options dummy numdummies=4')
 
     def test_disable_old_params_file_unchanged(self):
         mock_data = 'options notdummy numdummies=4'
 
-        set_module_args(dict(
+        with set_module_args(dict(
             name='dummy',
             state='present',
             params='numdummies=4',
             persistent='present'
-        ))
+        )):
+            module = build_module()
 
-        module = build_module()
+            self.get_bin_path.side_effect = ['modprobe']
 
-        self.get_bin_path.side_effect = ['modprobe']
+            modprobe = Modprobe(module)
 
-        modprobe = Modprobe(module)
-
-        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data=mock_data)) as mocked_file:
-            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modprobe_files'):
-                modprobe.modprobe_files = ['/etc/modprobe.d/dummy1.conf']
-                modprobe.disable_old_params()
-                mocked_file.assert_called_once_with('/etc/modprobe.d/dummy1.conf')
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data=mock_data)) as mocked_file:
+                with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modprobe_files'):
+                    modprobe.modprobe_files = ['/etc/modprobe.d/dummy1.conf']
+                    modprobe.disable_old_params()
+                    mocked_file.assert_called_once_with('/etc/modprobe.d/dummy1.conf')
 
 
 class TestDisableModulePermanent(ModuleTestCase):
@@ -443,43 +430,41 @@ class TestDisableModulePermanent(ModuleTestCase):
 
     def test_disable_module_permanent_file_changed(self):
 
-        set_module_args(dict(
+        with set_module_args(dict(
             name='dummy',
             state='present',
             params='numdummies=4',
             persistent='present'
-        ))
+        )):
+            module = build_module()
 
-        module = build_module()
+            self.get_bin_path.side_effect = ['modprobe']
 
-        self.get_bin_path.side_effect = ['modprobe']
+            modprobe = Modprobe(module)
 
-        modprobe = Modprobe(module)
-
-        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data='dummy')) as mocked_file:
-            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modules_files'):
-                modprobe.modules_files = ['/etc/modules-load.d/dummy.conf']
-                modprobe.disable_module_permanent()
-                mocked_file.assert_called_with('/etc/modules-load.d/dummy.conf', 'w')
-                mocked_file().write.assert_called_once_with('#dummy')
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data='dummy')) as mocked_file:
+                with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modules_files'):
+                    modprobe.modules_files = ['/etc/modules-load.d/dummy.conf']
+                    modprobe.disable_module_permanent()
+                    mocked_file.assert_called_with('/etc/modules-load.d/dummy.conf', 'w')
+                    mocked_file().write.assert_called_once_with('#dummy')
 
     def test_disable_module_permanent_file_unchanged(self):
 
-        set_module_args(dict(
+        with set_module_args(dict(
             name='dummy',
             state='present',
             params='numdummies=4',
             persistent='present'
-        ))
+        )):
+            module = build_module()
 
-        module = build_module()
+            self.get_bin_path.side_effect = ['modprobe']
 
-        self.get_bin_path.side_effect = ['modprobe']
+            modprobe = Modprobe(module)
 
-        modprobe = Modprobe(module)
-
-        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data='notdummy')) as mocked_file:
-            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modules_files'):
-                modprobe.modules_files = ['/etc/modules-load.d/dummy.conf']
-                modprobe.disable_module_permanent()
-                mocked_file.assert_called_once_with('/etc/modules-load.d/dummy.conf')
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data='notdummy')) as mocked_file:
+                with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modules_files'):
+                    modprobe.modules_files = ['/etc/modules-load.d/dummy.conf']
+                    modprobe.disable_module_permanent()
+                    mocked_file.assert_called_once_with('/etc/modules-load.d/dummy.conf')

--- a/tests/unit/plugins/modules/test_nomad_token.py
+++ b/tests/unit/plugins/modules/test_nomad_token.py
@@ -11,9 +11,7 @@ __metaclass__ = type
 import nomad
 from ansible_collections.community.general.plugins.modules import nomad_token
 from ansible_collections.community.general.tests.unit.compat.mock import patch
-from ansible_collections.community.general.tests.unit.plugins.modules.utils import AnsibleExitJson, AnsibleFailJson, \
-    ModuleTestCase, \
-    set_module_args
+from ansible_collections.community.general.tests.unit.plugins.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
 
 
 def mock_acl_get_tokens(empty_list=False):
@@ -102,8 +100,8 @@ class TestNomadTokenModule(ModuleTestCase):
 
     def test_should_fail_without_parameters(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            self.module.main()
+            with set_module_args({}):
+                self.module.main()
 
     def test_should_create_token_type_client(self):
         module_args = {
@@ -113,12 +111,12 @@ class TestNomadTokenModule(ModuleTestCase):
             'state': 'present'
         }
 
-        set_module_args(module_args)
-        with patch.object(nomad.api.acl.Acl, 'get_tokens', return_value=mock_acl_get_tokens()) as mock_get_tokens:
-            with patch.object(nomad.api.acl.Acl, 'create_token', return_value=mock_acl_create_update_token()) as \
-                    mock_create_update_token:
-                with self.assertRaises(AnsibleExitJson):
-                    self.module.main()
+        with set_module_args(module_args):
+            with patch.object(nomad.api.acl.Acl, 'get_tokens', return_value=mock_acl_get_tokens()) as mock_get_tokens:
+                with patch.object(nomad.api.acl.Acl, 'create_token', return_value=mock_acl_create_update_token()) as \
+                        mock_create_update_token:
+                    with self.assertRaises(AnsibleExitJson):
+                        self.module.main()
 
                 self.assertIs(mock_get_tokens.call_count, 1)
                 self.assertIs(mock_create_update_token.call_count, 1)
@@ -130,15 +128,15 @@ class TestNomadTokenModule(ModuleTestCase):
             'state': 'present'
         }
 
-        set_module_args(module_args)
+        with set_module_args(module_args):
 
-        with patch.object(nomad.api.acl.Acl, 'get_tokens') as mock_get_tokens:
-            with patch.object(nomad.api.Acl, 'generate_bootstrap') as mock_generate_bootstrap:
-                mock_get_tokens.return_value = mock_acl_get_tokens(empty_list=True)
-                mock_generate_bootstrap.return_value = mock_acl_generate_bootstrap()
+            with patch.object(nomad.api.acl.Acl, 'get_tokens') as mock_get_tokens:
+                with patch.object(nomad.api.Acl, 'generate_bootstrap') as mock_generate_bootstrap:
+                    mock_get_tokens.return_value = mock_acl_get_tokens(empty_list=True)
+                    mock_generate_bootstrap.return_value = mock_acl_generate_bootstrap()
 
-                with self.assertRaises(AnsibleExitJson):
-                    self.module.main()
+                    with self.assertRaises(AnsibleExitJson):
+                        self.module.main()
 
                 self.assertIs(mock_get_tokens.call_count, 1)
                 self.assertIs(mock_generate_bootstrap.call_count, 1)
@@ -149,14 +147,14 @@ class TestNomadTokenModule(ModuleTestCase):
             'state': 'absent'
         }
 
-        set_module_args(module_args)
-        with patch.object(nomad.api.acl.Acl, 'get_tokens') as mock_get_tokens:
-            with patch.object(nomad.api.acl.Acl, 'delete_token') as mock_delete_token:
-                mock_get_tokens.return_value = mock_acl_get_tokens()
-                mock_delete_token.return_value = mock_acl_delete_token()
+        with set_module_args(module_args):
+            with patch.object(nomad.api.acl.Acl, 'get_tokens') as mock_get_tokens:
+                with patch.object(nomad.api.acl.Acl, 'delete_token') as mock_delete_token:
+                    mock_get_tokens.return_value = mock_acl_get_tokens()
+                    mock_delete_token.return_value = mock_acl_delete_token()
 
-                with self.assertRaises(AnsibleFailJson):
-                    self.module.main()
+                    with self.assertRaises(AnsibleFailJson):
+                        self.module.main()
 
     def test_should_fail_delete_bootstrap_token(self):
         module_args = {
@@ -165,10 +163,10 @@ class TestNomadTokenModule(ModuleTestCase):
             'state': 'absent'
         }
 
-        set_module_args(module_args)
+        with set_module_args(module_args):
 
-        with self.assertRaises(AnsibleFailJson):
-            self.module.main()
+            with self.assertRaises(AnsibleFailJson):
+                self.module.main()
 
     def test_should_fail_delete_boostrap_token_by_name(self):
         module_args = {
@@ -177,10 +175,10 @@ class TestNomadTokenModule(ModuleTestCase):
             'state': 'absent'
         }
 
-        set_module_args(module_args)
+        with set_module_args(module_args):
 
-        with self.assertRaises(AnsibleFailJson):
-            self.module.main()
+            with self.assertRaises(AnsibleFailJson):
+                self.module.main()
 
     def test_should_delete_client_token(self):
         module_args = {
@@ -189,15 +187,15 @@ class TestNomadTokenModule(ModuleTestCase):
             'state': 'absent'
         }
 
-        set_module_args(module_args)
+        with set_module_args(module_args):
 
-        with patch.object(nomad.api.acl.Acl, 'get_tokens') as mock_get_tokens:
-            with patch.object(nomad.api.acl.Acl, 'delete_token') as mock_delete_token:
-                mock_get_tokens.return_value = mock_acl_get_tokens()
-                mock_delete_token.return_value = mock_acl_delete_token()
+            with patch.object(nomad.api.acl.Acl, 'get_tokens') as mock_get_tokens:
+                with patch.object(nomad.api.acl.Acl, 'delete_token') as mock_delete_token:
+                    mock_get_tokens.return_value = mock_acl_get_tokens()
+                    mock_delete_token.return_value = mock_acl_delete_token()
 
-                with self.assertRaises(AnsibleExitJson):
-                    self.module.main()
+                    with self.assertRaises(AnsibleExitJson):
+                        self.module.main()
 
                 self.assertIs(mock_delete_token.call_count, 1)
 
@@ -209,14 +207,14 @@ class TestNomadTokenModule(ModuleTestCase):
             'state': 'present'
         }
 
-        set_module_args(module_args)
+        with set_module_args(module_args):
 
-        with patch.object(nomad.api.acl.Acl, 'get_tokens') as mock_get_tokens:
-            with patch.object(nomad.api.acl.Acl, 'update_token') as mock_create_update_token:
-                mock_get_tokens.return_value = mock_acl_get_tokens()
-                mock_create_update_token.return_value = mock_acl_create_update_token()
+            with patch.object(nomad.api.acl.Acl, 'get_tokens') as mock_get_tokens:
+                with patch.object(nomad.api.acl.Acl, 'update_token') as mock_create_update_token:
+                    mock_get_tokens.return_value = mock_acl_get_tokens()
+                    mock_create_update_token.return_value = mock_acl_create_update_token()
 
-                with self.assertRaises(AnsibleExitJson):
-                    self.module.main()
+                    with self.assertRaises(AnsibleExitJson):
+                        self.module.main()
                 self.assertIs(mock_get_tokens.call_count, 1)
                 self.assertIs(mock_create_update_token.call_count, 1)

--- a/tests/unit/plugins/modules/test_npm.py
+++ b/tests/unit/plugins/modules/test_npm.py
@@ -34,17 +34,17 @@ class NPMModuleTestCase(ModuleTestCase):
         return exc.exception.args[0]
 
     def test_present(self):
-        set_module_args({
+        with set_module_args({
             'name': 'coffee-script',
             'global': 'true',
             'state': 'present'
-        })
-        self.module_main_command.side_effect = [
-            (0, '{}', ''),
-            (0, '{}', ''),
-        ]
+        }):
+            self.module_main_command.side_effect = [
+                (0, '{}', ''),
+                (0, '{}', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertTrue(result['changed'])
         self.module_main_command.assert_has_calls([
@@ -53,17 +53,17 @@ class NPMModuleTestCase(ModuleTestCase):
         ])
 
     def test_present_missing(self):
-        set_module_args({
+        with set_module_args({
             'name': 'coffee-script',
             'global': 'true',
             'state': 'present',
-        })
-        self.module_main_command.side_effect = [
-            (0, '{"dependencies": {"coffee-script": {"missing" : true}}}', ''),
-            (0, '{}', ''),
-        ]
+        }):
+            self.module_main_command.side_effect = [
+                (0, '{"dependencies": {"coffee-script": {"missing" : true}}}', ''),
+                (0, '{}', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertTrue(result['changed'])
         self.module_main_command.assert_has_calls([
@@ -72,18 +72,18 @@ class NPMModuleTestCase(ModuleTestCase):
         ])
 
     def test_present_version(self):
-        set_module_args({
+        with set_module_args({
             'name': 'coffee-script',
             'global': 'true',
             'state': 'present',
             'version': '2.5.1'
-        })
-        self.module_main_command.side_effect = [
-            (0, '{}', ''),
-            (0, '{}', ''),
-        ]
+        }):
+            self.module_main_command.side_effect = [
+                (0, '{}', ''),
+                (0, '{}', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertTrue(result['changed'])
         self.module_main_command.assert_has_calls([
@@ -92,18 +92,18 @@ class NPMModuleTestCase(ModuleTestCase):
         ])
 
     def test_present_version_update(self):
-        set_module_args({
+        with set_module_args({
             'name': 'coffee-script',
             'global': 'true',
             'state': 'present',
             'version': '2.5.1'
-        })
-        self.module_main_command.side_effect = [
-            (0, '{"dependencies": {"coffee-script": {"version" : "2.5.0"}}}', ''),
-            (0, '{}', ''),
-        ]
+        }):
+            self.module_main_command.side_effect = [
+                (0, '{"dependencies": {"coffee-script": {"version" : "2.5.0"}}}', ''),
+                (0, '{}', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertTrue(result['changed'])
         self.module_main_command.assert_has_calls([
@@ -112,18 +112,18 @@ class NPMModuleTestCase(ModuleTestCase):
         ])
 
     def test_present_version_exists(self):
-        set_module_args({
+        with set_module_args({
             'name': 'coffee-script',
             'global': 'true',
             'state': 'present',
             'version': '2.5.1'
-        })
-        self.module_main_command.side_effect = [
-            (0, '{"dependencies": {"coffee-script": {"version" : "2.5.1"}}}', ''),
-            (0, '{}', ''),
-        ]
+        }):
+            self.module_main_command.side_effect = [
+                (0, '{"dependencies": {"coffee-script": {"version" : "2.5.1"}}}', ''),
+                (0, '{}', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertFalse(result['changed'])
         self.module_main_command.assert_has_calls([
@@ -131,17 +131,17 @@ class NPMModuleTestCase(ModuleTestCase):
         ])
 
     def test_absent(self):
-        set_module_args({
+        with set_module_args({
             'name': 'coffee-script',
             'global': 'true',
             'state': 'absent'
-        })
-        self.module_main_command.side_effect = [
-            (0, '{"dependencies": {"coffee-script": {"version" : "2.5.1"}}}', ''),
-            (0, '{}', ''),
-        ]
+        }):
+            self.module_main_command.side_effect = [
+                (0, '{"dependencies": {"coffee-script": {"version" : "2.5.1"}}}', ''),
+                (0, '{}', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertTrue(result['changed'])
         self.module_main_command.assert_has_calls([
@@ -150,18 +150,18 @@ class NPMModuleTestCase(ModuleTestCase):
         ])
 
     def test_absent_version(self):
-        set_module_args({
+        with set_module_args({
             'name': 'coffee-script',
             'global': 'true',
             'state': 'absent',
             'version': '2.5.1'
-        })
-        self.module_main_command.side_effect = [
-            (0, '{"dependencies": {"coffee-script": {"version" : "2.5.1"}}}', ''),
-            (0, '{}', ''),
-        ]
+        }):
+            self.module_main_command.side_effect = [
+                (0, '{"dependencies": {"coffee-script": {"version" : "2.5.1"}}}', ''),
+                (0, '{}', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertTrue(result['changed'])
         self.module_main_command.assert_has_calls([
@@ -170,18 +170,18 @@ class NPMModuleTestCase(ModuleTestCase):
         ])
 
     def test_absent_version_different(self):
-        set_module_args({
+        with set_module_args({
             'name': 'coffee-script',
             'global': 'true',
             'state': 'absent',
             'version': '2.5.1'
-        })
-        self.module_main_command.side_effect = [
-            (0, '{"dependencies": {"coffee-script": {"version" : "2.5.0"}}}', ''),
-            (0, '{}', ''),
-        ]
+        }):
+            self.module_main_command.side_effect = [
+                (0, '{"dependencies": {"coffee-script": {"version" : "2.5.0"}}}', ''),
+                (0, '{}', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertTrue(result['changed'])
         self.module_main_command.assert_has_calls([
@@ -190,16 +190,16 @@ class NPMModuleTestCase(ModuleTestCase):
         ])
 
     def test_present_package_json(self):
-        set_module_args({
+        with set_module_args({
             'global': 'true',
             'state': 'present'
-        })
-        self.module_main_command.side_effect = [
-            (0, '{}', ''),
-            (0, '{}', ''),
-        ]
+        }):
+            self.module_main_command.side_effect = [
+                (0, '{}', ''),
+                (0, '{}', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertTrue(result['changed'])
         self.module_main_command.assert_has_calls([
@@ -207,17 +207,17 @@ class NPMModuleTestCase(ModuleTestCase):
         ])
 
     def test_present_package_json_production(self):
-        set_module_args({
+        with set_module_args({
             'production': 'true',
             'global': 'true',
             'state': 'present',
-        })
-        self.module_main_command.side_effect = [
-            (0, '{}', ''),
-            (0, '{}', ''),
-        ]
+        }):
+            self.module_main_command.side_effect = [
+                (0, '{}', ''),
+                (0, '{}', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertTrue(result['changed'])
         self.module_main_command.assert_has_calls([
@@ -225,17 +225,17 @@ class NPMModuleTestCase(ModuleTestCase):
         ])
 
     def test_present_package_json_ci(self):
-        set_module_args({
+        with set_module_args({
             'ci': 'true',
             'global': 'true',
             'state': 'present'
-        })
-        self.module_main_command.side_effect = [
-            (0, '{}', ''),
-            (0, '{}', ''),
-        ]
+        }):
+            self.module_main_command.side_effect = [
+                (0, '{}', ''),
+                (0, '{}', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertTrue(result['changed'])
         self.module_main_command.assert_has_calls([
@@ -243,18 +243,18 @@ class NPMModuleTestCase(ModuleTestCase):
         ])
 
     def test_present_package_json_ci_production(self):
-        set_module_args({
+        with set_module_args({
             'ci': 'true',
             'production': 'true',
             'global': 'true',
             'state': 'present'
-        })
-        self.module_main_command.side_effect = [
-            (0, '{}', ''),
-            (0, '{}', ''),
-        ]
+        }):
+            self.module_main_command.side_effect = [
+                (0, '{}', ''),
+                (0, '{}', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertTrue(result['changed'])
         self.module_main_command.assert_has_calls([

--- a/tests/unit/plugins/modules/test_ocapi_command.py
+++ b/tests/unit/plugins/modules/test_ocapi_command.py
@@ -188,20 +188,20 @@ class TestOcapiCommand(unittest.TestCase):
 
     def test_module_fail_when_required_args_missing(self):
         with self.assertRaises(AnsibleFailJson) as ansible_fail_json:
-            set_module_args({})
-            module.main()
+            with set_module_args({}):
+                module.main()
         self.assertIn("missing required arguments:", get_exception_message(ansible_fail_json))
 
     def test_module_fail_when_unknown_category(self):
         with self.assertRaises(AnsibleFailJson) as ansible_fail_json:
-            set_module_args({
+            with set_module_args({
                 'category': 'unknown',
                 'command': 'IndicatorLedOn',
                 'username': 'USERID',
                 'password': 'PASSW0RD=21',
                 'baseuri': MOCK_BASE_URI
-            })
-            module.main()
+            }):
+                module.main()
         self.assertIn("Invalid Category 'unknown", get_exception_message(ansible_fail_json))
 
     def test_set_power_mode(self):
@@ -210,14 +210,14 @@ class TestOcapiCommand(unittest.TestCase):
                             get_request=mock_get_request,
                             put_request=mock_put_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Chassis',
                     'command': 'PowerModeLow',
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(ACTION_WAS_SUCCESSFUL, get_exception_message(ansible_exit_json))
             self.assertTrue(is_changed(ansible_exit_json))
 
@@ -227,14 +227,14 @@ class TestOcapiCommand(unittest.TestCase):
                             get_request=mock_get_request,
                             put_request=mock_put_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Chassis',
                     'command': 'IndicatorLedOn',
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(ACTION_WAS_SUCCESSFUL, get_exception_message(ansible_exit_json))
             self.assertTrue(is_changed(ansible_exit_json))
 
@@ -244,14 +244,14 @@ class TestOcapiCommand(unittest.TestCase):
                             get_request=mock_get_request,
                             put_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Chassis',
                     'command': 'PowerModeNormal',
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(ACTION_WAS_SUCCESSFUL, get_exception_message(ansible_exit_json))
             self.assertFalse(is_changed(ansible_exit_json))
 
@@ -261,15 +261,15 @@ class TestOcapiCommand(unittest.TestCase):
                             get_request=mock_get_request,
                             put_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Chassis',
                     'command': 'IndicatorLedOn',
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21',
                     '_ansible_check_mode': True
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(UPDATE_NOT_PERFORMED_IN_CHECK_MODE, get_exception_message(ansible_exit_json))
             self.assertTrue(is_changed(ansible_exit_json))
 
@@ -279,15 +279,15 @@ class TestOcapiCommand(unittest.TestCase):
                             get_request=mock_get_request,
                             put_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Chassis',
                     'command': 'IndicatorLedOn',
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21',
                     '_ansible_check_mode': True
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(UPDATE_NOT_PERFORMED_IN_CHECK_MODE, get_exception_message(ansible_exit_json))
             self.assertTrue(is_changed(ansible_exit_json))
 
@@ -297,14 +297,14 @@ class TestOcapiCommand(unittest.TestCase):
                             get_request=mock_get_request,
                             put_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Chassis',
                     'command': 'IndicatorLedOff',
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(ACTION_WAS_SUCCESSFUL, get_exception_message(ansible_exit_json))
             self.assertFalse(is_changed(ansible_exit_json))
 
@@ -314,15 +314,15 @@ class TestOcapiCommand(unittest.TestCase):
                             get_request=mock_get_request,
                             put_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Chassis',
                     'command': 'IndicatorLedOff',
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21',
                     "_ansible_check_mode": True
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(NO_ACTION_PERFORMED_IN_CHECK_MODE, get_exception_message(ansible_exit_json))
             self.assertFalse(is_changed(ansible_exit_json))
 
@@ -331,14 +331,14 @@ class TestOcapiCommand(unittest.TestCase):
                             get_request=mock_get_request,
                             put_request=mock_put_request):
             with self.assertRaises(AnsibleFailJson) as ansible_fail_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Chassis',
                     'command': 'IndicatorLedBright',
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertIn("Invalid Command", get_exception_message(ansible_fail_json))
 
     def test_reset_enclosure(self):
@@ -346,14 +346,14 @@ class TestOcapiCommand(unittest.TestCase):
                             get_request=mock_get_request,
                             put_request=mock_put_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Systems',
                     'command': 'PowerGracefulRestart',
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(ACTION_WAS_SUCCESSFUL, get_exception_message(ansible_exit_json))
             self.assertTrue(is_changed(ansible_exit_json))
 
@@ -362,15 +362,15 @@ class TestOcapiCommand(unittest.TestCase):
                             get_request=mock_get_request,
                             put_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Systems',
                     'command': 'PowerGracefulRestart',
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21',
                     "_ansible_check_mode": True
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(UPDATE_NOT_PERFORMED_IN_CHECK_MODE, get_exception_message(ansible_exit_json))
             self.assertTrue(is_changed(ansible_exit_json))
 
@@ -379,14 +379,14 @@ class TestOcapiCommand(unittest.TestCase):
                             get_request=mock_get_request,
                             put_request=mock_put_request):
             with self.assertRaises(AnsibleFailJson) as ansible_fail_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Update',
                     'command': 'FWUpload',
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual("Missing update_image_path.", get_exception_message(ansible_fail_json))
 
     def test_firmware_upload_file_not_found(self):
@@ -394,15 +394,15 @@ class TestOcapiCommand(unittest.TestCase):
                             get_request=mock_get_request,
                             put_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleFailJson) as ansible_fail_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Update',
                     'command': 'FWUpload',
                     'update_image_path': 'nonexistentfile.bin',
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual("File does not exist.", get_exception_message(ansible_fail_json))
 
     def test_firmware_upload(self):
@@ -417,15 +417,15 @@ class TestOcapiCommand(unittest.TestCase):
                             put_request=mock_put_request,
                             post_request=mock_post_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Update',
                     'command': 'FWUpload',
                     'update_image_path': filepath,
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(ACTION_WAS_SUCCESSFUL, get_exception_message(ansible_exit_json))
             self.assertTrue(is_changed(ansible_exit_json))
 
@@ -441,7 +441,7 @@ class TestOcapiCommand(unittest.TestCase):
                             put_request=mock_put_request,
                             post_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Update',
                     'command': 'FWUpload',
                     'update_image_path': filepath,
@@ -449,8 +449,8 @@ class TestOcapiCommand(unittest.TestCase):
                     'username': 'USERID',
                     'password': 'PASSWORD=21',
                     "_ansible_check_mode": True
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(UPDATE_NOT_PERFORMED_IN_CHECK_MODE, get_exception_message(ansible_exit_json))
             self.assertTrue(is_changed(ansible_exit_json))
 
@@ -460,14 +460,14 @@ class TestOcapiCommand(unittest.TestCase):
                             put_request=mock_put_request,
                             post_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Update',
                     'command': 'FWUpdate',
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(ACTION_WAS_SUCCESSFUL, get_exception_message(ansible_exit_json))
             self.assertTrue(is_changed(ansible_exit_json))
 
@@ -477,15 +477,15 @@ class TestOcapiCommand(unittest.TestCase):
                             put_request=mock_invalid_http_request,
                             post_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Update',
                     'command': 'FWUpdate',
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21',
                     "_ansible_check_mode": True
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(UPDATE_NOT_PERFORMED_IN_CHECK_MODE, get_exception_message(ansible_exit_json))
             self.assertTrue(is_changed(ansible_exit_json))
 
@@ -495,14 +495,14 @@ class TestOcapiCommand(unittest.TestCase):
                             put_request=mock_put_request,
                             post_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Update',
                     'command': 'FWActivate',
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(ACTION_WAS_SUCCESSFUL, get_exception_message(ansible_exit_json))
             self.assertTrue(is_changed(ansible_exit_json))
 
@@ -512,15 +512,15 @@ class TestOcapiCommand(unittest.TestCase):
                             put_request=mock_invalid_http_request,
                             post_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Update',
                     'command': 'FWActivate',
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21',
                     "_ansible_check_mode": True
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(UPDATE_NOT_PERFORMED_IN_CHECK_MODE, get_exception_message(ansible_exit_json))
             self.assertTrue(is_changed(ansible_exit_json))
 
@@ -531,15 +531,15 @@ class TestOcapiCommand(unittest.TestCase):
                             put_request=mock_invalid_http_request,
                             post_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Jobs',
                     'command': 'DeleteJob',
                     'baseuri': MOCK_BASE_URI,
                     'job_name': MOCK_JOB_NAME,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(ACTION_WAS_SUCCESSFUL, get_exception_message(ansible_exit_json))
             self.assertTrue(is_changed(ansible_exit_json))
 
@@ -550,15 +550,15 @@ class TestOcapiCommand(unittest.TestCase):
                             put_request=mock_invalid_http_request,
                             post_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleFailJson) as ansible_fail_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Jobs',
                     'command': 'DeleteJob',
                     'baseuri': MOCK_BASE_URI,
                     'job_name': MOCK_JOB_NAME,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual("Cannot delete job because it is in progress.", get_exception_message(ansible_fail_json))
 
     def test_delete_job_in_progress_only_on_delete(self):
@@ -568,15 +568,15 @@ class TestOcapiCommand(unittest.TestCase):
                             put_request=mock_invalid_http_request,
                             post_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleFailJson) as ansible_fail_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Jobs',
                     'command': 'DeleteJob',
                     'baseuri': MOCK_BASE_URI,
                     'job_name': MOCK_JOB_NAME,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual("Cannot delete job because it is in progress.", get_exception_message(ansible_fail_json))
 
     def test_delete_job_check_mode(self):
@@ -586,7 +586,7 @@ class TestOcapiCommand(unittest.TestCase):
                             put_request=mock_invalid_http_request,
                             post_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Jobs',
                     'command': 'DeleteJob',
                     'baseuri': MOCK_BASE_URI,
@@ -594,8 +594,8 @@ class TestOcapiCommand(unittest.TestCase):
                     'username': 'USERID',
                     'password': 'PASSWORD=21',
                     '_ansible_check_mode': True
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(UPDATE_NOT_PERFORMED_IN_CHECK_MODE, get_exception_message(ansible_exit_json))
             self.assertTrue(is_changed(ansible_exit_json))
 
@@ -606,7 +606,7 @@ class TestOcapiCommand(unittest.TestCase):
                             put_request=mock_invalid_http_request,
                             post_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Jobs',
                     'command': 'DeleteJob',
                     'baseuri': MOCK_BASE_URI,
@@ -614,8 +614,8 @@ class TestOcapiCommand(unittest.TestCase):
                     'username': 'USERID',
                     'password': 'PASSWORD=21',
                     '_ansible_check_mode': True
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual("Job already deleted.", get_exception_message(ansible_exit_json))
             self.assertFalse(is_changed(ansible_exit_json))
 
@@ -626,7 +626,7 @@ class TestOcapiCommand(unittest.TestCase):
                             put_request=mock_invalid_http_request,
                             post_request=mock_invalid_http_request):
             with self.assertRaises(AnsibleFailJson) as ansible_fail_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Jobs',
                     'command': 'DeleteJob',
                     'baseuri': MOCK_BASE_URI,
@@ -634,6 +634,6 @@ class TestOcapiCommand(unittest.TestCase):
                     'username': 'USERID',
                     'password': 'PASSWORD=21',
                     '_ansible_check_mode': True
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual("Cannot delete job because it is in progress.", get_exception_message(ansible_fail_json))

--- a/tests/unit/plugins/modules/test_ocapi_info.py
+++ b/tests/unit/plugins/modules/test_ocapi_info.py
@@ -127,32 +127,32 @@ class TestOcapiInfo(unittest.TestCase):
 
     def test_module_fail_when_required_args_missing(self):
         with self.assertRaises(AnsibleFailJson) as ansible_fail_json:
-            set_module_args({})
-            module.main()
+            with set_module_args({}):
+                module.main()
         self.assertIn("missing required arguments:", get_exception_message(ansible_fail_json))
 
     def test_module_fail_when_unknown_category(self):
         with self.assertRaises(AnsibleFailJson) as ansible_fail_json:
-            set_module_args({
+            with set_module_args({
                 'category': 'unknown',
                 'command': 'JobStatus',
                 'username': 'USERID',
                 'password': 'PASSW0RD=21',
                 'baseuri': MOCK_BASE_URI
-            })
-            module.main()
+            }):
+                module.main()
         self.assertIn("Invalid Category 'unknown", get_exception_message(ansible_fail_json))
 
     def test_module_fail_when_unknown_command(self):
         with self.assertRaises(AnsibleFailJson) as ansible_fail_json:
-            set_module_args({
+            with set_module_args({
                 'category': 'Jobs',
                 'command': 'unknown',
                 'username': 'USERID',
                 'password': 'PASSW0RD=21',
                 'baseuri': MOCK_BASE_URI
-            })
-            module.main()
+            }):
+                module.main()
         self.assertIn("Invalid Command 'unknown", get_exception_message(ansible_fail_json))
 
     def test_job_status_in_progress(self):
@@ -162,15 +162,15 @@ class TestOcapiInfo(unittest.TestCase):
                             delete_request=mock_delete_request,
                             post_request=mock_post_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Jobs',
                     'command': 'JobStatus',
                     'job_name': MOCK_JOB_NAME_IN_PROGRESS,
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(ACTION_WAS_SUCCESSFUL, get_exception_message(ansible_exit_json))
             response_data = ansible_exit_json.exception.args[0]
             self.assertEqual(MOCK_HTTP_RESPONSE_JOB_IN_PROGRESS["data"]["PercentComplete"], response_data["percentComplete"])
@@ -190,15 +190,15 @@ class TestOcapiInfo(unittest.TestCase):
                             delete_request=mock_delete_request,
                             post_request=mock_post_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Jobs',
                     'command': 'JobStatus',
                     'job_name': MOCK_JOB_NAME_COMPLETE,
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(ACTION_WAS_SUCCESSFUL, get_exception_message(ansible_exit_json))
             response_data = ansible_exit_json.exception.args[0]
             self.assertEqual(MOCK_HTTP_RESPONSE_JOB_COMPLETE["data"]["PercentComplete"], response_data["percentComplete"])
@@ -218,15 +218,15 @@ class TestOcapiInfo(unittest.TestCase):
                             delete_request=mock_delete_request,
                             post_request=mock_post_request):
             with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                set_module_args({
+                with set_module_args({
                     'category': 'Jobs',
                     'command': 'JobStatus',
                     'job_name': MOCK_JOB_NAME_DOES_NOT_EXIST,
                     'baseuri': MOCK_BASE_URI,
                     'username': 'USERID',
                     'password': 'PASSWORD=21'
-                })
-                module.main()
+                }):
+                    module.main()
             self.assertEqual(ACTION_WAS_SUCCESSFUL, get_exception_message(ansible_exit_json))
             response_data = ansible_exit_json.exception.args[0]
             self.assertFalse(response_data["jobExists"])

--- a/tests/unit/plugins/modules/test_pacman.py
+++ b/tests/unit/plugins/modules/test_pacman.py
@@ -152,25 +152,25 @@ class TestPacman:
 
     def test_fail_without_required_args(self):
         with pytest.raises(AnsibleFailJson) as e:
-            set_module_args({})
-            pacman.main()
+            with set_module_args({}):
+                pacman.main()
         assert e.match(r"one of the following is required")
 
     def test_success(self, mock_empty_inventory):
-        set_module_args({"update_cache": True})  # Simplest args to let init go through
-        P = pacman.Pacman(pacman.setup_module())
-        with pytest.raises(AnsibleExitJson) as e:
-            P.success()
+        with set_module_args({"update_cache": True}):  # Simplest args to let init go through
+            P = pacman.Pacman(pacman.setup_module())
+            with pytest.raises(AnsibleExitJson) as e:
+                P.success()
 
     def test_fail(self, mock_empty_inventory):
-        set_module_args({"update_cache": True})
-        P = pacman.Pacman(pacman.setup_module())
+        with set_module_args({"update_cache": True}):
+            P = pacman.Pacman(pacman.setup_module())
 
-        args = dict(
-            msg="msg", stdout="something", stderr="somethingelse", cmd=["command", "with", "args"], rc=1
-        )
-        with pytest.raises(AnsibleFailJson) as e:
-            P.fail(**args)
+            args = dict(
+                msg="msg", stdout="something", stderr="somethingelse", cmd=["command", "with", "args"], rc=1
+            )
+            with pytest.raises(AnsibleFailJson) as e:
+                P.fail(**args)
 
         assert all(item in e.value.args[0] for item in args)
 
@@ -333,33 +333,33 @@ class TestPacman:
     def test_build_inventory(self, expected, run_command_side_effect, raises):
         self.mock_run_command.side_effect = run_command_side_effect
 
-        set_module_args({"update_cache": True})
-        if raises:
-            with pytest.raises(raises):
+        with set_module_args({"update_cache": True}):
+            if raises:
+                with pytest.raises(raises):
+                    P = pacman.Pacman(pacman.setup_module())
+                    P._build_inventory()
+            else:
                 P = pacman.Pacman(pacman.setup_module())
-                P._build_inventory()
-        else:
-            P = pacman.Pacman(pacman.setup_module())
-            assert P._build_inventory() == expected
+                assert P._build_inventory() == expected
 
     @pytest.mark.parametrize("check_mode_value", [True, False])
     def test_upgrade_check_empty_inventory(self, mock_empty_inventory, check_mode_value):
-        set_module_args({"upgrade": True, "_ansible_check_mode": check_mode_value})
-        P = pacman.Pacman(pacman.setup_module())
-        with pytest.raises(AnsibleExitJson) as e:
-            P.run()
-        self.mock_run_command.call_count == 0
+        with set_module_args({"upgrade": True, "_ansible_check_mode": check_mode_value}):
+            P = pacman.Pacman(pacman.setup_module())
+            with pytest.raises(AnsibleExitJson) as e:
+                P.run()
+        assert self.mock_run_command.call_count == 0
         out = e.value.args[0]
         assert "packages" not in out
         assert not out["changed"]
         assert "diff" not in out
 
     def test_update_db_check(self, mock_empty_inventory):
-        set_module_args({"update_cache": True, "_ansible_check_mode": True})
-        P = pacman.Pacman(pacman.setup_module())
+        with set_module_args({"update_cache": True, "_ansible_check_mode": True}):
+            P = pacman.Pacman(pacman.setup_module())
 
-        with pytest.raises(AnsibleExitJson) as e:
-            P.run()
+            with pytest.raises(AnsibleExitJson) as e:
+                P.run()
         self.mock_run_command.call_count == 0
         out = e.value.args[0]
         assert "packages" not in out
@@ -422,14 +422,14 @@ class TestPacman:
     def test_update_db(self, module_args, expected_calls, changed):
         args = {"update_cache": True}
         args.update(module_args)
-        set_module_args(args)
+        with set_module_args(args):
 
-        self.mock_run_command.side_effect = [
-            (rc, stdout, stderr) for expected_call, kwargs, rc, stdout, stderr in expected_calls
-        ]
-        with pytest.raises(AnsibleExitJson) as e:
-            P = pacman.Pacman(pacman.setup_module())
-            P.run()
+            self.mock_run_command.side_effect = [
+                (rc, stdout, stderr) for expected_call, kwargs, rc, stdout, stderr in expected_calls
+            ]
+            with pytest.raises(AnsibleExitJson) as e:
+                P = pacman.Pacman(pacman.setup_module())
+                P.run()
 
         self.mock_run_command.assert_has_calls([
             mock.call(mock.ANY, expected_call, **kwargs) for expected_call, kwargs, rc, stdout, stderr in expected_calls
@@ -475,16 +475,16 @@ class TestPacman:
         args = {"upgrade": True, "_ansible_check_mode": check_mode_value}
         if upgrade_extra_args:
             args["upgrade_extra_args"] = upgrade_extra_args
-        set_module_args(args)
+        with set_module_args(args):
 
-        if run_command_data and "return_value" in run_command_data:
-            self.mock_run_command.return_value = run_command_data["return_value"]
+            if run_command_data and "return_value" in run_command_data:
+                self.mock_run_command.return_value = run_command_data["return_value"]
 
-        P = pacman.Pacman(pacman.setup_module())
+            P = pacman.Pacman(pacman.setup_module())
 
-        with pytest.raises(AnsibleExitJson) as e:
-            P.run()
-        out = e.value.args[0]
+            with pytest.raises(AnsibleExitJson) as e:
+                P.run()
+            out = e.value.args[0]
 
         if check_mode_value:
             self.mock_run_command.call_count == 0
@@ -499,13 +499,13 @@ class TestPacman:
         assert out["diff"]["before"] and out["diff"]["after"]
 
     def test_upgrade_fail(self, mock_valid_inventory):
-        set_module_args({"upgrade": True})
-        self.mock_run_command.return_value = [1, "stdout", "stderr"]
-        P = pacman.Pacman(pacman.setup_module())
+        with set_module_args({"upgrade": True}):
+            self.mock_run_command.return_value = [1, "stdout", "stderr"]
+            P = pacman.Pacman(pacman.setup_module())
 
-        with pytest.raises(AnsibleFailJson) as e:
-            P.run()
-        self.mock_run_command.call_count == 1
+            with pytest.raises(AnsibleFailJson) as e:
+                P.run()
+        assert self.mock_run_command.call_count == 1
         out = e.value.args[0]
         assert out["failed"]
         assert out["stdout"] == "stdout"
@@ -633,19 +633,19 @@ class TestPacman:
     def test_package_list(
         self, mock_valid_inventory, state, pkg_names, expected, run_command_data, raises
     ):
-        set_module_args({"name": pkg_names, "state": state})
-        P = pacman.Pacman(pacman.setup_module())
-        P.inventory = P._build_inventory()
-        if run_command_data:
-            self.mock_run_command.side_effect = run_command_data["side_effect"]
-
-        if raises:
-            with pytest.raises(raises):
-                P.package_list()
-        else:
-            assert sorted(P.package_list()) == sorted(expected)
+        with set_module_args({"name": pkg_names, "state": state}):
+            P = pacman.Pacman(pacman.setup_module())
+            P.inventory = P._build_inventory()
             if run_command_data:
-                assert self.mock_run_command.mock_calls == run_command_data["calls"]
+                self.mock_run_command.side_effect = run_command_data["side_effect"]
+
+            if raises:
+                with pytest.raises(raises):
+                    P.package_list()
+            else:
+                assert sorted(P.package_list()) == sorted(expected)
+                if run_command_data:
+                    assert self.mock_run_command.mock_calls == run_command_data["calls"]
 
     @pytest.mark.parametrize("check_mode_value", [True, False])
     @pytest.mark.parametrize(
@@ -658,11 +658,11 @@ class TestPacman:
     def test_op_packages_nothing_to_do(
         self, mock_valid_inventory, mock_package_list, check_mode_value, name, state, package_list
     ):
-        set_module_args({"name": name, "state": state, "_ansible_check_mode": check_mode_value})
-        mock_package_list.return_value = package_list
-        P = pacman.Pacman(pacman.setup_module())
-        with pytest.raises(AnsibleExitJson) as e:
-            P.run()
+        with set_module_args({"name": name, "state": state, "_ansible_check_mode": check_mode_value}):
+            mock_package_list.return_value = package_list
+            P = pacman.Pacman(pacman.setup_module())
+            with pytest.raises(AnsibleExitJson) as e:
+                P.run()
         out = e.value.args[0]
         assert not out["changed"]
         assert "packages" in out
@@ -1079,13 +1079,13 @@ class TestPacman:
         run_command_data,
         raises,
     ):
-        set_module_args(module_args)
-        self.mock_run_command.side_effect = run_command_data["side_effect"]
-        mock_package_list.return_value = package_list_out
+        with set_module_args(module_args):
+            self.mock_run_command.side_effect = run_command_data["side_effect"]
+            mock_package_list.return_value = package_list_out
 
-        P = pacman.Pacman(pacman.setup_module())
-        with pytest.raises(raises) as e:
-            P.run()
+            P = pacman.Pacman(pacman.setup_module())
+            with pytest.raises(raises) as e:
+                P.run()
         out = e.value.args[0]
 
         assert self.mock_run_command.mock_calls == run_command_data["calls"]

--- a/tests/unit/plugins/modules/test_pagerduty_alert.py
+++ b/tests/unit/plugins/modules/test_pagerduty_alert.py
@@ -64,22 +64,22 @@ class TestPagerDutyAlertModule(ModuleTestCase):
 
     def test_module_fail_when_required_args_missing(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            self.module.main()
+            with set_module_args({}):
+                self.module.main()
 
     def test_ensure_alert_created_with_minimal_data(self):
-        set_module_args({
+        with set_module_args({
             'state': 'triggered',
             'api_version': 'v2',
             'integration_key': 'test',
             'source': 'My Ansible Script',
             'desc': 'Description for alert'
-        })
+        }):
 
-        with patch.object(pagerduty_alert, 'fetch_url') as fetch_url_mock:
-            fetch_url_mock.return_value = (Response(), {"status": 202})
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
+            with patch.object(pagerduty_alert, 'fetch_url') as fetch_url_mock:
+                fetch_url_mock.return_value = (Response(), {"status": 202})
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
             assert fetch_url_mock.call_count == 1
             url = fetch_url_mock.call_args[0][1]
@@ -95,7 +95,7 @@ class TestPagerDutyAlertModule(ModuleTestCase):
             assert data['payload']['timestamp'] is not None
 
     def test_ensure_alert_created_with_full_data(self):
-        set_module_args({
+        with set_module_args({
             'api_version': 'v2',
             'component': 'mysql',
             'custom_details': {'environment': 'production', 'notes': 'this is a test note'},
@@ -106,12 +106,12 @@ class TestPagerDutyAlertModule(ModuleTestCase):
             'link_text': 'PagerDuty',
             'state': 'triggered',
             'source': 'My Ansible Script',
-        })
+        }):
 
-        with patch.object(pagerduty_alert, 'fetch_url') as fetch_url_mock:
-            fetch_url_mock.return_value = (Response(), {"status": 202})
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
+            with patch.object(pagerduty_alert, 'fetch_url') as fetch_url_mock:
+                fetch_url_mock.return_value = (Response(), {"status": 202})
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
             assert fetch_url_mock.call_count == 1
             url = fetch_url_mock.call_args[0][1]
@@ -130,17 +130,17 @@ class TestPagerDutyAlertModule(ModuleTestCase):
             assert data['links'][0]['text'] == 'PagerDuty'
 
     def test_ensure_alert_acknowledged(self):
-        set_module_args({
+        with set_module_args({
             'state': 'acknowledged',
             'api_version': 'v2',
             'integration_key': 'test',
             'incident_key': 'incident_test_id',
-        })
+        }):
 
-        with patch.object(pagerduty_alert, 'fetch_url') as fetch_url_mock:
-            fetch_url_mock.return_value = (Response(), {"status": 202})
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
+            with patch.object(pagerduty_alert, 'fetch_url') as fetch_url_mock:
+                fetch_url_mock.return_value = (Response(), {"status": 202})
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
             assert fetch_url_mock.call_count == 1
             url = fetch_url_mock.call_args[0][1]

--- a/tests/unit/plugins/modules/test_pagerduty_change.py
+++ b/tests/unit/plugins/modules/test_pagerduty_change.py
@@ -26,19 +26,19 @@ class TestPagerDutyChangeModule(ModuleTestCase):
 
     def test_module_fail_when_required_args_missing(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            self.module.main()
+            with set_module_args({}):
+                self.module.main()
 
     def test_ensure_change_event_created_with_minimal_data(self):
-        set_module_args({
+        with set_module_args({
             'integration_key': 'test',
             'summary': 'Testing'
-        })
+        }):
 
-        with patch.object(pagerduty_change, 'fetch_url') as fetch_url_mock:
-            fetch_url_mock.return_value = (None, {"status": 202})
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
+            with patch.object(pagerduty_change, 'fetch_url') as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 202})
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
             assert fetch_url_mock.call_count == 1
             url = fetch_url_mock.call_args[0][1]
@@ -51,7 +51,7 @@ class TestPagerDutyChangeModule(ModuleTestCase):
             assert data['payload']['source'] == 'Ansible'
 
     def test_ensure_change_event_created_with_full_data(self):
-        set_module_args({
+        with set_module_args({
             'integration_key': 'test',
             'summary': 'Testing',
             'source': 'My Ansible Script',
@@ -61,12 +61,12 @@ class TestPagerDutyChangeModule(ModuleTestCase):
             'environment': 'production',
             'link_url': 'https://pagerduty.com',
             'link_text': 'PagerDuty'
-        })
+        }):
 
-        with patch.object(pagerduty_change, 'fetch_url') as fetch_url_mock:
-            fetch_url_mock.return_value = (None, {"status": 202})
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
+            with patch.object(pagerduty_change, 'fetch_url') as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 202})
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
             assert fetch_url_mock.call_count == 1
             url = fetch_url_mock.call_args[0][1]

--- a/tests/unit/plugins/modules/test_parted.py
+++ b/tests/unit/plugins/modules/test_parted.py
@@ -187,93 +187,93 @@ class TestParted(ModuleTestCase):
         self.assertEqual(parse_partition_info(parted_output2, 'MB'), parted_dict2)
 
     def test_partition_already_exists(self):
-        set_module_args({
+        with set_module_args({
             'device': '/dev/sdb',
             'number': 1,
             'state': 'present',
-        })
-        with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
-            self.execute_module(changed=False)
+        }):
+            with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
+                self.execute_module(changed=False)
 
     def test_create_new_partition(self):
-        set_module_args({
+        with set_module_args({
             'device': '/dev/sdb',
             'number': 4,
             'state': 'present',
-        })
-        with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
-            self.execute_module(changed=True, script='unit KiB mkpart primary 0% 100%')
+        }):
+            with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
+                self.execute_module(changed=True, script='unit KiB mkpart primary 0% 100%')
 
     def test_create_new_partition_1G(self):
-        set_module_args({
+        with set_module_args({
             'device': '/dev/sdb',
             'number': 4,
             'state': 'present',
             'part_end': '1GiB',
-        })
-        with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
-            self.execute_module(changed=True, script='unit KiB mkpart primary 0% 1GiB')
+        }):
+            with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
+                self.execute_module(changed=True, script='unit KiB mkpart primary 0% 1GiB')
 
     def test_create_new_partition_minus_1G(self):
-        set_module_args({
+        with set_module_args({
             'device': '/dev/sdb',
             'number': 4,
             'state': 'present',
             'fs_type': 'ext2',
             'part_start': '-1GiB',
-        })
-        with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
-            self.execute_module(changed=True, script='unit KiB mkpart primary ext2 -1GiB 100%')
+        }):
+            with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
+                self.execute_module(changed=True, script='unit KiB mkpart primary ext2 -1GiB 100%')
 
     def test_remove_partition_number_1(self):
-        set_module_args({
+        with set_module_args({
             'device': '/dev/sdb',
             'number': 1,
             'state': 'absent',
-        })
-        with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
-            self.execute_module(changed=True, script='rm 1')
+        }):
+            with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
+                self.execute_module(changed=True, script='rm 1')
 
     def test_resize_partition(self):
-        set_module_args({
+        with set_module_args({
             'device': '/dev/sdb',
             'number': 3,
             'state': 'present',
             'part_end': '100%',
             'resize': True
-        })
-        with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
-            self.execute_module(changed=True, script='resizepart 3 100%')
+        }):
+            with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
+                self.execute_module(changed=True, script='resizepart 3 100%')
 
     def test_change_flag(self):
         # Flags are set in a second run of parted().
         # Between the two runs, the partition dict is updated.
         # use checkmode here allow us to continue even if the dictionary is
         # not updated.
-        set_module_args({
+        with set_module_args({
             'device': '/dev/sdb',
             'number': 3,
             'state': 'present',
             'flags': ['lvm', 'boot'],
             '_ansible_check_mode': True,
-        })
+        }):
 
-        with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
-            self.parted.reset_mock()
-            self.execute_module(changed=True)
-            # When using multiple flags:
-            # order of execution is non deterministic, because set() operations are used in
-            # the current implementation.
-            expected_calls_order1 = [call('unit KiB set 3 lvm on set 3 boot on ',
-                                          '/dev/sdb', 'optimal')]
-            expected_calls_order2 = [call('unit KiB set 3 boot on set 3 lvm on ',
-                                          '/dev/sdb', 'optimal')]
-            self.assertTrue(self.parted.mock_calls == expected_calls_order1 or
-                            self.parted.mock_calls == expected_calls_order2)
+            with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
+                self.parted.reset_mock()
+                self.execute_module(changed=True)
+                # When using multiple flags:
+                # order of execution is non deterministic, because set() operations are used in
+                # the current implementation.
+                expected_calls_order1 = [call('unit KiB set 3 lvm on set 3 boot on ',
+                                              '/dev/sdb', 'optimal')]
+                expected_calls_order2 = [call('unit KiB set 3 boot on set 3 lvm on ',
+                                              '/dev/sdb', 'optimal')]
+                self.assertTrue(self.parted.mock_calls == expected_calls_order1 or
+                                self.parted.mock_calls == expected_calls_order2)
 
     def test_create_new_primary_lvm_partition(self):
         # use check_mode, see previous test comment
-        set_module_args({
+        with set_module_args({
             'device': '/dev/sdb',
             'number': 4,
             'flags': ["boot"],
@@ -281,15 +281,15 @@ class TestParted(ModuleTestCase):
             'part_start': '257GiB',
             'fs_type': 'ext3',
             '_ansible_check_mode': True,
-        })
-        with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
-            self.execute_module(changed=True, script='unit KiB mkpart primary ext3 257GiB 100% unit KiB set 4 boot on')
+        }):
+            with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
+                self.execute_module(changed=True, script='unit KiB mkpart primary ext3 257GiB 100% unit KiB set 4 boot on')
 
     def test_create_label_gpt(self):
         # Like previous test, current implementation use parted to create the partition and
         # then retrieve and update the dictionary. Use check_mode to force to continue even if
         # dictionary is not updated.
-        set_module_args({
+        with set_module_args({
             'device': '/dev/sdb',
             'number': 1,
             'flags': ["lvm"],
@@ -297,48 +297,48 @@ class TestParted(ModuleTestCase):
             'name': 'lvmpartition',
             'state': 'present',
             '_ansible_check_mode': True,
-        })
-        with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict2):
-            self.execute_module(changed=True, script='unit KiB mklabel gpt mkpart primary 0% 100% unit KiB name 1 \'"lvmpartition"\' set 1 lvm on')
+        }):
+            with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict2):
+                self.execute_module(changed=True, script='unit KiB mklabel gpt mkpart primary 0% 100% unit KiB name 1 \'"lvmpartition"\' set 1 lvm on')
 
     def test_change_label_gpt(self):
         # When partitions already exists and label is changed, mkpart should be called even when partition already exists,
         # because new empty label will be created anyway
-        set_module_args({
+        with set_module_args({
             'device': '/dev/sdb',
             'number': 1,
             'state': 'present',
             'label': 'gpt',
             '_ansible_check_mode': True,
-        })
-        with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
-            self.execute_module(changed=True, script='unit KiB mklabel gpt mkpart primary 0% 100%')
+        }):
+            with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict1):
+                self.execute_module(changed=True, script='unit KiB mklabel gpt mkpart primary 0% 100%')
 
     def test_check_mode_unchanged(self):
         # Test that get_device_info result is checked in check mode too
         # No change on partition 1
-        set_module_args({
+        with set_module_args({
             'device': '/dev/sdb',
             'number': 1,
             'state': 'present',
             'flags': ['some_flag'],
             '_ansible_check_mode': True,
-        })
-        with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict3):
-            self.execute_module(changed=False)
+        }):
+            with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict3):
+                self.execute_module(changed=False)
 
     def test_check_mode_changed(self):
         # Test that get_device_info result is checked in check mode too
         # Flag change on partition 1
-        set_module_args({
+        with set_module_args({
             'device': '/dev/sdb',
             'number': 1,
             'state': 'present',
             'flags': ['other_flag'],
             '_ansible_check_mode': True,
-        })
-        with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict3):
-            self.execute_module(changed=True)
+        }):
+            with patch('ansible_collections.community.general.plugins.modules.parted.get_device_info', return_value=parted_dict3):
+                self.execute_module(changed=True)
 
     def test_version_info(self):
         """Test that the parse_parted_version returns the expected tuple"""

--- a/tests/unit/plugins/modules/test_pmem.py
+++ b/tests/unit/plugins/modules/test_pmem.py
@@ -321,81 +321,81 @@ class TestPmem(ModuleTestCase):
 
     def test_fail_when_required_args_missing(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            pmem_module.main()
+            with set_module_args({}):
+                pmem_module.main()
 
     def test_fail_when_appdirect_only(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'appdirect': 10,
-            })
-            pmem_module.main()
+            }):
+                pmem_module.main()
 
     def test_fail_when_MemosyMode_only(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'memorymode': 70,
-            })
-            pmem_module.main()
+            }):
+                pmem_module.main()
 
     def test_fail_when_reserved_only(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'reserved': 10,
-            })
-            pmem_module.main()
+            }):
+                pmem_module.main()
 
     def test_fail_when_appdirect_memorymode_reserved_total_not_100(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'appdirect': 10,
                 'memorymode': 70,
                 'reserved': 10,
-            })
-            pmem_module.main()
+            }):
+                pmem_module.main()
 
     def test_when_appdirect_memorymode(self):
-        set_module_args({
+        with set_module_args({
             'appdirect': 10,
             'memorymode': 70,
-        })
-        with patch(
-                'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
-                side_effect=[goal_plain, goal, dimmlist]):
-            with self.assertRaises(AnsibleExitJson) as result:
-                pmem_module.main()
-            self.result_check(result, False, [25769803776], [188978561024], [328230764544])
+        }):
+            with patch(
+                    'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
+                    side_effect=[goal_plain, goal, dimmlist]):
+                with self.assertRaises(AnsibleExitJson) as result:
+                    pmem_module.main()
+                self.result_check(result, False, [25769803776], [188978561024], [328230764544])
 
     def test_when_appdirect_memorymode_reserved(self):
-        set_module_args({
+        with set_module_args({
             'appdirect': 10,
             'memorymode': 70,
             'reserved': 20,
-        })
-        with patch(
-                'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
-                side_effect=[goal_plain, goal, dimmlist]):
-            with self.assertRaises(AnsibleExitJson) as result:
-                pmem_module.main()
-            self.result_check(result, False, [25769803776], [188978561024], [328230764544])
+        }):
+            with patch(
+                    'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
+                    side_effect=[goal_plain, goal, dimmlist]):
+                with self.assertRaises(AnsibleExitJson) as result:
+                    pmem_module.main()
+                self.result_check(result, False, [25769803776], [188978561024], [328230764544])
 
     def test_when_appdirect_notinterleaved_memorymode_reserved(self):
-        set_module_args({
+        with set_module_args({
             'appdirect': 10,
             'appdirect_interleaved': False,
             'memorymode': 70,
             'reserved': 20,
-        })
-        with patch(
-                'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
-                side_effect=[goal_plain, goal, dimmlist]):
-            with self.assertRaises(AnsibleExitJson) as result:
-                pmem_module.main()
-            self.result_check(result, False, [25769803776], [188978561024], [328230764544])
+        }):
+            with patch(
+                    'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
+                    side_effect=[goal_plain, goal, dimmlist]):
+                with self.assertRaises(AnsibleExitJson) as result:
+                    pmem_module.main()
+                self.result_check(result, False, [25769803776], [188978561024], [328230764544])
 
     def test_fail_when_socket_id_appdirect(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'socket': [
                     {
                         'id': 0,
@@ -406,12 +406,12 @@ class TestPmem(ModuleTestCase):
                         'appdirect': 10,
                     },
                 ],
-            })
-            pmem_module.main()
+            }):
+                pmem_module.main()
 
     def test_fail_when_socket0_id_memorymode_socket1_id_appdirect(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'socket': [
                     {
                         'id': 0,
@@ -422,12 +422,12 @@ class TestPmem(ModuleTestCase):
                         'appdirect': 10,
                     },
                 ],
-            })
-            pmem_module.main()
+            }):
+                pmem_module.main()
 
     def test_fail_when_socket0_without_id(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'socket': [
                     {
                         'appdirect': 10,
@@ -439,11 +439,11 @@ class TestPmem(ModuleTestCase):
                         'memorymode': 70,
                     },
                 ],
-            })
-            pmem_module.main()
+            }):
+                pmem_module.main()
 
     def test_when_socket0_and_1_appdirect_memorymode(self):
-        set_module_args({
+        with set_module_args({
             'socket': [
                 {
                     'id': 0,
@@ -456,18 +456,18 @@ class TestPmem(ModuleTestCase):
                     'memorymode': 70,
                 },
             ],
-        })
-        with patch(
-                'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
-                side_effect=[
-                    show_skt, goal_plain_sk0, goal_sk0, dimmlist_sk0, goal_plain_sk1, goal_sk1, dimmlist_sk1]):
-            with self.assertRaises(AnsibleExitJson) as result:
-                pmem_module.main()
-            self.result_check(
-                result, True, [12884901888, 12884901888], [94489280512, 94489280512], [164115382272, 164115382272])
+        }):
+            with patch(
+                    'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
+                    side_effect=[
+                        show_skt, goal_plain_sk0, goal_sk0, dimmlist_sk0, goal_plain_sk1, goal_sk1, dimmlist_sk1]):
+                with self.assertRaises(AnsibleExitJson) as result:
+                    pmem_module.main()
+                self.result_check(
+                    result, True, [12884901888, 12884901888], [94489280512, 94489280512], [164115382272, 164115382272])
 
     def test_when_socket0_and_1_appdirect_memorymode_reserved(self):
-        set_module_args({
+        with set_module_args({
             'socket': [
                 {
                     'id': 0,
@@ -482,18 +482,18 @@ class TestPmem(ModuleTestCase):
                     'reserved': 20,
                 },
             ],
-        })
-        with patch(
-                'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
-                side_effect=[
-                    show_skt, goal_plain_sk0, goal_sk0, dimmlist_sk0, goal_plain_sk1, goal_sk1, dimmlist_sk1]):
-            with self.assertRaises(AnsibleExitJson) as result:
-                pmem_module.main()
-            self.result_check(
-                result, True, [12884901888, 12884901888], [94489280512, 94489280512], [164115382272, 164115382272])
+        }):
+            with patch(
+                    'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
+                    side_effect=[
+                        show_skt, goal_plain_sk0, goal_sk0, dimmlist_sk0, goal_plain_sk1, goal_sk1, dimmlist_sk1]):
+                with self.assertRaises(AnsibleExitJson) as result:
+                    pmem_module.main()
+                self.result_check(
+                    result, True, [12884901888, 12884901888], [94489280512, 94489280512], [164115382272, 164115382272])
 
     def test_when_socket0_appdirect_notinterleaved_memorymode_reserved_socket1_appdirect_memorymode_reserved(self):
-        set_module_args({
+        with set_module_args({
             'socket': [
                 {
                     'id': 0,
@@ -509,19 +509,19 @@ class TestPmem(ModuleTestCase):
                     'reserved': 20,
                 },
             ],
-        })
-        with patch(
-                'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
-                side_effect=[
-                    show_skt, goal_plain_sk0, goal_sk0, dimmlist_sk0, goal_plain_sk1, goal_sk1, dimmlist_sk1]):
-            with self.assertRaises(AnsibleExitJson) as result:
-                pmem_module.main()
-            self.result_check(
-                result, True, [12884901888, 12884901888], [94489280512, 94489280512], [164115382272, 164115382272])
+        }):
+            with patch(
+                    'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
+                    side_effect=[
+                        show_skt, goal_plain_sk0, goal_sk0, dimmlist_sk0, goal_plain_sk1, goal_sk1, dimmlist_sk1]):
+                with self.assertRaises(AnsibleExitJson) as result:
+                    pmem_module.main()
+                self.result_check(
+                    result, True, [12884901888, 12884901888], [94489280512, 94489280512], [164115382272, 164115382272])
 
     def test_fail_when_namespace_without_mode(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'namespace': [
                     {
                         'size': '1GB',
@@ -532,12 +532,12 @@ class TestPmem(ModuleTestCase):
                         'type': 'blk',
                     },
                 ],
-            })
-            pmem_module.main()
+            }):
+                pmem_module.main()
 
     def test_fail_when_region_is_empty(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'namespace': [
                     {
                         'size': '1GB',
@@ -545,15 +545,15 @@ class TestPmem(ModuleTestCase):
                         'mode': 'sector',
                     },
                 ],
-            })
-            with patch(
-                    'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
-                    side_effect=[ndctl_region_empty]):
-                pmem_module.main()
+            }):
+                with patch(
+                        'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
+                        side_effect=[ndctl_region_empty]):
+                    pmem_module.main()
 
     def test_fail_when_namespace_invalid_size(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'namespace': [
                     {
                         'size': '1XXX',
@@ -561,15 +561,15 @@ class TestPmem(ModuleTestCase):
                         'mode': 'sector',
                     },
                 ],
-            })
-            with patch(
-                    'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
-                    side_effect=[ndctl_region]):
-                pmem_module.main()
+            }):
+                with patch(
+                        'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
+                        side_effect=[ndctl_region]):
+                    pmem_module.main()
 
     def test_fail_when_size_is_invalid_alignment(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'namespace': [
                     {
                         'size': '400MB',
@@ -582,15 +582,15 @@ class TestPmem(ModuleTestCase):
                         'mode': 'sector'
                     },
                 ],
-            })
-            with patch(
-                    'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
-                    side_effect=[ndctl_region]):
-                pmem_module.main()
+            }):
+                with patch(
+                        'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
+                        side_effect=[ndctl_region]):
+                    pmem_module.main()
 
     def test_fail_when_blk_is_unsupported_type(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'namespace': [
                     {
                         'size': '4GB',
@@ -603,15 +603,15 @@ class TestPmem(ModuleTestCase):
                         'mode': 'sector'
                     },
                 ],
-            })
-            with patch(
-                    'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
-                    side_effect=[ndctl_region]):
-                pmem_module.main()
+            }):
+                with patch(
+                        'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
+                        side_effect=[ndctl_region]):
+                    pmem_module.main()
 
     def test_fail_when_size_isnot_set_to_multiple_namespaces(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'namespace': [
                     {
                         'type': 'pmem',
@@ -623,15 +623,15 @@ class TestPmem(ModuleTestCase):
                         'mode': 'sector'
                     },
                 ],
-            })
-            with patch(
-                    'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
-                    side_effect=[ndctl_region]):
-                pmem_module.main()
+            }):
+                with patch(
+                        'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
+                        side_effect=[ndctl_region]):
+                    pmem_module.main()
 
     def test_fail_when_size_of_namespace_over_available(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'namespace': [
                     {
                         'size': '400GB',
@@ -644,30 +644,30 @@ class TestPmem(ModuleTestCase):
                         'mode': 'sector'
                     },
                 ],
-            })
-            with patch(
-                    'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
-                    side_effect=[ndctl_region]):
-                pmem_module.main()
+            }):
+                with patch(
+                        'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
+                        side_effect=[ndctl_region]):
+                    pmem_module.main()
 
     def test_when_namespace0_without_size(self):
-        set_module_args({
+        with set_module_args({
             'namespace': [
                 {
                     'type': 'pmem',
                     'mode': 'sector'
                 },
             ],
-        })
-        with patch(
-                'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
-                side_effect=[ndctl_region, ndctl_create_without_size, ndctl_list_N]):
-            with self.assertRaises(AnsibleExitJson) as result:
-                pmem_module.main()
-            self.result_check_ns(result, ndctl_list_N)
+        }):
+            with patch(
+                    'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
+                    side_effect=[ndctl_region, ndctl_create_without_size, ndctl_list_N]):
+                with self.assertRaises(AnsibleExitJson) as result:
+                    pmem_module.main()
+                self.result_check_ns(result, ndctl_list_N)
 
     def test_when_namespace0_with_namespace_append(self):
-        set_module_args({
+        with set_module_args({
             'namespace': [
                 {
                     'size': '640MB',
@@ -676,16 +676,16 @@ class TestPmem(ModuleTestCase):
                 },
             ],
             'namespace_append': True,
-        })
-        with patch(
-                'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
-                side_effect=[ndctl_region, ndctl_create_640M, ndctl_list_N_two_namespaces]):
-            with self.assertRaises(AnsibleExitJson) as result:
-                pmem_module.main()
-            self.result_check_ns(result, ndctl_list_N_two_namespaces)
+        }):
+            with patch(
+                    'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
+                    side_effect=[ndctl_region, ndctl_create_640M, ndctl_list_N_two_namespaces]):
+                with self.assertRaises(AnsibleExitJson) as result:
+                    pmem_module.main()
+                self.result_check_ns(result, ndctl_list_N_two_namespaces)
 
     def test_when_namespace0_1GiB_pmem_sector_namespace1_640MiB_pmem_raw(self):
-        set_module_args({
+        with set_module_args({
             'namespace': [
                 {
                     'size': '1GB',
@@ -698,10 +698,10 @@ class TestPmem(ModuleTestCase):
                     'mode': 'raw',
                 },
             ],
-        })
-        with patch(
-                'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
-                side_effect=[ndctl_region, ndctl_create_1G, ndctl_create_640M, ndctl_list_N_two_namespaces]):
-            with self.assertRaises(AnsibleExitJson) as result:
-                pmem_module.main()
-            self.result_check_ns(result, ndctl_list_N_two_namespaces)
+        }):
+            with patch(
+                    'ansible_collections.community.general.plugins.modules.pmem.PersistentMemory.pmem_run_command',
+                    side_effect=[ndctl_region, ndctl_create_1G, ndctl_create_640M, ndctl_list_N_two_namespaces]):
+                with self.assertRaises(AnsibleExitJson) as result:
+                    pmem_module.main()
+                self.result_check_ns(result, ndctl_list_N_two_namespaces)

--- a/tests/unit/plugins/modules/test_pritunl_org.py
+++ b/tests/unit/plugins/modules/test_pritunl_org.py
@@ -64,14 +64,14 @@ class TestPritunlOrg(ModuleTestCase):
 
     def test_without_parameters(self):
         """Test without parameters"""
-        set_module_args({})
-        with self.assertRaises(AnsibleFailJson):
-            self.module.main()
+        with set_module_args({}):
+            with self.assertRaises(AnsibleFailJson):
+                self.module.main()
 
     def test_present(self):
         """Test Pritunl organization creation."""
         org_params = {"name": "NewOrg"}
-        set_module_args(
+        with set_module_args(
             dict_merge(
                 {
                     "pritunl_api_token": "token",
@@ -80,32 +80,32 @@ class TestPritunlOrg(ModuleTestCase):
                 },
                 org_params,
             )
-        )
-        # Test creation
-        with self.patch_get_pritunl_organizations(
-            side_effect=PritunlListOrganizationMock
-        ) as mock_get:
-            with self.patch_add_pritunl_organization(
-                side_effect=PritunlPostOrganizationMock
-            ) as mock_add:
-                with self.assertRaises(AnsibleExitJson) as create_result:
-                    self.module.main()
+        ):
+            # Test creation
+            with self.patch_get_pritunl_organizations(
+                side_effect=PritunlListOrganizationMock
+            ) as mock_get:
+                with self.patch_add_pritunl_organization(
+                    side_effect=PritunlPostOrganizationMock
+                ) as mock_add:
+                    with self.assertRaises(AnsibleExitJson) as create_result:
+                        self.module.main()
 
-        create_exc = create_result.exception.args[0]
+            create_exc = create_result.exception.args[0]
 
-        self.assertTrue(create_exc["changed"])
-        self.assertEqual(create_exc["response"]["name"], org_params["name"])
-        self.assertEqual(create_exc["response"]["user_count"], 0)
+            self.assertTrue(create_exc["changed"])
+            self.assertEqual(create_exc["response"]["name"], org_params["name"])
+            self.assertEqual(create_exc["response"]["user_count"], 0)
 
-        # Test module idempotency
-        with self.patch_get_pritunl_organizations(
-            side_effect=PritunlListOrganizationAfterPostMock
-        ) as mock_get:
-            with self.patch_add_pritunl_organization(
-                side_effect=PritunlPostOrganizationMock
-            ) as mock_add:
-                with self.assertRaises(AnsibleExitJson) as idempotent_result:
-                    self.module.main()
+            # Test module idempotency
+            with self.patch_get_pritunl_organizations(
+                side_effect=PritunlListOrganizationAfterPostMock
+            ) as mock_get:
+                with self.patch_add_pritunl_organization(
+                    side_effect=PritunlPostOrganizationMock
+                ) as mock_add:
+                    with self.assertRaises(AnsibleExitJson) as idempotent_result:
+                        self.module.main()
 
         idempotent_exc = idempotent_result.exception.args[0]
 
@@ -120,7 +120,7 @@ class TestPritunlOrg(ModuleTestCase):
     def test_absent(self):
         """Test organization removal from Pritunl."""
         org_params = {"name": "NewOrg"}
-        set_module_args(
+        with set_module_args(
             dict_merge(
                 {
                     "state": "absent",
@@ -130,31 +130,31 @@ class TestPritunlOrg(ModuleTestCase):
                 },
                 org_params,
             )
-        )
-        # Test deletion
-        with self.patch_get_pritunl_organizations(
-            side_effect=PritunlListOrganizationAfterPostMock
-        ) as mock_get:
-            with self.patch_delete_pritunl_organization(
-                side_effect=PritunlDeleteOrganizationMock
-            ) as mock_delete:
-                with self.assertRaises(AnsibleExitJson) as delete_result:
-                    self.module.main()
+        ):
+            # Test deletion
+            with self.patch_get_pritunl_organizations(
+                side_effect=PritunlListOrganizationAfterPostMock
+            ) as mock_get:
+                with self.patch_delete_pritunl_organization(
+                    side_effect=PritunlDeleteOrganizationMock
+                ) as mock_delete:
+                    with self.assertRaises(AnsibleExitJson) as delete_result:
+                        self.module.main()
 
-        delete_exc = delete_result.exception.args[0]
+            delete_exc = delete_result.exception.args[0]
 
-        self.assertTrue(delete_exc["changed"])
-        self.assertEqual(delete_exc["response"], {})
+            self.assertTrue(delete_exc["changed"])
+            self.assertEqual(delete_exc["response"], {})
 
-        # Test module idempotency
-        with self.patch_get_pritunl_organizations(
-            side_effect=PritunlListOrganizationMock
-        ) as mock_get:
-            with self.patch_delete_pritunl_organization(
-                side_effect=PritunlDeleteOrganizationMock
-            ) as mock_add:
-                with self.assertRaises(AnsibleExitJson) as idempotent_result:
-                    self.module.main()
+            # Test module idempotency
+            with self.patch_get_pritunl_organizations(
+                side_effect=PritunlListOrganizationMock
+            ) as mock_get:
+                with self.patch_delete_pritunl_organization(
+                    side_effect=PritunlDeleteOrganizationMock
+                ) as mock_add:
+                    with self.assertRaises(AnsibleExitJson) as idempotent_result:
+                        self.module.main()
 
         idempotent_exc = idempotent_result.exception.args[0]
 
@@ -172,33 +172,31 @@ class TestPritunlOrg(ModuleTestCase):
             "pritunl_url": "https://pritunl.domain.com",
             "name": "GumGum",
         }
-        set_module_args(module_args)
+        with set_module_args(module_args):
+            # Test deletion
+            with self.patch_get_pritunl_organizations(
+                side_effect=PritunlListOrganizationMock
+            ) as mock_get:
+                with self.patch_delete_pritunl_organization(
+                    side_effect=PritunlDeleteOrganizationMock
+                ) as mock_delete:
+                    with self.assertRaises(AnsibleFailJson) as failure_result:
+                        self.module.main()
 
-        # Test deletion
-        with self.patch_get_pritunl_organizations(
-            side_effect=PritunlListOrganizationMock
-        ) as mock_get:
-            with self.patch_delete_pritunl_organization(
-                side_effect=PritunlDeleteOrganizationMock
-            ) as mock_delete:
-                with self.assertRaises(AnsibleFailJson) as failure_result:
-                    self.module.main()
+            failure_exc = failure_result.exception.args[0]
 
-        failure_exc = failure_result.exception.args[0]
+            self.assertRegex(failure_exc["msg"], "Can not remove organization")
 
-        self.assertRegex(failure_exc["msg"], "Can not remove organization")
-
-        # Switch force=True which should run successfully
-        set_module_args(dict_merge(module_args, {"force": True}))
-
-        with self.patch_get_pritunl_organizations(
-            side_effect=PritunlListOrganizationMock
-        ) as mock_get:
-            with self.patch_delete_pritunl_organization(
-                side_effect=PritunlDeleteOrganizationMock
-            ) as mock_delete:
-                with self.assertRaises(AnsibleExitJson) as delete_result:
-                    self.module.main()
+            # Switch force=True which should run successfully
+            with set_module_args(dict_merge(module_args, {"force": True})):
+                with self.patch_get_pritunl_organizations(
+                    side_effect=PritunlListOrganizationMock
+                ) as mock_get:
+                    with self.patch_delete_pritunl_organization(
+                        side_effect=PritunlDeleteOrganizationMock
+                    ) as mock_delete:
+                        with self.assertRaises(AnsibleExitJson) as delete_result:
+                            self.module.main()
 
         delete_exc = delete_result.exception.args[0]
 

--- a/tests/unit/plugins/modules/test_pritunl_org_info.py
+++ b/tests/unit/plugins/modules/test_pritunl_org_info.py
@@ -49,9 +49,9 @@ class TestPritunlOrgInfo(ModuleTestCase):
         with self.patch_get_pritunl_organizations(
             side_effect=PritunlListOrganizationMock
         ) as org_mock:
-            set_module_args({})
-            with self.assertRaises(AnsibleFailJson):
-                self.module.main()
+            with set_module_args({}):
+                with self.assertRaises(AnsibleFailJson):
+                    self.module.main()
 
             self.assertEqual(org_mock.call_count, 0)
 
@@ -61,14 +61,14 @@ class TestPritunlOrgInfo(ModuleTestCase):
             side_effect=PritunlEmptyOrganizationMock
         ) as org_mock:
             with self.assertRaises(AnsibleExitJson) as result:
-                set_module_args(
+                with set_module_args(
                     {
                         "pritunl_api_token": "token",
                         "pritunl_api_secret": "secret",
                         "pritunl_url": "https://pritunl.domain.com",
                     }
-                )
-                self.module.main()
+                ):
+                    self.module.main()
 
                 self.assertEqual(org_mock.call_count, 1)
 
@@ -81,15 +81,15 @@ class TestPritunlOrgInfo(ModuleTestCase):
             side_effect=PritunlListOrganizationMock
         ) as org_mock:
             with self.assertRaises(AnsibleExitJson) as result:
-                set_module_args(
+                with set_module_args(
                     {
                         "pritunl_api_token": "token",
                         "pritunl_api_secret": "secret",
                         "pritunl_url": "https://pritunl.domain.com",
                         "org": "GumGum",
                     }
-                )
-                self.module.main()
+                ):
+                    self.module.main()
 
                 self.assertEqual(org_mock.call_count, 1)
 
@@ -102,15 +102,15 @@ class TestPritunlOrgInfo(ModuleTestCase):
             side_effect=PritunlListOrganizationMock
         ) as org_mock:
             with self.assertRaises(AnsibleFailJson) as result:
-                set_module_args(
+                with set_module_args(
                     {
                         "pritunl_api_token": "token",
                         "pritunl_api_secret": "secret",
                         "pritunl_url": "https://pritunl.domain.com",
                         "org": "Unknown",
                     }
-                )
-                self.module.main()
+                ):
+                    self.module.main()
 
                 self.assertEqual(org_mock.call_count, 1)
 
@@ -123,14 +123,14 @@ class TestPritunlOrgInfo(ModuleTestCase):
             side_effect=PritunlListOrganizationMock
         ) as org_mock:
             with self.assertRaises(AnsibleExitJson) as result:
-                set_module_args(
+                with set_module_args(
                     {
                         "pritunl_api_token": "token",
                         "pritunl_api_secret": "secret",
                         "pritunl_url": "https://pritunl.domain.com",
                     }
-                )
-                self.module.main()
+                ):
+                    self.module.main()
 
                 self.assertEqual(org_mock.call_count, 1)
 

--- a/tests/unit/plugins/modules/test_pritunl_user.py
+++ b/tests/unit/plugins/modules/test_pritunl_user.py
@@ -94,9 +94,9 @@ class TestPritunlUser(ModuleTestCase):
 
     def test_without_parameters(self):
         """Test without parameters"""
-        set_module_args({})
-        with self.assertRaises(AnsibleFailJson):
-            self.module.main()
+        with set_module_args({}):
+            with self.assertRaises(AnsibleFailJson):
+                self.module.main()
 
     @mock_pritunl_api
     def test_present(self):
@@ -105,7 +105,7 @@ class TestPritunlUser(ModuleTestCase):
             "user_name": "alice",
             "user_email": "alice@company.com",
         }
-        set_module_args(
+        with set_module_args(
             dict_merge(
                 {
                     "pritunl_api_token": "token",
@@ -115,13 +115,12 @@ class TestPritunlUser(ModuleTestCase):
                 },
                 user_params,
             )
-        )
-
-        with self.patch_update_pritunl_users(
-            side_effect=PritunlPostUserMock
-        ) as post_mock:
-            with self.assertRaises(AnsibleExitJson) as create_result:
-                self.module.main()
+        ):
+            with self.patch_update_pritunl_users(
+                side_effect=PritunlPostUserMock
+            ) as post_mock:
+                with self.assertRaises(AnsibleExitJson) as create_result:
+                    self.module.main()
 
         create_exc = create_result.exception.args[0]
 
@@ -137,7 +136,7 @@ class TestPritunlUser(ModuleTestCase):
             "user_email": "bob@company.com",
             "user_disabled": True,
         }
-        set_module_args(
+        with set_module_args(
             dict_merge(
                 {
                     "pritunl_api_token": "token",
@@ -147,14 +146,12 @@ class TestPritunlUser(ModuleTestCase):
                 },
                 new_user_params,
             )
-        )
-
-        with self.patch_update_pritunl_users(
-            side_effect=PritunlPutUserMock
-        ) as put_mock:
-
-            with self.assertRaises(AnsibleExitJson) as update_result:
-                self.module.main()
+        ):
+            with self.patch_update_pritunl_users(
+                side_effect=PritunlPutUserMock
+            ) as put_mock:
+                with self.assertRaises(AnsibleExitJson) as update_result:
+                    self.module.main()
 
         update_exc = update_result.exception.args[0]
 
@@ -168,7 +165,7 @@ class TestPritunlUser(ModuleTestCase):
     @mock_pritunl_api
     def test_absent(self):
         """Test user removal from Pritunl."""
-        set_module_args(
+        with set_module_args(
             {
                 "state": "absent",
                 "pritunl_api_token": "token",
@@ -177,10 +174,9 @@ class TestPritunlUser(ModuleTestCase):
                 "organization": "GumGum",
                 "user_name": "florian",
             }
-        )
-
-        with self.assertRaises(AnsibleExitJson) as result:
-            self.module.main()
+        ):
+            with self.assertRaises(AnsibleExitJson) as result:
+                self.module.main()
 
         exc = result.exception.args[0]
 
@@ -190,7 +186,7 @@ class TestPritunlUser(ModuleTestCase):
     @mock_pritunl_api
     def test_absent_failure(self):
         """Test user removal from a non existing organization."""
-        set_module_args(
+        with set_module_args(
             {
                 "state": "absent",
                 "pritunl_api_token": "token",
@@ -199,10 +195,9 @@ class TestPritunlUser(ModuleTestCase):
                 "organization": "Unknown",
                 "user_name": "floria@company.com",
             }
-        )
-
-        with self.assertRaises(AnsibleFailJson) as result:
-            self.module.main()
+        ):
+            with self.assertRaises(AnsibleFailJson) as result:
+                self.module.main()
 
         exc = result.exception.args[0]
 

--- a/tests/unit/plugins/modules/test_pritunl_user_info.py
+++ b/tests/unit/plugins/modules/test_pritunl_user_info.py
@@ -59,9 +59,9 @@ class TestPritunlUserInfo(ModuleTestCase):
             with self.patch_get_pritunl_users(
                 side_effect=PritunlListUserMock
             ) as user_mock:
-                set_module_args({})
-                with self.assertRaises(AnsibleFailJson):
-                    self.module.main()
+                with set_module_args({}):
+                    with self.assertRaises(AnsibleFailJson):
+                        self.module.main()
 
                 self.assertEqual(org_mock.call_count, 0)
                 self.assertEqual(user_mock.call_count, 0)
@@ -75,15 +75,15 @@ class TestPritunlUserInfo(ModuleTestCase):
                 side_effect=PritunlListUserMock
             ) as user_mock:
                 with self.assertRaises(AnsibleFailJson) as result:
-                    set_module_args(
+                    with set_module_args(
                         {
                             "pritunl_api_token": "token",
                             "pritunl_api_secret": "secret",
                             "pritunl_url": "https://pritunl.domain.com",
                             "organization": "Unknown",
                         }
-                    )
-                    self.module.main()
+                    ):
+                        self.module.main()
 
                 self.assertEqual(org_mock.call_count, 1)
                 self.assertEqual(user_mock.call_count, 0)
@@ -103,15 +103,15 @@ class TestPritunlUserInfo(ModuleTestCase):
                 side_effect=PritunlListUserMock
             ) as user_mock:
                 with self.assertRaises(AnsibleExitJson) as result:
-                    set_module_args(
+                    with set_module_args(
                         {
                             "pritunl_api_token": "token",
                             "pritunl_api_secret": "secret",
                             "pritunl_url": "https://pritunl.domain.com",
                             "organization": "GumGum",
                         }
-                    )
-                    self.module.main()
+                    ):
+                        self.module.main()
 
                 self.assertEqual(org_mock.call_count, 1)
                 self.assertEqual(user_mock.call_count, 1)
@@ -137,7 +137,7 @@ class TestPritunlUserInfo(ModuleTestCase):
                 side_effect=PritunlListUserMock
             ) as user_mock:
                 with self.assertRaises(AnsibleExitJson) as result:
-                    set_module_args(
+                    with set_module_args(
                         {
                             "pritunl_api_token": "token",
                             "pritunl_api_secret": "secret",
@@ -146,8 +146,8 @@ class TestPritunlUserInfo(ModuleTestCase):
                             "user_name": expected_user_name,
                             "user_type": expected_user_type,
                         }
-                    )
-                    self.module.main()
+                    ):
+                        self.module.main()
 
                 self.assertEqual(org_mock.call_count, 1)
                 self.assertEqual(user_mock.call_count, 1)

--- a/tests/unit/plugins/modules/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/test_proxmox_snap.py
@@ -51,9 +51,9 @@ def fake_api(mocker):
 
 
 def test_proxmox_snap_without_argument(capfd):
-    set_module_args({})
-    with pytest.raises(SystemExit) as results:
-        proxmox_snap.main()
+    with set_module_args({}):
+        with pytest.raises(SystemExit) as results:
+            proxmox_snap.main()
 
     out, err = capfd.readouterr()
     assert not err
@@ -62,19 +62,21 @@ def test_proxmox_snap_without_argument(capfd):
 
 @patch('ansible_collections.community.general.plugins.module_utils.proxmox.ProxmoxAnsible._connect')
 def test_create_snapshot_check_mode(connect_mock, capfd, mocker):
-    set_module_args({"hostname": "test-lxc",
-                     "api_user": "root@pam",
-                     "api_password": "secret",
-                     "api_host": "127.0.0.1",
-                     "state": "present",
-                     "snapname": "test",
-                     "timeout": "1",
-                     "force": True,
-                     "_ansible_check_mode": True})
-    proxmox_utils.HAS_PROXMOXER = True
-    connect_mock.side_effect = lambda: fake_api(mocker)
-    with pytest.raises(SystemExit) as results:
-        proxmox_snap.main()
+    with set_module_args({
+        "hostname": "test-lxc",
+        "api_user": "root@pam",
+        "api_password": "secret",
+        "api_host": "127.0.0.1",
+        "state": "present",
+        "snapname": "test",
+        "timeout": "1",
+        "force": True,
+        "_ansible_check_mode": True
+    }):
+        proxmox_utils.HAS_PROXMOXER = True
+        connect_mock.side_effect = lambda: fake_api(mocker)
+        with pytest.raises(SystemExit) as results:
+            proxmox_snap.main()
 
     out, err = capfd.readouterr()
     assert not err
@@ -83,19 +85,21 @@ def test_create_snapshot_check_mode(connect_mock, capfd, mocker):
 
 @patch('ansible_collections.community.general.plugins.module_utils.proxmox.ProxmoxAnsible._connect')
 def test_remove_snapshot_check_mode(connect_mock, capfd, mocker):
-    set_module_args({"hostname": "test-lxc",
-                     "api_user": "root@pam",
-                     "api_password": "secret",
-                     "api_host": "127.0.0.1",
-                     "state": "absent",
-                     "snapname": "test",
-                     "timeout": "1",
-                     "force": True,
-                     "_ansible_check_mode": True})
-    proxmox_utils.HAS_PROXMOXER = True
-    connect_mock.side_effect = lambda: fake_api(mocker)
-    with pytest.raises(SystemExit) as results:
-        proxmox_snap.main()
+    with set_module_args({
+        "hostname": "test-lxc",
+        "api_user": "root@pam",
+        "api_password": "secret",
+        "api_host": "127.0.0.1",
+        "state": "absent",
+        "snapname": "test",
+        "timeout": "1",
+        "force": True,
+        "_ansible_check_mode": True
+    }):
+        proxmox_utils.HAS_PROXMOXER = True
+        connect_mock.side_effect = lambda: fake_api(mocker)
+        with pytest.raises(SystemExit) as results:
+            proxmox_snap.main()
 
     out, err = capfd.readouterr()
     assert not err
@@ -104,19 +108,21 @@ def test_remove_snapshot_check_mode(connect_mock, capfd, mocker):
 
 @patch('ansible_collections.community.general.plugins.module_utils.proxmox.ProxmoxAnsible._connect')
 def test_rollback_snapshot_check_mode(connect_mock, capfd, mocker):
-    set_module_args({"hostname": "test-lxc",
-                     "api_user": "root@pam",
-                     "api_password": "secret",
-                     "api_host": "127.0.0.1",
-                     "state": "rollback",
-                     "snapname": "test",
-                     "timeout": "1",
-                     "force": True,
-                     "_ansible_check_mode": True})
-    proxmox_utils.HAS_PROXMOXER = True
-    connect_mock.side_effect = lambda: fake_api(mocker)
-    with pytest.raises(SystemExit) as results:
-        proxmox_snap.main()
+    with set_module_args({
+        "hostname": "test-lxc",
+        "api_user": "root@pam",
+        "api_password": "secret",
+        "api_host": "127.0.0.1",
+        "state": "rollback",
+        "snapname": "test",
+        "timeout": "1",
+        "force": True,
+        "_ansible_check_mode": True
+    }):
+        proxmox_utils.HAS_PROXMOXER = True
+        connect_mock.side_effect = lambda: fake_api(mocker)
+        with pytest.raises(SystemExit) as results:
+            proxmox_snap.main()
 
     out, err = capfd.readouterr()
     assert not err

--- a/tests/unit/plugins/modules/test_proxmox_storage_contents_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_storage_contents_info.py
@@ -76,14 +76,14 @@ class TestProxmoxStorageContentsInfo(ModuleTestCase):
 
     def test_module_fail_when_required_args_missing(self):
         with pytest.raises(AnsibleFailJson) as exc_info:
-            set_module_args({})
-            self.module.main()
+            with set_module_args({}):
+                self.module.main()
 
     def test_storage_contents_info(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
-            set_module_args(get_module_args(node=NODE1, storage="datastore"))
-            expected_output = {}
-            self.module.main()
+            with set_module_args(get_module_args(node=NODE1, storage="datastore")):
+                expected_output = {}
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert not result["changed"]

--- a/tests/unit/plugins/modules/test_proxmox_tasks_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_tasks_info.py
@@ -127,9 +127,9 @@ EXPECTED_SINGLE_TASK = [
 
 @patch('ansible_collections.community.general.plugins.module_utils.proxmox.ProxmoxAnsible._connect')
 def test_without_required_parameters(connect_mock, capfd, mocker):
-    set_module_args({})
-    with pytest.raises(SystemExit):
-        proxmox_tasks_info.main()
+    with set_module_args({}):
+        with pytest.raises(SystemExit):
+            proxmox_tasks_info.main()
     out, err = capfd.readouterr()
     assert not err
     assert json.loads(out)['failed']
@@ -145,16 +145,17 @@ def mock_api_tasks_response(mocker):
 
 @patch('ansible_collections.community.general.plugins.module_utils.proxmox.ProxmoxAnsible._connect')
 def test_get_tasks(connect_mock, capfd, mocker):
-    set_module_args({'api_host': 'proxmoxhost',
-                     'api_user': 'root@pam',
-                     'api_password': 'supersecret',
-                     'node': NODE})
+    with set_module_args({
+        'api_host': 'proxmoxhost',
+        'api_user': 'root@pam',
+        'api_password': 'supersecret',
+        'node': NODE
+    }):
+        connect_mock.side_effect = lambda: mock_api_tasks_response(mocker)
+        proxmox_utils.HAS_PROXMOXER = True
 
-    connect_mock.side_effect = lambda: mock_api_tasks_response(mocker)
-    proxmox_utils.HAS_PROXMOXER = True
-
-    with pytest.raises(SystemExit):
-        proxmox_tasks_info.main()
+        with pytest.raises(SystemExit):
+            proxmox_tasks_info.main()
     out, err = capfd.readouterr()
     assert not err
     assert len(json.loads(out)['proxmox_tasks']) != 0
@@ -163,17 +164,18 @@ def test_get_tasks(connect_mock, capfd, mocker):
 
 @patch('ansible_collections.community.general.plugins.module_utils.proxmox.ProxmoxAnsible._connect')
 def test_get_single_task(connect_mock, capfd, mocker):
-    set_module_args({'api_host': 'proxmoxhost',
-                     'api_user': 'root@pam',
-                     'api_password': 'supersecret',
-                     'node': NODE,
-                     'task': TASK_UPID})
+    with set_module_args({
+        'api_host': 'proxmoxhost',
+        'api_user': 'root@pam',
+        'api_password': 'supersecret',
+        'node': NODE,
+        'task': TASK_UPID
+    }):
+        connect_mock.side_effect = lambda: mock_api_tasks_response(mocker)
+        proxmox_utils.HAS_PROXMOXER = True
 
-    connect_mock.side_effect = lambda: mock_api_tasks_response(mocker)
-    proxmox_utils.HAS_PROXMOXER = True
-
-    with pytest.raises(SystemExit):
-        proxmox_tasks_info.main()
+        with pytest.raises(SystemExit):
+            proxmox_tasks_info.main()
     out, err = capfd.readouterr()
     assert not err
     assert len(json.loads(out)['proxmox_tasks']) == 1
@@ -183,17 +185,18 @@ def test_get_single_task(connect_mock, capfd, mocker):
 
 @patch('ansible_collections.community.general.plugins.module_utils.proxmox.ProxmoxAnsible._connect')
 def test_get_non_existent_task(connect_mock, capfd, mocker):
-    set_module_args({'api_host': 'proxmoxhost',
-                     'api_user': 'root@pam',
-                     'api_password': 'supersecret',
-                     'node': NODE,
-                     'task': 'UPID:nonexistent'})
+    with set_module_args({
+        'api_host': 'proxmoxhost',
+        'api_user': 'root@pam',
+        'api_password': 'supersecret',
+        'node': NODE,
+        'task': 'UPID:nonexistent'
+    }):
+        connect_mock.side_effect = lambda: mock_api_tasks_response(mocker)
+        proxmox_utils.HAS_PROXMOXER = True
 
-    connect_mock.side_effect = lambda: mock_api_tasks_response(mocker)
-    proxmox_utils.HAS_PROXMOXER = True
-
-    with pytest.raises(SystemExit):
-        proxmox_tasks_info.main()
+        with pytest.raises(SystemExit):
+            proxmox_tasks_info.main()
     out, err = capfd.readouterr()
     assert not err
     assert json.loads(out)['failed']

--- a/tests/unit/plugins/modules/test_proxmox_template.py
+++ b/tests/unit/plugins/modules/test_proxmox_template.py
@@ -48,7 +48,7 @@ class TestProxmoxTemplateModule(ModuleTestCase):
     def test_module_fail_when_toolbelt_not_installed_and_file_size_is_big(self, mock_stat):
         self.module.HAS_REQUESTS_TOOLBELT = False
         mock_stat.return_value.st_size = 268435460
-        set_module_args(
+        with set_module_args(
             {
                 "api_host": "host",
                 "api_user": "user",
@@ -57,9 +57,9 @@ class TestProxmoxTemplateModule(ModuleTestCase):
                 "src": "/tmp/mock.iso",
                 "content_type": "iso"
             }
-        )
-        with pytest.raises(AnsibleFailJson) as exc_info:
-            self.module.main()
+        ):
+            with pytest.raises(AnsibleFailJson) as exc_info:
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["failed"] is True

--- a/tests/unit/plugins/modules/test_proxmox_vm_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_vm_info.py
@@ -452,17 +452,17 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
 
     def test_module_fail_when_required_args_missing(self):
         with pytest.raises(AnsibleFailJson) as exc_info:
-            set_module_args({})
-            self.module.main()
+            with set_module_args({}):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["msg"] == "missing required arguments: api_host, api_user"
 
     def test_get_lxc_vms_information(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
-            set_module_args(get_module_args(type="lxc"))
-            expected_output = [vm for vm in EXPECTED_VMS_OUTPUT if vm["type"] == "lxc"]
-            self.module.main()
+            with set_module_args(get_module_args(type="lxc")):
+                expected_output = [vm for vm in EXPECTED_VMS_OUTPUT if vm["type"] == "lxc"]
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["changed"] is False
@@ -470,25 +470,25 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
 
     def test_get_qemu_vms_information(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
-            set_module_args(get_module_args(type="qemu"))
-            expected_output = [vm for vm in EXPECTED_VMS_OUTPUT if vm["type"] == "qemu"]
-            self.module.main()
+            with set_module_args(get_module_args(type="qemu")):
+                expected_output = [vm for vm in EXPECTED_VMS_OUTPUT if vm["type"] == "qemu"]
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
 
     def test_get_all_vms_information(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
-            set_module_args(get_module_args())
-            self.module.main()
+            with set_module_args(get_module_args()):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == EXPECTED_VMS_OUTPUT
 
     def test_vmid_is_converted_to_int(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
-            set_module_args(get_module_args(type="lxc"))
-            self.module.main()
+            with set_module_args(get_module_args(type="lxc")):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert isinstance(result["proxmox_vms"][0]["vmid"], int)
@@ -501,8 +501,8 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
                 for vm in EXPECTED_VMS_OUTPUT
                 if vm["vmid"] == vmid and vm["type"] == "lxc"
             ]
-            set_module_args(get_module_args(type="lxc", vmid=vmid))
-            self.module.main()
+            with set_module_args(get_module_args(type="lxc", vmid=vmid)):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
@@ -516,8 +516,8 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
                 for vm in EXPECTED_VMS_OUTPUT
                 if vm["vmid"] == vmid and vm["type"] == "qemu"
             ]
-            set_module_args(get_module_args(type="qemu", vmid=vmid))
-            self.module.main()
+            with set_module_args(get_module_args(type="qemu", vmid=vmid)):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
@@ -527,8 +527,8 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
         with pytest.raises(AnsibleExitJson) as exc_info:
             vmid = 100
             expected_output = [vm for vm in EXPECTED_VMS_OUTPUT if vm["vmid"] == vmid]
-            set_module_args(get_module_args(type="all", vmid=vmid))
-            self.module.main()
+            with set_module_args(get_module_args(type="all", vmid=vmid)):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
@@ -542,8 +542,8 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
 
         with pytest.raises(AnsibleExitJson) as exc_info:
             expected_output = [vm for vm in EXPECTED_VMS_OUTPUT if vm["name"] == name]
-            set_module_args(get_module_args(type="all", name=name))
-            self.module.main()
+            with set_module_args(get_module_args(type="all", name=name)):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
@@ -558,8 +558,8 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
 
         with pytest.raises(AnsibleExitJson) as exc_info:
             expected_output = [vm for vm in EXPECTED_VMS_OUTPUT if vm["name"] == name]
-            set_module_args(get_module_args(type="all", name=name))
-            self.module.main()
+            with set_module_args(get_module_args(type="all", name=name)):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
@@ -573,8 +573,8 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
 
         with pytest.raises(AnsibleExitJson) as exc_info:
             expected_output = [vm for vm in EXPECTED_VMS_OUTPUT if vm["name"] == name]
-            set_module_args(get_module_args(type="all", name=name))
-            self.module.main()
+            with set_module_args(get_module_args(type="all", name=name)):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
@@ -587,8 +587,8 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
                 for vm in EXPECTED_VMS_OUTPUT
                 if vm["node"] == NODE1 and vm["type"] == "lxc"
             ]
-            set_module_args(get_module_args(type="lxc", node=NODE1))
-            self.module.main()
+            with set_module_args(get_module_args(type="lxc", node=NODE1)):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
@@ -601,8 +601,8 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
                 for vm in EXPECTED_VMS_OUTPUT
                 if vm["node"] == NODE1 and vm["type"] == "qemu"
             ]
-            set_module_args(get_module_args(type="qemu", node=NODE1))
-            self.module.main()
+            with set_module_args(get_module_args(type="qemu", node=NODE1)):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
@@ -611,8 +611,8 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
     def test_get_all_vms_from_specific_node(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
             expected_output = [vm for vm in EXPECTED_VMS_OUTPUT if vm["node"] == NODE1]
-            set_module_args(get_module_args(node=NODE1))
-            self.module.main()
+            with set_module_args(get_module_args(node=NODE1)):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
@@ -621,8 +621,8 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
     def test_module_returns_empty_list_when_vm_does_not_exist(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
             vmid = 200
-            set_module_args(get_module_args(type="all", vmid=vmid))
-            self.module.main()
+            with set_module_args(get_module_args(type="all", vmid=vmid)):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == []
@@ -632,8 +632,8 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
             "Some mocked connection error."
         )
         with pytest.raises(AnsibleFailJson) as exc_info:
-            set_module_args(get_module_args(type="qemu"))
-            self.module.main()
+            with set_module_args(get_module_args(type="qemu")):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert "Failed to retrieve QEMU VMs information:" in result["msg"]
@@ -643,8 +643,8 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
             "Some mocked connection error."
         )
         with pytest.raises(AnsibleFailJson) as exc_info:
-            set_module_args(get_module_args(type="lxc"))
-            self.module.main()
+            with set_module_args(get_module_args(type="lxc")):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert "Failed to retrieve LXC VMs information:" in result["msg"]
@@ -654,8 +654,8 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
             "Some mocked connection error."
         )
         with pytest.raises(AnsibleFailJson) as exc_info:
-            set_module_args(get_module_args())
-            self.module.main()
+            with set_module_args(get_module_args()):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert (
@@ -665,8 +665,8 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
 
     def test_module_fail_when_node_does_not_exist(self):
         with pytest.raises(AnsibleFailJson) as exc_info:
-            set_module_args(get_module_args(type="all", node="NODE3"))
-            self.module.main()
+            with set_module_args(get_module_args(type="all", node="NODE3")):
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["msg"] == "Node NODE3 doesn't exist in PVE cluster"
@@ -677,10 +677,10 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
         ) as get_vmid_mock:
             with pytest.raises(AnsibleExitJson):
                 vmid = 100
-                set_module_args(
+                with set_module_args(
                     get_module_args(type="all", vmid=vmid, name="something")
-                )
-                self.module.main()
+                ):
+                    self.module.main()
 
         assert get_vmid_mock.call_count == 0
 
@@ -701,14 +701,14 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
 
         with pytest.raises(AnsibleExitJson) as exc_info:
             vmid = 101
-            set_module_args(get_module_args(
+            with set_module_args(get_module_args(
                 type="qemu",
                 vmid=vmid,
                 config="current",
-            ))
-            expected_output = [vm for vm in EXPECTED_VMS_OUTPUT if vm["vmid"] == vmid]
-            expected_output[0]["config"] = config_vm_value
-            self.module.main()
+            )):
+                expected_output = [vm for vm in EXPECTED_VMS_OUTPUT if vm["vmid"] == vmid]
+                expected_output[0]["config"] = config_vm_value
+                self.module.main()
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output

--- a/tests/unit/plugins/modules/test_redis_data.py
+++ b/tests/unit/plugins/modules/test_redis_data.py
@@ -21,9 +21,9 @@ if tuple(map(int, __version__.split('.'))) < (3, 4, 0):
 
 
 def test_redis_data_without_arguments(capfd):
-    set_module_args({})
-    with pytest.raises(SystemExit) as results:
-        redis_data.main()
+    with set_module_args({}):
+        with pytest.raises(SystemExit) as results:
+            redis_data.main()
     out, err = capfd.readouterr()
     assert not err
     assert json.loads(out)['failed']
@@ -31,16 +31,16 @@ def test_redis_data_without_arguments(capfd):
 
 @pytest.mark.skipif(not HAS_REDIS_USERNAME_OPTION, reason="Redis version < 3.4.0")
 def test_redis_data_key(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_user': 'root',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'value': 'baz',
-                     '_ansible_check_mode': False})
-    mocker.patch('redis.Redis.get', return_value='bar')
-    mocker.patch('redis.Redis.set', return_value=True)
-    with pytest.raises(SystemExit):
-        redis_data.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_user': 'root',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          'value': 'baz',
+                          '_ansible_check_mode': False}):
+        mocker.patch('redis.Redis.get', return_value='bar')
+        mocker.patch('redis.Redis.set', return_value=True)
+        with pytest.raises(SystemExit):
+            redis_data.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -52,17 +52,17 @@ def test_redis_data_key(capfd, mocker):
 
 @pytest.mark.skipif(not HAS_REDIS_USERNAME_OPTION, reason="Redis version < 3.4.0")
 def test_redis_data_existing_key_nx(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_user': 'root',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'value': 'baz',
-                     'non_existing': True,
-                     '_ansible_check_mode': False})
-    mocker.patch('redis.Redis.get', return_value='bar')
-    mocker.patch('redis.Redis.set', return_value=None)
-    with pytest.raises(SystemExit):
-        redis_data.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_user': 'root',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          'value': 'baz',
+                          'non_existing': True,
+                          '_ansible_check_mode': False}):
+        mocker.patch('redis.Redis.get', return_value='bar')
+        mocker.patch('redis.Redis.set', return_value=None)
+        with pytest.raises(SystemExit):
+            redis_data.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -76,17 +76,17 @@ def test_redis_data_existing_key_nx(capfd, mocker):
 
 @pytest.mark.skipif(not HAS_REDIS_USERNAME_OPTION, reason="Redis version < 3.4.0")
 def test_redis_data_non_existing_key_xx(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_user': 'root',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'value': 'baz',
-                     'existing': True,
-                     '_ansible_check_mode': False})
-    mocker.patch('redis.Redis.get', return_value=None)
-    mocker.patch('redis.Redis.set', return_value=None)
-    with pytest.raises(SystemExit):
-        redis_data.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_user': 'root',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          'value': 'baz',
+                          'existing': True,
+                          '_ansible_check_mode': False}):
+        mocker.patch('redis.Redis.get', return_value=None)
+        mocker.patch('redis.Redis.set', return_value=None)
+        with pytest.raises(SystemExit):
+            redis_data.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -100,15 +100,15 @@ def test_redis_data_non_existing_key_xx(capfd, mocker):
 
 @pytest.mark.skipif(not HAS_REDIS_USERNAME_OPTION, reason="Redis version < 3.4.0")
 def test_redis_data_delete_present_key(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_user': 'root',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'state': 'absent'})
-    mocker.patch('redis.Redis.get', return_value='bar')
-    mocker.patch('redis.Redis.delete', return_value=1)
-    with pytest.raises(SystemExit):
-        redis_data.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_user': 'root',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          'state': 'absent'}):
+        mocker.patch('redis.Redis.get', return_value='bar')
+        mocker.patch('redis.Redis.delete', return_value=1)
+        with pytest.raises(SystemExit):
+            redis_data.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -118,15 +118,15 @@ def test_redis_data_delete_present_key(capfd, mocker):
 
 @pytest.mark.skipif(not HAS_REDIS_USERNAME_OPTION, reason="Redis version < 3.4.0")
 def test_redis_data_delete_absent_key(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_user': 'root',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'state': 'absent'})
-    mocker.patch('redis.Redis.delete', return_value=0)
-    mocker.patch('redis.Redis.get', return_value=None)
-    with pytest.raises(SystemExit):
-        redis_data.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_user': 'root',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          'state': 'absent'}):
+        mocker.patch('redis.Redis.delete', return_value=0)
+        mocker.patch('redis.Redis.get', return_value=None)
+        with pytest.raises(SystemExit):
+            redis_data.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -136,14 +136,14 @@ def test_redis_data_delete_absent_key(capfd, mocker):
 
 @pytest.mark.skipif(HAS_REDIS_USERNAME_OPTION, reason="Redis version > 3.4.0")
 def test_redis_data_fail_username(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_user': 'root',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'value': 'baz',
-                     '_ansible_check_mode': False})
-    with pytest.raises(SystemExit):
-        redis_data.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_user': 'root',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          'value': 'baz',
+                          '_ansible_check_mode': False}):
+        with pytest.raises(SystemExit):
+            redis_data.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -153,15 +153,15 @@ def test_redis_data_fail_username(capfd, mocker):
 
 
 def test_redis_data_key_no_username(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'value': 'baz',
-                     '_ansible_check_mode': False})
-    mocker.patch('redis.Redis.get', return_value='bar')
-    mocker.patch('redis.Redis.set', return_value=True)
-    with pytest.raises(SystemExit):
-        redis_data.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          'value': 'baz',
+                          '_ansible_check_mode': False}):
+        mocker.patch('redis.Redis.get', return_value='bar')
+        mocker.patch('redis.Redis.set', return_value=True)
+        with pytest.raises(SystemExit):
+            redis_data.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -172,15 +172,15 @@ def test_redis_data_key_no_username(capfd, mocker):
 
 
 def test_redis_delete_key_no_username(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'state': 'absent',
-                     '_ansible_check_mode': False})
-    mocker.patch('redis.Redis.get', return_value='bar')
-    mocker.patch('redis.Redis.delete', return_value=1)
-    with pytest.raises(SystemExit):
-        redis_data.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          'state': 'absent',
+                          '_ansible_check_mode': False}):
+        mocker.patch('redis.Redis.get', return_value='bar')
+        mocker.patch('redis.Redis.delete', return_value=1)
+        with pytest.raises(SystemExit):
+            redis_data.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -189,15 +189,15 @@ def test_redis_delete_key_no_username(capfd, mocker):
 
 
 def test_redis_delete_key_non_existent_key(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'state': 'absent',
-                     '_ansible_check_mode': False})
-    mocker.patch('redis.Redis.get', return_value=None)
-    mocker.patch('redis.Redis.delete', return_value=0)
-    with pytest.raises(SystemExit):
-        redis_data.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          'state': 'absent',
+                          '_ansible_check_mode': False}):
+        mocker.patch('redis.Redis.get', return_value=None)
+        mocker.patch('redis.Redis.delete', return_value=0)
+        with pytest.raises(SystemExit):
+            redis_data.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -206,15 +206,15 @@ def test_redis_delete_key_non_existent_key(capfd, mocker):
 
 
 def test_redis_set_key_check_mode_nochange(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'state': 'present',
-                     'value': 'bar',
-                     '_ansible_check_mode': True})
-    mocker.patch('redis.Redis.get', return_value='bar')
-    with pytest.raises(SystemExit):
-        redis_data.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          'state': 'present',
+                          'value': 'bar',
+                          '_ansible_check_mode': True}):
+        mocker.patch('redis.Redis.get', return_value='bar')
+        with pytest.raises(SystemExit):
+            redis_data.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -225,15 +225,15 @@ def test_redis_set_key_check_mode_nochange(capfd, mocker):
 
 
 def test_redis_set_key_check_mode_delete_nx(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'state': 'present',
-                     'value': 'baz',
-                     '_ansible_check_mode': True})
-    mocker.patch('redis.Redis.get', return_value=None)
-    with pytest.raises(SystemExit):
-        redis_data.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          'state': 'present',
+                          'value': 'baz',
+                          '_ansible_check_mode': True}):
+        mocker.patch('redis.Redis.get', return_value=None)
+        with pytest.raises(SystemExit):
+            redis_data.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -243,15 +243,15 @@ def test_redis_set_key_check_mode_delete_nx(capfd, mocker):
 
 
 def test_redis_set_key_check_mode_delete(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'state': 'present',
-                     'value': 'baz',
-                     '_ansible_check_mode': True})
-    mocker.patch('redis.Redis.get', return_value='bar')
-    with pytest.raises(SystemExit):
-        redis_data.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          'state': 'present',
+                          'value': 'baz',
+                          '_ansible_check_mode': True}):
+        mocker.patch('redis.Redis.get', return_value='bar')
+        with pytest.raises(SystemExit):
+            redis_data.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -261,15 +261,15 @@ def test_redis_set_key_check_mode_delete(capfd, mocker):
 
 
 def test_redis_set_key_check_mode(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'state': 'present',
-                     'value': 'baz',
-                     '_ansible_check_mode': True})
-    mocker.patch('redis.Redis.get', return_value='bar')
-    with pytest.raises(SystemExit):
-        redis_data.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          'state': 'present',
+                          'value': 'baz',
+                          '_ansible_check_mode': True}):
+        mocker.patch('redis.Redis.get', return_value='bar')
+        with pytest.raises(SystemExit):
+            redis_data.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err

--- a/tests/unit/plugins/modules/test_redis_data_incr.py
+++ b/tests/unit/plugins/modules/test_redis_data_incr.py
@@ -25,9 +25,9 @@ if HAS_REDIS_USERNAME_OPTION:
 
 
 def test_redis_data_incr_without_arguments(capfd):
-    set_module_args({})
-    with pytest.raises(SystemExit) as results:
-        redis_data_incr.main()
+    with set_module_args({}):
+        with pytest.raises(SystemExit) as results:
+            redis_data_incr.main()
     out, err = capfd.readouterr()
     assert not err
     assert json.loads(out)['failed']
@@ -35,13 +35,13 @@ def test_redis_data_incr_without_arguments(capfd):
 
 @pytest.mark.skipif(not HAS_REDIS_USERNAME_OPTION, reason="Redis version < 3.4.0")
 def test_redis_data_incr(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_user': 'root',
-                     'login_password': 'secret',
-                     'key': 'foo', })
-    mocker.patch('redis.Redis.incr', return_value=57)
-    with pytest.raises(SystemExit):
-        redis_data_incr.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_user': 'root',
+                          'login_password': 'secret',
+                          'key': 'foo', }):
+        mocker.patch('redis.Redis.incr', return_value=57)
+        with pytest.raises(SystemExit):
+            redis_data_incr.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -53,14 +53,14 @@ def test_redis_data_incr(capfd, mocker):
 
 @pytest.mark.skipif(not HAS_REDIS_USERNAME_OPTION, reason="Redis version < 3.4.0")
 def test_redis_data_incr_int(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_user': 'root',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'increment_int': 10})
-    mocker.patch('redis.Redis.incrby', return_value=57)
-    with pytest.raises(SystemExit):
-        redis_data_incr.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_user': 'root',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          'increment_int': 10}):
+        mocker.patch('redis.Redis.incrby', return_value=57)
+        with pytest.raises(SystemExit):
+            redis_data_incr.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -72,14 +72,14 @@ def test_redis_data_incr_int(capfd, mocker):
 
 @pytest.mark.skipif(not HAS_REDIS_USERNAME_OPTION, reason="Redis version < 3.4.0")
 def test_redis_data_inc_float(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_user': 'root',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'increment_float': '5.5'})
-    mocker.patch('redis.Redis.incrbyfloat', return_value=57.45)
-    with pytest.raises(SystemExit):
-        redis_data_incr.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_user': 'root',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          'increment_float': '5.5'}):
+        mocker.patch('redis.Redis.incrbyfloat', return_value=57.45)
+        with pytest.raises(SystemExit):
+            redis_data_incr.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -91,13 +91,15 @@ def test_redis_data_inc_float(capfd, mocker):
 
 @pytest.mark.skipif(not HAS_REDIS_USERNAME_OPTION, reason="Redis version < 3.4.0")
 def test_redis_data_incr_float_wrong_value(capfd):
-    set_module_args({'login_host': 'localhost',
-                     'login_user': 'root',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'increment_float': 'not_a_number'})
-    with pytest.raises(SystemExit):
-        redis_data_incr.main()
+    with set_module_args({
+        'login_host': 'localhost',
+        'login_user': 'root',
+        'login_password': 'secret',
+        'key': 'foo',
+        'increment_float': 'not_a_number'
+    }):
+        with pytest.raises(SystemExit):
+            redis_data_incr.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -106,13 +108,13 @@ def test_redis_data_incr_float_wrong_value(capfd):
 
 @pytest.mark.skipif(HAS_REDIS_USERNAME_OPTION, reason="Redis version > 3.4.0")
 def test_redis_data_incr_fail_username(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_user': 'root',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     '_ansible_check_mode': False})
-    with pytest.raises(SystemExit):
-        redis_data_incr.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_user': 'root',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          '_ansible_check_mode': False}):
+        with pytest.raises(SystemExit):
+            redis_data_incr.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -122,12 +124,12 @@ def test_redis_data_incr_fail_username(capfd, mocker):
 
 
 def test_redis_data_incr_no_username(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_password': 'secret',
-                     'key': 'foo', })
-    mocker.patch('redis.Redis.incr', return_value=57)
-    with pytest.raises(SystemExit):
-        redis_data_incr.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_password': 'secret',
+                          'key': 'foo', }):
+        mocker.patch('redis.Redis.incr', return_value=57)
+        with pytest.raises(SystemExit):
+            redis_data_incr.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -138,13 +140,13 @@ def test_redis_data_incr_no_username(capfd, mocker):
 
 
 def test_redis_data_incr_float_no_username(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     'increment_float': '5.5'})
-    mocker.patch('redis.Redis.incrbyfloat', return_value=57.45)
-    with pytest.raises(SystemExit):
-        redis_data_incr.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          'increment_float': '5.5'}):
+        mocker.patch('redis.Redis.incrbyfloat', return_value=57.45)
+        with pytest.raises(SystemExit):
+            redis_data_incr.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -155,13 +157,13 @@ def test_redis_data_incr_float_no_username(capfd, mocker):
 
 
 def test_redis_data_incr_check_mode(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     '_ansible_check_mode': True})
-    mocker.patch('redis.Redis.get', return_value=10)
-    with pytest.raises(SystemExit):
-        redis_data_incr.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          '_ansible_check_mode': True}):
+        mocker.patch('redis.Redis.get', return_value=10)
+        with pytest.raises(SystemExit):
+            redis_data_incr.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -171,13 +173,13 @@ def test_redis_data_incr_check_mode(capfd, mocker):
 
 
 def test_redis_data_incr_check_mode_not_incrementable(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     '_ansible_check_mode': True})
-    mocker.patch('redis.Redis.get', return_value='bar')
-    with pytest.raises(SystemExit):
-        redis_data_incr.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          '_ansible_check_mode': True}):
+        mocker.patch('redis.Redis.get', return_value='bar')
+        with pytest.raises(SystemExit):
+            redis_data_incr.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -190,14 +192,14 @@ def test_redis_data_incr_check_mode_not_incrementable(capfd, mocker):
 
 @pytest.mark.skipif(not HAS_REDIS_USERNAME_OPTION, reason="Redis version < 3.4.0")
 def test_redis_data_incr_check_mode_permissions(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     '_ansible_check_mode': True})
-    redis.Redis.get = mocker.Mock(side_effect=NoPermissionError(
-        "this user has no permissions to run the 'get' command or its subcommand"))
-    with pytest.raises(SystemExit):
-        redis_data_incr.main()
+    with set_module_args({'login_host': 'localhost',
+                          'login_password': 'secret',
+                          'key': 'foo',
+                          '_ansible_check_mode': True}):
+        redis.Redis.get = mocker.Mock(side_effect=NoPermissionError(
+            "this user has no permissions to run the 'get' command or its subcommand"))
+        with pytest.raises(SystemExit):
+            redis_data_incr.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err

--- a/tests/unit/plugins/modules/test_redis_data_info.py
+++ b/tests/unit/plugins/modules/test_redis_data_info.py
@@ -23,9 +23,9 @@ if tuple(map(int, __version__.split('.'))) < (3, 4, 0):
 
 
 def test_redis_data_info_without_arguments(capfd):
-    set_module_args({})
-    with pytest.raises(SystemExit):
-        redis_data_info.main()
+    with set_module_args({}):
+        with pytest.raises(SystemExit):
+            redis_data_info.main()
     out, err = capfd.readouterr()
     assert not err
     assert json.loads(out)['failed']
@@ -33,14 +33,16 @@ def test_redis_data_info_without_arguments(capfd):
 
 @pytest.mark.skipif(not HAS_REDIS_USERNAME_OPTION, reason="Redis version < 3.4.0")
 def test_redis_data_info_existing_key(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_user': 'root',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     '_ansible_check_mode': False})
-    mocker.patch('redis.Redis.get', return_value='bar')
-    with pytest.raises(SystemExit):
-        redis_data_info.main()
+    with set_module_args({
+        'login_host': 'localhost',
+        'login_user': 'root',
+        'login_password': 'secret',
+        'key': 'foo',
+        '_ansible_check_mode': False
+    }):
+        mocker.patch('redis.Redis.get', return_value='bar')
+        with pytest.raises(SystemExit):
+            redis_data_info.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -50,14 +52,16 @@ def test_redis_data_info_existing_key(capfd, mocker):
 
 @pytest.mark.skipif(not HAS_REDIS_USERNAME_OPTION, reason="Redis version < 3.4.0")
 def test_redis_data_info_absent_key(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_user': 'root',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     '_ansible_check_mode': False})
-    mocker.patch('redis.Redis.get', return_value=None)
-    with pytest.raises(SystemExit):
-        redis_data_info.main()
+    with set_module_args({
+        'login_host': 'localhost',
+        'login_user': 'root',
+        'login_password': 'secret',
+        'key': 'foo',
+        '_ansible_check_mode': False
+    }):
+        mocker.patch('redis.Redis.get', return_value=None)
+        with pytest.raises(SystemExit):
+            redis_data_info.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -67,13 +71,15 @@ def test_redis_data_info_absent_key(capfd, mocker):
 
 @pytest.mark.skipif(HAS_REDIS_USERNAME_OPTION, reason="Redis version > 3.4.0")
 def test_redis_data_fail_username(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_user': 'root',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     '_ansible_check_mode': False})
-    with pytest.raises(SystemExit):
-        redis_data_info.main()
+    with set_module_args({
+        'login_host': 'localhost',
+        'login_user': 'root',
+        'login_password': 'secret',
+        'key': 'foo',
+        '_ansible_check_mode': False
+    }):
+        with pytest.raises(SystemExit):
+            redis_data_info.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -84,13 +90,15 @@ def test_redis_data_fail_username(capfd, mocker):
 
 @pytest.mark.skipif(HAS_REDIS_USERNAME_OPTION, reason="Redis version > 3.4.0")
 def test_redis_data_info_absent_key_no_username(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     '_ansible_check_mode': False})
-    mocker.patch('redis.Redis.get', return_value=None)
-    with pytest.raises(SystemExit):
-        redis_data_info.main()
+    with set_module_args({
+        'login_host': 'localhost',
+        'login_password': 'secret',
+        'key': 'foo',
+        '_ansible_check_mode': False
+    }):
+        mocker.patch('redis.Redis.get', return_value=None)
+        with pytest.raises(SystemExit):
+            redis_data_info.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err
@@ -100,13 +108,15 @@ def test_redis_data_info_absent_key_no_username(capfd, mocker):
 
 @pytest.mark.skipif(HAS_REDIS_USERNAME_OPTION, reason="Redis version > 3.4.0")
 def test_redis_data_info_existing_key_no_username(capfd, mocker):
-    set_module_args({'login_host': 'localhost',
-                     'login_password': 'secret',
-                     'key': 'foo',
-                     '_ansible_check_mode': False})
-    mocker.patch('redis.Redis.get', return_value='bar')
-    with pytest.raises(SystemExit):
-        redis_data_info.main()
+    with set_module_args({
+        'login_host': 'localhost',
+        'login_password': 'secret',
+        'key': 'foo',
+        '_ansible_check_mode': False
+    }):
+        mocker.patch('redis.Redis.get', return_value='bar')
+        with pytest.raises(SystemExit):
+            redis_data_info.main()
     out, err = capfd.readouterr()
     print(out)
     assert not err

--- a/tests/unit/plugins/modules/test_redis_info.py
+++ b/tests/unit/plugins/modules/test_redis_info.py
@@ -47,8 +47,8 @@ class TestRedisInfoModule(ModuleTestCase):
         """Test without parameters"""
         with self.patch_redis_client(side_effect=FakeRedisClient) as redis_client:
             with self.assertRaises(AnsibleExitJson) as result:
-                set_module_args({})
-                self.module.main()
+                with set_module_args({}):
+                    self.module.main()
             self.assertEqual(redis_client.call_count, 1)
             self.assertEqual(redis_client.call_args, ({'host': 'localhost',
                                                        'port': 6379,
@@ -64,12 +64,12 @@ class TestRedisInfoModule(ModuleTestCase):
         """Test with all parameters"""
         with self.patch_redis_client(side_effect=FakeRedisClient) as redis_client:
             with self.assertRaises(AnsibleExitJson) as result:
-                set_module_args({
+                with set_module_args({
                     'login_host': 'test',
                     'login_port': 1234,
                     'login_password': 'PASS'
-                })
-                self.module.main()
+                }):
+                    self.module.main()
             self.assertEqual(redis_client.call_count, 1)
             self.assertEqual(redis_client.call_args, ({'host': 'test',
                                                        'port': 1234,
@@ -85,7 +85,7 @@ class TestRedisInfoModule(ModuleTestCase):
         """Test with tls parameters"""
         with self.patch_redis_client(side_effect=FakeRedisClient) as redis_client:
             with self.assertRaises(AnsibleExitJson) as result:
-                set_module_args({
+                with set_module_args({
                     'login_host': 'test',
                     'login_port': 1234,
                     'login_password': 'PASS',
@@ -94,8 +94,8 @@ class TestRedisInfoModule(ModuleTestCase):
                     'client_cert_file': '/etc/ssl/client.pem',
                     'client_key_file': '/etc/ssl/client.key',
                     'validate_certs': False
-                })
-                self.module.main()
+                }):
+                    self.module.main()
             self.assertEqual(redis_client.call_count, 1)
             self.assertEqual(redis_client.call_args, ({'host': 'test',
                                                        'port': 1234,
@@ -111,7 +111,7 @@ class TestRedisInfoModule(ModuleTestCase):
         """Test failure message"""
         with self.patch_redis_client(side_effect=FakeRedisClientFail) as redis_client:
             with self.assertRaises(AnsibleFailJson) as result:
-                set_module_args({})
-                self.module.main()
+                with set_module_args({}):
+                    self.module.main()
             self.assertEqual(redis_client.call_count, 1)
             self.assertEqual(result.exception.args[0]['msg'], 'unable to connect to database: Test Error')

--- a/tests/unit/plugins/modules/test_rhsm_release.py
+++ b/tests/unit/plugins/modules/test_rhsm_release.py
@@ -52,15 +52,15 @@ class RhsmRepositoryReleaseModuleTestCase(ModuleTestCase):
     def test_release_set(self):
         # test that the module attempts to change the release when the current
         # release is not the same as the user-specific target release
-        set_module_args({'release': '7.5'})
-        self.module_main_command.side_effect = [
-            # first call, get_release: returns different version so set_release is called
-            (0, '7.4', ''),
-            # second call, set_release: just needs to exit with 0 rc
-            (0, '', ''),
-        ]
+        with set_module_args({'release': '7.5'}):
+            self.module_main_command.side_effect = [
+                # first call, get_release: returns different version so set_release is called
+                (0, '7.4', ''),
+                # second call, set_release: just needs to exit with 0 rc
+                (0, '', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertTrue(result['changed'])
         self.assertEqual('7.5', result['current_release'])
@@ -72,13 +72,13 @@ class RhsmRepositoryReleaseModuleTestCase(ModuleTestCase):
     def test_release_set_idempotent(self):
         # test that the module does not attempt to change the release when
         # the current release matches the user-specified target release
-        set_module_args({'release': '7.5'})
-        self.module_main_command.side_effect = [
-            # first call, get_release: returns same version, set_release is not called
-            (0, '7.5', ''),
-        ]
+        with set_module_args({'release': '7.5'}):
+            self.module_main_command.side_effect = [
+                # first call, get_release: returns same version, set_release is not called
+                (0, '7.5', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertFalse(result['changed'])
         self.assertEqual('7.5', result['current_release'])
@@ -89,15 +89,15 @@ class RhsmRepositoryReleaseModuleTestCase(ModuleTestCase):
     def test_release_unset(self):
         # test that the module attempts to change the release when the current
         # release is not the same as the user-specific target release
-        set_module_args({'release': None})
-        self.module_main_command.side_effect = [
-            # first call, get_release: returns version so set_release is called
-            (0, '7.5', ''),
-            # second call, set_release: just needs to exit with 0 rc
-            (0, '', ''),
-        ]
+        with set_module_args({'release': None}):
+            self.module_main_command.side_effect = [
+                # first call, get_release: returns version so set_release is called
+                (0, '7.5', ''),
+                # second call, set_release: just needs to exit with 0 rc
+                (0, '', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertTrue(result['changed'])
         self.assertIsNone(result['current_release'])
@@ -109,13 +109,13 @@ class RhsmRepositoryReleaseModuleTestCase(ModuleTestCase):
     def test_release_unset_idempotent(self):
         # test that the module attempts to change the release when the current
         # release is not the same as the user-specific target release
-        set_module_args({'release': None})
-        self.module_main_command.side_effect = [
-            # first call, get_release: returns no version, set_release is not called
-            (0, 'Release not set', ''),
-        ]
+        with set_module_args({'release': None}):
+            self.module_main_command.side_effect = [
+                # first call, get_release: returns no version, set_release is not called
+                (0, 'Release not set', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertFalse(result['changed'])
         self.assertIsNone(result['current_release'])
@@ -126,9 +126,8 @@ class RhsmRepositoryReleaseModuleTestCase(ModuleTestCase):
     def test_release_insane(self):
         # test that insane values for release trigger fail_json
         insane_value = 'this is an insane release value'
-        set_module_args({'release': insane_value})
-
-        result = self.module_main(AnsibleFailJson)
+        with set_module_args({'release': insane_value}):
+            result = self.module_main(AnsibleFailJson)
 
         # also ensure that the fail msg includes the insane value
         self.assertIn(insane_value, result['msg'])

--- a/tests/unit/plugins/modules/test_rpm_ostree_pkg.py
+++ b/tests/unit/plugins/modules/test_rpm_ostree_pkg.py
@@ -35,12 +35,12 @@ class RpmOSTreeModuleTestCase(ModuleTestCase):
         return exc.exception.args[0]
 
     def test_present(self):
-        set_module_args({'name': 'nfs-utils', 'state': 'present'})
-        self.module_main_command.side_effect = [
-            (0, '', ''),
-        ]
+        with set_module_args({'name': 'nfs-utils', 'state': 'present'}):
+            self.module_main_command.side_effect = [
+                (0, '', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertTrue(result['changed'])
         self.assertEqual(['nfs-utils'], result['packages'])
@@ -49,12 +49,12 @@ class RpmOSTreeModuleTestCase(ModuleTestCase):
         ])
 
     def test_present_unchanged(self):
-        set_module_args({'name': 'nfs-utils', 'state': 'present'})
-        self.module_main_command.side_effect = [
-            (77, '', ''),
-        ]
+        with set_module_args({'name': 'nfs-utils', 'state': 'present'}):
+            self.module_main_command.side_effect = [
+                (77, '', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertFalse(result['changed'])
         self.assertEqual(0, result['rc'])
@@ -64,12 +64,12 @@ class RpmOSTreeModuleTestCase(ModuleTestCase):
         ])
 
     def test_present_failed(self):
-        set_module_args({'name': 'nfs-utils', 'state': 'present'})
-        self.module_main_command.side_effect = [
-            (1, '', ''),
-        ]
+        with set_module_args({'name': 'nfs-utils', 'state': 'present'}):
+            self.module_main_command.side_effect = [
+                (1, '', ''),
+            ]
 
-        result = self.module_main(AnsibleFailJson)
+            result = self.module_main(AnsibleFailJson)
 
         self.assertFalse(result['changed'])
         self.assertEqual(1, result['rc'])
@@ -79,12 +79,12 @@ class RpmOSTreeModuleTestCase(ModuleTestCase):
         ])
 
     def test_absent(self):
-        set_module_args({'name': 'nfs-utils', 'state': 'absent'})
-        self.module_main_command.side_effect = [
-            (0, '', ''),
-        ]
+        with set_module_args({'name': 'nfs-utils', 'state': 'absent'}):
+            self.module_main_command.side_effect = [
+                (0, '', ''),
+            ]
 
-        result = self.module_main(AnsibleExitJson)
+            result = self.module_main(AnsibleExitJson)
 
         self.assertTrue(result['changed'])
         self.assertEqual(['nfs-utils'], result['packages'])
@@ -93,12 +93,12 @@ class RpmOSTreeModuleTestCase(ModuleTestCase):
         ])
 
     def test_absent_failed(self):
-        set_module_args({'name': 'nfs-utils', 'state': 'absent'})
-        self.module_main_command.side_effect = [
-            (1, '', ''),
-        ]
+        with set_module_args({'name': 'nfs-utils', 'state': 'absent'}):
+            self.module_main_command.side_effect = [
+                (1, '', ''),
+            ]
 
-        result = self.module_main(AnsibleFailJson)
+            result = self.module_main(AnsibleFailJson)
 
         self.assertFalse(result['changed'])
         self.assertEqual(1, result['rc'])

--- a/tests/unit/plugins/modules/test_scaleway_compute_private_network.py
+++ b/tests/unit/plugins/modules/test_scaleway_compute_private_network.py
@@ -62,9 +62,9 @@ def response_remove_nics():
 
 
 def test_scaleway_private_network_without_arguments(capfd):
-    set_module_args({})
-    with pytest.raises(SystemExit) as results:
-        scaleway_compute_private_network.main()
+    with set_module_args({}):
+        with pytest.raises(SystemExit) as results:
+            scaleway_compute_private_network.main()
     out, err = capfd.readouterr()
 
     assert not err
@@ -77,21 +77,22 @@ def test_scaleway_add_nic(capfd):
     cid = 'c004b4cd-ef5g-678h-90i1-jk2345678l90'
     url = 'servers/' + cid + '/private_nics'
 
-    set_module_args({"project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
-                     "state": "present",
-                     "region": "par1",
-                     "compute_id": cid,
-                     "private_network_id": pnid
-                     })
+    with set_module_args({
+        "project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
+        "state": "present",
+        "region": "par1",
+        "compute_id": cid,
+        "private_network_id": pnid
+    }):
 
-    with patch.object(Scaleway, 'get') as mock_scw_get:
-        mock_scw_get.return_value = response_without_nics()
-        with patch.object(Scaleway, 'post') as mock_scw_post:
-            mock_scw_post.return_value = response_when_add_nics()
-            with pytest.raises(SystemExit) as results:
-                scaleway_compute_private_network.main()
-        mock_scw_post.assert_any_call(path=url, data={"private_network_id": pnid})
-    mock_scw_get.assert_any_call(url)
+        with patch.object(Scaleway, 'get') as mock_scw_get:
+            mock_scw_get.return_value = response_without_nics()
+            with patch.object(Scaleway, 'post') as mock_scw_post:
+                mock_scw_post.return_value = response_when_add_nics()
+                with pytest.raises(SystemExit) as results:
+                    scaleway_compute_private_network.main()
+            mock_scw_post.assert_any_call(path=url, data={"private_network_id": pnid})
+        mock_scw_get.assert_any_call(url)
 
     out, err = capfd.readouterr()
     del os.environ['SCW_API_TOKEN']
@@ -105,18 +106,19 @@ def test_scaleway_add_existing_nic(capfd):
     cid = 'c004b4cd-ef5g-678h-90i1-jk2345678l90'
     url = 'servers/' + cid + '/private_nics'
 
-    set_module_args({"project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
-                     "state": "present",
-                     "region": "par1",
-                     "compute_id": cid,
-                     "private_network_id": pnid
-                     })
+    with set_module_args({
+        "project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
+        "state": "present",
+        "region": "par1",
+        "compute_id": cid,
+        "private_network_id": pnid
+    }):
 
-    with patch.object(Scaleway, 'get') as mock_scw_get:
-        mock_scw_get.return_value = response_with_nics()
-        with pytest.raises(SystemExit) as results:
-            scaleway_compute_private_network.main()
-    mock_scw_get.assert_any_call(url)
+        with patch.object(Scaleway, 'get') as mock_scw_get:
+            mock_scw_get.return_value = response_with_nics()
+            with pytest.raises(SystemExit) as results:
+                scaleway_compute_private_network.main()
+        mock_scw_get.assert_any_call(url)
 
     out, err = capfd.readouterr()
     del os.environ['SCW_API_TOKEN']
@@ -132,21 +134,22 @@ def test_scaleway_remove_existing_nic(capfd):
     url = 'servers/' + cid + '/private_nics'
     urlremove = 'servers/' + cid + '/private_nics/' + nicid
 
-    set_module_args({"project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
-                     "state": "absent",
-                     "region": "par1",
-                     "compute_id": cid,
-                     "private_network_id": pnid
-                     })
+    with set_module_args({
+        "project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
+        "state": "absent",
+        "region": "par1",
+        "compute_id": cid,
+        "private_network_id": pnid
+    }):
 
-    with patch.object(Scaleway, 'get') as mock_scw_get:
-        mock_scw_get.return_value = response_with_nics()
-        with patch.object(Scaleway, 'delete') as mock_scw_delete:
-            mock_scw_delete.return_value = response_remove_nics()
-            with pytest.raises(SystemExit) as results:
-                scaleway_compute_private_network.main()
-        mock_scw_delete.assert_any_call(urlremove)
-    mock_scw_get.assert_any_call(url)
+        with patch.object(Scaleway, 'get') as mock_scw_get:
+            mock_scw_get.return_value = response_with_nics()
+            with patch.object(Scaleway, 'delete') as mock_scw_delete:
+                mock_scw_delete.return_value = response_remove_nics()
+                with pytest.raises(SystemExit) as results:
+                    scaleway_compute_private_network.main()
+            mock_scw_delete.assert_any_call(urlremove)
+        mock_scw_get.assert_any_call(url)
 
     out, err = capfd.readouterr()
 
@@ -161,18 +164,19 @@ def test_scaleway_remove_absent_nic(capfd):
     cid = 'c004b4cd-ef5g-678h-90i1-jk2345678l90'
     url = 'servers/' + cid + '/private_nics'
 
-    set_module_args({"project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
-                     "state": "absent",
-                     "region": "par1",
-                     "compute_id": cid,
-                     "private_network_id": pnid
-                     })
+    with set_module_args({
+        "project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
+        "state": "absent",
+        "region": "par1",
+        "compute_id": cid,
+        "private_network_id": pnid
+    }):
 
-    with patch.object(Scaleway, 'get') as mock_scw_get:
-        mock_scw_get.return_value = response_without_nics()
-        with pytest.raises(SystemExit) as results:
-            scaleway_compute_private_network.main()
-    mock_scw_get.assert_any_call(url)
+        with patch.object(Scaleway, 'get') as mock_scw_get:
+            mock_scw_get.return_value = response_without_nics()
+            with pytest.raises(SystemExit) as results:
+                scaleway_compute_private_network.main()
+        mock_scw_get.assert_any_call(url)
 
     out, err = capfd.readouterr()
     del os.environ['SCW_API_TOKEN']

--- a/tests/unit/plugins/modules/test_scaleway_private_network.py
+++ b/tests/unit/plugins/modules/test_scaleway_private_network.py
@@ -71,9 +71,9 @@ def response_delete():
 
 
 def test_scaleway_private_network_without_arguments(capfd):
-    set_module_args({})
-    with pytest.raises(SystemExit) as results:
-        scaleway_private_network.main()
+    with set_module_args({}):
+        with pytest.raises(SystemExit) as results:
+            scaleway_private_network.main()
     out, err = capfd.readouterr()
 
     assert not err
@@ -81,20 +81,21 @@ def test_scaleway_private_network_without_arguments(capfd):
 
 
 def test_scaleway_create_pn(capfd):
-    set_module_args({"state": "present",
-                     "project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
-                     "region": "par2",
-                     "name": "new_network_name",
-                     "tags": ["tag1"]
-                     })
+    with set_module_args({
+        "state": "present",
+        "project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
+        "region": "par2",
+        "name": "new_network_name",
+        "tags": ["tag1"]
+    }):
 
-    os.environ['SCW_API_TOKEN'] = 'notrealtoken'
-    with patch.object(Scaleway, 'get') as mock_scw_get:
-        mock_scw_get.return_value = response_with_zero_network()
-        with patch.object(Scaleway, 'post') as mock_scw_post:
-            mock_scw_post.return_value = response_create_new()
-            with pytest.raises(SystemExit) as results:
-                scaleway_private_network.main()
+        os.environ['SCW_API_TOKEN'] = 'notrealtoken'
+        with patch.object(Scaleway, 'get') as mock_scw_get:
+            mock_scw_get.return_value = response_with_zero_network()
+            with patch.object(Scaleway, 'post') as mock_scw_post:
+                mock_scw_post.return_value = response_create_new()
+                with pytest.raises(SystemExit) as results:
+                    scaleway_private_network.main()
         mock_scw_post.assert_any_call(path='private-networks/', data={'name': 'new_network_name',
                                                                       'project_id': 'a123b4cd-ef5g-678h-90i1-jk2345678l90',
                                                                       'tags': ['tag1']})
@@ -105,18 +106,19 @@ def test_scaleway_create_pn(capfd):
 
 
 def test_scaleway_existing_pn(capfd):
-    set_module_args({"state": "present",
-                     "project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
-                     "region": "par2",
-                     "name": "new_network_name",
-                     "tags": ["tag1"]
-                     })
+    with set_module_args({
+        "state": "present",
+        "project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
+        "region": "par2",
+        "name": "new_network_name",
+        "tags": ["tag1"]
+    }):
 
-    os.environ['SCW_API_TOKEN'] = 'notrealtoken'
-    with patch.object(Scaleway, 'get') as mock_scw_get:
-        mock_scw_get.return_value = response_with_new_network()
-        with pytest.raises(SystemExit) as results:
-            scaleway_private_network.main()
+        os.environ['SCW_API_TOKEN'] = 'notrealtoken'
+        with patch.object(Scaleway, 'get') as mock_scw_get:
+            mock_scw_get.return_value = response_with_new_network()
+            with pytest.raises(SystemExit) as results:
+                scaleway_private_network.main()
     mock_scw_get.assert_any_call('private-networks', params={'name': 'new_network_name', 'order_by': 'name_asc', 'page': 1, 'page_size': 10})
 
     out, err = capfd.readouterr()
@@ -127,20 +129,21 @@ def test_scaleway_existing_pn(capfd):
 
 
 def test_scaleway_add_tag_pn(capfd):
-    set_module_args({"state": "present",
-                     "project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
-                     "region": "par2",
-                     "name": "new_network_name",
-                     "tags": ["newtag"]
-                     })
+    with set_module_args({
+        "state": "present",
+        "project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
+        "region": "par2",
+        "name": "new_network_name",
+        "tags": ["newtag"]
+    }):
 
-    os.environ['SCW_API_TOKEN'] = 'notrealtoken'
-    with patch.object(Scaleway, 'get') as mock_scw_get:
-        mock_scw_get.return_value = response_with_new_network()
-        with patch.object(Scaleway, 'patch') as mock_scw_patch:
-            mock_scw_patch.return_value = response_create_new_newtag()
-            with pytest.raises(SystemExit) as results:
-                scaleway_private_network.main()
+        os.environ['SCW_API_TOKEN'] = 'notrealtoken'
+        with patch.object(Scaleway, 'get') as mock_scw_get:
+            mock_scw_get.return_value = response_with_new_network()
+            with patch.object(Scaleway, 'patch') as mock_scw_patch:
+                mock_scw_patch.return_value = response_create_new_newtag()
+                with pytest.raises(SystemExit) as results:
+                    scaleway_private_network.main()
             mock_scw_patch.assert_any_call(path='private-networks/c123b4cd-ef5g-678h-90i1-jk2345678l90', data={'name': 'new_network_name', 'tags': ['newtag']})
     mock_scw_get.assert_any_call('private-networks', params={'name': 'new_network_name', 'order_by': 'name_asc', 'page': 1, 'page_size': 10})
 
@@ -152,20 +155,21 @@ def test_scaleway_add_tag_pn(capfd):
 
 
 def test_scaleway_remove_pn(capfd):
-    set_module_args({"state": "absent",
-                     "project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
-                     "region": "par2",
-                     "name": "new_network_name",
-                     "tags": ["newtag"]
-                     })
+    with set_module_args({
+        "state": "absent",
+        "project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
+        "region": "par2",
+        "name": "new_network_name",
+        "tags": ["newtag"]
+    }):
 
-    os.environ['SCW_API_TOKEN'] = 'notrealtoken'
-    with patch.object(Scaleway, 'get') as mock_scw_get:
-        mock_scw_get.return_value = response_with_new_network()
-        with patch.object(Scaleway, 'delete') as mock_scw_delete:
-            mock_scw_delete.return_value = response_delete()
-            with pytest.raises(SystemExit) as results:
-                scaleway_private_network.main()
+        os.environ['SCW_API_TOKEN'] = 'notrealtoken'
+        with patch.object(Scaleway, 'get') as mock_scw_get:
+            mock_scw_get.return_value = response_with_new_network()
+            with patch.object(Scaleway, 'delete') as mock_scw_delete:
+                mock_scw_delete.return_value = response_delete()
+                with pytest.raises(SystemExit) as results:
+                    scaleway_private_network.main()
         mock_scw_delete.assert_any_call('private-networks/c123b4cd-ef5g-678h-90i1-jk2345678l90')
     mock_scw_get.assert_any_call('private-networks', params={'name': 'new_network_name', 'order_by': 'name_asc', 'page': 1, 'page_size': 10})
 
@@ -177,18 +181,19 @@ def test_scaleway_remove_pn(capfd):
 
 
 def test_scaleway_absent_pn_not_exists(capfd):
-    set_module_args({"state": "absent",
-                     "project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
-                     "region": "par2",
-                     "name": "new_network_name",
-                     "tags": ["newtag"]
-                     })
+    with set_module_args({
+        "state": "absent",
+        "project": "a123b4cd-ef5g-678h-90i1-jk2345678l90",
+        "region": "par2",
+        "name": "new_network_name",
+        "tags": ["newtag"]
+    }):
 
-    os.environ['SCW_API_TOKEN'] = 'notrealtoken'
-    with patch.object(Scaleway, 'get') as mock_scw_get:
-        mock_scw_get.return_value = response_with_zero_network()
-        with pytest.raises(SystemExit) as results:
-            scaleway_private_network.main()
+        os.environ['SCW_API_TOKEN'] = 'notrealtoken'
+        with patch.object(Scaleway, 'get') as mock_scw_get:
+            mock_scw_get.return_value = response_with_zero_network()
+            with pytest.raises(SystemExit) as results:
+                scaleway_private_network.main()
     mock_scw_get.assert_any_call('private-networks', params={'name': 'new_network_name', 'order_by': 'name_asc', 'page': 1, 'page_size': 10})
 
     out, err = capfd.readouterr()

--- a/tests/unit/plugins/modules/test_simpleinit_msb.py
+++ b/tests/unit/plugins/modules/test_simpleinit_msb.py
@@ -91,110 +91,112 @@ class TestSimpleinitMSB(ModuleTestCase):
     def tearDown(self):
         super(TestSimpleinitMSB, self).tearDown()
 
-    def init_module(self, args):
-        set_module_args(args)
-
-        return SimpleinitMSB(build_module())
-
     @patch('os.path.exists', return_value=True)
     @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path', return_value="/sbin/telinit")
     def test_get_service_tools(self, *args, **kwargs):
-        simpleinit_msb = self.init_module({
+        with set_module_args({
             'name': 'smgl-suspend-single',
             'state': 'running',
-        })
+        }):
+            simpleinit_msb = SimpleinitMSB(build_module())
 
-        simpleinit_msb.get_service_tools()
+            simpleinit_msb.get_service_tools()
 
-        self.assertEqual(simpleinit_msb.telinit_cmd, "/sbin/telinit")
+            self.assertEqual(simpleinit_msb.telinit_cmd, "/sbin/telinit")
 
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.execute_command')
     def test_service_exists(self, execute_command):
-        simpleinit_msb = self.init_module({
+        with set_module_args({
             'name': 'smgl-suspend-single',
             'state': 'running',
-        })
+        }):
+            simpleinit_msb = SimpleinitMSB(build_module())
 
-        execute_command.return_value = (0, _TELINIT_LIST, "")
+            execute_command.return_value = (0, _TELINIT_LIST, "")
 
-        simpleinit_msb.service_exists()
+            simpleinit_msb.service_exists()
 
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.execute_command')
     def test_service_exists_not(self, execute_command):
-        simpleinit_msb = self.init_module({
+        with set_module_args({
             'name': 'ntp',
             'state': 'running',
-        })
+        }):
+            simpleinit_msb = SimpleinitMSB(build_module())
 
-        execute_command.return_value = (0, _TELINIT_LIST, "")
+            execute_command.return_value = (0, _TELINIT_LIST, "")
 
-        with self.assertRaises(AnsibleFailJson) as context:
-            simpleinit_msb.service_exists()
+            with self.assertRaises(AnsibleFailJson) as context:
+                simpleinit_msb.service_exists()
 
-        self.assertEqual("telinit could not find the requested service: ntp", context.exception.args[0]["msg"])
+            self.assertEqual("telinit could not find the requested service: ntp", context.exception.args[0]["msg"])
 
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_exists')
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.execute_command')
     def test_check_service_enabled(self, execute_command, service_exists):
-        simpleinit_msb = self.init_module({
+        with set_module_args({
             'name': 'nscd',
             'state': 'running',
             'enabled': 'true',
-        })
+        }):
+            simpleinit_msb = SimpleinitMSB(build_module())
 
-        service_exists.return_value = True
-        execute_command.return_value = (0, _TELINIT_LIST_ENABLED, "")
+            service_exists.return_value = True
+            execute_command.return_value = (0, _TELINIT_LIST_ENABLED, "")
 
-        self.assertTrue(simpleinit_msb.service_enabled())
+            self.assertTrue(simpleinit_msb.service_enabled())
 
-        # Race condition check
-        with patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_enabled', return_value=False):
-            execute_command.return_value = (0, "", _TELINIT_ALREADY_ENABLED)
+            # Race condition check
+            with patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_enabled', return_value=False):
+                execute_command.return_value = (0, "", _TELINIT_ALREADY_ENABLED)
 
-            simpleinit_msb.service_enable()
+                simpleinit_msb.service_enable()
 
-            self.assertFalse(simpleinit_msb.changed)
+                self.assertFalse(simpleinit_msb.changed)
 
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_exists')
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.execute_command')
     def test_check_service_disabled(self, execute_command, service_exists):
-        simpleinit_msb = self.init_module({
+        with set_module_args({
             'name': 'sysstat',
             'state': 'stopped',
             'enabled': 'false',
-        })
+        }):
+            simpleinit_msb = SimpleinitMSB(build_module())
 
-        service_exists.return_value = True
-        execute_command.return_value = (0, _TELINIT_LIST_DISABLED, "")
+            service_exists.return_value = True
+            execute_command.return_value = (0, _TELINIT_LIST_DISABLED, "")
 
-        self.assertFalse(simpleinit_msb.service_enabled())
+            self.assertFalse(simpleinit_msb.service_enabled())
 
-        # Race condition check
-        with patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_enabled', return_value=True):
-            execute_command.return_value = (0, "", _TELINIT_ALREADY_DISABLED)
+            # Race condition check
+            with patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_enabled', return_value=True):
+                execute_command.return_value = (0, "", _TELINIT_ALREADY_DISABLED)
 
-            simpleinit_msb.service_enable()
+                simpleinit_msb.service_enable()
 
-            self.assertFalse(simpleinit_msb.changed)
+                self.assertFalse(simpleinit_msb.changed)
 
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_control')
     def test_check_service_running(self, service_control):
-        simpleinit_msb = self.init_module({
+        with set_module_args({
             'name': 'sshd',
             'state': 'running',
-        })
+        }):
+            simpleinit_msb = SimpleinitMSB(build_module())
 
-        service_control.return_value = (0, _TELINIT_STATUS_RUNNING, "")
+            service_control.return_value = (0, _TELINIT_STATUS_RUNNING, "")
 
-        self.assertFalse(simpleinit_msb.get_service_status())
+            self.assertFalse(simpleinit_msb.get_service_status())
 
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_control')
     def test_check_service_running_not(self, service_control):
-        simpleinit_msb = self.init_module({
+        with set_module_args({
             'name': 'smgl-metalog',
             'state': 'running',
-        })
+        }):
+            simpleinit_msb = SimpleinitMSB(build_module())
 
-        service_control.return_value = (0, _TELINIT_STATUS_RUNNING_NOT, "")
+            service_control.return_value = (0, _TELINIT_STATUS_RUNNING_NOT, "")
 
-        self.assertFalse(simpleinit_msb.get_service_status())
+            self.assertFalse(simpleinit_msb.get_service_status())

--- a/tests/unit/plugins/modules/test_slack.py
+++ b/tests/unit/plugins/modules/test_slack.py
@@ -28,110 +28,105 @@ class TestSlackModule(ModuleTestCase):
     def test_without_required_parameters(self):
         """Failure must occurs when all parameters are missing"""
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            self.module.main()
+            with set_module_args({}):
+                self.module.main()
 
     def test_invalid_old_token(self):
         """Failure if there is an old style token"""
-        set_module_args({
+        with set_module_args({
             'token': 'test',
-        })
-        with self.assertRaises(AnsibleFailJson):
-            self.module.main()
+        }):
+            with self.assertRaises(AnsibleFailJson):
+                self.module.main()
 
     def test_successful_message(self):
         """tests sending a message. This is example 1 from the docs"""
-        set_module_args({
+        with set_module_args({
             'token': 'XXXX/YYYY/ZZZZ',
             'msg': 'test'
-        })
+        }):
+            with patch.object(slack, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 200})
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
-        with patch.object(slack, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = (None, {"status": 200})
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
-
-            self.assertTrue(fetch_url_mock.call_count, 1)
-            call_data = json.loads(fetch_url_mock.call_args[1]['data'])
-            assert call_data['username'] == "Ansible"
-            assert call_data['text'] == "test"
-            assert fetch_url_mock.call_args[1]['url'] == "https://hooks.slack.com/services/XXXX/YYYY/ZZZZ"
+        self.assertTrue(fetch_url_mock.call_count, 1)
+        call_data = json.loads(fetch_url_mock.call_args[1]['data'])
+        assert call_data['username'] == "Ansible"
+        assert call_data['text'] == "test"
+        assert fetch_url_mock.call_args[1]['url'] == "https://hooks.slack.com/services/XXXX/YYYY/ZZZZ"
 
     def test_failed_message(self):
         """tests failing to send a message"""
 
-        set_module_args({
+        with set_module_args({
             'token': 'XXXX/YYYY/ZZZZ',
             'msg': 'test'
-        })
-
-        with patch.object(slack, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = (None, {"status": 404, 'msg': 'test'})
-            with self.assertRaises(AnsibleFailJson):
-                self.module.main()
+        }):
+            with patch.object(slack, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 404, 'msg': 'test'})
+                with self.assertRaises(AnsibleFailJson):
+                    self.module.main()
 
     def test_message_with_thread(self):
         """tests sending a message with a thread"""
-        set_module_args({
+        with set_module_args({
             'token': 'XXXX/YYYY/ZZZZ',
             'msg': 'test',
             'thread_id': '100.00'
-        })
+        }):
+            with patch.object(slack, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 200})
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
-        with patch.object(slack, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = (None, {"status": 200})
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
-
-            self.assertTrue(fetch_url_mock.call_count, 1)
-            call_data = json.loads(fetch_url_mock.call_args[1]['data'])
-            assert call_data['username'] == "Ansible"
-            assert call_data['text'] == "test"
-            assert call_data['thread_ts'] == '100.00'
-            assert fetch_url_mock.call_args[1]['url'] == "https://hooks.slack.com/services/XXXX/YYYY/ZZZZ"
+        self.assertTrue(fetch_url_mock.call_count, 1)
+        call_data = json.loads(fetch_url_mock.call_args[1]['data'])
+        assert call_data['username'] == "Ansible"
+        assert call_data['text'] == "test"
+        assert call_data['thread_ts'] == '100.00'
+        assert fetch_url_mock.call_args[1]['url'] == "https://hooks.slack.com/services/XXXX/YYYY/ZZZZ"
 
     # https://github.com/ansible-collections/community.general/issues/1097
     def test_ts_in_message_does_not_cause_edit(self):
-        set_module_args({
+        with set_module_args({
             'token': 'xoxa-123456789abcdef',
             'msg': 'test with ts'
-        })
+        }):
+            with patch.object(slack, "fetch_url") as fetch_url_mock:
+                mock_response = Mock()
+                mock_response.read.return_value = '{"fake":"data"}'
+                fetch_url_mock.return_value = (mock_response, {"status": 200})
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
-        with patch.object(slack, "fetch_url") as fetch_url_mock:
-            mock_response = Mock()
-            mock_response.read.return_value = '{"fake":"data"}'
-            fetch_url_mock.return_value = (mock_response, {"status": 200})
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
-
-            self.assertTrue(fetch_url_mock.call_count, 1)
-            self.assertEqual(fetch_url_mock.call_args[1]['url'], "https://slack.com/api/chat.postMessage")
+        self.assertTrue(fetch_url_mock.call_count, 1)
+        self.assertEqual(fetch_url_mock.call_args[1]['url'], "https://slack.com/api/chat.postMessage")
 
     def test_edit_message(self):
-        set_module_args({
+        with set_module_args({
             'token': 'xoxa-123456789abcdef',
             'msg': 'test2',
             'message_id': '12345'
-        })
+        }):
+            with patch.object(slack, "fetch_url") as fetch_url_mock:
+                mock_response = Mock()
+                mock_response.read.return_value = '{"messages":[{"ts":"12345","msg":"test1"}]}'
+                fetch_url_mock.side_effect = [
+                    (mock_response, {"status": 200}),
+                    (mock_response, {"status": 200}),
+                ]
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
-        with patch.object(slack, "fetch_url") as fetch_url_mock:
-            mock_response = Mock()
-            mock_response.read.return_value = '{"messages":[{"ts":"12345","msg":"test1"}]}'
-            fetch_url_mock.side_effect = [
-                (mock_response, {"status": 200}),
-                (mock_response, {"status": 200}),
-            ]
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
-
-            self.assertTrue(fetch_url_mock.call_count, 2)
-            self.assertEqual(fetch_url_mock.call_args[1]['url'], "https://slack.com/api/chat.update")
-            call_data = json.loads(fetch_url_mock.call_args[1]['data'])
-            self.assertEqual(call_data['ts'], "12345")
+        self.assertTrue(fetch_url_mock.call_count, 2)
+        self.assertEqual(fetch_url_mock.call_args[1]['url'], "https://slack.com/api/chat.update")
+        call_data = json.loads(fetch_url_mock.call_args[1]['data'])
+        self.assertEqual(call_data['ts'], "12345")
 
     def test_message_with_blocks(self):
         """tests sending a message with blocks"""
-        set_module_args({
+        with set_module_args({
             'token': 'XXXX/YYYY/ZZZZ',
             'msg': 'test',
             'blocks': [{
@@ -153,28 +148,27 @@ class TestSlackModule(ModuleTestCase):
                     'emoji': True
                 }
             }]
-        })
+        }):
+            with patch.object(slack, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 200})
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
 
-        with patch.object(slack, "fetch_url") as fetch_url_mock:
-            fetch_url_mock.return_value = (None, {"status": 200})
-            with self.assertRaises(AnsibleExitJson):
-                self.module.main()
-
-            self.assertTrue(fetch_url_mock.call_count, 1)
-            call_data = json.loads(fetch_url_mock.call_args[1]['data'])
-            assert call_data['username'] == "Ansible"
-            assert call_data['blocks'][1]['text']['text'] == "test"
-            assert fetch_url_mock.call_args[1]['url'] == "https://hooks.slack.com/services/XXXX/YYYY/ZZZZ"
+        self.assertTrue(fetch_url_mock.call_count, 1)
+        call_data = json.loads(fetch_url_mock.call_args[1]['data'])
+        assert call_data['username'] == "Ansible"
+        assert call_data['blocks'][1]['text']['text'] == "test"
+        assert fetch_url_mock.call_args[1]['url'] == "https://hooks.slack.com/services/XXXX/YYYY/ZZZZ"
 
     def test_message_with_invalid_color(self):
         """tests sending invalid color value to module"""
-        set_module_args({
+        with set_module_args({
             'token': 'XXXX/YYYY/ZZZZ',
             'msg': 'test',
             'color': 'aa',
-        })
-        with self.assertRaises(AnsibleFailJson) as exec_info:
-            self.module.main()
+        }):
+            with self.assertRaises(AnsibleFailJson) as exec_info:
+                self.module.main()
 
         msg = "Color value specified should be either one of" \
               " ['normal', 'good', 'warning', 'danger'] or any valid" \

--- a/tests/unit/plugins/modules/test_solaris_zone.py
+++ b/tests/unit/plugins/modules/test_solaris_zone.py
@@ -54,16 +54,16 @@ def test_zone_create(mocked_zone_create, capfd):
     """
     test zone creation
     """
-    set_module_args(
+    with set_module_args(
         {
             "name": "z1",
             "state": "installed",
             "path": "/zones/z1",
             "_ansible_check_mode": False,
         }
-    )
-    with pytest.raises(SystemExit):
-        solaris_zone.main()
+    ):
+        with pytest.raises(SystemExit):
+            solaris_zone.main()
 
     out, err = capfd.readouterr()
     results = json.loads(out)
@@ -75,16 +75,16 @@ def test_zone_delete(mocked_zone_delete, capfd):
     """
     test zone deletion
     """
-    set_module_args(
+    with set_module_args(
         {
             "name": "z1",
             "state": "absent",
             "path": "/zones/z1",
             "_ansible_check_mode": False,
         }
-    )
-    with pytest.raises(SystemExit):
-        solaris_zone.main()
+    ):
+        with pytest.raises(SystemExit):
+            solaris_zone.main()
 
     out, err = capfd.readouterr()
     results = json.loads(out)
@@ -100,16 +100,16 @@ def test_zone_create_invalid_names(mocked_zone_create, capfd):
     # 2. Zone name > 64 characters.
     # 3. Zone name beginning with non-alphanumeric character.
     for invalid_name in ('foo!bar', 'z' * 65, '_zone'):
-        set_module_args(
+        with set_module_args(
             {
                 "name": invalid_name,
                 "state": "installed",
                 "path": "/zones/" + invalid_name,
                 "_ansible_check_mode": False,
             }
-        )
-        with pytest.raises(SystemExit):
-            solaris_zone.main()
+        ):
+            with pytest.raises(SystemExit):
+                solaris_zone.main()
 
         out, err = capfd.readouterr()
         results = json.loads(out)

--- a/tests/unit/plugins/modules/test_statsd.py
+++ b/tests/unit/plugins/modules/test_statsd.py
@@ -42,36 +42,36 @@ class TestStatsDModule(ModuleTestCase):
         """Test udp without parameters"""
         with self.patch_udp_statsd_client(side_effect=FakeStatsD) as fake_statsd:
             with self.assertRaises(AnsibleFailJson) as result:
-                set_module_args({})
-                self.module.main()
+                with set_module_args({}):
+                    self.module.main()
 
     def test_tcp_without_parameters(self):
         """Test tcp without parameters"""
         with self.patch_tcp_statsd_client(side_effect=FakeStatsD) as fake_statsd:
             with self.assertRaises(AnsibleFailJson) as result:
-                set_module_args({})
-                self.module.main()
+                with set_module_args({}):
+                    self.module.main()
 
     def test_udp_with_parameters(self):
         """Test udp with parameters"""
         with self.patch_udp_statsd_client(side_effect=FakeStatsD) as fake_statsd:
             with self.assertRaises(AnsibleExitJson) as result:
-                set_module_args({
+                with set_module_args({
                     'metric': 'my_counter',
                     'metric_type': 'counter',
                     'value': 1,
-                })
-                self.module.main()
+                }):
+                    self.module.main()
             self.assertEqual(result.exception.args[0]['msg'], 'Sent counter my_counter -> 1 to StatsD')
             self.assertEqual(result.exception.args[0]['changed'], True)
         with self.patch_udp_statsd_client(side_effect=FakeStatsD) as fake_statsd:
             with self.assertRaises(AnsibleExitJson) as result:
-                set_module_args({
+                with set_module_args({
                     'metric': 'my_gauge',
                     'metric_type': 'gauge',
                     'value': 3,
-                })
-                self.module.main()
+                }):
+                    self.module.main()
             self.assertEqual(result.exception.args[0]['msg'], 'Sent gauge my_gauge -> 3 (delta=False) to StatsD')
             self.assertEqual(result.exception.args[0]['changed'], True)
 
@@ -79,23 +79,23 @@ class TestStatsDModule(ModuleTestCase):
         """Test tcp with parameters"""
         with self.patch_tcp_statsd_client(side_effect=FakeStatsD) as fake_statsd:
             with self.assertRaises(AnsibleExitJson) as result:
-                set_module_args({
+                with set_module_args({
                     'protocol': 'tcp',
                     'metric': 'my_counter',
                     'metric_type': 'counter',
                     'value': 1,
-                })
-                self.module.main()
+                }):
+                    self.module.main()
             self.assertEqual(result.exception.args[0]['msg'], 'Sent counter my_counter -> 1 to StatsD')
             self.assertEqual(result.exception.args[0]['changed'], True)
         with self.patch_tcp_statsd_client(side_effect=FakeStatsD) as fake_statsd:
             with self.assertRaises(AnsibleExitJson) as result:
-                set_module_args({
+                with set_module_args({
                     'protocol': 'tcp',
                     'metric': 'my_gauge',
                     'metric_type': 'gauge',
                     'value': 3,
-                })
-                self.module.main()
+                }):
+                    self.module.main()
             self.assertEqual(result.exception.args[0]['msg'], 'Sent gauge my_gauge -> 3 (delta=False) to StatsD')
             self.assertEqual(result.exception.args[0]['changed'], True)

--- a/tests/unit/plugins/modules/test_sysupgrade.py
+++ b/tests/unit/plugins/modules/test_sysupgrade.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 from ansible.module_utils import basic
 from ansible_collections.community.general.tests.unit.compat.mock import patch
-from ansible_collections.community.general.tests.unit.plugins.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase
+from ansible_collections.community.general.tests.unit.plugins.modules.utils import set_module_args, AnsibleExitJson, AnsibleFailJson, ModuleTestCase
 from ansible_collections.community.general.plugins.modules import sysupgrade
 
 
@@ -48,11 +48,12 @@ class TestSysupgradeModule(ModuleTestCase):
         """
         stderr = ""
 
-        with patch.object(basic.AnsibleModule, "run_command") as run_command:
-            run_command.return_value = (rc, stdout, stderr)
-            with self.assertRaises(AnsibleExitJson) as result:
-                self.module.main()
-            self.assertTrue(result.exception.args[0]['changed'])
+        with set_module_args({}):
+            with patch.object(basic.AnsibleModule, "run_command") as run_command:
+                run_command.return_value = (rc, stdout, stderr)
+                with self.assertRaises(AnsibleExitJson) as result:
+                    self.module.main()
+                self.assertTrue(result.exception.args[0]['changed'])
 
     def test_upgrade_failed(self):
         """ Upgrade failed """
@@ -61,9 +62,10 @@ class TestSysupgradeModule(ModuleTestCase):
         stdout = ""
         stderr = "sysupgrade: need root privileges"
 
-        with patch.object(basic.AnsibleModule, "run_command") as run_command_mock:
-            run_command_mock.return_value = (rc, stdout, stderr)
-            with self.assertRaises(AnsibleFailJson) as result:
-                self.module.main()
-            self.assertTrue(result.exception.args[0]['failed'])
-            self.assertIn('need root', result.exception.args[0]['msg'])
+        with set_module_args({}):
+            with patch.object(basic.AnsibleModule, "run_command") as run_command_mock:
+                run_command_mock.return_value = (rc, stdout, stderr)
+                with self.assertRaises(AnsibleFailJson) as result:
+                    self.module.main()
+                self.assertTrue(result.exception.args[0]['failed'])
+                self.assertIn('need root', result.exception.args[0]['msg'])

--- a/tests/unit/plugins/modules/test_terraform.py
+++ b/tests/unit/plugins/modules/test_terraform.py
@@ -13,9 +13,9 @@ from ansible_collections.community.general.tests.unit.plugins.modules.utils impo
 
 
 def test_terraform_without_argument(capfd):
-    set_module_args({})
-    with pytest.raises(SystemExit) as results:
-        terraform.main()
+    with set_module_args({}):
+        with pytest.raises(SystemExit) as results:
+            terraform.main()
 
     out, err = capfd.readouterr()
     assert not err

--- a/tests/unit/plugins/modules/test_ufw.py
+++ b/tests/unit/plugins/modules/test_ufw.py
@@ -7,10 +7,8 @@ __metaclass__ = type
 from ansible_collections.community.general.tests.unit.compat import unittest
 from ansible_collections.community.general.tests.unit.compat.mock import patch
 from ansible.module_utils import basic
-from ansible.module_utils.common.text.converters import to_bytes
 import ansible_collections.community.general.plugins.modules.ufw as module
-
-import json
+from ansible_collections.community.general.tests.unit.plugins.modules.utils import AnsibleExitJson, AnsibleFailJson, set_module_args, exit_json, fail_json
 
 
 # mock ufw messages
@@ -104,35 +102,6 @@ def do_nothing_func_port_7000(*args, **kwarg):
     return 0, dry_mode_cmd_with_port_700[args[0]], ""
 
 
-def set_module_args(args):
-    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
-    """prepare arguments so that they will be picked up during module creation"""
-    basic._ANSIBLE_ARGS = to_bytes(args)
-
-
-class AnsibleExitJson(Exception):
-    """Exception class to be raised by module.exit_json and caught by the test case"""
-    pass
-
-
-class AnsibleFailJson(Exception):
-    """Exception class to be raised by module.fail_json and caught by the test case"""
-    pass
-
-
-def exit_json(*args, **kwargs):
-    """function to patch over exit_json; package return data into an exception"""
-    if 'changed' not in kwargs:
-        kwargs['changed'] = False
-    raise AnsibleExitJson(kwargs)
-
-
-def fail_json(*args, **kwargs):
-    """function to patch over fail_json; package return data into an exception"""
-    kwargs['failed'] = True
-    raise AnsibleFailJson(kwargs)
-
-
 def get_bin_path(self, arg, required=False):
     """Mock AnsibleModule.get_bin_path"""
     return arg
@@ -171,28 +140,28 @@ class TestUFW(unittest.TestCase):
         self.assertTrue(reg.match("::") is not None)
 
     def test_check_mode_add_rules(self):
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'proto': 'tcp',
             'port': '7000',
             '_ansible_check_mode': True
-        })
-        result = self.__getResult(do_nothing_func_port_7000)
+        }):
+            result = self.__getResult(do_nothing_func_port_7000)
         self.assertFalse(result.exception.args[0]['changed'])
 
     def test_check_mode_add_insert_rules(self):
-        set_module_args({
+        with set_module_args({
             'insert': '1',
             'rule': 'allow',
             'proto': 'tcp',
             'port': '7000',
             '_ansible_check_mode': True
-        })
-        result = self.__getResult(do_nothing_func_port_7000)
+        }):
+            result = self.__getResult(do_nothing_func_port_7000)
         self.assertFalse(result.exception.args[0]['changed'])
 
     def test_check_mode_add_detailed_route(self):
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'route': 'yes',
             'interface_in': 'foo',
@@ -203,13 +172,12 @@ class TestUFW(unittest.TestCase):
             'from_port': '7000',
             'to_port': '7001',
             '_ansible_check_mode': True
-        })
-
-        result = self.__getResult(do_nothing_func_port_7000)
+        }):
+            result = self.__getResult(do_nothing_func_port_7000)
         self.assertTrue(result.exception.args[0]['changed'])
 
     def test_check_mode_add_ambiguous_route(self):
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'route': 'yes',
             'interface_in': 'foo',
@@ -217,68 +185,66 @@ class TestUFW(unittest.TestCase):
             'direction': 'in',
             'interface': 'baz',
             '_ansible_check_mode': True
-        })
-
-        with self.assertRaises(AnsibleFailJson) as result:
-            self.__getResult(do_nothing_func_port_7000)
+        }):
+            with self.assertRaises(AnsibleFailJson) as result:
+                self.__getResult(do_nothing_func_port_7000)
 
         exc = result.exception.args[0]
         self.assertTrue(exc['failed'])
         self.assertIn('mutually exclusive', exc['msg'])
 
     def test_check_mode_add_interface_in(self):
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'proto': 'tcp',
             'port': '7003',
             'interface_in': 'foo',
             '_ansible_check_mode': True
-        })
-        result = self.__getResult(do_nothing_func_port_7000)
+        }):
+            result = self.__getResult(do_nothing_func_port_7000)
         self.assertTrue(result.exception.args[0]['changed'])
 
     def test_check_mode_add_interface_out(self):
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'proto': 'tcp',
             'port': '7004',
             'interface_out': 'foo',
             '_ansible_check_mode': True
-        })
-        result = self.__getResult(do_nothing_func_port_7000)
+        }):
+            result = self.__getResult(do_nothing_func_port_7000)
         self.assertTrue(result.exception.args[0]['changed'])
 
     def test_check_mode_add_non_route_interface_both(self):
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'proto': 'tcp',
             'port': '7004',
             'interface_in': 'foo',
             'interface_out': 'bar',
             '_ansible_check_mode': True
-        })
-
-        with self.assertRaises(AnsibleFailJson) as result:
-            self.__getResult(do_nothing_func_port_7000)
+        }):
+            with self.assertRaises(AnsibleFailJson) as result:
+                self.__getResult(do_nothing_func_port_7000)
 
         exc = result.exception.args[0]
         self.assertTrue(exc['failed'])
         self.assertIn('combine', exc['msg'])
 
     def test_check_mode_add_direction_in(self):
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'proto': 'tcp',
             'port': '7003',
             'direction': 'in',
             'interface': 'foo',
             '_ansible_check_mode': True
-        })
-        result = self.__getResult(do_nothing_func_port_7000)
+        }):
+            result = self.__getResult(do_nothing_func_port_7000)
         self.assertTrue(result.exception.args[0]['changed'])
 
     def test_check_mode_add_direction_in_with_ip(self):
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'proto': 'tcp',
             'from_ip': '1.1.1.1',
@@ -288,24 +254,24 @@ class TestUFW(unittest.TestCase):
             'direction': 'in',
             'interface': 'foo',
             '_ansible_check_mode': True
-        })
-        result = self.__getResult(do_nothing_func_port_7000)
+        }):
+            result = self.__getResult(do_nothing_func_port_7000)
         self.assertTrue(result.exception.args[0]['changed'])
 
     def test_check_mode_add_direction_out(self):
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'proto': 'tcp',
             'port': '7004',
             'direction': 'out',
             'interface': 'foo',
             '_ansible_check_mode': True
-        })
-        result = self.__getResult(do_nothing_func_port_7000)
+        }):
+            result = self.__getResult(do_nothing_func_port_7000)
         self.assertTrue(result.exception.args[0]['changed'])
 
     def test_check_mode_add_direction_out_with_ip(self):
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'proto': 'tcp',
             'from_ip': '1.1.1.1',
@@ -315,157 +281,149 @@ class TestUFW(unittest.TestCase):
             'direction': 'out',
             'interface': 'foo',
             '_ansible_check_mode': True
-        })
-        result = self.__getResult(do_nothing_func_port_7000)
+        }):
+            result = self.__getResult(do_nothing_func_port_7000)
         self.assertTrue(result.exception.args[0]['changed'])
 
     def test_check_mode_delete_existing_rules(self):
 
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'proto': 'tcp',
             'port': '7000',
             'delete': 'yes',
             '_ansible_check_mode': True,
-        })
-
-        self.assertTrue(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
+        }):
+            self.assertTrue(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
 
     def test_check_mode_delete_existing_insert_rules(self):
 
-        set_module_args({
+        with set_module_args({
             'insert': '1',
             'rule': 'allow',
             'proto': 'tcp',
             'port': '7000',
             'delete': 'yes',
             '_ansible_check_mode': True,
-        })
-
-        self.assertTrue(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
+        }):
+            self.assertTrue(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
 
     def test_check_mode_delete_not_existing_rules(self):
 
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'proto': 'tcp',
             'port': '7001',
             'delete': 'yes',
             '_ansible_check_mode': True,
-        })
-
-        self.assertFalse(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
+        }):
+            self.assertFalse(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
 
     def test_check_mode_delete_not_existing_insert_rules(self):
 
-        set_module_args({
+        with set_module_args({
             'insert': '1',
             'rule': 'allow',
             'proto': 'tcp',
             'port': '7001',
             'delete': 'yes',
             '_ansible_check_mode': True,
-        })
-
-        self.assertFalse(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
+        }):
+            self.assertFalse(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
 
     def test_enable_mode(self):
-        set_module_args({
+        with set_module_args({
             'state': 'enabled',
             '_ansible_check_mode': True
-        })
-
-        self.assertFalse(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
+        }):
+            self.assertFalse(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
 
     def test_disable_mode(self):
-        set_module_args({
+        with set_module_args({
             'state': 'disabled',
             '_ansible_check_mode': True
-        })
-
-        self.assertTrue(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
+        }):
+            self.assertTrue(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
 
     def test_logging_off(self):
-        set_module_args({
+        with set_module_args({
             'logging': 'off',
             '_ansible_check_mode': True
-        })
-
-        self.assertTrue(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
+        }):
+            self.assertTrue(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
 
     def test_logging_on(self):
-        set_module_args({
+        with set_module_args({
             'logging': 'on',
             '_ansible_check_mode': True
-        })
-
-        self.assertFalse(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
+        }):
+            self.assertFalse(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
 
     def test_default_changed(self):
-        set_module_args({
+        with set_module_args({
             'default': 'allow',
             "direction": "incoming",
             '_ansible_check_mode': True
-        })
-        self.assertTrue(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
+        }):
+            self.assertTrue(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
 
     def test_default_not_changed(self):
-        set_module_args({
+        with set_module_args({
             'default': 'deny',
             "direction": "incoming",
             '_ansible_check_mode': True
-        })
-        self.assertFalse(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
+        }):
+            self.assertFalse(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
 
     def test_ipv6_remove(self):
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'proto': 'udp',
             'port': '5353',
             'from': 'ff02::fb',
             'delete': 'yes',
             '_ansible_check_mode': True,
-        })
-        self.assertTrue(self.__getResult(do_nothing_func_ipv6).exception.args[0]['changed'])
+        }):
+            self.assertTrue(self.__getResult(do_nothing_func_ipv6).exception.args[0]['changed'])
 
     def test_ipv6_add_existing(self):
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'proto': 'udp',
             'port': '5353',
             'from': 'ff02::fb',
             '_ansible_check_mode': True,
-        })
-        self.assertFalse(self.__getResult(do_nothing_func_ipv6).exception.args[0]['changed'])
+        }):
+            self.assertFalse(self.__getResult(do_nothing_func_ipv6).exception.args[0]['changed'])
 
     def test_add_not_existing_ipv4_submask(self):
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'proto': 'udp',
             'port': '1577',
             'from': '10.0.0.0/24',
             '_ansible_check_mode': True,
-        })
-        self.assertTrue(self.__getResult(do_nothing_func_ipv6).exception.args[0]['changed'])
+        }):
+            self.assertTrue(self.__getResult(do_nothing_func_ipv6).exception.args[0]['changed'])
 
     def test_ipv4_add_with_existing_ipv6(self):
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'proto': 'udp',
             'port': '5353',
             'from': '224.0.0.252',
             '_ansible_check_mode': True,
-        })
-        self.assertTrue(self.__getResult(do_nothing_func_ipv6).exception.args[0]['changed'])
+        }):
+            self.assertTrue(self.__getResult(do_nothing_func_ipv6).exception.args[0]['changed'])
 
     def test_ipv6_add_from_nothing(self):
-        set_module_args({
+        with set_module_args({
             'rule': 'allow',
             'port': '23',
             'to': '::',
             '_ansible_check_mode': True,
-        })
-        result = self.__getResult(do_nothing_func_nothing).exception.args[0]
+        }):
+            result = self.__getResult(do_nothing_func_nothing).exception.args[0]
         print(result)
         self.assertTrue(result['changed'])
 

--- a/tests/unit/plugins/modules/test_usb_facts.py
+++ b/tests/unit/plugins/modules/test_usb_facts.py
@@ -5,42 +5,11 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import json
-
 from ansible_collections.community.general.tests.unit.compat import mock
 from ansible_collections.community.general.tests.unit.compat import unittest
 from ansible.module_utils import basic
-from ansible.module_utils.common.text.converters import to_bytes
 from ansible_collections.community.general.plugins.modules import usb_facts
-
-
-def set_module_args(args):
-    """prepare arguments so that they will be picked up during module creation"""
-    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
-    basic._ANSIBLE_ARGS = to_bytes(args)
-
-
-class AnsibleExitJson(Exception):
-    """Exception class to be raised by module.exit_json and caught by the test case"""
-    pass
-
-
-class AnsibleFailJson(Exception):
-    """Exception class to be raised by module.fail_json and caught by the test case"""
-    pass
-
-
-def exit_json(*args, **kwargs):
-    """function to patch over exit_json; package return data into an exception"""
-    if 'changed' not in kwargs:
-        kwargs['changed'] = False
-    raise AnsibleExitJson(kwargs)
-
-
-def fail_json(*args, **kwargs):
-    """function to patch over fail_json; package return data into an exception"""
-    kwargs['failed'] = True
-    raise AnsibleFailJson(kwargs)
+from ansible_collections.community.general.tests.unit.plugins.modules.utils import AnsibleExitJson, set_module_args, exit_json, fail_json
 
 
 def get_bin_path(self, arg, required=False):
@@ -85,8 +54,8 @@ class TestUsbFacts(unittest.TestCase):
                 command_output = data["input"]
                 mock_run_command.return_value = 0, command_output, None
                 with self.assertRaises(AnsibleExitJson) as result:
-                    set_module_args({})
-                    usb_facts.main()
+                    with set_module_args({}):
+                        usb_facts.main()
                 for output_field in self.output_fields:
                     self.assertEqual(result.exception.args[0]["ansible_facts"]["usb_devices"][0][output_field], data[output_field])
 
@@ -97,8 +66,8 @@ class TestUsbFacts(unittest.TestCase):
         with mock.patch.object(basic.AnsibleModule, 'run_command') as mock_run_command:
             mock_run_command.return_value = 0, input, None
             with self.assertRaises(AnsibleExitJson) as result:
-                set_module_args({})
-                usb_facts.main()
+                with set_module_args({}):
+                    usb_facts.main()
             for index in range(0, len(self.testing_data)):
                 for output_field in self.output_fields:
                     self.assertEqual(result.exception.args[0]["ansible_facts"]["usb_devices"][index][output_field],

--- a/tests/unit/plugins/modules/test_wdc_redfish_command.py
+++ b/tests/unit/plugins/modules/test_wdc_redfish_command.py
@@ -309,30 +309,30 @@ class TestWdcRedfishCommand(unittest.TestCase):
 
     def test_module_fail_when_required_args_missing(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            module.main()
+            with set_module_args({}):
+                module.main()
 
     def test_module_fail_when_unknown_category(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'category': 'unknown',
                 'command': 'FWActivate',
                 'username': 'USERID',
                 'password': 'PASSW0RD=21',
                 'ioms': [],
-            })
-            module.main()
+            }):
+                module.main()
 
     def test_module_fail_when_unknown_command(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'category': 'Update',
                 'command': 'unknown',
                 'username': 'USERID',
                 'password': 'PASSW0RD=21',
                 'ioms': [],
-            })
-            module.main()
+            }):
+                module.main()
 
     def test_module_chassis_power_mode_low(self):
         """Test setting chassis power mode to low (happy path)."""
@@ -344,15 +344,15 @@ class TestWdcRedfishCommand(unittest.TestCase):
             'resource_id': 'Enclosure',
             'baseuri': 'example.com'
         }
-        set_module_args(module_args)
-        with patch.multiple("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils",
-                            get_request=mock_get_request,
-                            post_request=mock_post_request):
-            with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                module.main()
-            self.assertEqual(ACTION_WAS_SUCCESSFUL_MESSAGE,
-                             get_exception_message(ansible_exit_json))
-            self.assertTrue(is_changed(ansible_exit_json))
+        with set_module_args(module_args):
+            with patch.multiple("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils",
+                                get_request=mock_get_request,
+                                post_request=mock_post_request):
+                with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
+                    module.main()
+                self.assertEqual(ACTION_WAS_SUCCESSFUL_MESSAGE,
+                                 get_exception_message(ansible_exit_json))
+                self.assertTrue(is_changed(ansible_exit_json))
 
     def test_module_chassis_power_mode_normal_when_already_normal(self):
         """Test setting chassis power mode to normal when it already is.  Verify we get changed=False."""
@@ -364,14 +364,14 @@ class TestWdcRedfishCommand(unittest.TestCase):
             'resource_id': 'Enclosure',
             'baseuri': 'example.com'
         }
-        set_module_args(module_args)
-        with patch.multiple("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils",
-                            get_request=mock_get_request):
-            with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                module.main()
-            self.assertEqual(ACTION_WAS_SUCCESSFUL_MESSAGE,
-                             get_exception_message(ansible_exit_json))
-            self.assertFalse(is_changed(ansible_exit_json))
+        with set_module_args(module_args):
+            with patch.multiple("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils",
+                                get_request=mock_get_request):
+                with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
+                    module.main()
+                self.assertEqual(ACTION_WAS_SUCCESSFUL_MESSAGE,
+                                 get_exception_message(ansible_exit_json))
+                self.assertFalse(is_changed(ansible_exit_json))
 
     def test_module_chassis_power_mode_invalid_command(self):
         """Test that we get an error when issuing an invalid PowerMode command."""
@@ -383,14 +383,14 @@ class TestWdcRedfishCommand(unittest.TestCase):
             'resource_id': 'Enclosure',
             'baseuri': 'example.com'
         }
-        set_module_args(module_args)
-        with patch.multiple("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils",
-                            get_request=mock_get_request):
-            with self.assertRaises(AnsibleFailJson) as ansible_fail_json:
-                module.main()
-            expected_error_message = "Invalid Command 'PowerModeExtraHigh'"
-            self.assertIn(expected_error_message,
-                          get_exception_message(ansible_fail_json))
+        with set_module_args(module_args):
+            with patch.multiple("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils",
+                                get_request=mock_get_request):
+                with self.assertRaises(AnsibleFailJson) as ansible_fail_json:
+                    module.main()
+                expected_error_message = "Invalid Command 'PowerModeExtraHigh'"
+                self.assertIn(expected_error_message,
+                              get_exception_message(ansible_fail_json))
 
     def test_module_enclosure_led_indicator_on(self):
         """Test turning on a valid LED indicator (in this case we use the Enclosure resource)."""
@@ -402,16 +402,15 @@ class TestWdcRedfishCommand(unittest.TestCase):
             "resource_id": "Enclosure",
             "baseuri": "example.com"
         }
-        set_module_args(module_args)
-
-        with patch.multiple("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils",
-                            get_request=mock_get_request,
-                            post_request=mock_post_request):
-            with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                module.main()
-            self.assertEqual(ACTION_WAS_SUCCESSFUL_MESSAGE,
-                             get_exception_message(ansible_exit_json))
-            self.assertTrue(is_changed(ansible_exit_json))
+        with set_module_args(module_args):
+            with patch.multiple("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils",
+                                get_request=mock_get_request,
+                                post_request=mock_post_request):
+                with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
+                    module.main()
+                self.assertEqual(ACTION_WAS_SUCCESSFUL_MESSAGE,
+                                 get_exception_message(ansible_exit_json))
+                self.assertTrue(is_changed(ansible_exit_json))
 
     def test_module_invalid_resource_led_indicator_on(self):
         """Test turning LED on for an invalid resource id."""
@@ -423,16 +422,15 @@ class TestWdcRedfishCommand(unittest.TestCase):
             "resource_id": "Disk99",
             "baseuri": "example.com"
         }
-        set_module_args(module_args)
-
-        with patch.multiple("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils",
-                            get_request=mock_get_request,
-                            post_request=mock_post_request):
-            with self.assertRaises(AnsibleFailJson) as ansible_fail_json:
-                module.main()
-            expected_error_message = "Chassis resource Disk99 not found"
-            self.assertEqual(expected_error_message,
-                             get_exception_message(ansible_fail_json))
+        with set_module_args(module_args):
+            with patch.multiple("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils",
+                                get_request=mock_get_request,
+                                post_request=mock_post_request):
+                with self.assertRaises(AnsibleFailJson) as ansible_fail_json:
+                    module.main()
+                expected_error_message = "Chassis resource Disk99 not found"
+                self.assertEqual(expected_error_message,
+                                 get_exception_message(ansible_fail_json))
 
     def test_module_enclosure_led_off_already_off(self):
         """Test turning LED indicator off when it's already off.  Confirm changed is False and no POST occurs."""
@@ -444,15 +442,14 @@ class TestWdcRedfishCommand(unittest.TestCase):
             "resource_id": "Enclosure",
             "baseuri": "example.com"
         }
-        set_module_args(module_args)
-
-        with patch.multiple("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils",
-                            get_request=mock_get_request):
-            with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                module.main()
-            self.assertEqual(ACTION_WAS_SUCCESSFUL_MESSAGE,
-                             get_exception_message(ansible_exit_json))
-            self.assertFalse(is_changed(ansible_exit_json))
+        with set_module_args(module_args):
+            with patch.multiple("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils",
+                                get_request=mock_get_request):
+                with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
+                    module.main()
+                self.assertEqual(ACTION_WAS_SUCCESSFUL_MESSAGE,
+                                 get_exception_message(ansible_exit_json))
+                self.assertFalse(is_changed(ansible_exit_json))
 
     def test_module_fw_activate_first_iom_unavailable(self):
         """Test that if the first IOM is not available, the 2nd one is used."""
@@ -467,26 +464,26 @@ class TestWdcRedfishCommand(unittest.TestCase):
             'password': 'PASSW0RD=21',
             'ioms': ioms
         }
-        set_module_args(module_args)
+        with set_module_args(module_args):
 
-        def mock_get_request(*args, **kwargs):
-            """Mock for get_request that will fail on the 'bad' IOM."""
-            if "bad.example.com" in args[1]:
-                return MOCK_URL_ERROR
-            else:
-                return mock_get_request_enclosure_single_tenant(*args, **kwargs)
+            def mock_get_request(*args, **kwargs):
+                """Mock for get_request that will fail on the 'bad' IOM."""
+                if "bad.example.com" in args[1]:
+                    return MOCK_URL_ERROR
+                else:
+                    return mock_get_request_enclosure_single_tenant(*args, **kwargs)
 
-        with patch.multiple(module.WdcRedfishUtils,
-                            _firmware_activate_uri=mock_fw_activate_url,
-                            _update_uri=mock_update_url,
-                            _find_updateservice_resource=empty_return,
-                            _find_updateservice_additional_uris=empty_return,
-                            get_request=mock_get_request,
-                            post_request=mock_post_request):
-            with self.assertRaises(AnsibleExitJson) as cm:
-                module.main()
-            self.assertEqual(ACTION_WAS_SUCCESSFUL_MESSAGE,
-                             get_exception_message(cm))
+            with patch.multiple(module.WdcRedfishUtils,
+                                _firmware_activate_uri=mock_fw_activate_url,
+                                _update_uri=mock_update_url,
+                                _find_updateservice_resource=empty_return,
+                                _find_updateservice_additional_uris=empty_return,
+                                get_request=mock_get_request,
+                                post_request=mock_post_request):
+                with self.assertRaises(AnsibleExitJson) as cm:
+                    module.main()
+                self.assertEqual(ACTION_WAS_SUCCESSFUL_MESSAGE,
+                                 get_exception_message(cm))
 
     def test_module_fw_activate_pass(self):
         """Test the FW Activate command in a passing scenario."""
@@ -508,69 +505,68 @@ class TestWdcRedfishCommand(unittest.TestCase):
                 'password': 'PASSW0RD=21',
             }
             module_args.update(uri_specifier)
-            set_module_args(module_args)
-
-            with patch.multiple("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils",
-                                _firmware_activate_uri=mock_fw_activate_url,
-                                _update_uri=mock_update_url,
-                                _find_updateservice_resource=empty_return,
-                                _find_updateservice_additional_uris=empty_return,
-                                get_request=mock_get_request_enclosure_single_tenant,
-                                post_request=mock_post_request):
-                with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                    module.main()
-                self.assertEqual(ACTION_WAS_SUCCESSFUL_MESSAGE,
-                                 get_exception_message(ansible_exit_json))
-                self.assertTrue(is_changed(ansible_exit_json))
+            with set_module_args(module_args):
+                with patch.multiple("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils",
+                                    _firmware_activate_uri=mock_fw_activate_url,
+                                    _update_uri=mock_update_url,
+                                    _find_updateservice_resource=empty_return,
+                                    _find_updateservice_additional_uris=empty_return,
+                                    get_request=mock_get_request_enclosure_single_tenant,
+                                    post_request=mock_post_request):
+                    with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
+                        module.main()
+                    self.assertEqual(ACTION_WAS_SUCCESSFUL_MESSAGE,
+                                     get_exception_message(ansible_exit_json))
+                    self.assertTrue(is_changed(ansible_exit_json))
 
     def test_module_fw_activate_service_does_not_support_fw_activate(self):
         """Test FW Activate when it is not supported."""
         expected_error_message = "Service does not support FWActivate"
-        set_module_args({
+        with set_module_args({
             'category': 'Update',
             'command': 'FWActivate',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
             'ioms': ["example1.example.com"]
-        })
+        }):
 
-        def mock_update_uri_response(*args, **kwargs):
-            return {
-                "ret": True,
-                "data": {}  # No Actions
-            }
+            def mock_update_uri_response(*args, **kwargs):
+                return {
+                    "ret": True,
+                    "data": {}  # No Actions
+                }
 
-        with patch.multiple(module.WdcRedfishUtils,
-                            _firmware_activate_uri=mocked_url_response,
-                            _update_uri=mock_update_url,
-                            _find_updateservice_resource=empty_return,
-                            _find_updateservice_additional_uris=empty_return,
-                            get_request=mock_update_uri_response):
-            with self.assertRaises(AnsibleFailJson) as cm:
-                module.main()
-            self.assertEqual(expected_error_message,
-                             get_exception_message(cm))
+            with patch.multiple(module.WdcRedfishUtils,
+                                _firmware_activate_uri=mocked_url_response,
+                                _update_uri=mock_update_url,
+                                _find_updateservice_resource=empty_return,
+                                _find_updateservice_additional_uris=empty_return,
+                                get_request=mock_update_uri_response):
+                with self.assertRaises(AnsibleFailJson) as cm:
+                    module.main()
+                self.assertEqual(expected_error_message,
+                                 get_exception_message(cm))
 
     def test_module_update_and_activate_image_uri_not_http(self):
         """Test Update and Activate when URI is not http(s)"""
         expected_error_message = "Bundle URI must be HTTP or HTTPS"
-        set_module_args({
+        with set_module_args({
             'category': 'Update',
             'command': 'UpdateAndActivate',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
             'ioms': ["example1.example.com"],
             'update_image_uri': "ftp://example.com/image"
-        })
-        with patch.multiple(module.WdcRedfishUtils,
-                            _firmware_activate_uri=mocked_url_response,
-                            _update_uri=mock_update_url,
-                            _find_updateservice_resource=empty_return,
-                            _find_updateservice_additional_uris=empty_return):
-            with self.assertRaises(AnsibleFailJson) as cm:
-                module.main()
-            self.assertEqual(expected_error_message,
-                             get_exception_message(cm))
+        }):
+            with patch.multiple(module.WdcRedfishUtils,
+                                _firmware_activate_uri=mocked_url_response,
+                                _update_uri=mock_update_url,
+                                _find_updateservice_resource=empty_return,
+                                _find_updateservice_additional_uris=empty_return):
+                with self.assertRaises(AnsibleFailJson) as cm:
+                    module.main()
+                self.assertEqual(expected_error_message,
+                                 get_exception_message(cm))
 
     def test_module_update_and_activate_target_not_ready_for_fw_update(self):
         """Test Update and Activate when target is not in the correct state."""
@@ -580,38 +576,38 @@ class TestWdcRedfishCommand(unittest.TestCase):
             mock_status_code,
             mock_status_description
         )
-        set_module_args({
+        with set_module_args({
             'category': 'Update',
             'command': 'UpdateAndActivate',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
             'ioms': ["example1.example.com"],
             'update_image_uri': "http://example.com/image"
-        })
-        with patch.object(module.WdcRedfishUtils, "get_simple_update_status") as mock_get_simple_update_status:
-            mock_get_simple_update_status.return_value = {
-                "ret": True,
-                "entries": {
-                    "StatusCode": mock_status_code,
-                    "Description": mock_status_description
+        }):
+            with patch.object(module.WdcRedfishUtils, "get_simple_update_status") as mock_get_simple_update_status:
+                mock_get_simple_update_status.return_value = {
+                    "ret": True,
+                    "entries": {
+                        "StatusCode": mock_status_code,
+                        "Description": mock_status_description
+                    }
                 }
-            }
 
-            with patch.multiple(module.WdcRedfishUtils,
-                                _firmware_activate_uri=mocked_url_response,
-                                _update_uri=mock_update_url,
-                                _find_updateservice_resource=empty_return,
-                                _find_updateservice_additional_uris=empty_return):
-                with self.assertRaises(AnsibleFailJson) as cm:
-                    module.main()
-                self.assertEqual(expected_error_message,
-                                 get_exception_message(cm))
+                with patch.multiple(module.WdcRedfishUtils,
+                                    _firmware_activate_uri=mocked_url_response,
+                                    _update_uri=mock_update_url,
+                                    _find_updateservice_resource=empty_return,
+                                    _find_updateservice_additional_uris=empty_return):
+                    with self.assertRaises(AnsibleFailJson) as cm:
+                        module.main()
+                    self.assertEqual(expected_error_message,
+                                     get_exception_message(cm))
 
     def test_module_update_and_activate_bundle_not_a_tarfile(self):
         """Test Update and Activate when bundle is not a tarfile"""
         mock_filename = os.path.abspath(__file__)
         expected_error_message = ERROR_MESSAGE_UNABLE_TO_EXTRACT_BUNDLE_VERSION
-        set_module_args({
+        with set_module_args({
             'category': 'Update',
             'command': 'UpdateAndActivate',
             'username': 'USERID',
@@ -622,24 +618,24 @@ class TestWdcRedfishCommand(unittest.TestCase):
                 "username": "image_user",
                 "password": "image_password"
             }
-        })
-        with patch('ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.fetch_file') as mock_fetch_file:
-            mock_fetch_file.return_value = mock_filename
-            with patch.multiple(module.WdcRedfishUtils,
-                                get_simple_update_status=mock_get_simple_update_status_ready_for_fw_update,
-                                _firmware_activate_uri=mocked_url_response,
-                                _update_uri=mock_update_url,
-                                _find_updateservice_resource=empty_return,
-                                _find_updateservice_additional_uris=empty_return):
-                with self.assertRaises(AnsibleFailJson) as cm:
-                    module.main()
-                self.assertEqual(expected_error_message,
-                                 get_exception_message(cm))
+        }):
+            with patch('ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.fetch_file') as mock_fetch_file:
+                mock_fetch_file.return_value = mock_filename
+                with patch.multiple(module.WdcRedfishUtils,
+                                    get_simple_update_status=mock_get_simple_update_status_ready_for_fw_update,
+                                    _firmware_activate_uri=mocked_url_response,
+                                    _update_uri=mock_update_url,
+                                    _find_updateservice_resource=empty_return,
+                                    _find_updateservice_additional_uris=empty_return):
+                    with self.assertRaises(AnsibleFailJson) as cm:
+                        module.main()
+                    self.assertEqual(expected_error_message,
+                                     get_exception_message(cm))
 
     def test_module_update_and_activate_bundle_contains_no_firmware_version(self):
         """Test Update and Activate when bundle contains no firmware version"""
         expected_error_message = ERROR_MESSAGE_UNABLE_TO_EXTRACT_BUNDLE_VERSION
-        set_module_args({
+        with set_module_args({
             'category': 'Update',
             'command': 'UpdateAndActivate',
             'username': 'USERID',
@@ -650,29 +646,29 @@ class TestWdcRedfishCommand(unittest.TestCase):
                 "username": "image_user",
                 "password": "image_password"
             }
-        })
+        }):
 
-        tar_name = "empty_tarfile{0}.tar".format(uuid.uuid4())
-        empty_tarfile = tarfile.open(os.path.join(self.tempdir, tar_name), "w")
-        empty_tarfile.close()
-        with patch('ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.fetch_file') as mock_fetch_file:
-            mock_fetch_file.return_value = os.path.join(self.tempdir, tar_name)
-            with patch.multiple(module.WdcRedfishUtils,
-                                get_simple_update_status=mock_get_simple_update_status_ready_for_fw_update,
-                                _firmware_activate_uri=mocked_url_response,
-                                _update_uri=mock_update_url,
-                                _find_updateservice_resource=empty_return,
-                                _find_updateservice_additional_uris=empty_return):
-                with self.assertRaises(AnsibleFailJson) as cm:
-                    module.main()
-                self.assertEqual(expected_error_message,
-                                 get_exception_message(cm))
+            tar_name = "empty_tarfile{0}.tar".format(uuid.uuid4())
+            empty_tarfile = tarfile.open(os.path.join(self.tempdir, tar_name), "w")
+            empty_tarfile.close()
+            with patch('ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.fetch_file') as mock_fetch_file:
+                mock_fetch_file.return_value = os.path.join(self.tempdir, tar_name)
+                with patch.multiple(module.WdcRedfishUtils,
+                                    get_simple_update_status=mock_get_simple_update_status_ready_for_fw_update,
+                                    _firmware_activate_uri=mocked_url_response,
+                                    _update_uri=mock_update_url,
+                                    _find_updateservice_resource=empty_return,
+                                    _find_updateservice_additional_uris=empty_return):
+                    with self.assertRaises(AnsibleFailJson) as cm:
+                        module.main()
+                    self.assertEqual(expected_error_message,
+                                     get_exception_message(cm))
 
     def test_module_update_and_activate_version_already_installed(self):
         """Test Update and Activate when the bundle version is already installed"""
         mock_firmware_version = "1.2.3"
         expected_error_message = ACTION_WAS_SUCCESSFUL_MESSAGE
-        set_module_args({
+        with set_module_args({
             'category': 'Update',
             'command': 'UpdateAndActivate',
             'username': 'USERID',
@@ -683,31 +679,31 @@ class TestWdcRedfishCommand(unittest.TestCase):
                 "username": "image_user",
                 "password": "image_password"
             }
-        })
+        }):
 
-        tar_name = self.generate_temp_bundlefile(mock_firmware_version=mock_firmware_version,
-                                                 is_multi_tenant=False)
-        with patch('ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.fetch_file') as mock_fetch_file:
-            mock_fetch_file.return_value = os.path.join(self.tempdir, tar_name)
-            with patch.multiple(module.WdcRedfishUtils,
-                                get_firmware_inventory=mock_get_firmware_inventory_version_1_2_3,
-                                get_simple_update_status=mock_get_simple_update_status_ready_for_fw_update,
-                                _firmware_activate_uri=mocked_url_response,
-                                _update_uri=mock_update_url,
-                                _find_updateservice_resource=empty_return,
-                                _find_updateservice_additional_uris=empty_return,
-                                get_request=mock_get_request_enclosure_single_tenant):
-                with self.assertRaises(AnsibleExitJson) as result:
-                    module.main()
-                self.assertEqual(expected_error_message,
-                                 get_exception_message(result))
-                self.assertFalse(is_changed(result))
+            tar_name = self.generate_temp_bundlefile(mock_firmware_version=mock_firmware_version,
+                                                     is_multi_tenant=False)
+            with patch('ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.fetch_file') as mock_fetch_file:
+                mock_fetch_file.return_value = os.path.join(self.tempdir, tar_name)
+                with patch.multiple(module.WdcRedfishUtils,
+                                    get_firmware_inventory=mock_get_firmware_inventory_version_1_2_3,
+                                    get_simple_update_status=mock_get_simple_update_status_ready_for_fw_update,
+                                    _firmware_activate_uri=mocked_url_response,
+                                    _update_uri=mock_update_url,
+                                    _find_updateservice_resource=empty_return,
+                                    _find_updateservice_additional_uris=empty_return,
+                                    get_request=mock_get_request_enclosure_single_tenant):
+                    with self.assertRaises(AnsibleExitJson) as result:
+                        module.main()
+                    self.assertEqual(expected_error_message,
+                                     get_exception_message(result))
+                    self.assertFalse(is_changed(result))
 
     def test_module_update_and_activate_version_already_installed_multi_tenant(self):
         """Test Update and Activate on multi-tenant when version is already installed"""
         mock_firmware_version = "1.2.3"
         expected_error_message = ACTION_WAS_SUCCESSFUL_MESSAGE
-        set_module_args({
+        with set_module_args({
             'category': 'Update',
             'command': 'UpdateAndActivate',
             'username': 'USERID',
@@ -718,30 +714,30 @@ class TestWdcRedfishCommand(unittest.TestCase):
                 "username": "image_user",
                 "password": "image_password"
             }
-        })
+        }):
 
-        tar_name = self.generate_temp_bundlefile(mock_firmware_version=mock_firmware_version,
-                                                 is_multi_tenant=True)
-        with patch('ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.fetch_file') as mock_fetch_file:
-            mock_fetch_file.return_value = os.path.join(self.tempdir, tar_name)
-            with patch.multiple(module.WdcRedfishUtils,
-                                get_firmware_inventory=mock_get_firmware_inventory_version_1_2_3,
-                                get_simple_update_status=mock_get_simple_update_status_ready_for_fw_update,
-                                _firmware_activate_uri=mocked_url_response,
-                                _update_uri=mock_update_url,
-                                _find_updateservice_resource=empty_return,
-                                _find_updateservice_additional_uris=empty_return,
-                                get_request=mock_get_request_enclosure_multi_tenant):
-                with self.assertRaises(AnsibleExitJson) as result:
-                    module.main()
-                self.assertEqual(expected_error_message,
-                                 get_exception_message(result))
-                self.assertFalse(is_changed(result))
+            tar_name = self.generate_temp_bundlefile(mock_firmware_version=mock_firmware_version,
+                                                     is_multi_tenant=True)
+            with patch('ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.fetch_file') as mock_fetch_file:
+                mock_fetch_file.return_value = os.path.join(self.tempdir, tar_name)
+                with patch.multiple(module.WdcRedfishUtils,
+                                    get_firmware_inventory=mock_get_firmware_inventory_version_1_2_3,
+                                    get_simple_update_status=mock_get_simple_update_status_ready_for_fw_update,
+                                    _firmware_activate_uri=mocked_url_response,
+                                    _update_uri=mock_update_url,
+                                    _find_updateservice_resource=empty_return,
+                                    _find_updateservice_additional_uris=empty_return,
+                                    get_request=mock_get_request_enclosure_multi_tenant):
+                    with self.assertRaises(AnsibleExitJson) as result:
+                        module.main()
+                    self.assertEqual(expected_error_message,
+                                     get_exception_message(result))
+                    self.assertFalse(is_changed(result))
 
     def test_module_update_and_activate_pass(self):
         """Test Update and Activate (happy path)"""
         mock_firmware_version = "1.2.2"
-        set_module_args({
+        with set_module_args({
             'category': 'Update',
             'command': 'UpdateAndActivate',
             'username': 'USERID',
@@ -752,34 +748,34 @@ class TestWdcRedfishCommand(unittest.TestCase):
                 "username": "image_user",
                 "password": "image_password"
             }
-        })
+        }):
 
-        tar_name = self.generate_temp_bundlefile(mock_firmware_version=mock_firmware_version,
-                                                 is_multi_tenant=False)
+            tar_name = self.generate_temp_bundlefile(mock_firmware_version=mock_firmware_version,
+                                                     is_multi_tenant=False)
 
-        with patch('ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.fetch_file') as mock_fetch_file:
-            mock_fetch_file.return_value = os.path.join(self.tempdir, tar_name)
-            with patch.multiple("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils",
-                                get_firmware_inventory=mock_get_firmware_inventory_version_1_2_3,
-                                simple_update=mock_simple_update,
-                                _simple_update_status_uri=mocked_url_response,
-                                # _find_updateservice_resource=empty_return,
-                                # _find_updateservice_additional_uris=empty_return,
-                                get_request=mock_get_request_enclosure_single_tenant,
-                                post_request=mock_post_request):
+            with patch('ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.fetch_file') as mock_fetch_file:
+                mock_fetch_file.return_value = os.path.join(self.tempdir, tar_name)
+                with patch.multiple("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils",
+                                    get_firmware_inventory=mock_get_firmware_inventory_version_1_2_3,
+                                    simple_update=mock_simple_update,
+                                    _simple_update_status_uri=mocked_url_response,
+                                    # _find_updateservice_resource=empty_return,
+                                    # _find_updateservice_additional_uris=empty_return,
+                                    get_request=mock_get_request_enclosure_single_tenant,
+                                    post_request=mock_post_request):
 
-                with patch("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils.get_simple_update_status"
-                           ) as mock_get_simple_update_status:
-                    mock_get_simple_update_status.side_effect = MOCK_SIMPLE_UPDATE_STATUS_LIST
-                    with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                        module.main()
-                    self.assertTrue(is_changed(ansible_exit_json))
-                    self.assertEqual(ACTION_WAS_SUCCESSFUL_MESSAGE, get_exception_message(ansible_exit_json))
+                    with patch("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils.get_simple_update_status"
+                               ) as mock_get_simple_update_status:
+                        mock_get_simple_update_status.side_effect = MOCK_SIMPLE_UPDATE_STATUS_LIST
+                        with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
+                            module.main()
+                        self.assertTrue(is_changed(ansible_exit_json))
+                        self.assertEqual(ACTION_WAS_SUCCESSFUL_MESSAGE, get_exception_message(ansible_exit_json))
 
     def test_module_update_and_activate_pass_multi_tenant(self):
         """Test Update and Activate with multi-tenant (happy path)"""
         mock_firmware_version = "1.2.2"
-        set_module_args({
+        with set_module_args({
             'category': 'Update',
             'command': 'UpdateAndActivate',
             'username': 'USERID',
@@ -790,34 +786,34 @@ class TestWdcRedfishCommand(unittest.TestCase):
                 "username": "image_user",
                 "password": "image_password"
             }
-        })
+        }):
 
-        tar_name = self.generate_temp_bundlefile(mock_firmware_version=mock_firmware_version,
-                                                 is_multi_tenant=True)
+            tar_name = self.generate_temp_bundlefile(mock_firmware_version=mock_firmware_version,
+                                                     is_multi_tenant=True)
 
-        with patch('ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.fetch_file') as mock_fetch_file:
-            mock_fetch_file.return_value = os.path.join(self.tempdir, tar_name)
-            with patch.multiple(module.WdcRedfishUtils,
-                                get_firmware_inventory=mock_get_firmware_inventory_version_1_2_3,
-                                simple_update=mock_simple_update,
-                                _simple_update_status_uri=mocked_url_response,
-                                # _find_updateservice_resource=empty_return,
-                                # _find_updateservice_additional_uris=empty_return,
-                                get_request=mock_get_request_enclosure_multi_tenant,
-                                post_request=mock_post_request):
-                with patch("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils.get_simple_update_status"
-                           ) as mock_get_simple_update_status:
-                    mock_get_simple_update_status.side_effect = MOCK_SIMPLE_UPDATE_STATUS_LIST
-                    with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                        module.main()
-                    self.assertTrue(is_changed(ansible_exit_json))
-                    self.assertEqual(ACTION_WAS_SUCCESSFUL_MESSAGE, get_exception_message(ansible_exit_json))
+            with patch('ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.fetch_file') as mock_fetch_file:
+                mock_fetch_file.return_value = os.path.join(self.tempdir, tar_name)
+                with patch.multiple(module.WdcRedfishUtils,
+                                    get_firmware_inventory=mock_get_firmware_inventory_version_1_2_3,
+                                    simple_update=mock_simple_update,
+                                    _simple_update_status_uri=mocked_url_response,
+                                    # _find_updateservice_resource=empty_return,
+                                    # _find_updateservice_additional_uris=empty_return,
+                                    get_request=mock_get_request_enclosure_multi_tenant,
+                                    post_request=mock_post_request):
+                    with patch("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils.get_simple_update_status"
+                               ) as mock_get_simple_update_status:
+                        mock_get_simple_update_status.side_effect = MOCK_SIMPLE_UPDATE_STATUS_LIST
+                        with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
+                            module.main()
+                        self.assertTrue(is_changed(ansible_exit_json))
+                        self.assertEqual(ACTION_WAS_SUCCESSFUL_MESSAGE, get_exception_message(ansible_exit_json))
 
     def test_module_fw_update_multi_tenant_firmware_single_tenant_enclosure(self):
         """Test Update and Activate using multi-tenant bundle on single-tenant enclosure"""
         mock_firmware_version = "1.1.1"
         expected_error_message = "Enclosure multi-tenant is False but bundle multi-tenant is True"
-        set_module_args({
+        with set_module_args({
             'category': 'Update',
             'command': 'UpdateAndActivate',
             'username': 'USERID',
@@ -828,30 +824,30 @@ class TestWdcRedfishCommand(unittest.TestCase):
                 "username": "image_user",
                 "password": "image_password"
             }
-        })
+        }):
 
-        tar_name = self.generate_temp_bundlefile(mock_firmware_version=mock_firmware_version,
-                                                 is_multi_tenant=True)
-        with patch('ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.fetch_file') as mock_fetch_file:
-            mock_fetch_file.return_value = os.path.join(self.tempdir, tar_name)
-            with patch.multiple(module.WdcRedfishUtils,
-                                get_firmware_inventory=mock_get_firmware_inventory_version_1_2_3(),
-                                get_simple_update_status=mock_get_simple_update_status_ready_for_fw_update,
-                                _firmware_activate_uri=mocked_url_response,
-                                _update_uri=mock_update_url,
-                                _find_updateservice_resource=empty_return,
-                                _find_updateservice_additional_uris=empty_return,
-                                get_request=mock_get_request_enclosure_single_tenant):
-                with self.assertRaises(AnsibleFailJson) as result:
-                    module.main()
-                self.assertEqual(expected_error_message,
-                                 get_exception_message(result))
+            tar_name = self.generate_temp_bundlefile(mock_firmware_version=mock_firmware_version,
+                                                     is_multi_tenant=True)
+            with patch('ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.fetch_file') as mock_fetch_file:
+                mock_fetch_file.return_value = os.path.join(self.tempdir, tar_name)
+                with patch.multiple(module.WdcRedfishUtils,
+                                    get_firmware_inventory=mock_get_firmware_inventory_version_1_2_3(),
+                                    get_simple_update_status=mock_get_simple_update_status_ready_for_fw_update,
+                                    _firmware_activate_uri=mocked_url_response,
+                                    _update_uri=mock_update_url,
+                                    _find_updateservice_resource=empty_return,
+                                    _find_updateservice_additional_uris=empty_return,
+                                    get_request=mock_get_request_enclosure_single_tenant):
+                    with self.assertRaises(AnsibleFailJson) as result:
+                        module.main()
+                    self.assertEqual(expected_error_message,
+                                     get_exception_message(result))
 
     def test_module_fw_update_single_tentant_firmware_multi_tenant_enclosure(self):
         """Test Update and Activate using singe-tenant bundle on multi-tenant enclosure"""
         mock_firmware_version = "1.1.1"
         expected_error_message = "Enclosure multi-tenant is True but bundle multi-tenant is False"
-        set_module_args({
+        with set_module_args({
             'category': 'Update',
             'command': 'UpdateAndActivate',
             'username': 'USERID',
@@ -862,24 +858,24 @@ class TestWdcRedfishCommand(unittest.TestCase):
                 "username": "image_user",
                 "password": "image_password"
             }
-        })
+        }):
 
-        tar_name = self.generate_temp_bundlefile(mock_firmware_version=mock_firmware_version,
-                                                 is_multi_tenant=False)
-        with patch('ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.fetch_file') as mock_fetch_file:
-            mock_fetch_file.return_value = os.path.join(self.tempdir, tar_name)
-            with patch.multiple(module.WdcRedfishUtils,
-                                get_firmware_inventory=mock_get_firmware_inventory_version_1_2_3(),
-                                get_simple_update_status=mock_get_simple_update_status_ready_for_fw_update,
-                                _firmware_activate_uri=mocked_url_response,
-                                _update_uri=mock_update_url,
-                                _find_updateservice_resource=empty_return,
-                                _find_updateservice_additional_uris=empty_return,
-                                get_request=mock_get_request_enclosure_multi_tenant):
-                with self.assertRaises(AnsibleFailJson) as result:
-                    module.main()
-                self.assertEqual(expected_error_message,
-                                 get_exception_message(result))
+            tar_name = self.generate_temp_bundlefile(mock_firmware_version=mock_firmware_version,
+                                                     is_multi_tenant=False)
+            with patch('ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.fetch_file') as mock_fetch_file:
+                mock_fetch_file.return_value = os.path.join(self.tempdir, tar_name)
+                with patch.multiple(module.WdcRedfishUtils,
+                                    get_firmware_inventory=mock_get_firmware_inventory_version_1_2_3(),
+                                    get_simple_update_status=mock_get_simple_update_status_ready_for_fw_update,
+                                    _firmware_activate_uri=mocked_url_response,
+                                    _update_uri=mock_update_url,
+                                    _find_updateservice_resource=empty_return,
+                                    _find_updateservice_additional_uris=empty_return,
+                                    get_request=mock_get_request_enclosure_multi_tenant):
+                    with self.assertRaises(AnsibleFailJson) as result:
+                        module.main()
+                    self.assertEqual(expected_error_message,
+                                     get_exception_message(result))
 
     def generate_temp_bundlefile(self,
                                  mock_firmware_version,

--- a/tests/unit/plugins/modules/test_wdc_redfish_info.py
+++ b/tests/unit/plugins/modules/test_wdc_redfish_info.py
@@ -77,140 +77,140 @@ class TestWdcRedfishInfo(unittest.TestCase):
 
     def test_module_fail_when_required_args_missing(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            module.main()
+            with set_module_args({}):
+                module.main()
 
     def test_module_fail_when_unknown_category(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'category': 'unknown',
                 'command': 'SimpleUpdateStatus',
                 'username': 'USERID',
                 'password': 'PASSW0RD=21',
                 'ioms': [],
-            })
-            module.main()
+            }):
+                module.main()
 
     def test_module_fail_when_unknown_command(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'category': 'Update',
                 'command': 'unknown',
                 'username': 'USERID',
                 'password': 'PASSW0RD=21',
                 'ioms': [],
-            })
-            module.main()
+            }):
+                module.main()
 
     def test_module_simple_update_status_pass(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Update',
             'command': 'SimpleUpdateStatus',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
             'ioms': ["example1.example.com"],
-        })
+        }):
 
-        def mock_simple_update_status(*args, **kwargs):
-            return {
-                "ret": True,
-                "data": {
-                    "Description": "Ready for FW update",
-                    "ErrorCode": 0,
-                    "EstimatedRemainingMinutes": 0,
-                    "StatusCode": 0
-                }
-            }
-
-        def mocked_string_response(*args, **kwargs):
-            return "mockedUrl"
-
-        def empty_return(*args, **kwargs):
-            return {"ret": True}
-
-        with patch.multiple(module.WdcRedfishUtils,
-                            _simple_update_status_uri=mocked_string_response,
-                            _find_updateservice_resource=empty_return,
-                            _find_updateservice_additional_uris=empty_return,
-                            get_request=mock_simple_update_status):
-            with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
-                module.main()
-            redfish_facts = get_redfish_facts(ansible_exit_json)
-            self.assertEqual(mock_simple_update_status()["data"],
-                             redfish_facts["simple_update_status"]["entries"])
-
-    def test_module_simple_update_status_updateservice_resource_not_found(self):
-        set_module_args({
-            'category': 'Update',
-            'command': 'SimpleUpdateStatus',
-            'username': 'USERID',
-            'password': 'PASSW0RD=21',
-            'ioms': ["example1.example.com"],
-        })
-        with patch.object(module.WdcRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {
-                "ret": True,
-                "data": {}  # Missing UpdateService property
-            }
-            with self.assertRaises(AnsibleFailJson) as ansible_exit_json:
-                module.main()
-            self.assertEqual("UpdateService resource not found",
-                             get_exception_message(ansible_exit_json))
-
-    def test_module_simple_update_status_service_does_not_support_simple_update(self):
-        set_module_args({
-            'category': 'Update',
-            'command': 'SimpleUpdateStatus',
-            'username': 'USERID',
-            'password': 'PASSW0RD=21',
-            'ioms': ["example1.example.com"],
-        })
-
-        def mock_get_request_function(uri):
-            mock_url_string = "mockURL"
-            if mock_url_string in uri:
+            def mock_simple_update_status(*args, **kwargs):
                 return {
                     "ret": True,
                     "data": {
-                        "Actions": {  # No #UpdateService.SimpleUpdate
-                        }
+                        "Description": "Ready for FW update",
+                        "ErrorCode": 0,
+                        "EstimatedRemainingMinutes": 0,
+                        "StatusCode": 0
                     }
                 }
-            else:
-                return {
-                    "ret": True,
-                    "data": mock_url_string
-                }
 
-        with patch.object(module.WdcRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.side_effect = mock_get_request_function
-            with self.assertRaises(AnsibleFailJson) as ansible_exit_json:
-                module.main()
-            self.assertEqual("UpdateService resource not found",
-                             get_exception_message(ansible_exit_json))
+            def mocked_string_response(*args, **kwargs):
+                return "mockedUrl"
 
-    def test_module_simple_update_status_service_does_not_support_fw_activate(self):
-        set_module_args({
+            def empty_return(*args, **kwargs):
+                return {"ret": True}
+
+            with patch.multiple(module.WdcRedfishUtils,
+                                _simple_update_status_uri=mocked_string_response,
+                                _find_updateservice_resource=empty_return,
+                                _find_updateservice_additional_uris=empty_return,
+                                get_request=mock_simple_update_status):
+                with self.assertRaises(AnsibleExitJson) as ansible_exit_json:
+                    module.main()
+                redfish_facts = get_redfish_facts(ansible_exit_json)
+                self.assertEqual(mock_simple_update_status()["data"],
+                                 redfish_facts["simple_update_status"]["entries"])
+
+    def test_module_simple_update_status_updateservice_resource_not_found(self):
+        with set_module_args({
             'category': 'Update',
             'command': 'SimpleUpdateStatus',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
             'ioms': ["example1.example.com"],
-        })
+        }):
+            with patch.object(module.WdcRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {
+                    "ret": True,
+                    "data": {}  # Missing UpdateService property
+                }
+                with self.assertRaises(AnsibleFailJson) as ansible_exit_json:
+                    module.main()
+                self.assertEqual("UpdateService resource not found",
+                                 get_exception_message(ansible_exit_json))
 
-        def mock_get_request_function(uri):
-            if uri.endswith("/redfish/v1") or uri.endswith("/redfish/v1/"):
-                return MOCK_SUCCESSFUL_RESPONSE_WITH_UPDATE_SERVICE_RESOURCE
-            elif uri.endswith("/mockedUrl"):
-                return MOCK_SUCCESSFUL_HTTP_EMPTY_RESPONSE
-            elif uri.endswith("/UpdateService"):
-                return MOCK_SUCCESSFUL_RESPONSE_WITH_SIMPLE_UPDATE_BUT_NO_FW_ACTIVATE
-            else:
-                raise RuntimeError("Illegal call to get_request in test: " + uri)
+    def test_module_simple_update_status_service_does_not_support_simple_update(self):
+        with set_module_args({
+            'category': 'Update',
+            'command': 'SimpleUpdateStatus',
+            'username': 'USERID',
+            'password': 'PASSW0RD=21',
+            'ioms': ["example1.example.com"],
+        }):
 
-        with patch("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils.get_request") as mock_get_request:
-            mock_get_request.side_effect = mock_get_request_function
-            with self.assertRaises(AnsibleFailJson) as ansible_exit_json:
-                module.main()
-            self.assertEqual("Service does not support FWActivate",
-                             get_exception_message(ansible_exit_json))
+            def mock_get_request_function(uri):
+                mock_url_string = "mockURL"
+                if mock_url_string in uri:
+                    return {
+                        "ret": True,
+                        "data": {
+                            "Actions": {  # No #UpdateService.SimpleUpdate
+                            }
+                        }
+                    }
+                else:
+                    return {
+                        "ret": True,
+                        "data": mock_url_string
+                    }
+
+            with patch.object(module.WdcRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.side_effect = mock_get_request_function
+                with self.assertRaises(AnsibleFailJson) as ansible_exit_json:
+                    module.main()
+                self.assertEqual("UpdateService resource not found",
+                                 get_exception_message(ansible_exit_json))
+
+    def test_module_simple_update_status_service_does_not_support_fw_activate(self):
+        with set_module_args({
+            'category': 'Update',
+            'command': 'SimpleUpdateStatus',
+            'username': 'USERID',
+            'password': 'PASSW0RD=21',
+            'ioms': ["example1.example.com"],
+        }):
+
+            def mock_get_request_function(uri):
+                if uri.endswith("/redfish/v1") or uri.endswith("/redfish/v1/"):
+                    return MOCK_SUCCESSFUL_RESPONSE_WITH_UPDATE_SERVICE_RESOURCE
+                elif uri.endswith("/mockedUrl"):
+                    return MOCK_SUCCESSFUL_HTTP_EMPTY_RESPONSE
+                elif uri.endswith("/UpdateService"):
+                    return MOCK_SUCCESSFUL_RESPONSE_WITH_SIMPLE_UPDATE_BUT_NO_FW_ACTIVATE
+                else:
+                    raise RuntimeError("Illegal call to get_request in test: " + uri)
+
+            with patch("ansible_collections.community.general.plugins.module_utils.wdc_redfish_utils.WdcRedfishUtils.get_request") as mock_get_request:
+                mock_get_request.side_effect = mock_get_request_function
+                with self.assertRaises(AnsibleFailJson) as ansible_exit_json:
+                    module.main()
+                self.assertEqual("Service does not support FWActivate",
+                                 get_exception_message(ansible_exit_json))

--- a/tests/unit/plugins/modules/test_xcc_redfish_command.py
+++ b/tests/unit/plugins/modules/test_xcc_redfish_command.py
@@ -30,33 +30,33 @@ class TestXCCRedfishCommand(unittest.TestCase):
 
     def test_module_fail_when_required_args_missing(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({})
-            module.main()
+            with set_module_args({}):
+                module.main()
 
     def test_module_fail_when_unknown_category(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'category': 'unknown',
                 'command': 'VirtualMediaEject',
                 'baseuri': '10.245.39.251',
                 'username': 'USERID',
                 'password': 'PASSW0RD=21',
-            })
-            module.main()
+            }):
+                module.main()
 
     def test_module_fail_when_unknown_command(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'category': 'Manager',
                 'command': 'unknown',
                 'baseuri': '10.245.39.251',
                 'username': 'USERID',
                 'password': 'PASSW0RD=21',
-            })
-            module.main()
+            }):
+                module.main()
 
     def test_module_command_VirtualMediaInsert_pass(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Manager',
             'command': 'VirtualMediaInsert',
             'baseuri': '10.245.39.251',
@@ -70,20 +70,20 @@ class TestXCCRedfishCommand(unittest.TestCase):
                 'write_protected': True,
                 'transfer_protocol_type': 'NFS'
             }
-        })
-        with patch.object(module.XCCRedfishUtils, '_find_systems_resource') as mock__find_systems_resource:
-            mock__find_systems_resource.return_value = {'ret': True, 'changed': True, 'msg': 'success'}
-            with patch.object(module.XCCRedfishUtils, '_find_managers_resource') as mock__find_managers_resource:
-                mock__find_managers_resource.return_value = {'ret': True, 'changed': True, 'msg': 'success'}
+        }):
+            with patch.object(module.XCCRedfishUtils, '_find_systems_resource') as mock__find_systems_resource:
+                mock__find_systems_resource.return_value = {'ret': True, 'changed': True, 'msg': 'success'}
+                with patch.object(module.XCCRedfishUtils, '_find_managers_resource') as mock__find_managers_resource:
+                    mock__find_managers_resource.return_value = {'ret': True, 'changed': True, 'msg': 'success'}
 
-                with patch.object(module.XCCRedfishUtils, 'virtual_media_insert') as mock_virtual_media_insert:
-                    mock_virtual_media_insert.return_value = {'ret': True, 'changed': True, 'msg': 'success'}
+                    with patch.object(module.XCCRedfishUtils, 'virtual_media_insert') as mock_virtual_media_insert:
+                        mock_virtual_media_insert.return_value = {'ret': True, 'changed': True, 'msg': 'success'}
 
-                    with self.assertRaises(AnsibleExitJson) as result:
-                        module.main()
+                        with self.assertRaises(AnsibleExitJson) as result:
+                            module.main()
 
     def test_module_command_VirtualMediaEject_pass(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Manager',
             'command': 'VirtualMediaEject',
             'baseuri': '10.245.39.251',
@@ -93,194 +93,184 @@ class TestXCCRedfishCommand(unittest.TestCase):
             'virtual_media': {
                 'image_url': "nfs://10.245.52.18:/home/nfs/bootable-sr635-20210111-autorun.iso",
             }
-        })
-        with patch.object(module.XCCRedfishUtils, '_find_systems_resource') as mock__find_systems_resource:
-            mock__find_systems_resource.return_value = {'ret': True, 'changed': True, 'msg': 'success'}
-            with patch.object(module.XCCRedfishUtils, '_find_managers_resource') as mock__find_managers_resource:
-                mock__find_managers_resource.return_value = {'ret': True, 'changed': True, 'msg': 'success'}
+        }):
+            with patch.object(module.XCCRedfishUtils, '_find_systems_resource') as mock__find_systems_resource:
+                mock__find_systems_resource.return_value = {'ret': True, 'changed': True, 'msg': 'success'}
+                with patch.object(module.XCCRedfishUtils, '_find_managers_resource') as mock__find_managers_resource:
+                    mock__find_managers_resource.return_value = {'ret': True, 'changed': True, 'msg': 'success'}
 
-                with patch.object(module.XCCRedfishUtils, 'virtual_media_eject') as mock_virtual_media_eject:
-                    mock_virtual_media_eject.return_value = {'ret': True, 'changed': True, 'msg': 'success'}
+                    with patch.object(module.XCCRedfishUtils, 'virtual_media_eject') as mock_virtual_media_eject:
+                        mock_virtual_media_eject.return_value = {'ret': True, 'changed': True, 'msg': 'success'}
 
-                    with self.assertRaises(AnsibleExitJson) as result:
-                        module.main()
+                        with self.assertRaises(AnsibleExitJson) as result:
+                            module.main()
 
     def test_module_command_VirtualMediaEject_fail_when_required_args_missing(self):
         with self.assertRaises(AnsibleFailJson):
-            set_module_args({
+            with set_module_args({
                 'category': 'Manager',
                 'command': 'VirtualMediaEject',
                 'baseuri': '10.245.39.251',
                 'username': 'USERID',
                 'password': 'PASSW0RD=21',
-            })
-            module.main()
+            }):
+                module.main()
 
     def test_module_command_GetResource_fail_when_required_args_missing(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'GetResource',
             'baseuri': '10.245.39.251',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
-        })
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx'}}
 
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx'}}
-
-            with self.assertRaises(AnsibleFailJson) as result:
-                module.main()
+                with self.assertRaises(AnsibleFailJson) as result:
+                    module.main()
 
     def test_module_command_GetResource_fail_when_get_return_false(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'GetResource',
             'baseuri': '10.245.39.251',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/testuri',
-        })
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {'ret': False, 'msg': '404 error'}
 
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {'ret': False, 'msg': '404 error'}
-
-            with self.assertRaises(AnsibleFailJson) as result:
-                module.main()
+                with self.assertRaises(AnsibleFailJson) as result:
+                    module.main()
 
     def test_module_command_GetResource_pass(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'GetResource',
             'baseuri': '10.245.39.251',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/testuri',
-        })
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx'}}
 
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx'}}
-
-            with self.assertRaises(AnsibleExitJson) as result:
-                module.main()
+                with self.assertRaises(AnsibleExitJson) as result:
+                    module.main()
 
     def test_module_command_GetCollectionResource_fail_when_required_args_missing(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'GetCollectionResource',
             'baseuri': '10.245.39.251',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
-        })
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx'}}
 
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx'}}
-
-            with self.assertRaises(AnsibleFailJson) as result:
-                module.main()
+                with self.assertRaises(AnsibleFailJson) as result:
+                    module.main()
 
     def test_module_command_GetCollectionResource_fail_when_get_return_false(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'GetCollectionResource',
             'baseuri': '10.245.39.251',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/testuri',
-        })
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {'ret': False, 'msg': '404 error'}
 
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {'ret': False, 'msg': '404 error'}
-
-            with self.assertRaises(AnsibleFailJson) as result:
-                module.main()
+                with self.assertRaises(AnsibleFailJson) as result:
+                    module.main()
 
     def test_module_command_GetCollectionResource_fail_when_get_not_colection(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'GetCollectionResource',
             'baseuri': '10.245.39.251',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/testuri',
-        })
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx'}}
 
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx'}}
-
-            with self.assertRaises(AnsibleFailJson) as result:
-                module.main()
+                with self.assertRaises(AnsibleFailJson) as result:
+                    module.main()
 
     def test_module_command_GetCollectionResource_pass_when_get_empty_collection(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'GetCollectionResource',
             'baseuri': '10.245.39.251',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/testuri',
-        })
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {'ret': True, 'data': {'Members': [], 'Members@odata.count': 0}}
 
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {'ret': True, 'data': {'Members': [], 'Members@odata.count': 0}}
-
-            with self.assertRaises(AnsibleExitJson) as result:
-                module.main()
+                with self.assertRaises(AnsibleExitJson) as result:
+                    module.main()
 
     def test_module_command_GetCollectionResource_pass_when_get_collection(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'GetCollectionResource',
             'baseuri': '10.245.39.251',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/testuri',
-        })
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {'ret': True, 'data': {'Members': [{'@odata.id': '/redfish/v1/testuri/1'}], 'Members@odata.count': 1}}
 
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {'ret': True, 'data': {'Members': [{'@odata.id': '/redfish/v1/testuri/1'}], 'Members@odata.count': 1}}
-
-            with self.assertRaises(AnsibleExitJson) as result:
-                module.main()
+                with self.assertRaises(AnsibleExitJson) as result:
+                    module.main()
 
     def test_module_command_PatchResource_fail_when_required_args_missing(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'PatchResource',
             'baseuri': '10.245.39.251',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
-        })
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx', '@odata.etag': '27f6eb13fa1c28a2711'}}
 
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx', '@odata.etag': '27f6eb13fa1c28a2711'}}
+                with patch.object(module.XCCRedfishUtils, 'patch_request') as mock_patch_request:
+                    mock_patch_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx'}}
 
-            with patch.object(module.XCCRedfishUtils, 'patch_request') as mock_patch_request:
-                mock_patch_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx'}}
-
-                with self.assertRaises(AnsibleFailJson) as result:
-                    module.main()
+                    with self.assertRaises(AnsibleFailJson) as result:
+                        module.main()
 
     def test_module_command_PatchResource_fail_when_required_args_missing_no_requestbody(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'PatchResource',
             'baseuri': '10.245.39.251',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/testuri',
-        })
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx', '@odata.etag': '27f6eb13fa1c28a2711'}}
 
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx', '@odata.etag': '27f6eb13fa1c28a2711'}}
+                with patch.object(module.XCCRedfishUtils, 'patch_request') as mock_patch_request:
+                    mock_patch_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx'}}
 
-            with patch.object(module.XCCRedfishUtils, 'patch_request') as mock_patch_request:
-                mock_patch_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx'}}
-
-                with self.assertRaises(AnsibleFailJson) as result:
-                    module.main()
+                    with self.assertRaises(AnsibleFailJson) as result:
+                        module.main()
 
     def test_module_command_PatchResource_fail_when_noexisting_property_in_requestbody(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'PatchResource',
             'baseuri': '10.245.39.251',
@@ -288,19 +278,18 @@ class TestXCCRedfishCommand(unittest.TestCase):
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/testuri',
             'request_body': {'teststr': 'yyyy', 'otherkey': 'unknownkey'}
-        })
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx', '@odata.etag': '27f6eb13fa1c28a2711'}}
 
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx', '@odata.etag': '27f6eb13fa1c28a2711'}}
+                with patch.object(module.XCCRedfishUtils, 'patch_request') as mock_patch_request:
+                    mock_patch_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx'}}
 
-            with patch.object(module.XCCRedfishUtils, 'patch_request') as mock_patch_request:
-                mock_patch_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx'}}
-
-                with self.assertRaises(AnsibleFailJson) as result:
-                    module.main()
+                    with self.assertRaises(AnsibleFailJson) as result:
+                        module.main()
 
     def test_module_command_PatchResource_fail_when_get_return_false(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'PatchResource',
             'baseuri': '10.245.39.251',
@@ -308,19 +297,18 @@ class TestXCCRedfishCommand(unittest.TestCase):
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/testuri',
             'request_body': {'teststr': 'yyyy'}
-        })
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx', '@odata.etag': '27f6eb13fa1c28a2711'}}
 
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx', '@odata.etag': '27f6eb13fa1c28a2711'}}
+                with patch.object(module.XCCRedfishUtils, 'patch_request') as mock_patch_request:
+                    mock_patch_request.return_value = {'ret': False, 'msg': '500 internal error'}
 
-            with patch.object(module.XCCRedfishUtils, 'patch_request') as mock_patch_request:
-                mock_patch_request.return_value = {'ret': False, 'msg': '500 internal error'}
-
-                with self.assertRaises(AnsibleFailJson) as result:
-                    module.main()
+                    with self.assertRaises(AnsibleFailJson) as result:
+                        module.main()
 
     def test_module_command_PatchResource_pass(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'PatchResource',
             'baseuri': '10.245.39.251',
@@ -328,170 +316,165 @@ class TestXCCRedfishCommand(unittest.TestCase):
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/testuri',
             'request_body': {'teststr': 'yyyy'}
-        })
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx', '@odata.etag': '27f6eb13fa1c28a2711'}}
 
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {'ret': True, 'data': {'teststr': 'xxxx', '@odata.etag': '27f6eb13fa1c28a2711'}}
+                with patch.object(module.XCCRedfishUtils, 'patch_request') as mock_patch_request:
+                    mock_patch_request.return_value = {'ret': True, 'data': {'teststr': 'yyyy', '@odata.etag': '322e0d45d9572723c98'}}
 
-            with patch.object(module.XCCRedfishUtils, 'patch_request') as mock_patch_request:
-                mock_patch_request.return_value = {'ret': True, 'data': {'teststr': 'yyyy', '@odata.etag': '322e0d45d9572723c98'}}
-
-                with self.assertRaises(AnsibleExitJson) as result:
-                    module.main()
+                    with self.assertRaises(AnsibleExitJson) as result:
+                        module.main()
 
     def test_module_command_PostResource_fail_when_required_args_missing(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'PostResource',
             'baseuri': '10.245.39.251',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
-        })
-
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {
-                'ret': True,
-                'data': {
-                    'Actions': {
-                        '#Bios.ChangePassword': {
-                            '@Redfish.ActionInfo': "/redfish/v1/Systems/1/Bios/ChangePasswordActionInfo",
-                            'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword",
-                            'title': "ChangePassword",
-                            'PasswordName@Redfish.AllowableValues': [
-                                "UefiAdminPassword",
-                                "UefiPowerOnPassword"
-                            ]
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {
+                    'ret': True,
+                    'data': {
+                        'Actions': {
+                            '#Bios.ChangePassword': {
+                                '@Redfish.ActionInfo': "/redfish/v1/Systems/1/Bios/ChangePasswordActionInfo",
+                                'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword",
+                                'title': "ChangePassword",
+                                'PasswordName@Redfish.AllowableValues': [
+                                    "UefiAdminPassword",
+                                    "UefiPowerOnPassword"
+                                ]
+                            },
+                            '#Bios.ResetBios': {
+                                'title': "ResetBios",
+                                'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios"
+                            }
                         },
-                        '#Bios.ResetBios': {
-                            'title': "ResetBios",
-                            'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios"
-                        }
-                    },
+                    }
                 }
-            }
 
-            with patch.object(module.XCCRedfishUtils, 'post_request') as mock_post_request:
-                mock_post_request.return_value = {'ret': True}
+                with patch.object(module.XCCRedfishUtils, 'post_request') as mock_post_request:
+                    mock_post_request.return_value = {'ret': True}
 
-                with self.assertRaises(AnsibleFailJson) as result:
-                    module.main()
+                    with self.assertRaises(AnsibleFailJson) as result:
+                        module.main()
 
     def test_module_command_PostResource_fail_when_invalid_resourceuri(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'PostResource',
             'baseuri': '10.245.39.251',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/testuri',
-        })
-
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {
-                'ret': True,
-                'data': {
-                    'Actions': {
-                        '#Bios.ChangePassword': {
-                            '@Redfish.ActionInfo': "/redfish/v1/Systems/1/Bios/ChangePasswordActionInfo",
-                            'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword",
-                            'title': "ChangePassword",
-                            'PasswordName@Redfish.AllowableValues': [
-                                "UefiAdminPassword",
-                                "UefiPowerOnPassword"
-                            ]
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {
+                    'ret': True,
+                    'data': {
+                        'Actions': {
+                            '#Bios.ChangePassword': {
+                                '@Redfish.ActionInfo': "/redfish/v1/Systems/1/Bios/ChangePasswordActionInfo",
+                                'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword",
+                                'title': "ChangePassword",
+                                'PasswordName@Redfish.AllowableValues': [
+                                    "UefiAdminPassword",
+                                    "UefiPowerOnPassword"
+                                ]
+                            },
+                            '#Bios.ResetBios': {
+                                'title': "ResetBios",
+                                'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios"
+                            }
                         },
-                        '#Bios.ResetBios': {
-                            'title': "ResetBios",
-                            'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios"
-                        }
-                    },
+                    }
                 }
-            }
 
-            with patch.object(module.XCCRedfishUtils, 'post_request') as mock_post_request:
-                mock_post_request.return_value = {'ret': True}
+                with patch.object(module.XCCRedfishUtils, 'post_request') as mock_post_request:
+                    mock_post_request.return_value = {'ret': True}
 
-                with self.assertRaises(AnsibleFailJson) as result:
-                    module.main()
+                    with self.assertRaises(AnsibleFailJson) as result:
+                        module.main()
 
     def test_module_command_PostResource_fail_when_no_requestbody(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'PostResource',
             'baseuri': '10.245.39.251',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword',
-        })
-
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {
-                'ret': True,
-                'data': {
-                    'Actions': {
-                        '#Bios.ChangePassword': {
-                            '@Redfish.ActionInfo': "/redfish/v1/Systems/1/Bios/ChangePasswordActionInfo",
-                            'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword",
-                            'title': "ChangePassword",
-                            'PasswordName@Redfish.AllowableValues': [
-                                "UefiAdminPassword",
-                                "UefiPowerOnPassword"
-                            ]
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {
+                    'ret': True,
+                    'data': {
+                        'Actions': {
+                            '#Bios.ChangePassword': {
+                                '@Redfish.ActionInfo': "/redfish/v1/Systems/1/Bios/ChangePasswordActionInfo",
+                                'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword",
+                                'title': "ChangePassword",
+                                'PasswordName@Redfish.AllowableValues': [
+                                    "UefiAdminPassword",
+                                    "UefiPowerOnPassword"
+                                ]
+                            },
+                            '#Bios.ResetBios': {
+                                'title': "ResetBios",
+                                'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios"
+                            }
                         },
-                        '#Bios.ResetBios': {
-                            'title': "ResetBios",
-                            'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios"
-                        }
-                    },
+                    }
                 }
-            }
 
-            with patch.object(module.XCCRedfishUtils, 'post_request') as mock_post_request:
-                mock_post_request.return_value = {'ret': True}
+                with patch.object(module.XCCRedfishUtils, 'post_request') as mock_post_request:
+                    mock_post_request.return_value = {'ret': True}
 
-                with self.assertRaises(AnsibleFailJson) as result:
-                    module.main()
+                    with self.assertRaises(AnsibleFailJson) as result:
+                        module.main()
 
     def test_module_command_PostResource_fail_when_no_requestbody(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'PostResource',
             'baseuri': '10.245.39.251',
             'username': 'USERID',
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword',
-        })
-
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {
-                'ret': True,
-                'data': {
-                    'Actions': {
-                        '#Bios.ChangePassword': {
-                            '@Redfish.ActionInfo': "/redfish/v1/Systems/1/Bios/ChangePasswordActionInfo",
-                            'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword",
-                            'title': "ChangePassword",
-                            'PasswordName@Redfish.AllowableValues': [
-                                "UefiAdminPassword",
-                                "UefiPowerOnPassword"
-                            ]
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {
+                    'ret': True,
+                    'data': {
+                        'Actions': {
+                            '#Bios.ChangePassword': {
+                                '@Redfish.ActionInfo': "/redfish/v1/Systems/1/Bios/ChangePasswordActionInfo",
+                                'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword",
+                                'title': "ChangePassword",
+                                'PasswordName@Redfish.AllowableValues': [
+                                    "UefiAdminPassword",
+                                    "UefiPowerOnPassword"
+                                ]
+                            },
+                            '#Bios.ResetBios': {
+                                'title': "ResetBios",
+                                'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios"
+                            }
                         },
-                        '#Bios.ResetBios': {
-                            'title': "ResetBios",
-                            'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios"
-                        }
-                    },
+                    }
                 }
-            }
 
-            with patch.object(module.XCCRedfishUtils, 'post_request') as mock_post_request:
-                mock_post_request.return_value = {'ret': True}
+                with patch.object(module.XCCRedfishUtils, 'post_request') as mock_post_request:
+                    mock_post_request.return_value = {'ret': True}
 
-                with self.assertRaises(AnsibleFailJson) as result:
-                    module.main()
+                    with self.assertRaises(AnsibleFailJson) as result:
+                        module.main()
 
     def test_module_command_PostResource_fail_when_requestbody_mismatch_with_data_from_actioninfo_uri(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'PostResource',
             'baseuri': '10.245.39.251',
@@ -499,39 +482,38 @@ class TestXCCRedfishCommand(unittest.TestCase):
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword',
             'request_body': {'PasswordName': 'UefiAdminPassword', 'NewPassword': 'PASSW0RD=='}
-        })
-
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {
-                'ret': True,
-                'data': {
-                    'Parameters': [],
-                    'Actions': {
-                        '#Bios.ChangePassword': {
-                            '@Redfish.ActionInfo': "/redfish/v1/Systems/1/Bios/ChangePasswordActionInfo",
-                            'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword",
-                            'title': "ChangePassword",
-                            'PasswordName@Redfish.AllowableValues': [
-                                "UefiAdminPassword",
-                                "UefiPowerOnPassword"
-                            ]
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {
+                    'ret': True,
+                    'data': {
+                        'Parameters': [],
+                        'Actions': {
+                            '#Bios.ChangePassword': {
+                                '@Redfish.ActionInfo': "/redfish/v1/Systems/1/Bios/ChangePasswordActionInfo",
+                                'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword",
+                                'title': "ChangePassword",
+                                'PasswordName@Redfish.AllowableValues': [
+                                    "UefiAdminPassword",
+                                    "UefiPowerOnPassword"
+                                ]
+                            },
+                            '#Bios.ResetBios': {
+                                'title': "ResetBios",
+                                'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios"
+                            }
                         },
-                        '#Bios.ResetBios': {
-                            'title': "ResetBios",
-                            'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios"
-                        }
-                    },
+                    }
                 }
-            }
 
-            with patch.object(module.XCCRedfishUtils, 'post_request') as mock_post_request:
-                mock_post_request.return_value = {'ret': True}
+                with patch.object(module.XCCRedfishUtils, 'post_request') as mock_post_request:
+                    mock_post_request.return_value = {'ret': True}
 
-                with self.assertRaises(AnsibleFailJson) as result:
-                    module.main()
+                    with self.assertRaises(AnsibleFailJson) as result:
+                        module.main()
 
     def test_module_command_PostResource_fail_when_get_return_false(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'PostResource',
             'baseuri': '10.245.39.251',
@@ -539,19 +521,18 @@ class TestXCCRedfishCommand(unittest.TestCase):
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword',
             'request_body': {'PasswordName': 'UefiAdminPassword', 'NewPassword': 'PASSW0RD=='}
-        })
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {'ret': False, 'msg': '404 error'}
 
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {'ret': False, 'msg': '404 error'}
+                with patch.object(module.XCCRedfishUtils, 'post_request') as mock_post_request:
+                    mock_post_request.return_value = {'ret': True}
 
-            with patch.object(module.XCCRedfishUtils, 'post_request') as mock_post_request:
-                mock_post_request.return_value = {'ret': True}
-
-                with self.assertRaises(AnsibleFailJson) as result:
-                    module.main()
+                    with self.assertRaises(AnsibleFailJson) as result:
+                        module.main()
 
     def test_module_command_PostResource_fail_when_post_return_false(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'PostResource',
             'baseuri': '10.245.39.251',
@@ -559,38 +540,37 @@ class TestXCCRedfishCommand(unittest.TestCase):
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios',
             'request_body': {}
-        })
-
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {
-                'ret': True,
-                'data': {
-                    'Actions': {
-                        '#Bios.ChangePassword': {
-                            '@Redfish.ActionInfo': "/redfish/v1/Systems/1/Bios/ChangePasswordActionInfo",
-                            'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword",
-                            'title': "ChangePassword",
-                            'PasswordName@Redfish.AllowableValues': [
-                                "UefiAdminPassword",
-                                "UefiPowerOnPassword"
-                            ]
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {
+                    'ret': True,
+                    'data': {
+                        'Actions': {
+                            '#Bios.ChangePassword': {
+                                '@Redfish.ActionInfo': "/redfish/v1/Systems/1/Bios/ChangePasswordActionInfo",
+                                'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword",
+                                'title': "ChangePassword",
+                                'PasswordName@Redfish.AllowableValues': [
+                                    "UefiAdminPassword",
+                                    "UefiPowerOnPassword"
+                                ]
+                            },
+                            '#Bios.ResetBios': {
+                                'title': "ResetBios",
+                                'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios"
+                            }
                         },
-                        '#Bios.ResetBios': {
-                            'title': "ResetBios",
-                            'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios"
-                        }
-                    },
+                    }
                 }
-            }
 
-            with patch.object(module.XCCRedfishUtils, 'post_request') as mock_post_request:
-                mock_post_request.return_value = {'ret': False, 'msg': '500 internal error'}
+                with patch.object(module.XCCRedfishUtils, 'post_request') as mock_post_request:
+                    mock_post_request.return_value = {'ret': False, 'msg': '500 internal error'}
 
-                with self.assertRaises(AnsibleFailJson) as result:
-                    module.main()
+                    with self.assertRaises(AnsibleFailJson) as result:
+                        module.main()
 
     def test_module_command_PostResource_pass(self):
-        set_module_args({
+        with set_module_args({
             'category': 'Raw',
             'command': 'PostResource',
             'baseuri': '10.245.39.251',
@@ -598,32 +578,31 @@ class TestXCCRedfishCommand(unittest.TestCase):
             'password': 'PASSW0RD=21',
             'resource_uri': '/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios',
             'request_body': {}
-        })
-
-        with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
-            mock_get_request.return_value = {
-                'ret': True,
-                'data': {
-                    'Actions': {
-                        '#Bios.ChangePassword': {
-                            '@Redfish.ActionInfo': "/redfish/v1/Systems/1/Bios/ChangePasswordActionInfo",
-                            'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword",
-                            'title': "ChangePassword",
-                            'PasswordName@Redfish.AllowableValues': [
-                                "UefiAdminPassword",
-                                "UefiPowerOnPassword"
-                            ]
+        }):
+            with patch.object(module.XCCRedfishUtils, 'get_request') as mock_get_request:
+                mock_get_request.return_value = {
+                    'ret': True,
+                    'data': {
+                        'Actions': {
+                            '#Bios.ChangePassword': {
+                                '@Redfish.ActionInfo': "/redfish/v1/Systems/1/Bios/ChangePasswordActionInfo",
+                                'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword",
+                                'title': "ChangePassword",
+                                'PasswordName@Redfish.AllowableValues': [
+                                    "UefiAdminPassword",
+                                    "UefiPowerOnPassword"
+                                ]
+                            },
+                            '#Bios.ResetBios': {
+                                'title': "ResetBios",
+                                'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios"
+                            }
                         },
-                        '#Bios.ResetBios': {
-                            'title': "ResetBios",
-                            'target': "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios"
-                        }
-                    },
+                    }
                 }
-            }
 
-            with patch.object(module.XCCRedfishUtils, 'post_request') as mock_post_request:
-                mock_post_request.return_value = {'ret': True, 'msg': 'post success'}
+                with patch.object(module.XCCRedfishUtils, 'post_request') as mock_post_request:
+                    mock_post_request.return_value = {'ret': True, 'msg': 'post success'}
 
-                with self.assertRaises(AnsibleExitJson) as result:
-                    module.main()
+                    with self.assertRaises(AnsibleExitJson) as result:
+                        module.main()

--- a/tests/unit/plugins/modules/utils.py
+++ b/tests/unit/plugins/modules/utils.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import contextlib as _contextlib
 import json
 
 from ansible_collections.community.general.tests.unit.compat import unittest
@@ -13,14 +14,16 @@ from ansible.module_utils import basic
 from ansible.module_utils.common.text.converters import to_bytes
 
 
+@_contextlib.contextmanager
 def set_module_args(args):
     if '_ansible_remote_tmp' not in args:
         args['_ansible_remote_tmp'] = '/tmp'
     if '_ansible_keep_remote_files' not in args:
         args['_ansible_keep_remote_files'] = False
 
-    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
-    basic._ANSIBLE_ARGS = to_bytes(args)
+    serialized_args = to_bytes(json.dumps({'ANSIBLE_MODULE_ARGS': args}))
+    with patch.object(basic, '_ANSIBLE_ARGS', serialized_args):
+        yield
 
 
 class AnsibleExitJson(Exception):


### PR DESCRIPTION
##### SUMMARY
Manual backport of #9838 to stable-9.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
various module unit tests
