### PR TITLE
systemd_info - extend support to timer unit

### DIFF
--- a/changelogs/fragments/9891-systemd_info-add_timer.yml
+++ b/changelogs/fragments/9891-systemd_info-add_timer.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - systemd_info - extend support to timer units (https://github.com/ansible-collections/community.general/pull/9891).

--- a/plugins/modules/systemd_info.py
+++ b/plugins/modules/systemd_info.py
@@ -13,9 +13,10 @@ DOCUMENTATION = r'''
 module: systemd_info
 short_description: Gather C(systemd) unit info
 description:
-  - This module gathers info about systemd units (services, targets, sockets, mount).
+  - This module gathers info about systemd units (services, targets, sockets, mount, timer).
   - It runs C(systemctl list-units) (or processes selected units) and collects properties
     for each unit using C(systemctl show).
+  - In case a unit has multiple properties with the same name, only the value of the first one will be collected.
   - Even if a unit has a RV(units.loadstate) of V(not-found) or V(masked), it is returned,
     but only with the minimal properties (RV(units.name), RV(units.loadstate), RV(units.activestate), RV(units.substate)).
   - When O(unitname) and O(extra_properties) are used, the module first checks if the unit exists,
@@ -27,7 +28,8 @@ options:
   unitname:
     description:
       - List of unit names to process.
-      - It supports C(.service), C(.target), C(.socket), and C(.mount) units type.
+      - It supports C(.service), C(.target), C(.socket), C(.mount) and C(.timer) units type.
+      - C(.timer) units are supported since community.general 10.5.0.
       - Each name must correspond to the full name of the C(systemd) unit or to a wildcard expression like V('ssh*') and V('*.service').
       - Wildcard expressions in O(unitname) are supported since community.general 10.5.0.
     type: list
@@ -49,7 +51,7 @@ extends_documentation_fragment:
 
 EXAMPLES = r'''
 ---
-# Gather info for all systemd services, targets, sockets and mount
+# Gather info for all systemd services, targets, sockets, mount and timer
 - name: Gather all systemd unit info
   community.general.systemd_info:
   register: results
@@ -71,6 +73,15 @@ EXAMPLES = r'''
   community.general.systemd_info:
     unitname:
       - 'systemd-*'
+  register: results
+
+# Gather info for systemd-tmpfiles-clean.timer with extra properties
+- name: Gather info of systemd-tmpfiles-clean.timer and extra AccuracyUSec
+  community.general.systemd_info:
+    unitname:
+      - systemd-tmpfiles-clean.timer
+    extra_properties:
+      - AccuracyUSec
   register: results
 '''
 
@@ -255,6 +266,8 @@ def determine_category(unit):
         return 'socket'
     elif unit.endswith('.mount'):
         return 'mount'
+    elif unit.endswith('.timer'):
+        return 'timer'
     else:
         return None
 
@@ -275,7 +288,8 @@ def get_category_base_props(category):
         'service': ['FragmentPath', 'UnitFileState', 'UnitFilePreset', 'MainPID', 'ExecMainPID'],
         'target': ['FragmentPath', 'UnitFileState', 'UnitFilePreset'],
         'socket': ['FragmentPath', 'UnitFileState', 'UnitFilePreset'],
-        'mount': ['Where', 'What', 'Options', 'Type']
+        'mount': ['Where', 'What', 'Options', 'Type'],
+        'timer': ['FragmentPath', 'UnitFileState', 'UnitFilePreset']
     }
     return base_props.get(category, [])
 
@@ -364,7 +378,7 @@ def main():
     state_props = ['LoadState', 'ActiveState', 'SubState']
     results = {}
 
-    unit_types = ["service", "target", "socket", "mount"]
+    unit_types = ["service", "target", "socket", "mount", "timer"]
 
     list_output = list_units(base_runner, unit_types)
     units_info = {}

