### PR TITLE
Homebrew: Emit a useful error message if brew info reports a package tap is null.

### DIFF
--- a/changelogs/fragments/10012-improve-error-handling-homebrew-missing-tap.yml
+++ b/changelogs/fragments/10012-improve-error-handling-homebrew-missing-tap.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - homebrew - Emit a useful error message if `brew info` reports a package tap is null. (https://github.com/ansible-collections/community.general/pull/10013, https://github.com/ansible-collections/community.general/issues/10012).
+  - homebrew - emit a useful error message if ``brew info`` reports a package tap is null (https://github.com/ansible-collections/community.general/pull/10013, https://github.com/ansible-collections/community.general/issues/10012).

--- a/changelogs/fragments/10012-improve-error-handling-homebrew-missing-tap.yml
+++ b/changelogs/fragments/10012-improve-error-handling-homebrew-missing-tap.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - homebrew - emit a useful error message if ``brew info`` reports a package tap is null (https://github.com/ansible-collections/community.general/pull/10013, https://github.com/ansible-collections/community.general/issues/10012).
+  - homebrew - emit a useful error message if ``brew info`` reports a package tap is ``null`` (https://github.com/ansible-collections/community.general/pull/10013, https://github.com/ansible-collections/community.general/issues/10012).

--- a/changelogs/fragments/10012-improve-error-handling-homebrew-missing-tap.yml
+++ b/changelogs/fragments/10012-improve-error-handling-homebrew-missing-tap.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - homebrew - Emit a useful error message if `brew info` reports a package tap is null. (https://github.com/ansible-collections/community.general/pull/10013, https://github.com/ansible-collections/community.general/issues/10012).

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -399,17 +399,14 @@ class Homebrew(object):
             name = package_detail["name"]
             full_name = package_detail["full_name"]
 
-        if not package_detail["tap"]:
-            # This can happen if an already installed package has been
-            # subsequently withdrawn by homebrew. See issue #10012.
-            self.failed = True
-            self.message = "No tap found for package '{0}'.".format(name)
-            raise HomebrewException(self.message)
-
-        tapped_name = package_detail["tap"] + "/" + name
+        # Issue #9803: name can include the tap as a prefix, in order to
+        # disambiguate, e.g. casks from identically named formulae.
+        #
+        # Issue #10012: package_detail["tap"] is None if package is no longer
+        # available.
+        tapped_name = [package_detail["tap"] + "/" + name] if package_detail["tap"] else []
         aliases = package_detail.get("aliases", [])
-
-        package_names = set([name, full_name, tapped_name] + aliases)
+        package_names = set([name, full_name] + tapped_name + aliases)
 
         # Finally, identify which of all those package names was the one supplied by the user.
         package_names = package_names & set(self.packages)

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -399,6 +399,13 @@ class Homebrew(object):
             name = package_detail["name"]
             full_name = package_detail["full_name"]
 
+        if not package_detail["tap"]:
+            # This can happen if an already installed package has been
+            # subsequently withdrawn by homebrew. See issue #10012.
+            self.failed = True
+            self.message = "No tap found for package '{0}'.".format(name)
+            raise HomebrewException(self.message)
+
         tapped_name = package_detail["tap"] + "/" + name
         aliases = package_detail.get("aliases", [])
 

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -402,8 +402,8 @@ class Homebrew(object):
         # Issue #9803: name can include the tap as a prefix, in order to
         # disambiguate, e.g. casks from identically named formulae.
         #
-        # Issue #10012: package_detail["tap"] is None if package is no longer
-        # available.
+        # Issue https://github.com/ansible-collections/community.general/issues/10012:
+        # package_detail["tap"] is None if package is no longer available.
         tapped_name = [package_detail["tap"] + "/" + name] if package_detail["tap"] else []
         aliases = package_detail.get("aliases", [])
         package_names = set([name, full_name] + tapped_name + aliases)

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -399,8 +399,9 @@ class Homebrew(object):
             name = package_detail["name"]
             full_name = package_detail["full_name"]
 
-        # Issue #9803: name can include the tap as a prefix, in order to
-        # disambiguate, e.g. casks from identically named formulae.
+        # Issue https://github.com/ansible-collections/community.general/issues/9803:
+        # name can include the tap as a prefix, in order to disambiguate,
+        # e.g. casks from identically named formulae.
         #
         # Issue https://github.com/ansible-collections/community.general/issues/10012:
         # package_detail["tap"] is None if package is no longer available.


### PR DESCRIPTION


##### SUMMARY

Homebrew: Emit a useful error message if `brew info` reports a package tap is null.  This can happen if an installed package is subsequently removed from the tap (e.g. it is withdrawn by homebrew).  



Fixes #10012

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
homebrew

##### ADDITIONAL INFORMATION

Note: the task fails with an error referencing the broken package, as requested in the bug report.  No attempt is made to continue or recover the task.

Note: failure case is hard to reproduce.  No test added.

