### PR TITLE
param pkcs12_alias and cert_alias to be optional in java_cert module 

### DIFF
--- a/changelogs/fragments/9970-pkcs12_alias_cert_alias_optional.yml
+++ b/changelogs/fragments/9970-pkcs12_alias_cert_alias_optional.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - java_cert module - param pkcs12_alias and cert_alias optional (https://github.com/ansible-collections/community.general/pull/9970).
+  - java_cert - the module no longer fails if the optional parameters ``pkcs12_alias`` and ``cert_alias`` are not provided (https://github.com/ansible-collections/community.general/pull/9970).

--- a/changelogs/fragments/9970-pkcs12_alias_cert_alias_optional.yml
+++ b/changelogs/fragments/9970-pkcs12_alias_cert_alias_optional.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - java_cert module - param pkcs12_alias and cert_alias optional (https://github.com/ansible-collections/community.general/pull/9970).

--- a/changelogs/fragments/9970-pkcs12_alias_cert_alias_optional.yml
+++ b/changelogs/fragments/9970-pkcs12_alias_cert_alias_optional.yml
@@ -1,2 +1,2 @@
-minor_changes:
+bugfixes:
   - java_cert - the module no longer fails if the optional parameters ``pkcs12_alias`` and ``cert_alias`` are not provided (https://github.com/ansible-collections/community.general/pull/9970).

--- a/plugins/modules/java_cert.py
+++ b/plugins/modules/java_cert.py
@@ -315,12 +315,13 @@ def _export_public_cert_from_pkcs12(module, executable, pkcs_file, alias, passwo
         "-noprompt",
         "-keystore",
         pkcs_file,
-        "-alias",
-        alias,
         "-storetype",
         "pkcs12",
         "-rfc"
     ]
+    # Append optional alias
+    if alias:
+        export_cmd.extend(["-alias", alias])
     (export_rc, export_stdout, export_err) = module.run_command(export_cmd, data=password, check_rc=False)
 
     if export_rc != 0:
@@ -393,6 +394,10 @@ def import_pkcs12_path(module, executable, pkcs12_path, pkcs12_pass, pkcs12_alia
                        keystore_path, keystore_pass, keystore_alias, keystore_type):
     ''' Import pkcs12 from path into keystore located on
         keystore_path as alias '''
+    optional_aliases = {
+        "-destalias": keystore_alias,
+        "-srcalias": pkcs12_alias
+    }
     import_cmd = [
         executable,
         "-importkeystore",
@@ -401,13 +406,14 @@ def import_pkcs12_path(module, executable, pkcs12_path, pkcs12_pass, pkcs12_alia
         "pkcs12",
         "-srckeystore",
         pkcs12_path,
-        "-srcalias",
-        pkcs12_alias,
         "-destkeystore",
         keystore_path,
-        "-destalias",
-        keystore_alias
     ]
+    # Append optional aliases
+    for flag, value in optional_aliases.items():
+        if value:
+            import_cmd.extend([flag, value])
+
     import_cmd += _get_keystore_type_keytool_parameters(keystore_type)
 
     secret_data = "%s\n%s" % (keystore_pass, pkcs12_pass)

--- a/tests/integration/targets/java_cert/tasks/main.yml
+++ b/tests/integration/targets/java_cert/tasks/main.yml
@@ -10,7 +10,6 @@
 
 - when: has_java_keytool
   block:
-
     - name: prep pkcs12 file
       ansible.builtin.copy:
         src: "{{ test_pkcs12_path }}"
@@ -32,6 +31,21 @@
       ansible.builtin.assert:
         that:
         - result_success is successful
+
+    - name: import pkcs12 without alias params
+      community.general.java_cert:
+        pkcs12_path: "{{ remote_tmp_dir }}/{{ test_pkcs12_path }}"
+        pkcs12_password: changeit
+        keystore_path: "{{ remote_tmp_dir }}/{{ test_keystore_path }}"
+        keystore_pass: changeme_keystore
+        keystore_create: true
+        state: present
+      register: result_success_excl_aliases
+
+    - name: verify success
+      ansible.builtin.assert:
+        that:
+        - result_success_excl_aliases is successful
 
     - name: import pkcs12 with wrong password
       community.general.java_cert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #6010
This pull request permit the module to use aliases as optional.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
 java_cert
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
The keytool util can import a pkcs12 certificate without specify the alias, example:
```keytool -importkeystore -srckeystore mypfxfile.pfx -srcstoretype pkcs12 -destkeystore clientcert.jks -deststoretype JKS```
Omitting the pkcs12_alias and cert_alias result in a command error.
This pull request permit the module to use aliases as optional, a test has been added to test this change.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
