### PR TITLE
Drop support for ansible-core 2.15; update CI to move ansible-core 2.16 to EOL CI; remove compat code for ansible-core < 2.14

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -96,19 +96,6 @@ stages:
             - test: 2
             - test: 3
             - test: 4
-  - stage: Sanity_2_16
-    displayName: Sanity 2.16
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Test {0}
-          testFormat: 2.16/sanity/{0}
-          targets:
-            - test: 1
-            - test: 2
-            - test: 3
-            - test: 4
 ### Units
   - stage: Units_devel
     displayName: Units devel
@@ -147,18 +134,6 @@ stages:
           targets:
             - test: 3.7
             - test: "3.12"
-  - stage: Units_2_16
-    displayName: Units 2.16
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.16/units/{0}/1
-          targets:
-            - test: 2.7
-            - test: 3.6
-            - test: "3.11"
 
 ## Remote
   - stage: Remote_devel_extra_vms
@@ -233,28 +208,6 @@ stages:
             - 1
             - 2
             - 3
-  - stage: Remote_2_16
-    displayName: Remote 2.16
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.16/{0}
-          targets:
-            - name: macOS 13.2
-              test: macos/13.2
-            - name: RHEL 9.2
-              test: rhel/9.2
-            - name: RHEL 8.8
-              test: rhel/8.8
-            - name: RHEL 7.9
-              test: rhel/7.9
-            # - name: FreeBSD 13.2
-            #   test: freebsd/13.2
-          groups:
-            - 1
-            - 2
-            - 3
 
 ### Docker
   - stage: Docker_devel
@@ -309,26 +262,6 @@ stages:
               test: alpine319
             - name: Ubuntu 20.04
               test: ubuntu2004
-          groups:
-            - 1
-            - 2
-            - 3
-  - stage: Docker_2_16
-    displayName: Docker 2.16
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.16/linux/{0}
-          targets:
-            - name: Fedora 38
-              test: fedora38
-            - name: openSUSE 15
-              test: opensuse15
-            - name: Alpine 3
-              test: alpine3
-            - name: CentOS 7
-              test: centos7
           groups:
             - 1
             - 2
@@ -390,18 +323,6 @@ stages:
 #          targets:
 #            - test: '3.7'
 #            - test: '3.12'
-#  - stage: Generic_2_16
-#    displayName: Generic 2.16
-#    dependsOn: []
-#    jobs:
-#      - template: templates/matrix.yml
-#        parameters:
-#          nameFormat: Python {0}
-#          testFormat: 2.16/generic/{0}/1
-#          targets:
-#            - test: '2.7'
-#            - test: '3.6'
-#            - test: '3.11'
 
   - stage: Summary
     condition: succeededOrFailed()
@@ -409,25 +330,20 @@ stages:
       - Sanity_devel
       - Sanity_2_18
       - Sanity_2_17
-      - Sanity_2_16
       - Units_devel
       - Units_2_18
       - Units_2_17
-      - Units_2_16
       - Remote_devel_extra_vms
       - Remote_devel
       - Remote_2_18
       - Remote_2_17
-      - Remote_2_16
       - Docker_devel
       - Docker_2_18
       - Docker_2_17
-      - Docker_2_16
       - Docker_community_devel
 # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
 #      - Generic_devel
 #      - Generic_2_18
 #      - Generic_2_17
-#      - Generic_2_16
     jobs:
       - template: templates/coverage.yml

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -99,6 +99,7 @@ jobs:
           - ansible: ''
         include:
           # 2.16
+          # CentOS 7 does not work in GHA, that's why it's not listed here.
           - ansible: '2.16'
             docker: fedora38
             python: ''
@@ -135,19 +136,6 @@ jobs:
             docker: alpine3
             python: ''
             target: azp/posix/3/
-          # CentOS 7 doesn't work in GHA:
-          # - ansible: '2.16'
-          #   docker: centos7
-          #   python: ''
-          #   target: azp/posix/1/
-          # - ansible: '2.16'
-          #   docker: centos7
-          #   python: ''
-          #   target: azp/posix/2/
-          # - ansible: '2.16'
-          #   docker: centos7
-          #   python: ''
-          #   target: azp/posix/3/
           # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
           # - ansible: '2.16'
           #   docker: default

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - '2.15'
+          - '2.16'
     runs-on: ubuntu-latest
     steps:
       - name: Perform sanity testing
@@ -57,12 +57,12 @@ jobs:
         exclude:
           - ansible: ''
         include:
-          - ansible: '2.15'
+          - ansible: '2.16'
             python: '2.7'
-          - ansible: '2.15'
-            python: '3.5'
-          - ansible: '2.15'
-            python: '3.10'
+          - ansible: '2.16'
+            python: '3.6'
+          - ansible: '2.16'
+            python: '3.11'
 
     steps:
       - name: >-
@@ -98,43 +98,68 @@ jobs:
         exclude:
           - ansible: ''
         include:
