### PR TITLE
sysrc: extend the list of FreeBSD releases where the jail test fails

### DIFF
--- a/tests/integration/targets/sysrc/tasks/main.yml
+++ b/tests/integration/targets/sysrc/tasks/main.yml
@@ -140,12 +140,12 @@
     - name: Test within jail
       #
       # NOTE: currently fails with FreeBSD 12 with minor version less than 4
-      # NOTE: currently fails with FreeBSD 13 with minor version less than 2
+      # NOTE: currently fails with FreeBSD 13 with minor version less than 4
       # NOTE: currently fails with FreeBSD 14 with minor version less than 1
       #
       when: >-
         ansible_distribution_version is version('12.4', '>=') and ansible_distribution_version is version('13', '<')
-        or ansible_distribution_version is version('13.2', '>=') and ansible_distribution_version is version('14', '<')
+        or ansible_distribution_version is version('13.4', '>=') and ansible_distribution_version is version('14', '<')
         or ansible_distribution_version is version('14.1', '>=')
       block:
         - name: Setup testjail


### PR DESCRIPTION
##### SUMMARY
Seems to fail on FreeBSD 13.3 now as well:
- https://dev.azure.com/ansible/community.general/_build/results?buildId=140368&view=logs&j=cca960fa-8b56-5d5b-2101-d10f9d7d8d91&t=43b0dc61-bb49-56ab-e70c-fc121671321c&l=5832
- https://dev.azure.com/ansible/community.general/_build/results?buildId=140389&view=logs&j=cca960fa-8b56-5d5b-2101-d10f9d7d8d91&t=43b0dc61-bb49-56ab-e70c-fc121671321c&l=5844
- https://dev.azure.com/ansible/community.general/_build/results?buildId=140390&view=logs&j=cca960fa-8b56-5d5b-2101-d10f9d7d8d91&t=43b0dc61-bb49-56ab-e70c-fc121671321c&l=5847

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
sysrc tests
