### PR TITLE
proxmox_vm_info: don't expect key 'template' exists in dictionary

### DIFF
--- a/changelogs/fragments/9875-proxmox-dont-expect-key-template-to-exist.yml
+++ b/changelogs/fragments/9875-proxmox-dont-expect-key-template-to-exist.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - proxmox_vm_info - don't expect that key ``template`` exists in dictionary (https://github.com/ansible-collections/community.general/issues/9875, https://github.com/ansible-collections/community.general/pull/9910).
+  - proxmox_vm_info - the module no longer expects that the key ``template`` exists in a dictionary returned by Proxmox (https://github.com/ansible-collections/community.general/issues/9875, https://github.com/ansible-collections/community.general/pull/9910).

--- a/changelogs/fragments/9875-proxmox-dont-expect-key-template-to-exist.yml
+++ b/changelogs/fragments/9875-proxmox-dont-expect-key-template-to-exist.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_vm_info - don't expect that key ``template`` exists in dictionary (https://github.com/ansible-collections/community.general/issues/9875, https://github.com/ansible-collections/community.general/pull/9910).

--- a/plugins/modules/proxmox_vm_info.py
+++ b/plugins/modules/proxmox_vm_info.py
@@ -200,7 +200,7 @@ class ProxmoxVmInfoAnsible(ProxmoxAnsible):
                 if desired_vm:
                     desired_vm.update(detected_vm)
                     desired_vm["vmid"] = this_vm_id
-                    desired_vm["template"] = proxmox_to_ansible_bool(desired_vm["template"])
+                    desired_vm["template"] = proxmox_to_ansible_bool(desired_vm.get("template", 0))
                     # When user wants to retrieve the VM configuration
                     if config != "none":
                         # pending = 0, current = 1


### PR DESCRIPTION
##### SUMMARY

In rare cases it can happen that the dictionary containing info's about a virtual machine doesn't contain the key `template` and therefore we would get an KeyError. Use `dict.get` to handle that case properly.

Fixes #9875

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/proxmox_vm_info.py