--- a/plugins/modules/systemd_info.py
+++ b/plugins/modules/systemd_info.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: systemd_info
 short_description: Gather C(systemd) unit info
 description:
-  - This module gathers info about systemd units (services, targets, sockets, mount, timer).
+  - This module gathers info about systemd units (services, targets, sockets, mounts, timers).
+  - Timer units are supported since community.general 10.5.0.
   - It runs C(systemctl list-units) (or processes selected units) and collects properties
     for each unit using C(systemctl show).
   - In case a unit has multiple properties with the same name, only the value of the first one will be collected.
@@ -289,7 +290,7 @@ def get_category_base_props(category):
         'target': ['FragmentPath', 'UnitFileState', 'UnitFilePreset'],
         'socket': ['FragmentPath', 'UnitFileState', 'UnitFilePreset'],
         'mount': ['Where', 'What', 'Options', 'Type'],
-        'timer': ['FragmentPath', 'UnitFileState', 'UnitFilePreset']
+        'timer': ['FragmentPath', 'UnitFileState', 'UnitFilePreset'],
     }
     return base_props.get(category, [])
 

--- a/tests/integration/targets/systemd_info/tasks/tests.yml
+++ b/tests/integration/targets/systemd_info/tasks/tests.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Gather all units from shell
-  ansible.builtin.command: systemctl list-units --no-pager --type service,target,socket,mount --all --plain --no-legend
+  ansible.builtin.command: systemctl list-units --no-pager --type service,target,socket,mount,timer --all --plain --no-legend
   register: all_units
 
 - name: Assert command run successfully
@@ -137,3 +137,27 @@
   vars:
     all_keys: "{{ result_multi.units | dict2items | map(attribute='key') | list }}"
     unique_keys: "{{ all_keys | unique }}"
+
+- name: Gather info of systemd-tmpfiles-clean.timer and extra AccuracyUSec
+  community.general.systemd_info:
+    unitname:
+      - systemd-tmpfiles-clean.timer
+    extra_properties:
+      - AccuracyUSec
+  register: result_timer
+
+- name: Check timer unit properties
+  ansible.builtin.assert:
+    that:
+      - result_timer.units is defined
+      - result_timer.units['systemd-tmpfiles-clean.timer'] is defined
+      - result_timer.units['systemd-tmpfiles-clean.timer'].name is defined
+      - result_timer.units['systemd-tmpfiles-clean.timer'].loadstate is defined
+      - result_timer.units['systemd-tmpfiles-clean.timer'].activestate is defined
+      - result_timer.units['systemd-tmpfiles-clean.timer'].substate is defined
+      - result_timer.units['systemd-tmpfiles-clean.timer'].fragmentpath is defined
+      - result_timer.units['systemd-tmpfiles-clean.timer'].unitfilestate is defined
+      - result_timer.units['systemd-tmpfiles-clean.timer'].unitfilepreset is defined
+      - result_timer.units['systemd-tmpfiles-clean.timer'].accuracyusec is defined
+      - result_timer.units['systemd-tmpfiles-clean.timer'].accuracyusec | length > 0
+    success_msg: "Success: All properties collected."


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR extends **`systemd_info`** support to **`timer`** units. 

Example:
```yaml
- name: Gather info of systemd-tmpfiles-clean.timer and extra AccuracyUSec
  community.general.systemd_info:
    unitname:
      - systemd-tmpfiles-clean.timer
    extra_properties:
      - AccuracyUSec
  register: results
```

In addition, it also fulfills the requirements outlined in the description of Feature Idea #4896.

- added timers to **`determine_category()`**
- added timers to **`get_category_base_props()`**
- added timers to **`unit_types[]`**
- updated the main **`description`** and the one for **`unitname`**
- added new steps to the **`integration`** test tasks

Additionally, I wanted to update the description to clarify how the property values are collected, in order to avoid any misunderstandings for users.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #4896
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/modules/systemd_info.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
