### PR TITLE
crypttab: removes jijna delimiters from example using when

### DIFF
--- a/plugins/modules/crypttab.py
+++ b/plugins/modules/crypttab.py
@@ -72,7 +72,7 @@ EXAMPLES = r"""
     state: opts_present
     opts: discard
   loop: '{{ ansible_mounts }}'
-  when: "'/dev/mapper/luks-' in {{ item.device }}"
+  when: "'/dev/mapper/luks-' in item.device"
 """
 
 import os


### PR DESCRIPTION
##### SUMMARY

The current example includes extra jinja delimiters which
result in double-interpretation of the statement.

Fixes: #10078

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE

- Docs Pull Request

