### PR TITLE
Adding Audio device support to proxmox_kvm

### DIFF
--- a/changelogs/fragments/9847-Adding_audio_device-support_to_proxmox_kvm.yml
+++ b/changelogs/fragments/9847-Adding_audio_device-support_to_proxmox_kvm.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - audio - add missing audio hardware device handling for proxmox_kvm module (https://github.com/ansible-collections/community.general/issues/5192).
+  - proxmox_kvm - add missing audio hardware device handling (https://github.com/ansible-collections/community.general/issues/5192 with https://github.com/ansible-collections/community.general/pull/9847).

--- a/changelogs/fragments/9847-Adding_audio_device-support_to_proxmox_kvm.yml
+++ b/changelogs/fragments/9847-Adding_audio_device-support_to_proxmox_kvm.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - audio - add missing audio hardware device handling for proxmox_kvm module (https://github.com/ansible-collections/community.general/issues/5192).

--- a/changelogs/fragments/9847-Adding_audio_device-support_to_proxmox_kvm.yml
+++ b/changelogs/fragments/9847-Adding_audio_device-support_to_proxmox_kvm.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox_kvm - add missing audio hardware device handling (https://github.com/ansible-collections/community.general/issues/5192 with https://github.com/ansible-collections/community.general/pull/9847).
+  - proxmox_kvm - add missing audio hardware device handling (https://github.com/ansible-collections/community.general/issues/5192, https://github.com/ansible-collections/community.general/pull/9847).

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -51,6 +51,7 @@ options:
       - device is either V(ich9-intel-hda) or V(intel-hda) or V(AC97).
       - Option C(driver) is V(none) or V(spice).
     type: dict
+    version_added: 10.5.0
   autostart:
     description:
       - Specify if the VM should be automatically restarted after crash (currently ignored in PVE API).

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -48,7 +48,7 @@ options:
       - A hash/dictionary of audio devices for the VM. O(audio='{"key":"value", "key":"value"}').
       - Keys allowed are - C(audio[n]) where 0 ≤ n ≤ N.
       - Values allowed are - C(device="ich9-intel-hda|intel-hda|AC97",driver="none|spice").
-      - device is either V(ich9-intel-hda) or V(intel-hda) or V(AC97).
+      - C(device) is either V(ich9-intel-hda) or V(intel-hda) or V(AC97).
       - Option C(driver) is V(none) or V(spice).
     type: dict
     version_added: 10.5.0

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -43,6 +43,14 @@ options:
       - Pass arbitrary arguments to kvm.
       - This option is for experts only!
     type: str
+  audio:
+    description:
+      - A hash/dictionary of audio devices for the VM. O(audio='{"key":"value", "key":"value"}').
+      - Keys allowed are - C(audio[n]) where 0 ≤ n ≤ N.
+      - Values allowed are - C(device="ich9-intel-hda|intel-hda|AC97",driver="none|spice").
+      - device is either V(ich9-intel-hda) or V(intel-hda) or V(AC97).
+      - Option C(driver) is V(none) or V(spice).
+    type: dict
   autostart:
     description:
       - Specify if the VM should be automatically restarted after crash (currently ignored in PVE API).
@@ -1086,7 +1094,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
             )
 
         # Convert all dict in kwargs to elements.
-        # For hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n], ipconfig[n], usb[n]
+        # For audio[n], hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n], ipconfig[n], usb[n]
         for k in list(kwargs.keys()):
             if isinstance(kwargs[k], dict):
                 kwargs.update(kwargs[k])
@@ -1227,6 +1235,7 @@ def main():
         acpi=dict(type='bool'),
         agent=dict(type='str'),
         args=dict(type='str'),
+        audio=dict(type='dict'),
         autostart=dict(type='bool'),
         balloon=dict(type='int'),
         bios=dict(choices=['seabios', 'ovmf']),
@@ -1435,6 +1444,7 @@ def main():
                               archive=module.params['archive'],
                               acpi=module.params['acpi'],
                               agent=module.params['agent'],
+                              audio=module.params['audio'],
                               autostart=module.params['autostart'],
                               balloon=module.params['balloon'],
                               bios=module.params['bios'],

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -45,7 +45,7 @@ options:
     type: str
   audio:
     description:
-      - A hash/dictionary of audio devices for the VM. O(audio='{"key":"value", "key":"value"}').
+      - A hash/dictionary of audio devices for the VM. O(audio={"key":"value", "key":"value"}).
       - Keys allowed are - C(audio[n]) where 0 ≤ n ≤ N.
       - Values allowed are - C(device="ich9-intel-hda|intel-hda|AC97",driver="none|spice").
       - C(device) is either V(ich9-intel-hda) or V(intel-hda) or V(AC97).


### PR DESCRIPTION
##### SUMMARY

When updating a PROXMOX VM hardware, it was not possible to add an audio device.
This patch enable to update KVM with a hardware audio device.

##### ISSUE TYPE

Feature Pull Request for "adding support for adding proxmox audio and usb ports via spice #5192"

##### COMPONENT NAME

proxmox_kvm

##### ADDITIONAL INFORMATION

BEFORE : Audio device was unsupported with message :

```
FAILED! => {"changed": false, "msg": "Unsupported parameters for (community.general.proxmox_kvm) module: audio. Supported parameters include: acpi, agent, api_host, api_password, api_port, api_token_id, api_token_secret, api_user, archive, args, autostart, balloon, bios, boot, bootdisk, cicustom, cipassword, citype, ciupgrade, ciuser, clone, cores, cpu, cpulimit, cpuunits, delete, description, digest, efidisk0, force, format, freeze, full, hookscript, hostpci, hotplug, hugepages, ide, ipconfig, keyboard, kvm, localtime, lock, machine, memory, migrate, migrate_downtime, migrate_speed, name, nameservers, net, newid, node, numa, numa_enabled, onboot, ostype, parallel, pool, protection, reboot, revert, sata, scsi, scsihw, searchdomains, serial, shares, skiplock, smbios, snapname, sockets, sshkeys, startdate, startup, state, storage, tablet, tags, target, tdf, template, timeout, tpmstate0, update, update_unsafe, usb, validate_certs, vcpus, vga, virtio, vmid, watchdog."}
```

AFTER : Audio device can be added with following code :

```yaml
- name: Add Spice compatible audio device
  community.general.proxmox_kvm:
    api_user: "{{ api_user }}"
    api_password: "{{ api_password }}"
    api_host: "{{ api_host }}"
    node: "{{ node_name }}"
    vmid: "{{ proxmox_vmid }}"
    audio: '{"audio0":"device=ich9-intel-hda,driver=spice"}'
    update: true
  delegate_to: localhost
```

USB is working too with the following entry :

```yaml
- name: Add Spice compatible usb device
  community.general.proxmox_kvm:
    api_user: "{{ api_user }}"
    api_password: "{{ api_password }}"
    api_host: "{{ api_host }}"
    node: "{{ node_name }}"
    vmid: "{{ proxmox_vmid }}"
    usb: '{"usb0":"spice,usb3=1"}'
    update: true
  delegate_to: localhost
```

RESULT :

<img width="433" alt="Capture d’écran 2025-03-08 à 00 09 33" src="https://github.com/user-attachments/assets/b6e608a6-9ff9-468b-9517-5b78528309f8" />
