### PR TITLE
NMAP Inventory Plugin: Added option for specifying DNS servers for name resolution

### DIFF
--- a/changelogs/fragments/9849-nmap_dns_servers.yml
+++ b/changelogs/fragments/9849-nmap_dns_servers.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - nmap inventory plugin - adds ``dns_servers`` option for specifying DNS servers for name resolution. Accepts hostnames or IP addresses in the same format as the ``exclude`` option (https://github.com/ansible-collections/community.general/pull/9849).

--- a/changelogs/fragments/nmap_dns_servers.yml
+++ b/changelogs/fragments/nmap_dns_servers.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - community.general.nmap - adds dns_servers option for specifying DNS servers for name resolution. Accepts hostnames or IP addresses in the same format as the except option.

--- a/changelogs/fragments/nmap_dns_servers.yml
+++ b/changelogs/fragments/nmap_dns_servers.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - community.general.nmap - adds dns_servers option for specifying DNS servers for name resolution. Accepts hostnames or IP addresses in the same format as the except option.

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -86,6 +86,10 @@ DOCUMENTATION = '''
             type: boolean
             default: false
             version_added: 6.1.0
+        dns_servers:
+            description: Specify which DNS servers to use for name resolution.
+            type: string
+            default: false
         use_arp_ping:
             description: Whether to always (V(true)) use the quick ARP ping or (V(false)) a slower but more reliable method.
             type: boolean
@@ -230,6 +234,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             if self.get_option('dns_resolve'):
                 cmd.append('-n')
+
+            if self.get_option('dns_servers'):
+                cmd.append('--dns-servers')
+                cmd.append(','.join(self.get_option('dns_servers')))
 
             if self.get_option('udp_scan'):
                 cmd.append('-sU')

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -88,8 +88,8 @@ DOCUMENTATION = '''
             version_added: 6.1.0
         dns_servers:
             description: Specify which DNS servers to use for name resolution.
-            type: string
-            default: false
+            type: list
+            elements: string
         use_arp_ping:
             description: Whether to always (V(true)) use the quick ARP ping or (V(false)) a slower but more reliable method.
             type: boolean

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -90,6 +90,7 @@ DOCUMENTATION = '''
             description: Specify which DNS servers to use for name resolution.
             type: list
             elements: string
+            version_added: 10.5.0
         use_arp_ping:
             description: Whether to always (V(true)) use the quick ARP ping or (V(false)) a slower but more reliable method.
             type: boolean


### PR DESCRIPTION
minor_changes:
  - community.general.nmap - adds ``dns_servers`` option for specifying DNS servers for name resolution. Accepts hostnames or IP addresses in the same format as the ``except`` option.

nmap.yml
```command
---
plugin: community.general.nmap
address: 10.10.10.0/24
dns_servers: 10.10.10.11
```