### PR TITLE
[stable-8] redis_info: adjust tests for Arch Linux

### DIFF
--- a/tests/integration/targets/setup_redis_replication/defaults/main.yml
+++ b/tests/integration/targets/setup_redis_replication/defaults/main.yml
@@ -8,7 +8,7 @@ redis_packages:
   Alpine:
   - redis
   Archlinux:
-  - redis
+  - valkey
   Debian:
   - redis-server
   Ubuntu:
@@ -24,7 +24,7 @@ redis_packages:
 
 redis_user:
   Alpine: redis
-  Archlinux: redis
+  Archlinux: valkey
   Debian: redis
   Ubuntu: redis
   openSUSE Leap: redis

--- a/tests/integration/targets/setup_redis_replication/defaults/main.yml
+++ b/tests/integration/targets/setup_redis_replication/defaults/main.yml
@@ -22,13 +22,23 @@ redis_packages:
   FreeBSD:
   - redis
 
+redis_user:
+  Alpine: redis
+  Archlinux: redis
+  Debian: redis
+  Ubuntu: redis
+  openSUSE Leap: redis
+  Fedora: "{{ '998' if ansible_distribution_major_version is version('41', '>=') else 'redis' }}"
+  CentOS: redis
+  FreeBSD: redis
+
 redis_bin:
   Alpine: /usr/bin/redis-server
   Archlinux: /usr/bin/redis-server
   Debian: /usr/bin/redis-server
   Ubuntu: /usr/bin/redis-server
   openSUSE Leap: /usr/sbin/redis-server
-  Fedora: /usr/bin/redis-server
+  Fedora: "/usr/bin/{{ 'valkey-server' if ansible_distribution_major_version is version('41', '>=') else 'redis-server' }}"
   CentOS: /usr/bin/redis-server
   FreeBSD: /usr/local/bin/redis-server
 

--- a/tests/integration/targets/setup_redis_replication/tasks/setup_redis_cluster.yml
+++ b/tests/integration/targets/setup_redis_replication/tasks/setup_redis_cluster.yml
@@ -24,8 +24,8 @@
   file:                                                                                                                                                                                                 
     path: "{{ item }}"
     state: directory                                                                                                                                                                                    
-    owner: redis
-    group: redis
+    owner: "{{ redis_user[ansible_distribution] }}"
+    group: "{{ redis_user[ansible_distribution] }}"
   loop:
   - "{{ master_datadir }}"
   - "{{ master_logdir }}"
@@ -54,10 +54,10 @@
     datadir: "{{ replica_datadir }}"
 
 - name: Start redis master
-  shell: "{{ redis_bin[ansible_distribution] }} {{ master_conf }}"
+  ansible.builtin.command: "{{ redis_bin[ansible_distribution] }} {{ master_conf }}"
 
 - name: Start redis replica
-  shell: "{{ redis_bin[ansible_distribution] }} {{ replica_conf }} --{% if old_redis %}slaveof{% else %}replicaof{% endif %} 127.0.0.1 {{ master_port }}"
+  ansible.builtin.command: "{{ redis_bin[ansible_distribution] }} {{ replica_conf }} --{% if old_redis %}slaveof{% else %}replicaof{% endif %} 127.0.0.1 {{ master_port }}"
 
 - name: Wait for redis master to be started
   ansible.builtin.wait_for:


### PR DESCRIPTION
##### SUMMARY
Manual backport of #10129 to stable-8.

Needed parts of another commit that added new platforms to CI and introduced infrastructure that #10129 needs.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
redis