### PR TITLE
Rocketchat webhook payload without "payload="

### DIFF
--- a/plugins/modules/rocketchat.py
+++ b/plugins/modules/rocketchat.py
@@ -195,7 +195,7 @@ def build_payload_for_rocketchat(module, text, channel, username, icon_url, icon
                 attachment['fallback'] = attachment['text']
             payload['attachments'].append(attachment)
 
-    payload = "payload=" + module.jsonify(payload)
+    payload = module.jsonify(payload)
     return payload
 
 


### PR DESCRIPTION
##### SUMMARY
Rocketchat webhook does not need to have `payload={{data}}` as payload but only data directly as payload.

```
bugfixes:
  - rocketchat: fix webhook payload
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rocketchat

##### ADDITIONAL INFORMATION

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# before the payload was like this:
"payload={\"text\": \"Test\", \"channel\": \"#test\", \"username\": \"me\", \"icon_url\": \"https://docs.ansible.com/favicon.ico\", \"link_names\": 1}"}

# but this results in a 400 bad request
"body": "{\"success\":false,\"error\":\"Unexpected token 'p', \\\"payload{\\\"t\\\"... is not valid JSON\"}"

# after this change the payload is like that
"{\"text\": \"Test\", \"channel\": \"#test\", \"username\": \"me\", \"icon_url\": \"https://docs.ansible.com/favicon.ico\", \"link_names\": 1}"
```
