### PR TITLE
fix duplicate json conversion for rocketchat pre740

### DIFF
--- a/changelogs/fragments/9965-fix-duplicate-jsonify-payload-for-rocketchat-pre740.yml
+++ b/changelogs/fragments/9965-fix-duplicate-jsonify-payload-for-rocketchat-pre740.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - rocketchat - fix duplicate JSON conversion for Rocket.Chat < 7.4.0

--- a/changelogs/fragments/9965-fix-duplicate-jsonify-payload-for-rocketchat-pre740.yml
+++ b/changelogs/fragments/9965-fix-duplicate-jsonify-payload-for-rocketchat-pre740.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - rocketchat - fix duplicate JSON conversion for Rocket.Chat < 7.4.0
+  - rocketchat - fix duplicate JSON conversion for Rocket.Chat < 7.4.0 (https://github.com/ansible-collections/community.general/pull/9965).

--- a/plugins/modules/rocketchat.py
+++ b/plugins/modules/rocketchat.py
@@ -206,7 +206,7 @@ def build_payload_for_rocketchat(module, text, channel, username, icon_url, icon
 
     payload = module.jsonify(payload)
     if is_pre740:
-        payload = "payload=" + module.jsonify(payload)
+        payload = "payload=" + payload
     return payload
 
 


### PR DESCRIPTION
##### SUMMARY
This PR fix incorrect backward compatibility with RocketChat before 7.4.1 causing msg :
```
failed to send message, return status=400
```
For rocketchat < 7.4.0 payload is "jsonify" twice.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
Rocket Chat