### PR TITLE
Fix method exists in sysrc

### DIFF
--- a/plugins/modules/sysrc.py
+++ b/plugins/modules/sysrc.py
@@ -122,14 +122,10 @@ class Sysrc(object):
         return err.find("unknown variable") > 0 or out.find("unknown variable") > 0
 
     def exists(self):
-        # sysrc doesn't really use exit codes
-        (rc, out, err) = self.run_sysrc(self.name)
-        if self.value is None:
-            regex = "%s: " % re.escape(self.name)
-        else:
-            regex = "%s: %s$" % (re.escape(self.name), re.escape(self.value))
-
-        return not self.has_unknown_variable(out, err) and re.match(regex, out) is not None
+        # sysrc doesn't really use exit codes. Read all variables.
+        (rc, out, err) = self.run_sysrc('-e', '-a')
+        conf = dict([i.split('=') for i in out.splitlines()])
+        return self.name in conf
 
     def contains(self):
         (rc, out, err) = self.run_sysrc('-n', self.name)


### PR DESCRIPTION
##### SUMMARY
The method ``exists`` should test whether a variable (name) is present in the configuration file (path). You can not use the binary ``sysrc -x <name>`` for this because sysrc silently ignores missing variables and always returns ``rc=0``.  The idea is to test the presence of a variable in the configuration file and report ``changed=false`` when missing. 

Unfortunately, the method ``exists`` always reports that the variable (name) is present.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #10004

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.general.sysrc

##### ADDITIONAL INFORMATION

 Instead of a complex regex testing, read the file and create the dictionary conf comprising all variables (names). 

```python
     def exists(self):
            # sysrc doesn't really use exit codes. Read all variables.
            (rc, out, err) = self.run_sysrc('-e', '-a')
            conf = dict([i.split('=') for i in out.splitlines()])
            return self.name in conf
```

Quoting [man sysrc](https://man.freebsd.org/cgi/man.cgi?sysrc)

> -e	Print  query  results as sh(1) compatible syntax (for example, var=value').

> -a	Dump a list of all non-default configuration variables.
