### PR TITLE
vmadm - Add new options

### DIFF
--- a/changelogs/fragments/9892-vmadm-add-new-options.yml
+++ b/changelogs/fragments/9892-vmadm-add-new-options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmadm - add new options ``flexible_disk_size`` and ``owner_uuid`` (https://github.com/ansible-collections/community.general/pull/9892).

--- a/changelogs/fragments/9892-vmadm-add-optional-options.yml
+++ b/changelogs/fragments/9892-vmadm-add-optional-options.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - vmadm - add optional options (https://github.com/ansible-collections/community.general/pull/9892).

--- a/changelogs/fragments/9892-vmadm-add-optional-options.yml
+++ b/changelogs/fragments/9892-vmadm-add-optional-options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmadm - add optional options (https://github.com/ansible-collections/community.general/pull/9892).

--- a/plugins/modules/vmadm.py
+++ b/plugins/modules/vmadm.py
@@ -107,8 +107,9 @@ options:
   flexible_disk_size:
     required: false
     description:
-      - This sets an upper bound for the amount of space that a bhyve instance may use for its disks and snapshots of those disks (in MiBs)
+      - This sets an upper bound for the amount of space that a bhyve instance may use for its disks and snapshots of those disks (in MiBs).
     type: int
+    version_added: 10.5.0
   force:
     required: false
     description:
@@ -215,8 +216,9 @@ options:
   owner_uuid:
     required: false
     description:
-      - This parameter can be used for defining the UUID of an ´owner´ for this VM.
+      - Define the UUID of the owner of the VM.
     type: str
+    version_added: 10.5.0
   qemu_opts:
     required: false
     description:

--- a/plugins/modules/vmadm.py
+++ b/plugins/modules/vmadm.py
@@ -104,6 +104,11 @@ options:
     description:
       - Enables the firewall, allowing fwadm(1M) rules to be applied.
     type: bool
+  flexible_disk_size:
+    required: false
+    description:
+      - This sets an upper bound for the amount of space that a bhyve instance may use for its disks and snapshots of those disks (in MiBs)
+    type: int
   force:
     required: false
     description:
@@ -207,6 +212,11 @@ options:
     description:
       - Consider the provisioning complete when the VM first starts, rather than when the VM has rebooted.
     type: bool
+  owner_uuid:
+    required: false
+    description:
+      - This parameter can be used for defining the UUID of an ´owner´ for this VM.
+    type: str
   qemu_opts:
     required: false
     description:
@@ -633,9 +643,9 @@ def main():
         'str': [
             'boot', 'disk_driver', 'dns_domain', 'fs_allowed', 'hostname',
             'image_uuid', 'internal_metadata_namespace', 'kernel_version',
-            'limit_priv', 'nic_driver', 'qemu_opts', 'qemu_extra_opts',
-            'spice_opts', 'uuid', 'vga', 'zfs_data_compression',
-            'zfs_root_compression', 'zpool'
+            'limit_priv', 'nic_driver', 'owner_uuid', 'qemu_opts',
+            'qemu_extra_opts', 'spice_opts', 'uuid', 'vga',
+            'zfs_data_compression', 'zfs_root_compression', 'zpool'
         ],
         'bool': [
             'archive_on_delete', 'autoboot', 'delegate_dataset',
@@ -643,12 +653,12 @@ def main():
             'indestructible_zoneroot', 'maintain_resolvers', 'nowait'
         ],
         'int': [
-            'cpu_cap', 'cpu_shares', 'max_locked_memory', 'max_lwps',
-            'max_physical_memory', 'max_swap', 'mdata_exec_timeout',
-            'quota', 'ram', 'tmpfs', 'vcpus', 'virtio_txburst',
-            'virtio_txtimer', 'vnc_port', 'zfs_data_recsize',
-            'zfs_filesystem_limit', 'zfs_io_priority', 'zfs_root_recsize',
-            'zfs_snapshot_limit'
+            'cpu_cap', 'cpu_shares', 'flexible_disk_size',
+            'max_locked_memory', 'max_lwps', 'max_physical_memory',
+            'max_swap', 'mdata_exec_timeout', 'quota', 'ram',
+            'tmpfs', 'vcpus', 'virtio_txburst', 'virtio_txtimer',
+            'vnc_port', 'zfs_data_recsize', 'zfs_filesystem_limit',
+            'zfs_io_priority', 'zfs_root_recsize', 'zfs_snapshot_limit'
         ],
         'dict': ['customer_metadata', 'internal_metadata', 'routes'],
     }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds 2 additional options that are available to users in `vmadm`: `flexible_disk_size` and `owner_uuid`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

plugins/modules/vmadm.py

