### PR TITLE
update PHP apache module workaround

### DIFF
--- a/changelogs/fragments/9951-mod-php-identifier.yml
+++ b/changelogs/fragments/9951-mod-php-identifier.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - apache2_module - added workaround for new php module name, from ``php7_module`` to ``php_module`` (https://github.com/ansible-collections/community.general/pull/9951).
+  - apache2_module - added workaround for new PHP module name, from ``php7_module`` to ``php_module`` (https://github.com/ansible-collections/community.general/pull/9951).

--- a/changelogs/fragments/9951-mod-php-identifier.yml
+++ b/changelogs/fragments/9951-mod-php-identifier.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - apache2_module - added workaround for new php module name (php7_module -> php_module)
+  - apache2_module - added workaround for new php module name, from ``php7_module`` to ``php_module`` (https://github.com/ansible-collections/community.general/pull/9951).

--- a/changelogs/fragments/9951-mod-php-identifier.yml
+++ b/changelogs/fragments/9951-mod-php-identifier.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - apache2_module - added workaround for new php module name (php7_module -> php_module)

--- a/plugins/modules/apache2_module.py
+++ b/plugins/modules/apache2_module.py
@@ -194,7 +194,7 @@ def create_apache_identifier(name):
 
     # re expressions to extract subparts of names
     re_workarounds = [
-        ('php', re.compile(r'^(php\d)\.')),
+        ('php', re.compile(r'^(php)[\d\.]+')),
     ]
 
     for a2enmod_spelling, module_name in text_workarounds:

--- a/plugins/modules/apache2_module.py
+++ b/plugins/modules/apache2_module.py
@@ -194,8 +194,8 @@ def create_apache_identifier(name):
 
     # re expressions to extract subparts of names
     re_workarounds = [
-        ('php', re.compile(r'^(php\d)\.')),
         ('php8', re.compile(r'^(php)[\d\.]+')),
+        ('php', re.compile(r'^(php\d)\.')),
     ]
 
     for a2enmod_spelling, module_name in text_workarounds:

--- a/plugins/modules/apache2_module.py
+++ b/plugins/modules/apache2_module.py
@@ -194,7 +194,7 @@ def create_apache_identifier(name):
 
     # re expressions to extract subparts of names
     re_workarounds = [
-        ('php7', re.compile(r'^(php7)[\d\.]+')),      
+        ('php', re.compile(r'^(php\d)\.')),
         ('php8', re.compile(r'^(php)[\d\.]+')),
     ]
 

--- a/plugins/modules/apache2_module.py
+++ b/plugins/modules/apache2_module.py
@@ -194,7 +194,8 @@ def create_apache_identifier(name):
 
     # re expressions to extract subparts of names
     re_workarounds = [
-        ('php', re.compile(r'^(php)[\d\.]+')),
+        ('php7', re.compile(r'^(php7)[\d\.]+')),      
+        ('php8', re.compile(r'^(php)[\d\.]+')),
     ]
 
     for a2enmod_spelling, module_name in text_workarounds:


### PR DESCRIPTION
##### SUMMARY
the php apache module name has changed: https://php.watch/versions/8.0/mod_php-rename

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apache_module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

before:

```console
TASK [apache-server : enable modules] *******************************************************************
failed:
  coldfront-dev (item=php8.3) =>
  ansible_loop_var: item
  changed: false
  item: php8.3
  msg: |-
    Failed to set module php8.3 to enabled:
    Considering dependency mpm_prefork for php8.3:
    Considering conflict mpm_event for mpm_prefork:
    Considering conflict mpm_worker for mpm_prefork:
    Module mpm_prefork already enabled
    Considering conflict php5 for php8.3:
    Module php8.3 already enabled

    Maybe the module identifier (php8_module) was guessed incorrectly.Consider setting the "identifier" option.
  rc: 0
  stderr: ''
  stdout: |-
    Considering dependency mpm_prefork for php8.3:
    Considering conflict mpm_event for mpm_prefork:
    Considering conflict mpm_worker for mpm_prefork:
    Module mpm_prefork already enabled
    Considering conflict php5 for php8.3:
    Module php8.3 already enabled
```

the name `php8.3` is interpreted as `php8_module`, but it's supposed to be `php_module`.

after, there is no error.
