### PR TITLE
ini_file: fix unmatched whitespace before comment

### DIFF
--- a/changelogs/fragments/10102-ini_file-fix-unmatched-whitespace-before-comment.yml
+++ b/changelogs/fragments/10102-ini_file-fix-unmatched-whitespace-before-comment.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ini_file - modify an inactive option also when there are spaces in front of the comment symbol (https://github.com/ansible-collections/community.general/pull/10102, https://github.com/ansible-collections/community.general/issues/8539).

--- a/changelogs/fragments/10102-ini_file-fix-unmatched-whitespace-before-comment.yml
+++ b/changelogs/fragments/10102-ini_file-fix-unmatched-whitespace-before-comment.yml
@@ -1,2 +1,2 @@
-bugfixes:
+minor_changes:
   - ini_file - modify an inactive option also when there are spaces in front of the comment symbol (https://github.com/ansible-collections/community.general/pull/10102, https://github.com/ansible-collections/community.general/issues/8539).

--- a/plugins/modules/ini_file.py
+++ b/plugins/modules/ini_file.py
@@ -268,21 +268,21 @@ from ansible.module_utils.common.text.converters import to_bytes, to_text
 
 def match_opt(option, line):
     option = re.escape(option)
-    return re.match('([#;]?)( |\t)*(%s)( |\t)*(=|$)( |\t)*(.*)' % option, line)
+    return re.match('( |\t)*([#;]?)( |\t)*(%s)( |\t)*(=|$)( |\t)*(.*)' % option, line)
 
 
 def match_active_opt(option, line):
     option = re.escape(option)
-    return re.match('()( |\t)*(%s)( |\t)*(=|$)( |\t)*(.*)' % option, line)
+    return re.match('()()( |\t)*(%s)( |\t)*(=|$)( |\t)*(.*)' % option, line)
 
 
 def update_section_line(option, changed, section_lines, index, changed_lines, ignore_spaces, newline, msg):
     option_changed = None
     if ignore_spaces:
         old_match = match_opt(option, section_lines[index])
-        if not old_match.group(1):
+        if not old_match.group(2):
             new_match = match_opt(option, newline)
-            option_changed = old_match.group(7) != new_match.group(7)
+            option_changed = old_match.group(8) != new_match.group(8)
     if option_changed is None:
         option_changed = section_lines[index] != newline
     if option_changed:
@@ -299,7 +299,7 @@ def check_section_has_values(section_has_values, section_lines):
         for condition in section_has_values:
             for line in section_lines:
                 match = match_opt(condition["option"], line)
-                if match and (len(condition["values"]) == 0 or match.group(7) in condition["values"]):
+                if match and (len(condition["values"]) == 0 or match.group(8) in condition["values"]):
                     break
             else:
                 return False
@@ -432,8 +432,8 @@ def do_ini(module, filename, section=None, section_has_values=None, option=None,
         for index, line in enumerate(section_lines):
             if match_function(option, line):
                 match = match_function(option, line)
-                if values and match.group(7) in values:
-                    matched_value = match.group(7)
+                if values and match.group(8) in values:
+                    matched_value = match.group(8)
                     if not matched_value and allow_no_value:
                         # replace existing option with no value line(s)
                         newline = u'%s\n' % option
@@ -505,7 +505,7 @@ def do_ini(module, filename, section=None, section_has_values=None, option=None,
                     section_lines = new_section_lines
             elif not exclusive and len(values) > 0:
                 # delete specified option=value line(s)
-                new_section_lines = [i for i in section_lines if not (match_active_opt(option, i) and match_active_opt(option, i).group(7) in values)]
+                new_section_lines = [i for i in section_lines if not (match_active_opt(option, i) and match_active_opt(option, i).group(8) in values)]
                 if section_lines != new_section_lines:
                     changed = True
                     msg = 'option changed'

--- a/tests/integration/targets/ini_file/tasks/tests/06-modify_inactive_option.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/06-modify_inactive_option.yml
@@ -121,3 +121,45 @@
       - result3 is changed
       - result3.msg == 'option changed'
       - content3 == expected3
+
+
+- name: test-modify_inactive_option 4 - create test file with spaces before commented option
+  copy:
+    content: |
+
+      [section1]
+      # Uncomment the line below to enable foo
+        # foo = bar
+
+    dest: "{{ output_file }}"
+
+- name: test-modify_inactive_option 4 - set value for foo with modify_inactive_option set to true
+  ini_file:
+    path: "{{ output_file }}"
+    section: section1
+    option: foo
+    value: bar
+    modify_inactive_option: true
+  register: result4
+
+- name: test-modify_inactive_option 4 - read content from output file
+  slurp:
+      src: "{{ output_file }}"
+  register: output_content
+
+- name: test-modify_inactive_option 4 - set expected content and get current ini file content
+  set_fact:
+    expected4: |
+
+      [section1]
+      # Uncomment the line below to enable foo
+      foo = bar
+
+    content4: "{{ output_content.content | b64decode }}"
+
+- name: test-modify_inactive_option 4 - assert 'changed' is true and content is OK and option changed
+  assert:
+    that:
+      - result4 is changed
+      - result4.msg == 'option changed'
+      - content4 == expected4


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Expanded the regular expression for inactive ("commented out") options to also match when the comment symbol (`#` or `;`) is preceded by whitespace.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible-collections/community.general/issues/8539

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
ini_file

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Example input
```ini
[section1]
  # option1 = value1
```

Example task using ini_file module
```yaml
- name: Edit option 1 in section 1 to have value = value2
  ini_file:
    path: /path/to/file
    modify_inactive_option: true
    section: "section1"
    option: "option1"
    value: "value2"
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
Output before this change
```ini
[section1]
option1 = value2
  # option1 = value1
```

Output after this change
```ini
[section1]
option1 = value2
```
