### PR TITLE
lvm_pv: new module for LVM Physical Volumes

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -905,6 +905,8 @@ files:
     maintainers: nerzhul
   $modules/lvg.py:
     maintainers: abulimov
+  $modules/lvm_pv.py:
+    maintainers: klention
   $modules/lvg_rename.py:
     maintainers: lszomor
   $modules/lvol.py:

--- a/plugins/modules/lpv.py
+++ b/plugins/modules/lpv.py
@@ -1,0 +1,198 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2025, Klention Mali <klention@gmail.com>
+# Based on lvol module by Jeroen Hoekx <jeroen.hoekx@dsquare.be>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: lpv
+short_description: Manage LVM Physical Volumes
+description:
+  - Creates, resizes or removes LVM Physical Volumes.
+author:
+  - Klention Mali (@klention)
+options:
+  device:
+    description:
+      - Path to the block device to manage.
+    type: str
+    required: true
+  state:
+    description:
+      - Control if the physical volume exists.
+    type: str
+    choices: [ present, absent ]
+    default: present
+  force:
+    description:
+      - Force dangerous operations (equivalent to C(pvcreate -f) or C(pvremove -ff)).
+    type: bool
+    default: false
+  resize:
+    description:
+      - Resize PV to device size when state=present.
+    type: bool
+    default: false
+notes:
+  - Requires LVM2 utilities installed on the target system.
+  - Device path must exist when creating a PV.
+'''
+
+EXAMPLES = r'''
+- name: Creating physical volume on /dev/sdb
+  community.general.lpv:
+    device: /dev/sdb
+
+- name: Resizing existing PV
+  community.general.lpv:
+    device: /dev/sdb
+    resize: true
+
+- name: Removing physical volume that is not part of any volume group
+  community.general.lpv:
+    device: /dev/sdb
+    state: absent
+
+- name: Force removing physical volume that is already part of a volume group
+  community.general.lpv:
+    device: /dev/sdb
+    force: true
+    state: absent
+'''
+
+RETURN = r'''
+msg:
+  description: Execution status message
+  returned: always
+  type: str
+'''
+
+import os
+from ansible.module_utils.basic import AnsibleModule
+
+def get_pv_status(module, device):
+    """Check if the device is already a PV."""
+    cmd = ['pvs', '--noheadings', '--readonly', device]
+    return module.run_command(cmd)[0] == 0
+
+def get_pv_size(module, device):
+    """Get current PV size in bytes."""
+    cmd = ['pvs', '--noheadings', '--nosuffix', '--units', 'b', '-o', 'pv_size', device]
+    rc, out, err = module.run_command(cmd)
+    if rc != 0:
+        module.fail_json(msg="Failed to get PV size: %s" % err)
+    return int(out.strip())
+
+def rescan_device(module, device):
+    """Perform storage rescan for the device."""
+    # Extract the base device name (e.g., /dev/sdb -> sdb)
+    base_device = os.path.basename(device)
+    rescan_path = f"/sys/block/{base_device}/device/rescan"
+    
+    if os.path.exists(rescan_path):
+        try:
+            with open(rescan_path, 'w') as f:
+                f.write('1')
+            return True
+        except IOError as e:
+            module.warn(f"Failed to rescan device {device}: {str(e)}")
+            return False
+    else:
+        module.warn(f"Rescan path not found for device {device}")
+        return False
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            device=dict(type='str', required=True),
+            state=dict(type='str', default='present', choices=['present', 'absent']),
+            force=dict(type='bool', default=False),
+            resize=dict(type='bool', default=False),
+        ),
+        supports_check_mode=True,
+    )
+
+    device = module.params['device']
+    state = module.params['state']
+    force = module.params['force']
+    resize = module.params['resize']
+    changed = False
+    actions = []
+
+    # Validate device existence for present state
+    if state == 'present' and not os.path.exists(device):
+        module.fail_json(msg="Device %s not found" % device)
+
+    is_pv = get_pv_status(module, device)
+
+    if state == 'present':
+        # Create PV if needed
+        if not is_pv:
+            if module.check_mode:
+                changed = True
+                actions.append('created')
+            else:
+                cmd = ['pvcreate']
+                if force:
+                    cmd.append('-f')
+                cmd.append(device)
+                rc, out, err = module.run_command(cmd)
+                if rc != 0:
+                    module.fail_json(msg="Failed to create PV: %s" % err)
+                changed = True
+                actions.append('created')
+            is_pv = True
+
+        # Handle resizing
+        if resize and is_pv:
+            if not module.check_mode:
+                # Perform device rescan if each time
+                if rescan_device(module, device):
+                    actions.append('rescanned')
+                original_size = get_pv_size(module, device)
+                rc, out, err = module.run_command(['pvresize', device])
+                if rc != 0:
+                    module.fail_json(msg="PV resize failed: %s" % err)
+                new_size = get_pv_size(module, device)
+                if new_size != original_size:
+                    changed = True
+                    actions.append('resized')
+            else:
+                # In check mode, assume resize would change
+                changed = True
+                actions.append('would be resized')
+
+    elif state == 'absent':
+        if is_pv:
+            if module.check_mode:
+                changed = True
+                actions.append('would be removed')
+            else:
+                cmd = ['pvremove']
+                if force:
+                    cmd.extend(['-ff', '-y'])
+                else:
+                    cmd.append('-y')
+                cmd.append(device)
+                rc, out, err = module.run_command(cmd)
+                if rc != 0:
+                    module.fail_json(msg="Failed to remove PV: %s" % err)
+                changed = True
+                actions.append('removed')
+
+    # Generate final message
+    if not actions:
+        msg = "No changes needed for PV %s" % device
+    else:
+        msg = "PV %s: %s" % (device, ', '.join(actions))
+
+    module.exit_json(changed=changed, msg=msg)
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/lvm_pv.py
+++ b/plugins/modules/lvm_pv.py
@@ -7,8 +7,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-import os
-from ansible.module_utils.basic import AnsibleModule
 
 
 DOCUMENTATION = r'''
