### PR TITLE
Use StrictVersion class to avoid wrong version comparisons that happen in some cases using LooseVersion class results in TypeError

### DIFF
--- a/plugins/modules/cobbler_system.py
+++ b/plugins/modules/cobbler_system.py
@@ -157,11 +157,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.six.moves import xmlrpc_client
 from ansible.module_utils.common.text.converters import to_text
+from ansible.module_utils.compat.version import StrictVersion
 
 from ansible_collections.community.general.plugins.module_utils.datetime import (
     now,
 )
-from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 
 
 IFPROPS_MAPPING = dict(
@@ -281,7 +281,7 @@ def main():
         if system:
             # Update existing entry
             system_id = None
-            if LooseVersion(str(conn.version())) >= LooseVersion('3.4.0'):
+            if StrictVersion(str(conn.version())) >= StrictVersion('3.4.0'):
                 system_id = conn.get_system_handle(name)
             else:
                 system_id = conn.get_system_handle(name, token)

--- a/plugins/modules/cobbler_system.py
+++ b/plugins/modules/cobbler_system.py
@@ -280,7 +280,7 @@ def main():
 
         if system:
             # Update existing entry
-            system_id = None
+            system_id = ''
             if StrictVersion(str(conn.version())) >= StrictVersion('3.4.0'):
                 system_id = conn.get_system_handle(name)
             else:


### PR DESCRIPTION
##### SUMMARY
Fixes #8506 and complements #10145

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`cobbler_system` plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When running a task with state param set to `present` (default value) as in the following example:
```
- name: Ensure cobbler systems were created
  community.general.cobbler_system:
    host: <hostname>
    username: cobbler
    password: <pwd>
    name: <profile_name>
    use_ssl: false
    state: present
```
I get the following error:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
xmlrpc.client.Fault: <Fault 1: "<class 'TypeError'>:CobblerXMLRPCInterface.get_system_handle() takes 2 positional arguments but 3 were given">
```
This still happens after the fix #10145 because `LooseVersion` class does not compare correctly version numbers that are in different formats (the class just does a simple string comparison). As a result the comparison in [line](https://github.com/ansible-collections/community.general/blob/stable-10/plugins/modules/cobbler_system.py#L284) gives the following:
```
>>> LooseVersion("3.4") >= LooseVersion('3.4.0')
False
```
The expected result of the above comparison is True.

When using `StrictVersion` class we get the expected result:
```
>>> StrictVersion("3.4") == StrictVersion("3.4.0")
True
```

###### Cobbler version
```
Cobbler 3.4.0
```

###### Ansible version
```
ansible [core 2.14.6]
```

###### community.general
```
community.general 10.6.0 
```
