### PR TITLE
Fix Keycloak authentication flow configuration issues

### DIFF
--- a/changelogs/fragments/9987-keycloak-auth-flow-fix-config.yaml
+++ b/changelogs/fragments/9987-keycloak-auth-flow-fix-config.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_authentication - fix authentification config duplication (https://github.com/ansible-collections/community.general/pull/9987).

--- a/changelogs/fragments/9987-keycloak-auth-flow-fix-config.yaml
+++ b/changelogs/fragments/9987-keycloak-auth-flow-fix-config.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - keycloak_authentication - fix authentification config duplication (https://github.com/ansible-collections/community.general/pull/9987).
+  - keycloak_authentication - fix authentification config duplication for Keycloak < 26.2.0 (https://github.com/ansible-collections/community.general/pull/9987).

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -2224,6 +2224,24 @@ class KeycloakAPI(object):
         except Exception as e:
             self.fail_request(e, msg="Unable to add authenticationConfig %s: %s" % (executionId, str(e)))
 
+    def delete_authentication_config(self, configId, realm='master'):
+        """ Delete authenticator config
+
+        :param configId: id of authentification config
+        :param realm: realm of client to be deleted
+        :return: HTTPResponse object on success
+        """
+        try:
+            self._request(
+                URL_AUTHENTICATION_CONFIG.format(
+                    url=self.baseurl,
+                    realm=realm,
+                    id=configId),
+                method='DELETE'
+                )
+        except Exception as e:
+            self.fail_request(e, msg="Unable to delete authentication config %s: %s" % (configId, str(e)))
+
     def create_subflow(self, subflowName, flowAlias, realm='master', flowType='basic-flow'):
         """ Create new sublow on the flow
 

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -2227,18 +2227,17 @@ class KeycloakAPI(object):
     def delete_authentication_config(self, configId, realm='master'):
         """ Delete authenticator config
 
-        :param configId: id of authentification config
-        :param realm: realm of client to be deleted
-        :return: HTTPResponse object on success
+        :param configId: id of authentication config
+        :param realm: realm of authentication config to be deleted
         """
         try:
+            # Send a DELETE request to remove the specified authentication config from the Keycloak server.
             self._request(
                 URL_AUTHENTICATION_CONFIG.format(
                     url=self.baseurl,
                     realm=realm,
                     id=configId),
-                method='DELETE'
-                )
+                method='DELETE')
         except Exception as e:
             self.fail_request(e, msg="Unable to delete authentication config %s: %s" % (configId, str(e)))
 

--- a/plugins/modules/keycloak_authentication.py
+++ b/plugins/modules/keycloak_authentication.py
@@ -309,7 +309,7 @@ def create_or_update_executions(kc, config, realm='master'):
                         # add the execution configuration
                         if new_exec["authenticationConfig"] is not None:
                             if "authenticationConfig" in execution and "id" in execution["authenticationConfig"]:
-                              kc.delete_authentication_config(execution["authenticationConfig"]["id"], realm=realm)
+                                kc.delete_authentication_config(execution["authenticationConfig"]["id"], realm=realm)
                             kc.add_authenticationConfig_to_execution(updated_exec["id"], new_exec["authenticationConfig"], realm=realm)
                         for key in new_exec:
                             # remove unwanted key for the next API call

--- a/plugins/modules/keycloak_authentication.py
+++ b/plugins/modules/keycloak_authentication.py
@@ -308,6 +308,8 @@ def create_or_update_executions(kc, config, realm='master'):
                         }
                         # add the execution configuration
                         if new_exec["authenticationConfig"] is not None:
+                            if "authenticationConfig" in execution and "id" in execution["authenticationConfig"]:
+                              kc.delete_authentication_config(execution["authenticationConfig"]["id"], realm=realm)
                             kc.add_authenticationConfig_to_execution(updated_exec["id"], new_exec["authenticationConfig"], realm=realm)
                         for key in new_exec:
                             # remove unwanted key for the next API call

--- a/tests/integration/targets/keycloak_authentication/README.md
+++ b/tests/integration/targets/keycloak_authentication/README.md
@@ -5,18 +5,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
 -->
 # Running keycloak_authentication module integration test
 
-To run Keycloak component info module's integration test, start a keycloak server using Docker:
-
-    
-    docker run -d --rm --name mykeycloak -p 8080:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=password quay.io/keycloak/keycloak:latest start-dev --http-relative-path /auth
-
-
 Run integration tests:
 
     ansible-test integration -v keycloak_authentication --allow-unsupported --docker fedora35 --docker-network host
-
-Cleanup:
-
-    docker stop mykeycloak
-
-

--- a/tests/integration/targets/keycloak_authentication/README.md
+++ b/tests/integration/targets/keycloak_authentication/README.md
@@ -1,0 +1,22 @@
+<!--
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+# Running keycloak_authentication module integration test
+
+To run Keycloak component info module's integration test, start a keycloak server using Docker:
+
+    
+    docker run -d --rm --name mykeycloak -p 8080:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=password quay.io/keycloak/keycloak:latest start-dev --http-relative-path /auth
+
+
+Run integration tests:
+
+    ansible-test integration -v keycloak_authentication --allow-unsupported --docker fedora35 --docker-network host
+
+Cleanup:
+
+    docker stop mykeycloak
+
+

--- a/tests/integration/targets/keycloak_authentication/aliases
+++ b/tests/integration/targets/keycloak_authentication/aliases
@@ -1,0 +1,5 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+unsupported

--- a/tests/integration/targets/keycloak_authentication/tasks/access_token.yml
+++ b/tests/integration/targets/keycloak_authentication/tasks/access_token.yml
@@ -1,0 +1,24 @@
+---
+- name: Get access token
+  ansible.builtin.uri:
+    url: "{{ url }}/realms/{{ admin_realm }}/protocol/openid-connect/token"
+    method: POST
+    return_content: true
+    status_code: 200
+    headers:
+      X-Requested-By: "Jenkins"
+      Accept: application/json
+      User-agent: Ansible
+    body_format: form-urlencoded
+    body:
+      grant_type: "password"
+      client_id: "admin-cli"
+      username: "{{ admin_user }}"
+      password: "{{ admin_password }}"
+  register: token_response
+  no_log: true
+
+- name: Extract access token
+  ansible.builtin.set_fact:
+    access_token: "{{ token_response.json['access_token'] }}"
+  no_log: true

--- a/tests/integration/targets/keycloak_authentication/tasks/access_token.yml
+++ b/tests/integration/targets/keycloak_authentication/tasks/access_token.yml
@@ -6,10 +6,8 @@
   ansible.builtin.uri:
     url: "{{ url }}/realms/{{ admin_realm }}/protocol/openid-connect/token"
     method: POST
-    return_content: true
     status_code: 200
     headers:
-      X-Requested-By: "Jenkins"
       Accept: application/json
       User-agent: Ansible
     body_format: form-urlencoded

--- a/tests/integration/targets/keycloak_authentication/tasks/access_token.yml
+++ b/tests/integration/targets/keycloak_authentication/tasks/access_token.yml
@@ -1,3 +1,6 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 ---
 - name: Get access token
   ansible.builtin.uri:

--- a/tests/integration/targets/keycloak_authentication/tasks/main.yml
+++ b/tests/integration/targets/keycloak_authentication/tasks/main.yml
@@ -1,0 +1,170 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+- name: Install jmespath
+  pip:
+    name: jmespath
+  register: result
+#  environment: 
+#    https_proxy: http://10.249.120.90:8080
+#    http_proxy: http://10.249.120.90:8080
+  until: result is success
+
+- name: Wait for Keycloak
+  uri:
+    url: "{{ url }}/admin/"
+    status_code: 200
+    validate_certs: no
+  register: result
+  until: result.status == 200
+  retries: 10
+  delay: 10
+
+- name: Delete realm if exists
+  community.general.keycloak_realm:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    state: absent
+
+- name: Create realm
+  community.general.keycloak_realm:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    id: "{{ realm }}"
+    realm: "{{ realm }}"
+    state: present
+
+- name: Create an authentication flow from first broker login and add an execution to it.
+  community.general.keycloak_authentication:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    alias: "Test first broker login"
+    copyFrom: "first broker login"
+    authenticationExecutions:
+      - providerId: "idp-review-profile"
+        requirement: "REQUIRED"
+        authenticationConfig: 
+          alias: "Test review profile config"
+          config: 
+            update.profile.on.first.login: "missing"
+
+- name: Create auth flow
+  community.general.keycloak_authentication:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    alias: "My conditionnal browser otp"
+    description: "browser based authentication with otp"
+    providerId: "basic-flow"
+    authenticationExecutions:
+    - displayName: Cookie
+      providerId: auth-cookie
+      requirement: ALTERNATIVE
+    - displayName: Kerberos
+      providerId: auth-spnego
+      requirement: DISABLED
+    - displayName: Identity Provider Redirector
+      providerId: identity-provider-redirector
+      requirement: ALTERNATIVE
+    - displayName: My browser otp forms
+      requirement: ALTERNATIVE
+    - displayName: Username Password Form
+      flowAlias: My browser otp forms
+      providerId: auth-username-password-form
+      requirement: REQUIRED
+    - displayName: My browser otp Browser - Conditional OTP
+      flowAlias: My browser otp forms
+      requirement: REQUIRED
+      providerId: "auth-conditional-otp-form"
+      authenticationConfig:
+        alias: my-conditional-otp-config
+        config: 
+          defaultOtpOutcome: "force"
+          noOtpRequiredForHeaderPattern: "{{ keycloak_no_otp_required_pattern_orinale }}"
+    state: present
+
+
+- name: Modified auth flow with new config
+  community.general.keycloak_authentication:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    alias: "My conditionnal browser otp"
+    description: "browser based authentication with otp"
+    providerId: "basic-flow"
+    authenticationExecutions:
+    - displayName: Cookie
+      providerId: auth-cookie
+      requirement: ALTERNATIVE
+    - displayName: Kerberos
+      providerId: auth-spnego
+      requirement: DISABLED
+    - displayName: Identity Provider Redirector
+      providerId: identity-provider-redirector
+      requirement: ALTERNATIVE
+    - displayName: My browser otp forms
+      requirement: ALTERNATIVE
+    - displayName: Username Password Form
+      flowAlias: My browser otp forms
+      providerId: auth-username-password-form
+      requirement: REQUIRED
+    - displayName: My browser otp Browser - Conditional OTP
+      flowAlias: My browser otp forms
+      requirement: REQUIRED
+      providerId: "auth-conditional-otp-form"
+      authenticationConfig:
+        alias: my-conditional-otp-config
+        config: 
+          defaultOtpOutcome: "force"
+          noOtpRequiredForHeaderPattern: "{{ keycloak_no_otp_required_pattern_modifed }}"
+    state: present
+  register: result
+
+- name: Retrive access
+  ansible.builtin.include_tasks:
+    file: access_token.yml
+
+- name: Export realm
+  ansible.builtin.uri:
+    url: "{{ url }}/admin/realms/{{ realm }}/partial-export?exportClients=false&exportGroupsAndRoles=false"
+    method: POST
+    return_content: true
+    status_code: 200
+    headers:
+      X-Requested-By: "Jenkins"
+      Accept: application/json
+      User-agent: Ansible
+      Authorization: "Bearer {{ access_token }}"
+    body_format: form-urlencoded
+    body: {}
+  register: exported_realm
+
+- name: Assert `my-conditional-otp-config` exists only once
+  ansible.builtin.assert:
+    that:
+    - exported_realm.json | community.general.json_query('authenticatorConfig[?alias==`my-conditional-otp-config`]') | length == 1
+
+- name: Delete auth flow
+  community.general.keycloak_authentication:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    alias: "My conditionnal browser otp"
+    state: absent
+  register: result
+

--- a/tests/integration/targets/keycloak_authentication/tasks/main.yml
+++ b/tests/integration/targets/keycloak_authentication/tasks/main.yml
@@ -94,7 +94,6 @@
           noOtpRequiredForHeaderPattern: "{{ keycloak_no_otp_required_pattern_orinale }}"
     state: present
 
-
 - name: Modified auth flow with new config
   community.general.keycloak_authentication:
     auth_keycloak_url: "{{ url }}"
@@ -167,4 +166,3 @@
     alias: "My conditionnal browser otp"
     state: absent
   register: result
-

--- a/tests/integration/targets/keycloak_authentication/tasks/main.yml
+++ b/tests/integration/targets/keycloak_authentication/tasks/main.yml
@@ -2,14 +2,28 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-- name: Install jmespath
+- name: Install required packages
   pip:
-    name: jmespath
+    name:
+      - jmespath
+      - requests
   register: result
-#  environment: 
-#    https_proxy: http://10.249.120.90:8080
-#    http_proxy: http://10.249.120.90:8080
   until: result is success
+
+- name: Start container
+  community.docker.docker_container:
+    name: mykeycloak
+    image: "quay.io/keycloak/keycloak:{{ keycloak_version }}"
+    command: start-dev
+    env:
+      KC_HTTP_RELATIVE_PATH: /auth
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: password
+    ports:
+      - "{{ keycloak_port }}:8080"
+    detach: true
+    auto_remove: true
+    memory: 2200M
 
 - name: Wait for Keycloak
   uri:
@@ -140,16 +154,14 @@
   ansible.builtin.uri:
     url: "{{ url }}/admin/realms/{{ realm }}/partial-export?exportClients=false&exportGroupsAndRoles=false"
     method: POST
-    return_content: true
-    status_code: 200
     headers:
-      X-Requested-By: "Jenkins"
       Accept: application/json
       User-agent: Ansible
       Authorization: "Bearer {{ access_token }}"
     body_format: form-urlencoded
     body: {}
   register: exported_realm
+  no_log: true
 
 - name: Assert `my-conditional-otp-config` exists only once
   ansible.builtin.assert:
@@ -166,3 +178,8 @@
     alias: "My conditionnal browser otp"
     state: absent
   register: result
+
+- name: Remove container
+  community.docker.docker_container:
+    name: mykeycloak
+    state: absent

--- a/tests/integration/targets/keycloak_authentication/vars/main.yml
+++ b/tests/integration/targets/keycloak_authentication/vars/main.yml
@@ -2,8 +2,10 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
+keycloak_version: latest
+keycloak_port: 8080
 
-url: http://localhost:8080/auth
+url: "http://localhost:{{ keycloak_port }}/auth"
 admin_realm: master
 admin_user: admin
 admin_password: password

--- a/tests/integration/targets/keycloak_authentication/vars/main.yml
+++ b/tests/integration/targets/keycloak_authentication/vars/main.yml
@@ -1,0 +1,14 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+url: http://localhost:8080/auth
+admin_realm: master
+admin_user: admin
+admin_password: password
+realm: myrealm
+
+
+keycloak_no_otp_required_pattern_orinale: "X-Forwarded-For: 10\\.[0-9\\.:]+"
+keycloak_no_otp_required_pattern_modifed: "X-Original-Forwarded-For: 10\\.[0-9\\.:]+"


### PR DESCRIPTION
##### SUMMARY
Fix authentification flow configuration duplication

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
keycloak_authentication.py
keycloak.py

##### ADDITIONAL INFORMATION
Modification to authentification flow configuration cause the creation of a duplicate record in AUTHENTICATOR_CONFIG and AUTHENTICATOR_CONFIG_ENTRY

KC26 exported realm:
```json
    {
      "id": "f76d998c-6eb4-42fa-b3b1-df8ae2be926c",
      "alias": "my-conditional-reset-otp-config",
      "config": {
        "defaultOtpOutcome": "force",
        "noOtpRequiredForHeaderPattern": "X-Forwarded-For: 10\\.[0-9\\.:]+"
      }
    },
    {
      "id": "e195fad8-4470-47be-ada2-ecf44146a0eb",
      "alias": "my-conditional-reset-otp-config",
      "config": {
        "defaultOtpOutcome": "force",
        "noOtpRequiredForHeaderPattern": "X-Original-Forwarded-For: 10.[0-9\\.:]+"
      }
    }
```