@@ -77,6 +75,10 @@ msg:
 '''
 
 
+import os
+from ansible.module_utils.basic import AnsibleModule
+
+
 def get_pv_status(module, device):
     """Check if the device is already a PV."""
     cmd = ['pvs', '--noheadings', '--readonly', device]
@@ -104,7 +106,7 @@ def rescan_device(module, device):
                 f.write('1')
             return True
         except IOError as e:
-            module.warn(f"Failed to rescan device {device}: {str(e)}")
+            module.warn("Failed to rescan device {0}: {1}".format(device, str(e)))
             return False
     else:
         module.warn(f"Rescan path not found for device {device}")

--- a/plugins/modules/lvm_pv.py
+++ b/plugins/modules/lvm_pv.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 ---
 module: lvm_pv
 short_description: Manage LVM Physical Volumes
-version_added: "10.7.0"
+version_added: "11.0.0"
 description:
 - Creates, resizes or removes LVM Physical Volumes.
 author:
@@ -138,7 +138,7 @@ def main():
         if not is_pv:
             if module.check_mode:
                 changed = True
-                actions.append('created')
+                actions.append('would be created')
             else:
                 cmd = ['pvcreate']
                 if force:
@@ -150,7 +150,7 @@ def main():
             is_pv = True
 
         # Handle resizing
-        if resize and is_pv:
+        elif resize and is_pv:
             if not module.check_mode:
                 # Perform device rescan if each time
                 if rescan_device(module, device):
@@ -170,10 +170,11 @@ def main():
         if is_pv:
             if module.check_mode:
                 changed = True
+            else:
                 cmd = ['pvremove', '-y']
                 if force:
                     cmd.append('-ff')
-
+                changed = True
                 cmd.append(device)
                 rc, out, err = module.run_command(cmd, check_rc=True)
                 actions.append('removed')

--- a/plugins/modules/lvm_pv.py
+++ b/plugins/modules/lvm_pv.py
@@ -70,10 +70,6 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-msg:
-  description: Execution status message
-  returned: always
-  type: str
 '''
 
 

--- a/plugins/modules/lvm_pv.py
+++ b/plugins/modules/lvm_pv.py
@@ -151,7 +151,11 @@ def main():
 
         # Handle resizing
         elif resize and is_pv:
-            if not module.check_mode:
+            if module.check_mode:
+                # In check mode, assume resize would change
+                changed = True
+                actions.append('would be resized')
+            else:
                 # Perform device rescan if each time
                 if rescan_device(module, device):
                     actions.append('rescanned')
