### PR TITLE
redis_info: adjust tests for Arch Linux

### DIFF
--- a/tests/integration/targets/setup_redis_replication/defaults/main.yml
+++ b/tests/integration/targets/setup_redis_replication/defaults/main.yml
@@ -8,7 +8,7 @@ redis_packages:
   Alpine:
   - redis
   Archlinux:
-  - redis
+  - valkey
   Debian:
   - redis-server
   Ubuntu:
@@ -24,7 +24,7 @@ redis_packages:
 
 redis_user:
   Alpine: redis
-  Archlinux: redis
+  Archlinux: valkey
   Debian: redis
   Ubuntu: redis
   openSUSE Leap: redis


### PR DESCRIPTION
##### SUMMARY
The tests currently fail because the user `redis` no longer exists. It has been renamed to `valkey`, together with the package.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
redis
