### PR TITLE
antsibull-nox: use community.crypto 2.x.y for ansible-core < 2.17

### DIFF
--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -8,6 +8,14 @@
 "community.docker" = "git+https://github.com/ansible-collections/community.docker.git,main"
 "community.internal_test_tools" = "git+https://github.com/ansible-collections/community.internal_test_tools.git,main"
 
+[collection_sources_per_ansible.'2.15']
+# community.crypto's main branch needs ansible-core >= 2.17
+"community.crypto" = "git+https://github.com/ansible-collections/community.crypto.git,stable-2"
+
+[collection_sources_per_ansible.'2.16']
+# community.crypto's main branch needs ansible-core >= 2.17
+"community.crypto" = "git+https://github.com/ansible-collections/community.crypto.git,stable-2"
+
 [sessions]
 
 [sessions.docs_check]


### PR DESCRIPTION
##### SUMMARY
This is mainly important for #10104.

Ref: https://github.com/ansible-community/antsibull-nox/pull/77

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