@@ -161,15 +165,12 @@ def main():
                 if new_size != original_size:
                     changed = True
                     actions.append('resized')
-            else:
-                # In check mode, assume resize would change
-                changed = True
-                actions.append('would be resized')
 
     elif state == 'absent':
         if is_pv:
             if module.check_mode:
                 changed = True
+                actions.append('would be removed')
             else:
                 cmd = ['pvremove', '-y']
                 if force:

--- a/plugins/modules/lvm_pv.py
+++ b/plugins/modules/lvm_pv.py
@@ -15,36 +15,36 @@ module: lvm_pv
 short_description: Manage LVM Physical Volumes
 version_added: "11.0.0"
 description:
-- Creates, resizes or removes LVM Physical Volumes.
+  - Creates, resizes or removes LVM Physical Volumes.
 author:
-- Klention Mali (@klention)
+  - Klention Mali (@klention)
 options:
   device:
     description:
-    - Path to the block device to manage.
+      - Path to the block device to manage.
     type: path
     required: true
   state:
     description:
-    - Control if the physical volume exists.
+      - Control if the physical volume exists.
     type: str
     choices: [ present, absent ]
     default: present
   force:
     description:
-    - Force the operation.
-    - When O(state=present) (creating a PV), this uses C(pvcreate -f) to force creation.
-    - When O(state=absent) (removing a PV), this uses C(pvremove -ff) to force removal even if part of a volume group.
+      - Force the operation.
+      - When O(state=present) (creating a PV), this uses C(pvcreate -f) to force creation.
+      - When O(state=absent) (removing a PV), this uses C(pvremove -ff) to force removal even if part of a volume group.
     type: bool
     default: false
   resize:
     description:
-    - Resize PV to device size when O(state=present).
+      - Resize PV to device size when O(state=present).
     type: bool
     default: false
 notes:
-- Requires LVM2 utilities installed on the target system.
-- Device path must exist when creating a PV.
+  - Requires LVM2 utilities installed on the target system.
+  - Device path must exist when creating a PV.
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/lvm_pv.py
+++ b/plugins/modules/lvm_pv.py
@@ -22,7 +22,7 @@ options:
   device:
     description:
     - Path to the block device to manage.
-    type: str
+    type: path
     required: true
   state:
     description:
@@ -112,7 +112,7 @@ def rescan_device(module, device):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            device=dict(type='str', required=True),
+            device=dict(type='path', required=True),
             state=dict(type='str', default='present', choices=['present', 'absent']),
             force=dict(type='bool', default=False),
             resize=dict(type='bool', default=False),

--- a/plugins/modules/lvm_pv.py
+++ b/plugins/modules/lvm_pv.py
@@ -109,7 +109,7 @@ def rescan_device(module, device):
             module.warn("Failed to rescan device {0}: {1}".format(device, str(e)))
             return False
     else:
-        module.warn(f"Rescan path not found for device {device}")
+        module.warn("Rescan path not found for device {0}".format(device))
         return False
 
 

--- a/tests/integration/targets/lvm_pv/aliases
+++ b/tests/integration/targets/lvm_pv/aliases
@@ -1,0 +1,13 @@
+# Copyright (c) Contributors to the Ansible project
+# Based on the integraton test for the lvg module
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+azp/posix/1
+azp/posix/vm
+destructive
+needs/privileged
+skip/aix
+skip/freebsd
+skip/osx
+skip/macos

--- a/tests/integration/targets/lvm_pv/meta/main.yml
+++ b/tests/integration/targets/lvm_pv/meta/main.yml
@@ -1,0 +1,9 @@
+---
+# Copyright (c) Ansible Project
+# Based on the integraton test for the lvg module
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependencies:
+  - setup_pkg_mgr
+  - setup_remote_tmp_dir

--- a/tests/integration/targets/lvm_pv/tasks/cleanup.yml
+++ b/tests/integration/targets/lvm_pv/tasks/cleanup.yml
@@ -8,5 +8,5 @@
 
 - name: Removing loop device file
   ansible.builtin.file:
-    path: /tmp/test_lvm_pv.img
+    path: "{{ remote_tmp_dir }}/test_lvm_pv.img"
     state: absent

