### PR TITLE
Feat: Add infiniband mac address support in nmcli module

### DIFF
--- a/changelogs/fragments/9962-nmcli-add-infiniband-mac-support.yml
+++ b/changelogs/fragments/9962-nmcli-add-infiniband-mac-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmcli - Add support for infiniband mac setting when type is infiniband (https://github.com/ansible-collections/community.general/pull/9962).

--- a/changelogs/fragments/9962-nmcli-add-infiniband-mac-support.yml
+++ b/changelogs/fragments/9962-nmcli-add-infiniband-mac-support.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - nmcli - Add support for infiniband mac setting when type is infiniband (https://github.com/ansible-collections/community.general/pull/9962).
+  - nmcli - Add support for Infiniband MAC setting when ``type`` is ``infiniband`` (https://github.com/ansible-collections/community.general/pull/9962).

--- a/changelogs/fragments/9962-nmcli-add-infiniband-mac-support.yml
+++ b/changelogs/fragments/9962-nmcli-add-infiniband-mac-support.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - nmcli - Add support for Infiniband MAC setting when ``type`` is ``infiniband`` (https://github.com/ansible-collections/community.general/pull/9962).
+  - nmcli - add support for Infiniband MAC setting when ``type`` is ``infiniband`` (https://github.com/ansible-collections/community.general/pull/9962).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -103,6 +103,7 @@ options:
     description:
       - MAC address of the Infiniband IPoIB devices.
     type: str
+    version_added: 10.6.0
   slave_type:
     description:
       - Type of the device of this slave's master connection (for example V(bond)).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -2041,9 +2041,7 @@ class Nmcli(object):
                 'infiniband.transport-mode': self.transport_mode,
             })
             if self.infiniband_mac:
-                options.update({
-                    'infiniband.mac-address': self.infiniband_mac,
-                })
+                options['infiniband.mac-address'] = self.infiniband_mac
         elif self.type == 'vrf':
             options.update({
                 'table': self.table,

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -99,6 +99,10 @@ options:
     type: str
     choices: [datagram, connected]
     version_added: 5.8.0
+  infiniband_mac:
+    description:
+      - MAC address of the Infiniband IPoIB devices.
+    type: str
   slave_type:
     description:
       - Type of the device of this slave's master connection (for example V(bond)).
@@ -428,10 +432,6 @@ options:
     description:
       - MAC address of the connection.
       - Note this requires a recent kernel feature, originally introduced in 3.15 upstream kernel.
-    type: str
-  infiniband_mac:
-    description:
-      - MAC address of the Infiniband IPoIB devices.
     type: str
   slavepriority:
     description:
@@ -1741,7 +1741,6 @@ class Nmcli(object):
         self.hairpin = module.params['hairpin']
         self.path_cost = module.params['path_cost']
         self.mac = module.params['mac']
-        self.infiniband_mac = module.params['infiniband_mac']
         self.runner = module.params['runner']
         self.runner_hwaddr_policy = module.params['runner_hwaddr_policy']
         self.runner_fast_rate = module.params['runner_fast_rate']
@@ -1769,6 +1768,7 @@ class Nmcli(object):
         self.wireguard = module.params['wireguard']
         self.vpn = module.params['vpn']
         self.transport_mode = module.params['transport_mode']
+        self.infiniband_mac = module.params['infiniband_mac']
         self.sriov = module.params['sriov']
 
         if self.method4:

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -429,6 +429,10 @@ options:
       - MAC address of the connection.
       - Note this requires a recent kernel feature, originally introduced in 3.15 upstream kernel.
     type: str
+  infiniband_mac:
+    description:
+      - MAC address of the Infiniband IPoIB devices.
+    type: str
   slavepriority:
     description:
       - This is only used with 'bridge-slave' - [<0-63>] - STP priority of this slave.
@@ -1737,6 +1741,7 @@ class Nmcli(object):
         self.hairpin = module.params['hairpin']
         self.path_cost = module.params['path_cost']
         self.mac = module.params['mac']
+        self.infiniband_mac = module.params['infiniband_mac']
         self.runner = module.params['runner']
         self.runner_hwaddr_policy = module.params['runner_hwaddr_policy']
         self.runner_fast_rate = module.params['runner_fast_rate']
@@ -2034,6 +2039,10 @@ class Nmcli(object):
             options.update({
                 'infiniband.transport-mode': self.transport_mode,
             })
+            if self.infiniband_mac:
+                options.update({
+                    'infiniband.mac-address': self.infiniband_mac,
+                })
         elif self.type == 'vrf':
             options.update({
                 'table': self.table,
@@ -2708,9 +2717,12 @@ def main():
                               tap=dict(type='bool'))),
             wireguard=dict(type='dict'),
             vpn=dict(type='dict'),
-            transport_mode=dict(type='str', choices=['datagram', 'connected']),
             sriov=dict(type='dict'),
             table=dict(type='int'),
+            # infiniband specific vars
+            transport_mode=dict(type='str', choices=['datagram', 'connected']),
+            infiniband_mac=dict(type='str'),
+
         ),
         mutually_exclusive=[['never_default4', 'gw4'],
                             ['routes4_extended', 'routes4'],

--- a/tests/unit/plugins/modules/test_nmcli.py
+++ b/tests/unit/plugins/modules/test_nmcli.py
@@ -4485,8 +4485,10 @@ def test_bond_connection_unchanged(mocked_generic_connection_diff_check, capfd):
             macvlan=dict(type='dict'),
             wireguard=dict(type='dict'),
             vpn=dict(type='dict'),
-            transport_mode=dict(type='str', choices=['datagram', 'connected']),
             sriov=dict(type='dict'),
+            # infiniband specific vars
+            transport_mode=dict(type='str', choices=['datagram', 'connected']),
+            infiniband_mac=dict(type='str'),
         ),
         mutually_exclusive=[['never_default4', 'gw4'],
                             ['routes4_extended', 'routes4'],


### PR DESCRIPTION
##### SUMMARY

Add support for `infiniband.mac-address` option, for interconnect devices.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
nmcli module

##### ADDITIONAL INFORMATION

This was asked at https://github.com/bluebanquise/bluebanquise/issues/1003 .

Please note that I do not have the hardware to test this feature, so I tested the python syntax and logic only, but could not make sure the nmcli execution will apply the setting.