### PR TITLE
CI: Use community.crypto 2.x.y for ansible-core 2.16 and before

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -151,12 +151,13 @@ jobs:
           integration-continue-on-error: 'false'
           integration-diff: 'false'
           integration-retry-on-error: 'true'
+          # TODO: remove "--branch stable-2" from community.crypto install once we're only using ansible-core 2.17 or newer!
           pre-test-cmd: >-
             mkdir -p ../../ansible
             ;
             git clone --depth=1 --single-branch https://github.com/ansible-collections/ansible.posix.git ../../ansible/posix
             ;
-            git clone --depth=1 --single-branch https://github.com/ansible-collections/community.crypto.git ../../community/crypto
+            git clone --depth=1 --single-branch --branch stable-2 https://github.com/ansible-collections/community.crypto.git ../../community/crypto
             ;
             git clone --depth=1 --single-branch https://github.com/ansible-collections/community.docker.git ../../community/docker
             ;

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -10,6 +10,7 @@ IFS='/:' read -ra args <<< "$1"
 
 ansible_version="${args[0]}"
 script="${args[1]}"
+after_script="${args[2]}"
 
 function join {
     local IFS="$1";
@@ -71,6 +72,9 @@ export ANSIBLE_COLLECTIONS_PATHS="${PWD}/../../../"
 
 COMMUNITY_CRYPTO_BRANCH=main
 if [ "${ansible_version}" == "2.16" ]; then
+    COMMUNITY_CRYPTO_BRANCH=stable-2
+fi
+if [ "${script}" == "linux" ] && [ "$after_script" == "ubuntu2004" ]; then
     COMMUNITY_CRYPTO_BRANCH=stable-2
 fi
 

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -69,6 +69,11 @@ export ANSIBLE_COLLECTIONS_PATHS="${PWD}/../../../"
 
 # START: HACK install dependencies
 
+COMMUNITY_CRYPTO_BRANCH=main
+if [ "${ansible_version}" == "2.16" ]; then
+    COMMUNITY_CRYPTO_BRANCH=stable-2
+fi
+
 # Nothing further should be added to this list.
 # This is to prevent modules or plugins in this collection having a runtime dependency on other collections.
 retry git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/internal_test_tools"
@@ -78,7 +83,7 @@ retry git clone --depth=1 --single-branch https://github.com/ansible-collections
 if [ "${script}" != "sanity" ] && [ "${script}" != "units" ]; then
     # To prevent Python dependencies on other collections only install other collections for integration tests
     retry git clone --depth=1 --single-branch https://github.com/ansible-collections/ansible.posix.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/ansible/posix"
-    retry git clone --depth=1 --single-branch https://github.com/ansible-collections/community.crypto.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/crypto"
+    retry git clone --depth=1 --single-branch --branch "${COMMUNITY_CRYPTO_BRANCH}" https://github.com/ansible-collections/community.crypto.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/crypto"
     retry git clone --depth=1 --single-branch https://github.com/ansible-collections/community.docker.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/docker"
     # NOTE: we're installing with git to work around Galaxy being a huge PITA (https://github.com/ansible/galaxy/issues/2429)
     # retry ansible-galaxy -vvv collection install ansible.posix


### PR DESCRIPTION
##### SUMMARY
community.crypto 3.x.y will require ansible-core >= 2.17. The repo's `main` branch already dropped compatibility for certain things.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
