### PR TITLE
proxmox: support create and update of container in the same task

### DIFF
--- a/changelogs/fragments/10010-proxmox-support-create-update-ct.yml
+++ b/changelogs/fragments/10010-proxmox-support-create-update-ct.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox - add support for creating and updating containers in the same task (https://github.com/ansible-collections/community.general/pull/10010)

--- a/changelogs/fragments/10010-proxmox-support-create-update-ct.yml
+++ b/changelogs/fragments/10010-proxmox-support-create-update-ct.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox - add support for creating and updating containers in the same task (https://github.com/ansible-collections/community.general/pull/10010)
+  - proxmox - add support for creating and updating containers in the same task (https://github.com/ansible-collections/community.general/pull/10010).

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -747,7 +747,7 @@ def get_ansible_module():
         ],
         mutually_exclusive=[
             # Creating a new container is done either by cloning an existing one, or based on a template.
-            ("clone", "ostemplate", "update"),
+            ("clone", "ostemplate"),
             ("disk", "disk_volume"),
             ("storage", "disk_volume"),
             ("mounts", "mount_volumes"),


### PR DESCRIPTION
##### SUMMARY
Allowing `update` at the same time as `clone` or `ostemplate` make it possible to create a task that will create a container when it doesn't exit and update it when it does.

This also fix a case (`ostemplate` is present, and the container exist) with an unfixable deprecation warning for `update`. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
proxmox

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
