### PR TITLE
Add caddy example to copr module

### DIFF
--- a/plugins/modules/copr.py
+++ b/plugins/modules/copr.py
@@ -77,6 +77,13 @@ EXAMPLES = r"""
   community.general.copr:
     state: absent
     name: '@copr/integration_tests'
+
+- name: Install Caddy
+  community.general.copr:
+    name: '@caddy/caddy'
+    chroot: fedora-rawhide-{{ ansible_facts.architecture }}
+    includepkgs:
+      - caddy
 """
 
 RETURN = r"""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add an example on how to install caddy using `includepkgs`. This also serves as an example on how to mimic a dnf copr enable without a specified chroot (i.e. fedora-LATEST).

Closes #9879 

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

copr

##### ADDITIONAL INFORMATION

