### PR TITLE
homebrew_cask: Handle unusual brew version strings

### DIFF
--- a/changelogs/fragments/homebrew_cask.yml
+++ b/changelogs/fragments/homebrew_cask.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - homebrew_cask - handle unusual brew version strings (https://github.com/ansible-collections/community.general/issues/8432, https://github.com/ansible-collections/community.general/pull/9881).

--- a/tests/unit/plugins/modules/test_homebrew_cask.py
+++ b/tests/unit/plugins/modules/test_homebrew_cask.py
@@ -6,18 +6,33 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
-from ansible_collections.community.general.tests.unit.compat import unittest
-from ansible_collections.community.general.plugins.modules.homebrew_cask import HomebrewCask
+from ansible_collections.community.general.plugins.modules.homebrew_cask import (
+    HomebrewCask,
+)
+from ansible_collections.community.general.plugins.module_utils.homebrew import (
+    HomebrewValidate,
+)
 
 
-class TestHomebrewCaskModule(unittest.TestCase):
+def test_valid_cask_names():
+    brew_cask_names = ["visual-studio-code", "firefox"]
+    for name in brew_cask_names:
+        assert HomebrewCask.valid_cask(name)
 
-    def setUp(self):
-        self.brew_cask_names = [
-            'visual-studio-code',
-            'firefox'
-        ]
 
-    def test_valid_cask_names(self):
-        for name in self.brew_cask_names:
-            self.assertTrue(HomebrewCask.valid_cask(name))
+def test_homebrew_version(mocker):
+    brew_versions = [
+        "Homebrew 4.1.0",
+        "Homebrew >=4.1.0 (shallow or no git repository)",
+        "Homebrew 4.1.0-dirty",
+    ]
+    module = mocker.Mock()
+
+    mocker.patch.object(HomebrewCask, "valid_module", return_value=True)
+    mocker.patch.object(HomebrewValidate, "valid_path", return_value=True)
+    mocker.patch.object(HomebrewValidate, "valid_brew_path", return_value=True)
+
+    homebrewcask = HomebrewCask(module=module)
+    for version in brew_versions:
+        module.run_command.return_value = (0, version, "")
+        assert homebrewcask._get_brew_version() == "4.1.0"


### PR DESCRIPTION
##### SUMMARY

* Use regex to parse unusual brew version strings

Fixes: #8432

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


