### PR TITLE
Mark supervisorctl tests as unstable

### DIFF
--- a/tests/integration/targets/supervisorctl/aliases
+++ b/tests/integration/targets/supervisorctl/aliases
@@ -7,3 +7,4 @@ destructive
 skip/aix
 skip/rhel  # TODO executables are installed in /usr/local/bin, which isn't part of $PATH
 skip/macos  # TODO executables are installed in /Library/Frameworks/Python.framework/Versions/3.11/bin, which isn't part of $PATH
+unstable # TODO fix!


### PR DESCRIPTION
##### SUMMARY
They seem to fail when running all tests, but not when only the supervisorctl tests are being run. Also they are disabled for some systems, etc. I think they need a bigger overhaul.

Until that's done, marking them as `unstable` should help CI failing for everyone else because of them.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
supervisorctl
