### PR TITLE
allow gitlab-project-members module to handle user level "owner"

### DIFF
--- a/changelogs/fragments/9953-gitlab-project-members-support-owner-level.yml
+++ b/changelogs/fragments/9953-gitlab-project-members-support-owner-level.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - gitlab_project_members - extend choices parameter ``access_level`` by missing upstream valid value ``owner`` (https://github.com/ansible-collections/community.general/pull/9953).

--- a/plugins/modules/gitlab_project_members.py
+++ b/plugins/modules/gitlab_project_members.py
@@ -48,6 +48,7 @@ options:
     description:
       - The access level for the user.
       - Required if O(state=present), user state is set to present.
+      - V(owner) was added in community.general 10.6.0.
     type: str
     choices: ['guest', 'reporter', 'developer', 'maintainer', 'owner']
   gitlab_users_access:

--- a/plugins/modules/gitlab_project_members.py
+++ b/plugins/modules/gitlab_project_members.py
@@ -68,6 +68,7 @@ options:
         description:
           - The access level for the user.
           - Required if O(state=present), user state is set to present.
+          - V(owner) was added in community.general 10.6.0.
         type: str
         choices: ['guest', 'reporter', 'developer', 'maintainer', 'owner']
         required: true
@@ -85,6 +86,7 @@ options:
       - Adds/remove users of the given access_level to match the given O(gitlab_user)/O(gitlab_users_access) list. If omitted
         do not purge orphaned members.
       - Is only used when O(state=present).
+      - V(owner) was added in community.general 10.6.0.
     type: list
     elements: str
     choices: ['guest', 'reporter', 'developer', 'maintainer', 'owner']

--- a/plugins/modules/gitlab_project_members.py
+++ b/plugins/modules/gitlab_project_members.py
@@ -49,7 +49,7 @@ options:
       - The access level for the user.
       - Required if O(state=present), user state is set to present.
     type: str
-    choices: ['guest', 'reporter', 'developer', 'maintainer']
+    choices: ['guest', 'reporter', 'developer', 'maintainer', 'owner']
   gitlab_users_access:
     description:
       - Provide a list of user to access level mappings.
@@ -68,7 +68,7 @@ options:
           - The access level for the user.
           - Required if O(state=present), user state is set to present.
         type: str
-        choices: ['guest', 'reporter', 'developer', 'maintainer']
+        choices: ['guest', 'reporter', 'developer', 'maintainer', 'owner']
         required: true
     version_added: 3.7.0
   state:
@@ -86,7 +86,7 @@ options:
       - Is only used when O(state=present).
     type: list
     elements: str
-    choices: ['guest', 'reporter', 'developer', 'maintainer']
+    choices: ['guest', 'reporter', 'developer', 'maintainer', 'owner']
     version_added: 3.7.0
 """
 
@@ -239,16 +239,16 @@ def main():
         project=dict(type='str', required=True),
         gitlab_user=dict(type='list', elements='str'),
         state=dict(type='str', default='present', choices=['present', 'absent']),
-        access_level=dict(type='str', choices=['guest', 'reporter', 'developer', 'maintainer']),
+        access_level=dict(type='str', choices=['guest', 'reporter', 'developer', 'maintainer', 'owner']),
         purge_users=dict(type='list', elements='str', choices=[
-                         'guest', 'reporter', 'developer', 'maintainer']),
+                         'guest', 'reporter', 'developer', 'maintainer', 'owner']),
         gitlab_users_access=dict(
             type='list',
             elements='dict',
             options=dict(
                 name=dict(type='str', required=True),
                 access_level=dict(type='str', choices=[
-                                  'guest', 'reporter', 'developer', 'maintainer'], required=True),
+                                  'guest', 'reporter', 'developer', 'maintainer', 'owner'], required=True),
             )
         ),
     ))
@@ -286,6 +286,7 @@ def main():
         'reporter': gitlab.const.REPORTER_ACCESS,
         'developer': gitlab.const.DEVELOPER_ACCESS,
         'maintainer': gitlab.const.MAINTAINER_ACCESS,
+        'owner': gitlab.const.OWNER_ACCESS,
     }
 
     gitlab_project = module.params['project']

--- a/tests/integration/targets/gitlab_project_members/defaults/main.yml
+++ b/tests/integration/targets/gitlab_project_members/defaults/main.yml
@@ -16,3 +16,5 @@ dedicated_access_users:
     access_level: "developer"
   - name: username2
     access_level: "maintainer"
+  - name: username3
+    access_level: "owner"

--- a/tests/integration/targets/gitlab_project_members/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_members/tasks/main.yml
@@ -10,9 +10,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Install required library
-  pip:
+  ansible.builtin.pip:
     name: python-gitlab
     state: present
+    extra_args: >-
+      --break-system-packages
 
 - name: Clean UP before tests
   community.general.gitlab_project_members:
@@ -20,6 +22,7 @@
     api_token: "{{ gitlab_api_access_token }}"
     project: "{{ gitlab_project }}"
     gitlab_user: "{{ username }}"
+    access_level: "{{ gitlab_access_level }}"
     state: absent
 
 - name: Add a User to A GitLab Project
@@ -58,6 +61,7 @@
     api_token: "{{ gitlab_api_access_token }}"
     project: "{{ gitlab_project }}"
     gitlab_user: "{{ username }}"
+    access_level: "{{ gitlab_access_level }}"
     state: absent
   register: remove_gitlab_project_members_state
 
@@ -72,6 +76,7 @@
     api_token: "{{ gitlab_api_access_token }}"
     project: "{{ gitlab_project }}"
     gitlab_user: "{{ username }}"
+    access_level: "{{ gitlab_access_level }}"
     state: absent
   register: remove_gitlab_project_members_state_again
 
@@ -90,15 +95,16 @@
     state: present
 
 - name: Remove a list of Users to A GitLab Project
-  community.general.gitlab_project_members::
+  community.general.gitlab_project_members:
     api_url: "{{ gitlab_server_url }}"
     api_token: "{{ gitlab_api_access_token }}"
     project: "{{ gitlab_project }}"
     gitlab_user: "{{ userlist }}"
+    access_level: "{{ gitlab_access_level }}"
     state: absent
 
 - name: Add a list of Users with Dedicated Access Levels to A GitLab Project
-  community.general.gitlab_project_members::
+  community.general.gitlab_project_members:
     api_url: "{{ gitlab_server_url }}"
     api_token: "{{ gitlab_api_access_token }}"
     project: "{{ gitlab_project }}"
@@ -106,7 +112,7 @@
     state: present
 
 - name: Remove a list of Users with Dedicated Access Levels to A GitLab Project
-  community.general.gitlab_project_members::
+  community.general.gitlab_project_members:
     api_url: "{{ gitlab_server_url }}"
     api_token: "{{ gitlab_api_access_token }}"
     project: "{{ gitlab_project }}"
@@ -114,11 +120,11 @@
     state: absent
 
 - name: Add a user, remove all others which might be on this access level
-  community.general.gitlab_project_members::
+  community.general.gitlab_project_members:
     api_url: "{{ gitlab_server_url }}"
     api_token: "{{ gitlab_api_access_token }}"
     project: "{{ gitlab_project }}"
     gitlab_user: "{{ username }}"
     access_level: "{{ gitlab_access_level }}"
-    pruge_users: "{{ gitlab_access_level }}"
+    purge_users: "{{ gitlab_access_level }}"
     state: present

--- a/tests/integration/targets/gitlab_project_members/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_members/tasks/main.yml
@@ -13,8 +13,6 @@
   ansible.builtin.pip:
     name: python-gitlab
     state: present
-    extra_args: >-
-      --break-system-packages
 
 - name: Clean UP before tests
   community.general.gitlab_project_members:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The job of the `gitlab_project_members` is it to add / invite users to a project (git repository) giving them one of various predefined roles for this project which decides what exactly they are allowed to do on this project.
The highest of these roles / levels named `owner` is currently not yet supported by this module for some reason
and this PR wants to fix this.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
gitlab_project_members

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The implementation changes here are rather primitive and simple, just add `owner` everywhere where the other access levels are already handled. It also can help to look the `gitlab_group_members` module which basically does the same as this module just for gitlab groups and is already supporting the `owner` level.

Considering testing. Integration tests for this module were a bit broken here and there and needed some general fixing but at the end I got them working and running through against our local gitlab server. Also the production pipeline for which we need this change is working fine against our fork with this fix included.