### PR TITLE
Add connection_timeout option to cobbler inventory

### DIFF
--- a/changelogs/fragments/10063-cobbler-add-connection-timeout.yml
+++ b/changelogs/fragments/10063-cobbler-add-connection-timeout.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cobbler inventory plugin - add ``connection_timeout`` option to specify the connection timeout to the cobbler server (https://github.com/ansible-collections/community.general/pull/11063).


### PR DESCRIPTION
##### SUMMARY
This adds a `connection_timeout` option to cobbler.  Helpful for when some remote cobbler servers are not accessible.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cobbler