### PR TITLE
cmd_runner tests: fix reliance on unspecified behavior

### DIFF
--- a/tests/integration/targets/cmd_runner/library/cmd_echo.py
+++ b/tests/integration/targets/cmd_runner/library/cmd_echo.py
@@ -7,6 +7,8 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+import traceback
+
 
 DOCUMENTATION = ""
 
@@ -43,15 +45,18 @@ def main():
 
         arg_formats[arg] = func(*args)
 
-    runner = CmdRunner(module, [module.params["cmd"], '--'], arg_formats=arg_formats, path_prefix=module.params["path_prefix"])
+    try:
+        runner = CmdRunner(module, [module.params["cmd"], '--'], arg_formats=arg_formats, path_prefix=module.params["path_prefix"])
 
-    with runner.context(p['arg_order'], check_mode_skip=p['check_mode_skip']) as ctx:
-        result = ctx.run(**p['arg_values'])
-        info = ctx.run_info
-    check = "check"
-    rc, out, err = result if result is not None else (None, None, None)
+        with runner.context(p['arg_order'], check_mode_skip=p['check_mode_skip']) as ctx:
+            result = ctx.run(**p['arg_values'])
+            info = ctx.run_info
+        check = "check"
+        rc, out, err = result if result is not None else (None, None, None)
 
-    module.exit_json(rc=rc, out=out, err=err, info=info)
+        module.exit_json(rc=rc, out=out, err=err, info=info)
+    except Exception as exc:
+        module.fail_json(rc=1, module_stderr=traceback.format_exc(), msg="Module crashed with exception")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
Modules exiting by exception resulting in crashing the module before the data tagging PR. Unfortunately the tests relied on the old behavior.

Modules that support ansible-core before data tagging should never crash intentionally, and if they do, should not rely on anything except that the task fails.

Extracted from #9833.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
cmd_runner integration tests
