### PR TITLE
fix: github_deploy_key check key exists on 422

### DIFF
--- a/changelogs/fragments/10011-github_deploy_key-check-key-present
+++ b/changelogs/fragments/10011-github_deploy_key-check-key-present
@@ -1,0 +1,2 @@
+bugfixes:
+  - github_deploy_key - fix: check that key really exists on 422 to avoid masking other errors (https://github.com/ansible-collections/community.general/issues/6718) 

--- a/changelogs/fragments/10011-github_deploy_key-check-key-present
+++ b/changelogs/fragments/10011-github_deploy_key-check-key-present
@@ -1,2 +1,0 @@
-bugfixes:
-  - github_deploy_key - fix: check that key really exists on 422 to avoid masking other errors (https://github.com/ansible-collections/community.general/issues/6718) 

--- a/changelogs/fragments/10011-github_deploy_key-check-key-present.yml
+++ b/changelogs/fragments/10011-github_deploy_key-check-key-present.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - github_deploy_key - fix: check that key really exists on 422 to avoid masking other errors (https://github.com/ansible-collections/community.general/issues/6718, https://github.com/ansible-collections/community.general/pull/10011) 

--- a/changelogs/fragments/10011-github_deploy_key-check-key-present.yml
+++ b/changelogs/fragments/10011-github_deploy_key-check-key-present.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - github_deploy_key - fix: check that key really exists on 422 to avoid masking other errors (https://github.com/ansible-collections/community.general/issues/6718, https://github.com/ansible-collections/community.general/pull/10011) 
+  - "github_deploy_key - fix: check that key really exists on 422 to avoid masking other errors (https://github.com/ansible-collections/community.general/issues/6718, https://github.com/ansible-collections/community.general/pull/10011)"

--- a/changelogs/fragments/10011-github_deploy_key-check-key-present.yml
+++ b/changelogs/fragments/10011-github_deploy_key-check-key-present.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "github_deploy_key - fix: check that key really exists on 422 to avoid masking other errors (https://github.com/ansible-collections/community.general/issues/6718, https://github.com/ansible-collections/community.general/pull/10011)"
+  - "github_deploy_key - check that key really exists on 422 to avoid masking other errors (https://github.com/ansible-collections/community.general/issues/6718, https://github.com/ansible-collections/community.general/pull/10011)."

--- a/plugins/modules/github_deploy_key.py
+++ b/plugins/modules/github_deploy_key.py
@@ -259,7 +259,12 @@ class GithubDeployKey(object):
             key_id = response_body["id"]
             self.module.exit_json(changed=True, msg="Deploy key successfully added", id=key_id)
         elif status_code == 422:
-            self.module.exit_json(changed=False, msg="Deploy key already exists")
+            # there might be multiple reasons for a 422
+            # so we must check if the reason is that the key already exists
+            if self.get_existing_key():
+                self.module.exit_json(changed=False, msg="Deploy key already exists")
+            else:
+                self.handle_error(method="POST", info=info)
         else:
             self.handle_error(method="POST", info=info)
 


### PR DESCRIPTION
##### SUMMARY

Currently if we add a deploy key, if we get a 422 we consider that the key is already there and exit with changed=false, giving the impression that all is fine.

But in reality there can be many other reason for a 422, for example:
* the key is not in a valid format
* the key is already used in another repository

This is really annoying as one thinks the operation went well, whereas it failed.

The proposed fix it that if we get a 422 response code as we add a key, we check if it's because the key already exists or for another reason. And based on that we return with success or we fail.

fixes: #6718

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

github_deploy_key

##### ADDITIONAL INFORMATION

With a key which is a content in base64 that I forgot to decode

Before:
```
TASK [xxxx : add the key on github] ***************************************************
ok: [my-server]
```
(while the key was not added)

After:
```
TASK [xxxx : add the key on github] ***************************************************
fatal: [my-server]: FAILED! => {"changed": false, "error": "Validation Failed", "http_status_code": 422, "msg": "Failed to add deploy key"}
```