--- a/tests/integration/targets/lvm_pv/tasks/cleanup.yml
+++ b/tests/integration/targets/lvm_pv/tasks/cleanup.yml
@@ -1,0 +1,12 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Detaching loop device
+  ansible.builtin.command: losetup -d {{ loop_device.stdout }}
+
+- name: Removing loop device file
+  ansible.builtin.file:
+    path: /tmp/test_lvm_pv.img
+    state: absent

--- a/tests/integration/targets/lvm_pv/tasks/creation.yml
+++ b/tests/integration/targets/lvm_pv/tasks/creation.yml
@@ -4,16 +4,16 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Creating a 50MB file for loop device
-  ansible.builtin.command: dd if=/dev/zero of=/tmp/test_lvm_pv.img bs=1M count=50
+  ansible.builtin.command: dd if=/dev/zero of={{ remote_tmp_dir }}/test_lvm_pv.img bs=1M count=50
   args:
-    creates: /tmp/test_lvm_pv.img
+    creates: "{{ remote_tmp_dir }}/test_lvm_pv.img"
 
 - name: Creating loop device
   ansible.builtin.command: losetup -f
   register: loop_device
 
 - name: Associating loop device with file
-  ansible.builtin.command: 'losetup {{ loop_device.stdout }} /tmp/test_lvm_pv.img'
+  ansible.builtin.command: 'losetup {{ loop_device.stdout }} {{ remote_tmp_dir }}/test_lvm_pv.img'
 
 - name: Creating physical volume
   community.general.lvm_pv:

--- a/tests/integration/targets/lvm_pv/tasks/creation.yml
+++ b/tests/integration/targets/lvm_pv/tasks/creation.yml
@@ -8,21 +8,12 @@
   args:
     creates: /tmp/test_lvm_pv.img
 
-- name: Setting up loop device for the file (Alpine Linux)
-  block:
-  - name: Creating loop device
-    ansible.builtin.command: mknod /dev/loop9 b 7 9
-
-  - name: Associating loop device with file
-    ansible.builtin.command: 'losetup /dev/loop9 /tmp/test_lvm_pv.img'
-    register: loop_device
-  when: ansible_distribution == "Alpine"
-
-- name: Associating loop device with file (non-Alpine Linux)
-  ansible.builtin.command:
-    cmd: losetup --find --show /tmp/test_lvm_pv.img
+- name: Creating loop device
+  ansible.builtin.command: losetup -f
   register: loop_device
-  when: ansible_distribution != "Alpine"
+
+- name: Associating loop device with file
+  ansible.builtin.command: 'losetup {{ loop_device.stdout }} /tmp/test_lvm_pv.img'
 
 - name: Creating physical volume
   community.general.lvm_pv:

--- a/tests/integration/targets/lvm_pv/tasks/creation.yml
+++ b/tests/integration/targets/lvm_pv/tasks/creation.yml
@@ -1,0 +1,30 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Creating a 50MB file for loop device
+  ansible.builtin.command: dd if=/dev/zero of=/tmp/test_lvm_pv.img bs=1M count=50
+  args:
+    creates: /tmp/test_lvm_pv.img
+
+- name: Associating the loop device with the file and get device name
+  ansible.builtin.command: losetup --find --show /tmp/test_lvm_pv.img
+  register: loop_device
+
+- name: Creating physical volume
+  community.general.lvm_pv:
+    device: "{{ loop_device.stdout }}"
+  register: result
+
+- name: Checking physical volume size
+  ansible.builtin.command: pvs --noheadings -o pv_size --units M {{ loop_device.stdout }}
+  register: pv_size_output
+
+- name: Asserting physical volume was created
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - (pv_size_output.stdout | trim | regex_replace('M', '') | float) > 45
+      - (pv_size_output.stdout | trim | regex_replace('M', '') | float) < 55
+      - "'created' in result.msg"

--- a/tests/integration/targets/lvm_pv/tasks/creation.yml
+++ b/tests/integration/targets/lvm_pv/tasks/creation.yml
@@ -8,9 +8,21 @@
   args:
     creates: /tmp/test_lvm_pv.img
 
-- name: Associating the loop device with the file and get device name
-  ansible.builtin.command: losetup --find --show /tmp/test_lvm_pv.img
+- name: Setting up loop device for the file (Alpine Linux)
+  block:
+  - name: Creating loop device
+    ansible.builtin.command: mknod /dev/loop9 b 7 9
+
+  - name: Associating loop device with file
+    ansible.builtin.command: 'losetup /dev/loop9 /tmp/test_lvm_pv.img'
+    register: loop_device
+  when: ansible_distribution == "Alpine"
+
+- name: Associating loop device with file (non-Alpine Linux)
+  ansible.builtin.command:
+    cmd: losetup --find --show /tmp/test_lvm_pv.img
   register: loop_device
