### PR TITLE
keycloak_identity_provider: add `hideOnLogin` parameter to module

### DIFF
--- a/changelogs/fragments/9983-keycloak_idp-add-hideOnLogin-param.yml
+++ b/changelogs/fragments/9983-keycloak_idp-add-hideOnLogin-param.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_identity_provider - add ``hideOnLogin`` parameter to the module, the old parameter ``config/hideOnLoginPage`` is kept for compatibility (https://github.com/ansible-collections/community.general/pull/9983).

--- a/plugins/modules/keycloak_identity_provider.py
+++ b/plugins/modules/keycloak_identity_provider.py
@@ -127,7 +127,7 @@ options:
   hide_on_login:
     description:
       - If hidden, login with this provider is possible only if requested explicitly, for example using the C(kc_idp_hint)
-      - Parameter was added in Keycloak 26, for older Keycloak versions use O(hide_on_login_page) in the O(config) dict
+      - Parameter was added in Keycloak 26, for older Keycloak versions use O(config.hide_on_login_page)
     aliases:
       - hideOnLogin
     type: bool

--- a/plugins/modules/keycloak_identity_provider.py
+++ b/plugins/modules/keycloak_identity_provider.py
@@ -124,6 +124,15 @@ options:
       - providerId
     type: str
 
+  hide_on_login:
+    description:
+      - If hidden, login with this provider is possible only if requested explicitly, for example using the C(kc_idp_hint)
+      - Parameter was added in Keycloak 26, for older Keycloak versions use O(hide_on_login_page) in the O(config) dict
+    aliases:
+      - hideOnLogin
+    type: bool
+    version_added: 10.6.0
+
   config:
     description:
       - Dict specifying the configuration options for the provider; the contents differ depending on the value of O(provider_id).
@@ -490,6 +499,7 @@ def main():
         provider_id=dict(type='str', aliases=['providerId']),
         store_token=dict(type='bool', aliases=['storeToken']),
         trust_email=dict(type='bool', aliases=['trustEmail']),
+        hide_on_login=dict(type='bool', aliases=['hideOnLogin']),
         mappers=dict(type='list', elements='dict', options=mapper_spec),
     )
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `hideOnLoginPage` parameter was moved out of the `config` dict and renamed to `hideOnLogin` in Keycloak 26. KC26 still seems to accept `config/hideOnLoginPage` in a request, but the response always only contains `hideOnLogin`.

The MR adds the parameter to the module and keeps the old parameter for compatibility.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_identity_provider
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
KC 26 IDP response:
```
{
  "alias": "IDP",
  "displayName": "IDP",
  "internalId": "cf6795b3-7e97-4a4a-82b4-767ee6a89a88",
  "providerId": "keycloak-oidc",
  "linkOnly": false,
  "hideOnLogin": false,
  "config": {
    ...
  }
}
```
KC 25:
```
{
  "alias": "keycloak-oidc",
  "displayName": "",
  "internalId": "9048593b-f534-40c5-8c49-9de4e3058580",
  "providerId": "keycloak-oidc",
  "enabled": true,
  "config": {
    "validateSignature": "false",
    "hideOnLoginPage": "true",
    "tokenUrl": "http://localhost:8999",
    ...
  }
}
```
See also in the docu: https://www.keycloak.org/docs-api/latest/rest-api/index.html#IdentityProviderRepresentation and https://www.keycloak.org/docs-api/25.0.6/rest-api/index.html#IdentityProviderRepresentation
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
