### PR TITLE
proxmox: fix: cannot access local variable 'identifier' where it is not associated with a value

### DIFF
--- a/changelogs/fragments/10155-proxmox-bugfix.yml
+++ b/changelogs/fragments/10155-proxmox-bugfix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "proxmox - fix crash in module when the used on an existing LXC container with ``state=present`` and ``force=true`` (https://github.com/ansible-collections/community.proxmox/pull/91, https://github.com/ansible-collections/community.general/pull/10155)."

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -890,6 +890,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
                 self.module.exit_json(
                     changed=False, vmid=vmid, msg="VM %s already exists." % identifier
                 )
+            identifier = self.format_vm_identifier(vmid, lxc["name"])
             self.module.debug(
                 "VM %s already exists, but we don't update and instead forcefully recreate it."
                 % identifier


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible-collections/community.proxmox/pull/91.

I re-created the commit of that PR as the commit from https://github.com/ansible-collections/community.general/pull/10030 by @iphoneintosh + a commit for the changelog fragment.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox
