### PR TITLE
Remove blanket skips for Python 3 in CI

### DIFF
--- a/tests/integration/targets/hg/aliases
+++ b/tests/integration/targets/hg/aliases
@@ -4,3 +4,4 @@
 
 azp/posix/2
 skip/aix
+skip/macos

--- a/tests/integration/targets/hg/aliases
+++ b/tests/integration/targets/hg/aliases
@@ -3,5 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python3
 skip/aix

--- a/tests/integration/targets/hg/aliases
+++ b/tests/integration/targets/hg/aliases
@@ -5,3 +5,4 @@
 azp/posix/2
 skip/aix
 skip/macos
+disabled  # TODO osdn.net is out of business, so cloning a repo from there does not work

--- a/tests/integration/targets/hg/meta/main.yml
+++ b/tests/integration/targets/hg/meta/main.yml
@@ -6,3 +6,4 @@
 dependencies:
   - setup_pkg_mgr
   - setup_remote_tmp_dir
+  - setup_epel

--- a/tests/integration/targets/hg/tasks/install.yml
+++ b/tests/integration/targets/hg/tasks/install.yml
@@ -26,6 +26,12 @@
   shell: apt-get -y update && apt-get -y install mercurial
   when: ansible_facts.pkg_mgr == 'apt'
 
+- name: install packages (apk)
+  package:
+    name: mercurial
+    state: present
+  when: ansible_facts.pkg_mgr in ['apk', 'community.general.apk']
+
 - name: install mercurial (dnf)
   dnf:
     name: mercurial
@@ -35,6 +41,11 @@
   yum:
     name: mercurial
   when: ansible_facts.pkg_mgr == 'yum'
+
+- name: install mercurial (pacman)
+  package:
+    name: mercurial
+  when: ansible_facts.pkg_mgr in ['pacman', 'community.general.pacman']
 
 - name: install mercurial (pkgng)
   package:

--- a/tests/integration/targets/hg/tasks/uninstall.yml
+++ b/tests/integration/targets/hg/tasks/uninstall.yml
@@ -16,6 +16,12 @@
     line: "#!{{ stat_hg_interpreter.stat.path }}"
   when: stat_hg_interpreter.stat.islnk
 
+- name: uninstall packages which were not originally installed (apk)
+  package:
+    name: mercurial
+    state: absent
+  when: ansible_facts.pkg_mgr in ['apk', 'community.general.apk']
+
 # using the apt module prevents autoremove from working, so call apt-get via shell instead
 - name: uninstall packages which were not originally installed (apt)
   shell: apt-get -y remove mercurial && apt-get -y autoremove
@@ -32,6 +38,12 @@
 - name: uninstall packages which were not originally installed (yum)
   shell: yum -y autoremove mercurial
   when: ansible_facts.pkg_mgr == 'yum'
+
+- name: uninstall packages which were not originally installed (pacman)
+  package:
+    name: mercurial
+    state: absent
+  when: ansible_facts.pkg_mgr in ['pacman', 'community.general.pacman']
 
 - name: uninstall packages which were not originally installed (pkgng)
   package:

--- a/tests/integration/targets/supervisorctl/aliases
+++ b/tests/integration/targets/supervisorctl/aliases
@@ -5,3 +5,5 @@
 azp/posix/2
 destructive
 skip/aix
+skip/rhel  # TODO executables are installed in /usr/local/bin, which isn't part of $PATH
+skip/macos  # TODO executables are installed in /Library/Frameworks/Python.framework/Versions/3.11/bin, which isn't part of $PATH

--- a/tests/integration/targets/supervisorctl/aliases
+++ b/tests/integration/targets/supervisorctl/aliases
@@ -4,5 +4,4 @@
 
 azp/posix/2
 destructive
-skip/python3
 skip/aix

--- a/tests/integration/targets/supervisorctl/tasks/install_pip.yml
+++ b/tests/integration/targets/supervisorctl/tasks/install_pip.yml
@@ -5,5 +5,5 @@
 
 - name: install supervisord
   pip:
-    name: supervisor<4.0.0  # supervisor version 4.0.0 fails tests
+    name: supervisor
     state: present

--- a/tests/integration/targets/supervisorctl/tasks/main.yml
+++ b/tests/integration/targets/supervisorctl/tasks/main.yml
@@ -8,50 +8,52 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- block:
-  - tempfile:
-      state: directory
-      suffix: supervisorctl-tests
-    register: supervisord_sock_path
+- when:
+    # setuptools is too old on RHEL/CentOS 6 (https://github.com/Supervisor/meld3/issues/23)
+    - ansible_os_family != 'RedHat' or ansible_distribution_major_version|int > 6
+    # For some reason CentOS 7 and OpenSuSE 15 do not work on ansible-core 2.16
+    - ansible_version.minor != 16 or ansible_distribution not in ['CentOS', 'openSUSE Leap']
+  block:
+    - block:
+      - tempfile:
+          state: directory
+          suffix: supervisorctl-tests
+        register: supervisord_sock_path
 
-  - command: 'echo {{ remote_tmp_dir }}'
-    register: echo
-  - set_fact:
-      remote_dir: '{{ echo.stdout }}'
+      - command: 'echo {{ remote_tmp_dir }}'
+        register: echo
+      - set_fact:
+          remote_dir: '{{ echo.stdout }}'
 
-  - include_vars: '{{ item }}'
-    with_first_found:
-      - files:
-          - '{{ ansible_distribution }}.yml'
-          - '{{ ansible_os_family }}.yml'
-          - 'defaults.yml'
+      - include_vars: '{{ item }}'
+        with_first_found:
+          - files:
+              - '{{ ansible_distribution }}.yml'
+              - '{{ ansible_os_family }}.yml'
+              - 'defaults.yml'
 
