### PR TITLE
proxmox_kvm: add rng option

### DIFF
--- a/changelogs/fragments/10114-proxmox-kvm-add-rng.yml
+++ b/changelogs/fragments/10114-proxmox-kvm-add-rng.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox_kvm - add ``rng0`` option to specify an RNG device.

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -369,6 +369,9 @@ options:
     description:
       - Revert a pending change.
     type: str
+  rng0:
+    description: RNG device
+    type: str
   sata:
     description:
       - A hash/dictionary of volume used as sata hard disk or CD-ROM. O(sata='{"key":"value", "key":"value"}').
@@ -1295,6 +1298,7 @@ def main():
         protection=dict(type='bool'),
         reboot=dict(type='bool'),
         revert=dict(type='str'),
+        rng0=dict(type='str'),
         sata=dict(type='dict'),
         scsi=dict(type='dict'),
         scsihw=dict(choices=['lsi', 'lsi53c810', 'virtio-scsi-pci', 'virtio-scsi-single', 'megasas', 'pvscsi']),
@@ -1485,6 +1489,7 @@ def main():
                               pool=module.params['pool'],
                               protection=module.params['protection'],
                               reboot=module.params['reboot'],
+                              rng0=module.params['rng0'],
                               sata=module.params['sata'],
                               scsi=module.params['scsi'],
                               scsihw=module.params['scsihw'],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

Since PVE 8.3.5, an RNG device is required to use PXE booting. So suddenly adding an RNG device becomes a necessity. This PR adds an option for it. 

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
proxmox_kvm