-          # 2.15
-          - ansible: '2.15'
+          # 2.16
+          - ansible: '2.16'
+            docker: fedora38
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.16'
+            docker: fedora38
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.16'
+            docker: fedora38
+            python: ''
+            target: azp/posix/3/
+          - ansible: '2.16'
+            docker: opensuse15
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.16'
+            docker: opensuse15
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.16'
+            docker: opensuse15
+            python: ''
+            target: azp/posix/3/
+          - ansible: '2.16'
             docker: alpine3
             python: ''
             target: azp/posix/1/
-          - ansible: '2.15'
+          - ansible: '2.16'
             docker: alpine3
             python: ''
             target: azp/posix/2/
-          - ansible: '2.15'
+          - ansible: '2.16'
             docker: alpine3
             python: ''
             target: azp/posix/3/
-          - ansible: '2.15'
-            docker: fedora37
-            python: ''
-            target: azp/posix/1/
-          - ansible: '2.15'
-            docker: fedora37
-            python: ''
-            target: azp/posix/2/
-          - ansible: '2.15'
-            docker: fedora37
-            python: ''
-            target: azp/posix/3/
+          # CentOS 7 doesn't work in GHA:
+          # - ansible: '2.16'
+          #   docker: centos7
+          #   python: ''
+          #   target: azp/posix/1/
+          # - ansible: '2.16'
+          #   docker: centos7
+          #   python: ''
+          #   target: azp/posix/2/
+          # - ansible: '2.16'
+          #   docker: centos7
+          #   python: ''
+          #   target: azp/posix/3/
           # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
-          # - ansible: '2.13'
+          # - ansible: '2.16'
           #   docker: default
-          #   python: '3.9'
+          #   python: '2.7'
           #   target: azp/generic/1/
-          # - ansible: '2.14'
+          # - ansible: '2.16'
           #   docker: default
-          #   python: '3.10'
+          #   python: '3.6'
           #   target: azp/generic/1/
-          # - ansible: '2.15'
+          # - ansible: '2.16'
           #   docker: default
