### PR TITLE
cmd_runner_fmt.as_fixed() now accepts list of args

### DIFF
--- a/changelogs/fragments/9893-cmdrunner-as-fixed-args.yml
+++ b/changelogs/fragments/9893-cmdrunner-as-fixed-args.yml
@@ -1,0 +1,2 @@
+mionr_changes:
+  - CmdRunner module utils - the convenience method ``cmd_runner_fmt.as_fixed()`` now accepts multiple arguments as a list (https://github.com/ansible-collections/community.general/pull/9893).

--- a/changelogs/fragments/9893-cmdrunner-as-fixed-args.yml
+++ b/changelogs/fragments/9893-cmdrunner-as-fixed-args.yml
@@ -1,2 +1,2 @@
-mionr_changes:
+minor_changes:
   - CmdRunner module utils - the convenience method ``cmd_runner_fmt.as_fixed()`` now accepts multiple arguments as a list (https://github.com/ansible-collections/community.general/pull/9893).

--- a/docs/docsite/rst/guide_cmdrunner.rst
+++ b/docs/docsite/rst/guide_cmdrunner.rst
@@ -267,24 +267,54 @@ In these descriptions ``value`` refers to the single parameter passed to the for
         +------------+-------------------------+
 
 - ``cmd_runner_fmt.as_fixed()``
-    This method receives one parameter ``arg``, the function expects no ``value`` - if one
-    is provided then it is ignored.
-    The function returns ``arg`` as-is.
+    This method defines one or more fixed arguments that are returned by the generated function
+    regardless whether ``value`` is passed to it or not.
 
-    - Creation:
-        ``cmd_runner_fmt.as_fixed("--version")``
+    This method accepts these arguments in one of three forms:
+
+        * one scalar parameter ``arg``, which will be returned as ``[arg]`` by the function, or
+        * one sequence parameter, such as a list, ``arg``, which will be returned by the function as ``arg[0]``, or
+        * multiple parameters ``args``, which will be returned as ``args`` directly by the function.
+
+    See the examples below for each one of those forms. And, stressing that the generated function expects no ``value`` - if one
+    is provided then it is ignored.
+
+    - Creation (one scalar argument):
+        * ``cmd_runner_fmt.as_fixed("--version")``
     - Examples:
-        +---------+-----------------------+
-        | Value   | Outcome               |
-        +=========+=======================+
-        |         | ``["--version"]``     |
-        +---------+-----------------------+
-        | 57      | ``["--version"]``     |
-        +---------+-----------------------+
+        +---------+--------------------------------------+
+        | Value   | Outcome                              |
+        +=========+======================================+
+        |         | * ``["--version"]``                  |
+        +---------+--------------------------------------+
+        | 57      | * ``["--version"]``                  |
+        +---------+--------------------------------------+
+
+    - Creation (one sequence argument):
+        * ``cmd_runner_fmt.as_fixed(["--list", "--json"])``
+    - Examples:
+        +---------+--------------------------------------+
+        | Value   | Outcome                              |
+        +=========+======================================+
+        |         | * ``["--list", "--json"]``           |
+        +---------+--------------------------------------+
+        | True    | * ``["--list", "--json"]``           |
+        +---------+--------------------------------------+
+
+    - Creation (multiple arguments):
+        * ``cmd_runner_fmt.as_fixed("--one", "--two", "--three")``
+    - Examples:
+        +---------+--------------------------------------+
+        | Value   | Outcome                              |
+        +=========+======================================+
+        |         | * ``["--one", "--two", "--three"]``  |
+        +---------+--------------------------------------+
+        | False   | * ``["--one", "--two", "--three"]``  |
+        +---------+--------------------------------------+
 
     - Note:
         This is the only special case in which a value can be missing for the formatting function.
-        The example also comes from the code in `Quickstart`_.
+        The first example here comes from the code in `Quickstart`_.
         In that case, the module has code to determine the command's version so that it can assert compatibility.
         There is no *value* to be passed for that CLI argument.
 

--- a/plugins/module_utils/cmd_runner_fmt.py
+++ b/plugins/module_utils/cmd_runner_fmt.py
@@ -78,8 +78,10 @@ def as_list(ignore_none=None, min_len=0, max_len=None):
     return _ArgFormat(func, ignore_none=ignore_none)
 
 
-def as_fixed(args):
-    return _ArgFormat(lambda value: _ensure_list(args), ignore_none=False, ignore_missing_value=True)
+def as_fixed(*args):
+    if len(args) == 1 and is_sequence(args[0]):
+        args = args[0]
+    return _ArgFormat(lambda value: _ensure_list(*args), ignore_none=False, ignore_missing_value=True)
 
 
 def as_func(func, ignore_none=None):

--- a/plugins/module_utils/cmd_runner_fmt.py
+++ b/plugins/module_utils/cmd_runner_fmt.py
@@ -81,7 +81,7 @@ def as_list(ignore_none=None, min_len=0, max_len=None):
 def as_fixed(*args):
     if len(args) == 1 and is_sequence(args[0]):
         args = args[0]
-    return _ArgFormat(lambda value: _ensure_list(*args), ignore_none=False, ignore_missing_value=True)
+    return _ArgFormat(lambda value: _ensure_list(args), ignore_none=False, ignore_missing_value=True)
 
 
 def as_func(func, ignore_none=None):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The function `cmd_runner_fmt.as_fixed()` now accepts an arbitrarily sized list as argument, while retaining backward compatibility.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/module_utils/cmd_runner_fmt.py