### PR TITLE
Canonicalize value for AAAA records

### DIFF
--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -422,6 +422,7 @@ record:
       sample: sample.com
 """
 
+from ipaddress import IPv6Address
 import json
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
@@ -477,7 +478,7 @@ class CloudflareAPI(object):
             self.value = self.value.rstrip('.').lower()
 
         if (self.type == 'AAAA') and (self.value is not None):
-            self.value = self.value.lower()
+            self.value = str(IPv6Address(self.value))
 
         if (self.type == 'SRV'):
             if (self.proto is not None) and (not self.proto.startswith('_')):


### PR DESCRIPTION
##### SUMMARY

This ensures that any AAAA record value provided by the user is converted into a canonical and correctly-shortened form before any other processing takes place. In particular, this fixes an issue where a record containing a non-canonical address is not found by the fetch -> create/update logic, causing the API to return an error saying that the record already exists.

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudflare_dns

##### ADDITIONAL INFORMATION

A single IPv6 address can have many valid string representations. This makes comparing addresses difficult and to remedy this, [RFC 5952] specifies several rules for unambiguously shortening and canonicalizing IPv6 addresses.

[RFC 5952]: https://datatracker.ietf.org/doc/html/rfc5952

When Cloudflare's DNS API receives a request to set or update a AAAA record to a given v6 address, it silently converts it into an RFC 5952-compliant version of the address and saves that to its database but the `cloudflare_dns` module is not aware of this. When deciding whether to create or update the record, it tries to look up the existing record with the value given in the task. If that is not the canonical representation, then that record will not be found. If the record has already been set once before, this module tries to create the record and the DNS API hands back an error saying that the record already exists.

The fix is to simply pass the value given in the task into Python's built-in `ipaddress.IPv6Address` class (which automatically canonicalizes the address) and pull the string representation back out. The docs for the [ipaddress module] don't mention RFC 5952 but I have tested it and it appears to obey all of the rules mentioned.

[ipaddress module]: https://docs.python.org/3/library/ipaddress.html#ipaddress.IPv6Address

I looked into doing the same for IPv4 addresses but from my testing, it doesn't look like Python's `ipaddress` module accepts any non-standard IPv4 address representations.

I used the following playbook to test this change. (You will have to provide your own domain and API token to reproduce this.)

```yaml
- hosts: localhost
  connection: local
  gather_facts: no
  vars:
    zone: example.com
    api_token: "1234567890123456789012345678901234567890"

  tasks:
    - name: test canonical IPv6 address
      community.general.cloudflare_dns:
        api_token: "{{ api_token }}"
        zone: "{{ zone }}"
        type: AAAA
        record: test1
        value: "2001:db8::1:0:0:1"

    # This address "breaks" the following rules:
    # * Removal of leading zeroes in a field
    # * Use of `::` to shorten on the right instead of left
    # * Uppercase hex instead of lowercase
    - name: test non-canonical IPv6 address
      delegate_to: localhost
      community.general.cloudflare_dns:
        api_token: "{{ api_token }}"
        zone: "{{ zone }}"
        type: AAAA
        record: test2
        value: "2001:DB8:0:00:1::1"
```

Ansible output before change (with records pre-existing):

```
$ ansible-playbook -i test_inventory test-cfdns.yaml --diff 

PLAY [localhost] ************************************************************************************************************

TASK [test canonical IPv6 address] ******************************************************************************************
ok: [localhost]

TASK [test non-canonical IPv6 address] **************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "API bad request; Status: 400; Method: POST: Call: /zones/47e18f879d57884b89407531d310e324/dns_records; Error details: code: 81058, error: An identical record already exists.; "}

PLAY RECAP ******************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   

```

Ansible output after this change:

```
$ ansible-playbook -i test_inventory test-cfdns.yaml --diff 

PLAY [localhost] ************************************************************************************************************

TASK [test canonical IPv6 address] ******************************************************************************************
ok: [localhost]

TASK [test non-canonical IPv6 address] **************************************************************************************
ok: [localhost]

PLAY RECAP ******************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
