### PR TITLE
lxc: fix unit tests

### DIFF
--- a/tests/unit/plugins/connection/test_lxc.py
+++ b/tests/unit/plugins/connection/test_lxc.py
@@ -117,14 +117,14 @@ class TestLXCConnectionClass():
 
         # first call initializes the connection
         conn._connect()
-        assert conn.container_name is container1_name
+        assert conn.container_name == container1_name
         assert conn.container is not None
         assert conn.container.name == container1_name
         container1 = conn.container
 
         # second call is basically a no-op
         conn._connect()
-        assert conn.container_name is container1_name
+        assert conn.container_name == container1_name
         assert conn.container is container1
         assert conn.container.name == container1_name
 


### PR DESCRIPTION
##### SUMMARY
They currently fail with ansible-core devel since they assume that passing a string through `set_option()`/`get_option()` will have the same identity.

Ref: https://dev.azure.com/ansible/community.general/_build/results?buildId=145426&view=logs&j=b23b1ec0-763d-57f2-9c2f-789c257dd001&t=4c6b7fe9-5394-5461-43e4-9d6229dcb341

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
lxc connection unit tests
