### PR TITLE
pacemaker unit test: passing null with UTHelper

### DIFF
--- a/tests/unit/plugins/modules/test_pacemaker_resource.yaml
+++ b/tests/unit/plugins/modules/test_pacemaker_resource.yaml
@@ -22,7 +22,7 @@ test_cases:
         - "ip=[192.168.2.1]"
     output:
       changed: true
-      previous_value:
+      previous_value: null
       value: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
     mocks:
       run_command:
@@ -76,8 +76,8 @@ test_cases:
       name: virtual-ip
     output:
       changed: false
-      previous_value:
-      value:
+      previous_value: null
+      value: null
     mocks:
       run_command:
         - command: [/testbin/pcs, resource, status, virtual-ip]
@@ -102,7 +102,7 @@ test_cases:
     output:
       changed: true
       previous_value: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
-      value:
+      value: null
     mocks:
       run_command:
         - command: [/testbin/pcs, resource, status, virtual-ip]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Circling back on the comment at:
https://github.com/ansible-collections/community.general/pull/9531#discussion_r1941499903

Trying to test passing `null` as value (instead of empty) in the YAML file used by UTHelper.

It has worked in local tests, submitting to the CI to check if it blows up in any combination of Python/Ansible.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
pacemaker_resource