-          #   python: '3.9'
+          #   python: '3.11'
           #   target: azp/generic/1/
 
     steps:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For more information about communication, see the [Ansible communication guide](
 
 ## Tested with Ansible
 
-Tested with the current ansible-core 2.15, ansible-core 2.16, ansible-core 2.17, ansible-core 2.18 releases and the current development version of ansible-core. Ansible-core versions before 2.15.0 are not supported. This includes all ansible-base 2.10 and Ansible 2.9 releases.
+Tested with the current ansible-core 2.16, ansible-core 2.17, ansible-core 2.18 releases and the current development version of ansible-core. Ansible-core versions before 2.16.0 are not supported. This includes all ansible-base 2.10 and Ansible 2.9 releases.
 
 ## External requirements
 

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -8,10 +8,6 @@
 "community.docker" = "git+https://github.com/ansible-collections/community.docker.git,main"
 "community.internal_test_tools" = "git+https://github.com/ansible-collections/community.internal_test_tools.git,main"
 
-[collection_sources_per_ansible.'2.15']
-# community.crypto's main branch needs ansible-core >= 2.17
-"community.crypto" = "git+https://github.com/ansible-collections/community.crypto.git,stable-2"
-
 [collection_sources_per_ansible.'2.16']
 # community.crypto's main branch needs ansible-core >= 2.17
 "community.crypto" = "git+https://github.com/ansible-collections/community.crypto.git,stable-2"

--- a/changelogs/fragments/ansible-core-support.yml
+++ b/changelogs/fragments/ansible-core-support.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - "Dropped support for ansible-core 2.15. The collection now requires ansible-core 2.16 or newer. This means that on the controller, Python 3.10+ is required. On the target side, Python 2.7 and Python 3.6+ are supported (https://github.com/ansible-collections/community.general/pull/10160)."

--- a/changelogs/fragments/ansible-core-support.yml
+++ b/changelogs/fragments/ansible-core-support.yml
@@ -1,2 +1,7 @@
 removed_features:
   - "Dropped support for ansible-core 2.15. The collection now requires ansible-core 2.16 or newer. This means that on the controller, Python 3.10+ is required. On the target side, Python 2.7 and Python 3.6+ are supported (https://github.com/ansible-collections/community.general/pull/10160)."
+minor_changes:
+  - "cartesian lookup plugin - removed compatibility code for ansible-core < 2.14 (https://github.com/ansible-collections/community.general/pull/10160)."
+  - "dependent lookup plugin - removed compatibility code for ansible-core < 2.14 (https://github.com/ansible-collections/community.general/pull/10160)."
+  - "flattened lookup plugin - removed compatibility code for ansible-core < 2.14 (https://github.com/ansible-collections/community.general/pull/10160)."
+  - "redfish module utils - removed compatibility code for ansible-core < 2.14 (https://github.com/ansible-collections/community.general/pull/10160)."

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-requires_ansible: '>=2.15.0'
+requires_ansible: '>=2.16.0'
 action_groups:
   consul:
     - consul_agent_check

--- a/plugins/lookup/cartesian.py
+++ b/plugins/lookup/cartesian.py
@@ -66,13 +66,7 @@ class LookupModule(LookupBase):
         """
         results = []
         for x in terms:
-            try:
-                intermediate = listify_lookup_plugin_terms(x, templar=self._templar)
-            except TypeError:
-                # The loader argument is deprecated in ansible-core 2.14+. Fall back to
-                # pre-2.14 behavior for older ansible-core versions.
-                intermediate = listify_lookup_plugin_terms(x, templar=self._templar, loader=self._loader)
-            results.append(intermediate)
+            results.append(listify_lookup_plugin_terms(x, templar=self._templar))
         return results
 
     def run(self, terms, variables=None, **kwargs):

--- a/plugins/lookup/dependent.py
+++ b/plugins/lookup/dependent.py
@@ -127,18 +127,11 @@ from ansible.plugins.lookup import LookupBase
 from ansible.release import __version__ as ansible_version
 from ansible.template import Templar
 
-from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
-
 try:
     from ansible.template import trust_as_template as _trust_as_template
     HAS_DATATAGGING = True
 except ImportError:
     HAS_DATATAGGING = False
-
-
-# Whether Templar has a cache, which can be controlled by Templar.template()'s cache option.
-# The cache was removed for ansible-core 2.14 (https://github.com/ansible/ansible/pull/78419)
-_TEMPLAR_HAS_TEMPLATE_CACHE = LooseVersion(ansible_version) < LooseVersion('2.14.0')
 
 
 def _make_safe(value):
@@ -156,8 +149,6 @@ class LookupModule(LookupBase):
         """
         templar.available_variables = variables or {}
         quoted_expression = "{0}{1}{2}".format("{{", expression, "}}")
-        if _TEMPLAR_HAS_TEMPLATE_CACHE:
-            return templar.template(quoted_expression, cache=False)
         if hasattr(templar, 'evaluate_expression'):
             # This is available since the Data Tagging PR has been merged
             return templar.evaluate_expression(_make_safe(expression))

--- a/plugins/lookup/flattened.py
+++ b/plugins/lookup/flattened.py
@@ -67,12 +67,7 @@ class LookupModule(LookupBase):
 
             if isinstance(term, string_types):
                 # convert a variable to a list
-                try:
-                    term2 = listify_lookup_plugin_terms(term, templar=self._templar)
-                except TypeError:
-                    # The loader argument is deprecated in ansible-core 2.14+. Fall back to
-                    # pre-2.14 behavior for older ansible-core versions.
-                    term2 = listify_lookup_plugin_terms(term, templar=self._templar, loader=self._loader)
+                term2 = listify_lookup_plugin_terms(term, templar=self._templar)
                 # but avoid converting a plain string to a list of one string
                 if term2 != [term]:
                     term = term2

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -10,9 +10,7 @@ import json
 import os
 import random
 import string
-import gzip
 import time
-from io import BytesIO
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.common.text.converters import to_text
@@ -21,8 +19,6 @@ from ansible.module_utils.six import text_type
 from ansible.module_utils.six.moves import http_client
 from ansible.module_utils.six.moves.urllib.error import URLError, HTTPError
 from ansible.module_utils.six.moves.urllib.parse import urlparse
-from ansible.module_utils.ansible_release import __version__ as ansible_version
-from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 
 GET_HEADERS = {'accept': 'application/json', 'OData-Version': '4.0'}
 POST_HEADERS = {'content-type': 'application/json', 'accept': 'application/json',
@@ -183,12 +179,7 @@ class RedfishUtils(object):
                 timeout=timeout,
             )
             try:
-                if headers.get('content-encoding') == 'gzip' and LooseVersion(ansible_version) < LooseVersion('2.14'):
-                    # Older versions of Ansible do not automatically decompress the data
-                    # Starting in 2.14, open_url will decompress the response data by default
-                    data = json.loads(to_native(gzip.open(BytesIO(resp.read()), 'rt', encoding='utf-8').read()))
-                else:
-                    data = json.loads(to_native(resp.read()))
+                data = json.loads(to_native(resp.read()))
             except Exception as e:
                 # No response data; this is okay in certain cases
                 data = None

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -17,8 +17,6 @@ short_description: Manage services on Source Mage GNU/Linux
 version_added: 7.5.0
 description:
   - Controls services on remote hosts using C(simpleinit-msb).
-notes:
-  - This module needs ansible-core 2.15.5 or newer. Older versions have a broken and insufficient daemonize functionality.
 author: "Vlad Glagolev (@vaygr)"
 extends_documentation_fragment:
   - community.general.attributes


### PR DESCRIPTION
##### SUMMARY
Regular cleanup for a new major release.

##### ISSUE TYPE
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
various
