### PR TITLE
Fix typo in rpm_ostree_pkg documentation example

### DIFF
--- a/plugins/modules/rpm_ostree_pkg.py
+++ b/plugins/modules/rpm_ostree_pkg.py
@@ -78,7 +78,7 @@ EXAMPLES = r"""
   register: rpm_ostree_pkg
   until: rpm_ostree_pkg is not failed
   retries: 10
-  dealy: 30
+  delay: 30
 """
 
 RETURN = r"""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In the documentation for the rpm_ostree_pkg module, the example showing how to improve resiliency by using a delay did not work, as delay was misspelled.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
rpm_ostree_pkg
