### PR TITLE
proxmox: fix: cannot access local variable 'identifier' where it is not associ…

### DIFF
--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -890,6 +890,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
                 self.module.exit_json(
                     changed=False, vmid=vmid, msg="VM %s already exists." % identifier
                 )
+            identifier = self.format_vm_identifier(vmid, lxc["name"])
             self.module.debug(
                 "VM %s already exists, but we don't update and instead forcefully recreate it."
                 % identifier


### PR DESCRIPTION
##### SUMMARY
If `community.general.proxmox` is called on an existing lxc container with `state=present` and `force: true` then we take a code path in which a debugging message is printed but the identifier was no defined beforehand, leading to the error "An error occurred: cannot access local variable 'identifier' where it is not associated with a value".

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox