### PR TITLE
Fix TypeError caused by giving more than 2 positional arguments to CobblerXMLRPCInterface.get_system_handle() 

### DIFF
--- a/changelogs/fragments/10145-fix-typeerror-cobbler-xmlrpc.yml
+++ b/changelogs/fragments/10145-fix-typeerror-cobbler-xmlrpc.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cobbler_system - fix bug with Cobbler >= 3.4.0 caused by giving more than 2 positional arguments to ``CobblerXMLRPCInterface.get_system_handle()`` (https://github.com/ansible-collections/community.general/issues/8506, https://github.com/ansible-collections/community.general/pull/10145).

--- a/plugins/modules/cobbler_system.py
+++ b/plugins/modules/cobbler_system.py
@@ -161,6 +161,8 @@ from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.community.general.plugins.module_utils.datetime import (
     now,
 )
+from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
+
 
 IFPROPS_MAPPING = dict(
     bondingopts='bonding_opts',
@@ -278,7 +280,11 @@ def main():
 
         if system:
             # Update existing entry
-            system_id = conn.get_system_handle(name, token)
+            system_id = None
+            if LooseVersion(str(conn.version())) >= LooseVersion('3.4.0'):
+                system_id = conn.get_system_handle(name)
+            else:
+                system_id = conn.get_system_handle(name, token)
 
             for key, value in iteritems(module.params['properties']):
                 if key not in system:


### PR DESCRIPTION
##### SUMMARY
Fixes #8506 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`cobbler_system` plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When running a task with state param set to `present` (default value) as in the following example:
```
- name: Ensure cobbler systems were created
  community.general.cobbler_system:
    host: <hostname>
    username: cobbler
    password: <pwd>
    name: <profile_name>
    use_ssl: false
    state: present
```
I get the following error:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
xmlrpc.client.Fault: <Fault 1: "<class 'TypeError'>:CobblerXMLRPCInterface.get_system_handle() takes 2 positional arguments but 3 were given">
```
Checked Cobbler xmlrpc client and indeed the `get_system_handle`  method only accepts two arguments as can be seen in the code here https://github.com/cobbler/cobbler/blob/main/cobbler/remote.py#L1533

###### Cobbler version
```
Cobbler 3.4.0
```

###### Ansible version
```
ansible [core 2.14.6]
```

###### community.general
```
community.general 10.6.0 
```