### PR TITLE
Allowing uppercase tags in proxmox & proxmox_kvm

### DIFF
--- a/changelogs/fragments/9895-proxmox_tags_with_uppercase_chars.yml
+++ b/changelogs/fragments/9895-proxmox_tags_with_uppercase_chars.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox and proxmox_kvm modules - allow uppercase characters in VM/container tags (https://github.com/ansible-collections/community.general/issues/9895).
+  - proxmox and proxmox_kvm modules - allow uppercase characters in VM/container tags (https://github.com/ansible-collections/community.general/issues/9895, https://github.com/ansible-collections/community.general/pull/10024).

--- a/changelogs/fragments/9895-proxmox_tags_with_uppercase_chars.yml
+++ b/changelogs/fragments/9895-proxmox_tags_with_uppercase_chars.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox and proxmox_kvm modules - allow uppercase characters in VM/container tags (https://github.com/ansible-collections/community.general/issues/9895).

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -1696,7 +1696,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
 
     def validate_tags(self, tags):
         """Check if the specified tags are valid."""
-        re_tag = re.compile(r"^[a-z0-9_][a-z0-9_\-\+\.]*$")
+        re_tag = re.compile(r"^[a-zA-Z0-9_][a-zA-Z0-9_\-\+\.]*$")
         for tag in tags:
             if not re_tag.match(tag):
                 self.module.fail_json(msg="%s is not a valid tag" % tag)

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -1126,7 +1126,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
 
         # VM tags are expected to be valid and presented as a comma/semi-colon delimited string
         if 'tags' in kwargs:
-            re_tag = re.compile(r'^[a-z0-9_][a-z0-9_\-\+\.]*$')
+            re_tag = re.compile(r'^[a-zA-Z0-9_][a-zA-Z0-9_\-\+\.]*$')
             for tag in kwargs['tags']:
                 if not re_tag.match(tag):
                     self.module.fail_json(msg='%s is not a valid tag' % tag)

--- a/tests/integration/targets/proxmox/tasks/main.yml
+++ b/tests/integration/targets/proxmox/tasks/main.yml
@@ -165,6 +165,8 @@
         name: test-instance
         clone: 'yes'
         state: present
+        tags:
+          - TagWithUppercaseChars
         timeout: 500
       register: results_kvm
 


### PR DESCRIPTION
* Fix the 'not a valid tag' error message when the VM or container tag contains uppercase characters

##### SUMMARY
Fixes #9895

minor_changes:
  - proxmox and proxmox_kvm modules - allow uppercase characters in VM/container tags (https://github.com/ansible-collections/community.general/issues/9895).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox, proxmox_kvm

##### ADDITIONAL INFORMATION
Regexp pattern updated to allow uppercase characters in VM and container tags, as there is no such limitation in the PVE WebUI.

```
- name: Now working example creating new VM with tags including uppercase letters
  community.general.proxmox_kvm:
    api_user: root@pam
    api_password: secret
    api_host: helldorado
    name: spynal
    node: sabrewulf
    tags:
      - Debian
      - DEBIAN
      - dEBIAN
```