+  when: ansible_distribution != "Alpine"
 
 - name: Creating physical volume
   community.general.lvm_pv:

--- a/tests/integration/targets/lvm_pv/tasks/main.yml
+++ b/tests/integration/targets/lvm_pv/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) Contributors to the Ansible project
+# Based on the integraton test for the lvg module
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Install required packages (Linux)
+  when: ansible_system == 'Linux'
+  ansible.builtin.package:
+    name: lvm2
+    state: present
+
+- name: Testing lvg_pv module
+  block:
+    - import_tasks: creation.yml
+
+    - import_tasks: resizing.yml
+
+    - import_tasks: removal.yml
+
+  always:
+    - import_tasks: cleanup.yml

--- a/tests/integration/targets/lvm_pv/tasks/removal.yml
+++ b/tests/integration/targets/lvm_pv/tasks/removal.yml
@@ -1,0 +1,16 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Removing physical volume
+  community.general.lvm_pv:
+    device: "{{ loop_device.stdout }}"
+    state: absent
+  register: remove_result
+
+- name: Asserting physical volume was removed
+  ansible.builtin.assert:
+    that:
+      - remove_result.changed == true
+      - "'removed' in remove_result.msg"

--- a/tests/integration/targets/lvm_pv/tasks/resizing.yml
+++ b/tests/integration/targets/lvm_pv/tasks/resizing.yml
@@ -1,0 +1,27 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Growing the loop device file to 100MB
+  ansible.builtin.shell: truncate -s 100M /tmp/test_lvm_pv.img
+
+- name: Refreshing the loop device
+  ansible.builtin.shell: losetup -c {{ loop_device.stdout }}
+
+- name: Resizing the physical volume
+  community.general.lvm_pv:
+    device: "{{ loop_device.stdout }}"
+    resize: true
+  register: resize_result
+
+- name: Checking physical volume size
+  ansible.builtin.command: pvs --noheadings -o pv_size --units M {{ loop_device.stdout }}
+  register: pv_size_output
+
+- name: Asserting physical volume was resized
+  ansible.builtin.assert:
+    that:
+      - resize_result.changed == true
+      - (pv_size_output.stdout | trim | regex_replace('M', '') | float) > 95
+      - "'resized' in resize_result.msg"

--- a/tests/integration/targets/lvm_pv/tasks/resizing.yml
+++ b/tests/integration/targets/lvm_pv/tasks/resizing.yml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Growing the loop device file to 100MB
-  ansible.builtin.shell: truncate -s 100M /tmp/test_lvm_pv.img
+  ansible.builtin.shell: truncate -s 100M {{ remote_tmp_dir }}/test_lvm_pv.img
 
 - name: Refreshing the loop device
   ansible.builtin.shell: losetup -c {{ loop_device.stdout }}


### PR DESCRIPTION
##### SUMMARY

This pull request introduces a new `lvm_pv` module for managing LVM Physical Volumes. The module provides comprehensive functionality for:

- Creating and removing physical volumes
- Resizing existing PVs (with automatic device rescan capability)
- Forceful operations when needed
- Full idempotency and check mode support

Key features:
- Supports all basic PV operations (`pvcreate`, `pvremove`, `pvresize`)
- Automatically handles device rescans before resize operations
- Provides clear status messages and change detection
- Includes thorough parameter validation and error handling

The module fills a gap in Ansible's storage management capabilities, complementing the existing `lvg` and `lvol` modules.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
lvm_pv

##### ADDITIONAL INFORMATION

Example usage:
```yaml
- name: Creating physical volume on /dev/sdb
  community.general.lvm_pv:
    device: /dev/sdb

- name: Creating and resizing (if needed) physical volume
  community.general.lvm_pv:
    device: /dev/sdb
    resize: true

- name: Removing physical volume that is not part of any volume group
  community.general.lvm_pv:
    device: /dev/sdb
    state: absent

- name: Force removing physical volume that is already part of a volume group
  community.general.lvm_pv:
    device: /dev/sdb
    force: true
    state: absent