-  - include_tasks: '{{ item }}'
-    with_first_found:
-      - files:
-        - 'install_{{ ansible_distribution }}.yml' # CentOS
-        - 'install_{{ ansible_os_family }}.yml'    # RedHat
-        - 'install_{{ ansible_system }}.yml'       # Linux
+      - include_tasks: '{{ item }}'
+        with_first_found:
+          - files:
+            - 'install_{{ ansible_distribution }}.yml' # CentOS
+            - 'install_{{ ansible_os_family }}.yml'    # RedHat
+            - 'install_{{ ansible_system }}.yml'       # Linux
 
-  - include_tasks: test.yml
-    with_items:
-        - { username: '', password: '' }
-        - { username: 'testétest', password: 'passéword' } # non-ASCII credentials
-    loop_control:
-      loop_var: credentials
+      - include_tasks: test.yml
+        with_items:
+            - { username: '', password: '' }
+            - { username: 'testétest', password: 'passéword' } # non-ASCII credentials
+        loop_control:
+          loop_var: credentials
 
-  # setuptools is too old on RHEL/CentOS 6 (https://github.com/Supervisor/meld3/issues/23)
-  when: ansible_os_family != 'RedHat' or ansible_distribution_major_version|int > 6
+      always:
+      - include_tasks: '{{ item }}'
+        with_first_found:
+          - files:
+            - 'uninstall_{{ ansible_distribution }}.yml' # CentOS
+            - 'uninstall_{{ ansible_os_family }}.yml'    # RedHat
+            - 'uninstall_{{ ansible_system }}.yml'       # Linux
 
-  always:
-  - include_tasks: '{{ item }}'
-    when: ansible_os_family != 'RedHat' or ansible_distribution_major_version|int > 6
-    with_first_found:
-      - files:
-        - 'uninstall_{{ ansible_distribution }}.yml' # CentOS
-        - 'uninstall_{{ ansible_os_family }}.yml'    # RedHat
-        - 'uninstall_{{ ansible_system }}.yml'       # Linux
-
-  - file:
-      path: '{{ supervisord_sock_path.path }}'
-      state: absent
+      - file:
+          path: '{{ supervisord_sock_path.path }}'
+          state: absent

--- a/tests/integration/targets/supervisorctl/tasks/test.yml
+++ b/tests/integration/targets/supervisorctl/tasks/test.yml
@@ -7,6 +7,7 @@
   template:
     src: supervisord.conf
     dest: '{{ remote_dir }}/supervisord.conf'
+  diff: true
 
 - block:
     - import_tasks: start_supervisord.yml

--- a/tests/integration/targets/supervisorctl/tasks/test_start.yml
+++ b/tests/integration/targets/supervisorctl/tasks/test_start.yml
@@ -22,6 +22,8 @@
   when: credentials.username != ''
 
 - command: "supervisorctl -c {{ remote_dir }}/supervisord.conf {% if credentials.username %}-u {{ credentials.username }} -p {{ credentials.password }}{% endif %} status"
+  register: result_cmd
+  failed_when: result_cmd.rc not in [0, 3]
 
 - name: check that service is started
   assert:

--- a/tests/integration/targets/supervisorctl/tasks/test_start.yml
+++ b/tests/integration/targets/supervisorctl/tasks/test_start.yml
@@ -32,8 +32,9 @@
       - (result is changed and result_with_auth is skip) or (result is skip and result_with_auth is changed)
 
 - name: check that service is running (part1) # py1.log content is checked below
-  script: "files/sendProcessStdin.py 'pys:py1' 2 \
-    '{{ credentials.username }}' '{{ credentials.password }}'"
+  script:
+    cmd: "files/sendProcessStdin.py 'pys:py1' 2 '{{ credentials.username }}' '{{ credentials.password }}'"
+    executable: "{{ ansible_facts.python.executable }}"
 
 - name: try again to start py1 service (without auth)
   supervisorctl:

--- a/tests/integration/targets/supervisorctl/tasks/test_stop.yml
+++ b/tests/integration/targets/supervisorctl/tasks/test_stop.yml
@@ -34,8 +34,9 @@
       - (result is changed and result_with_auth is skip) or (result is skip and result_with_auth is changed)
 
 - name: "check that service isn't running"
-  script: "files/sendProcessStdin.py 'pys:py1' 1 \
-    '{{ credentials.username }}' '{{ credentials.password }}'"
+  script:
+    cmd: "files/sendProcessStdin.py 'pys:py1' 1 '{{ credentials.username }}' '{{ credentials.password }}'"
+    executable: "{{ ansible_facts.python.executable }}"
   register: is_py1_alive
   failed_when: is_py1_alive is success
 

--- a/tests/integration/targets/supervisorctl/tasks/test_stop.yml
+++ b/tests/integration/targets/supervisorctl/tasks/test_stop.yml
@@ -24,6 +24,8 @@
   when: credentials.username != ''
 
 - command: "supervisorctl -c {{ remote_dir }}/supervisord.conf {% if credentials.username %}-u {{ credentials.username }} -p {{ credentials.password }}{% endif %} status"
+  register: result_cmd
+  failed_when: result_cmd.rc not in [0, 3]
 
 - name: check that service is stopped
   assert:


### PR DESCRIPTION
##### SUMMARY
Right now two integration tests skip Python 3 completely in CI.

This either is an oversight that should be fixed, or the tests should be fixed, or the modules should be deprecated.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
hg
supervisorctl
