### PR TITLE
pacemaker: add cluster maintenance mode checks

### DIFF
--- a/changelogs/fragments/10194-add-pcs-resource-maintenace-mode.yml
+++ b/changelogs/fragments/10194-add-pcs-resource-maintenace-mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - pacemaker_resource - add maintenance mode support for handling resource creation and deletion (https://github.com/ansible-collections/community.general/issues/10180, https://github.com/ansible-collections/community.general/pull/10194).

--- a/plugins/module_utils/pacemaker.py
+++ b/plugins/module_utils/pacemaker.py
@@ -41,10 +41,10 @@ def get_pacemaker_maintenance_mode(runner):
     with runner("config") as ctx:
         rc, out, err = ctx.run()
         maintenance_mode_output = list(filter(lambda string: "maintenance-mode=true" in string.lower(), out.splitlines()))
-        return True if maintenance_mode_output else False
+        return bool(maintenance_mode_output)
 
 
-def pacemaker_runner(module, cli_action="", **kwargs):
+def pacemaker_runner(module, cli_action=None, **kwargs):
     runner_command = ['pcs']
     if cli_action:
         runner_command.append(cli_action)
@@ -61,7 +61,7 @@ def pacemaker_runner(module, cli_action="", **kwargs):
             resource_argument=cmd_runner_fmt.as_func(fmt_resource_argument),
             wait=cmd_runner_fmt.as_opt_eq_val("--wait"),
             config=cmd_runner_fmt.as_fixed("config"),
-            force=cmd_runner_fmt.as_fixed("--force"),
+            force=cmd_runner_fmt.as_bool("--force"),
         ),
         **kwargs
     )

--- a/plugins/module_utils/pacemaker.py
+++ b/plugins/module_utils/pacemaker.py
@@ -61,6 +61,7 @@ def pacemaker_runner(module, cli_action="", **kwargs):
             resource_argument=cmd_runner_fmt.as_func(fmt_resource_argument),
             wait=cmd_runner_fmt.as_opt_eq_val("--wait"),
             config=cmd_runner_fmt.as_fixed("config"),
+            force=cmd_runner_fmt.as_fixed("--force"),
         ),
         **kwargs
     )

--- a/plugins/module_utils/pacemaker.py
+++ b/plugins/module_utils/pacemaker.py
@@ -37,10 +37,20 @@ def fmt_resource_argument(value):
     return ['--group' if value['argument_action'] == 'group' else value['argument_action']] + value['argument_option']
 
 
-def pacemaker_runner(module, cli_action, **kwargs):
+def get_pacemaker_maintenance_mode(runner):
+    with runner("config") as ctx:
+        rc, out, err = ctx.run()
+        maintenance_mode_output = list(filter(lambda string: "maintenace-mode=true" in string.lower(), out.splitlines()))
+        return True if maintenance_mode_output else False
+
+
+def pacemaker_runner(module, cli_action="", **kwargs):
+    runner_command = ['pcs']
+    if cli_action:
+        runner_command.append(cli_action)
     runner = CmdRunner(
         module,
-        command=['pcs', cli_action],
+        command=runner_command,
         arg_formats=dict(
             state=cmd_runner_fmt.as_map(_state_map),
             name=cmd_runner_fmt.as_list(),
@@ -50,6 +60,7 @@ def pacemaker_runner(module, cli_action, **kwargs):
             resource_meta=cmd_runner_fmt.stack(cmd_runner_fmt.as_opt_val)("meta"),
             resource_argument=cmd_runner_fmt.as_func(fmt_resource_argument),
             wait=cmd_runner_fmt.as_opt_eq_val("--wait"),
+            config=cmd_runner_fmt.as_fixed("config"),
         ),
         **kwargs
     )

--- a/plugins/module_utils/pacemaker.py
+++ b/plugins/module_utils/pacemaker.py
@@ -40,7 +40,7 @@ def fmt_resource_argument(value):
 def get_pacemaker_maintenance_mode(runner):
     with runner("config") as ctx:
         rc, out, err = ctx.run()
-        maintenance_mode_output = list(filter(lambda string: "maintenace-mode=true" in string.lower(), out.splitlines()))
+        maintenance_mode_output = list(filter(lambda string: "maintenance-mode=true" in string.lower(), out.splitlines()))
         return True if maintenance_mode_output else False
 
 

--- a/plugins/modules/pacemaker_resource.py
+++ b/plugins/modules/pacemaker_resource.py
@@ -186,11 +186,10 @@ class PacemakerResource(StateModuleHelper):
             return ctx.run(state='status')
 
     def state_absent(self):
-        runner_args = ['state', 'name']
-        if get_pacemaker_maintenance_mode(self._maintenance_mode_runner):
-            runner_args.append('force')
-        with self.runner(" ".join(runner_args), output_process=self._process_command_output(True, "does not exist"), check_mode_skip=True) as ctx:
-            ctx.run()
+        runner_args = ['state', 'name', 'force']
+        force = get_pacemaker_maintenance_mode(self._maintenance_mode_runner)
+        with self.runner(runner_args, output_process=self._process_command_output(True, "does not exist"), check_mode_skip=True) as ctx:
+            ctx.run(force=force)
             self.vars.set('value', self._get())
             self.vars.stdout = ctx.results_out
             self.vars.stderr = ctx.results_err

--- a/plugins/modules/pacemaker_resource.py
+++ b/plugins/modules/pacemaker_resource.py
@@ -135,7 +135,7 @@ cluster_resources:
 '''
 
 from ansible_collections.community.general.plugins.module_utils.module_helper import StateModuleHelper
-from ansible_collections.community.general.plugins.module_utils.pacemaker import pacemaker_runner
+from ansible_collections.community.general.plugins.module_utils.pacemaker import pacemaker_runner, get_pacemaker_maintenance_mode
 
 
 class PacemakerResource(StateModuleHelper):
@@ -169,6 +169,7 @@ class PacemakerResource(StateModuleHelper):
 
     def __init_module__(self):
         self.runner = pacemaker_runner(self.module, cli_action='resource')
+        self._maintenance_mode_runner = pacemaker_runner(self.module, cli_action='property')
         self.vars.set('previous_value', self._get())
         self.vars.set('value', self.vars.previous_value, change=True, diff=True)
 
@@ -195,7 +196,7 @@ class PacemakerResource(StateModuleHelper):
     def state_present(self):
         with self.runner(
                 'state name resource_type resource_option resource_operation resource_meta resource_argument wait',
-                output_process=self._process_command_output(True, "already exists"),
+                output_process=self._process_command_output(not get_pacemaker_maintenance_mode(self._maintenance_mode_runner), "already exists"),
                 check_mode_skip=True) as ctx:
             ctx.run()
             self.vars.set('value', self._get())

--- a/plugins/modules/pacemaker_resource.py
+++ b/plugins/modules/pacemaker_resource.py
@@ -186,7 +186,10 @@ class PacemakerResource(StateModuleHelper):
             return ctx.run(state='status')
 
     def state_absent(self):
-        with self.runner('state name', output_process=self._process_command_output(True, "does not exist"), check_mode_skip=True) as ctx:
+        runner_args = ['state', 'name']
+        if get_pacemaker_maintenance_mode(self._maintenance_mode_runner):
+            runner_args.append('force')
+        with self.runner(" ".join(runner_args), output_process=self._process_command_output(True, "does not exist"), check_mode_skip=True) as ctx:
             ctx.run()
             self.vars.set('value', self._get())
             self.vars.stdout = ctx.results_out

--- a/tests/unit/plugins/modules/test_pacemaker_resource.yaml
+++ b/tests/unit/plugins/modules/test_pacemaker_resource.yaml
@@ -30,6 +30,16 @@ test_cases:
           environ: *env-def
           rc: 1
           out: ""
+          err: "Error: resource or tag id 'virtual-ip' not found"
+        - command: [/testbin/pcs, property, config]
+          environ: *env-def
+          rc: 1
+          out: |
+            Cluster Properties: cib-bootstrap-options
+            cluster-infrastructure=corosync
+            cluster-name=hacluster
+            dc-version=2.1.9-1.fc41-7188dbf
+            have-watchdog=false
           err: ""
         - command: [/testbin/pcs, resource, create, virtual-ip, IPaddr2, "ip=[192.168.2.1]", --wait=300]
           environ: *env-def
@@ -60,6 +70,16 @@ test_cases:
           rc: 0
           out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
           err: ""
+        - command: [/testbin/pcs, property, config]
+          environ: *env-def
+          rc: 1
+          out: |
+            Cluster Properties: cib-bootstrap-options
+            cluster-infrastructure=corosync
+            cluster-name=hacluster
+            dc-version=2.1.9-1.fc41-7188dbf
+            have-watchdog=false
+          err: ""
         - command: [/testbin/pcs, resource, create, virtual-ip, IPaddr2, "ip=[192.168.2.1]", --wait=300]
           environ: *env-def
           rc: 1
@@ -69,6 +89,46 @@ test_cases:
           environ: *env-def
           rc: 0
           out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
+          err: ""
+  - id: test_present_minimal_input_resource_maintenance_mode
+    input:
+      state: present
+      name: virtual-ip
+      resource_type:
+        resource_name: IPaddr2
+      resource_option:
+        - "ip=[192.168.2.1]"
+    output:
+      changed: true
+      previous_value: null
+      value: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Stopped"
+    mocks:
+      run_command:
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 1
+          out: ""
+          err: ""
+        - command: [/testbin/pcs, property, config]
+          environ: *env-def
+          rc: 0
+          out: |
+            Cluster Properties: cib-bootstrap-options
+            cluster-infrastructure=corosync
+            cluster-name=hacluster
+            dc-version=2.1.9-1.fc41-7188dbf
+            have-watchdog=false
+            maintenance-mode=true
+          err: ""
+        - command: [/testbin/pcs, resource, create, virtual-ip, IPaddr2, "ip=[192.168.2.1]", --wait=300]
+          environ: *env-def
+          rc: 1
+          out: ""
+          err: ""
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Stopped"
           err: ""
   - id: test_absent_minimal_input_resource_not_exist
     input:
@@ -84,7 +144,7 @@ test_cases:
           environ: *env-def
           rc: 1
           out: ""
-          err: ""
+          err: "Error: resource or tag id 'virtual-ip' not found"
         - command: [/testbin/pcs, resource, remove, virtual-ip]
           environ: *env-def
           rc: 1
@@ -94,7 +154,7 @@ test_cases:
           environ: *env-def
           rc: 1
           out: ""
-          err: ""
+          err: "Error: resource or tag id 'virtual-ip' not found"
   - id: test_absent_minimal_input_resource_exists
     input:
       state: absent
@@ -119,7 +179,7 @@ test_cases:
           environ: *env-def
           rc: 1
           out: ""
-          err: ""
+          err: "Error: resource or tag id 'virtual-ip' not found"
   - id: test_enabled_minimal_input_resource_not_exists
     input:
       state: enabled
@@ -133,7 +193,7 @@ test_cases:
           environ: *env-def
           rc: 1
           out: ""
-          err: ""
+          err: "Error: resource or tag id 'virtual-ip' not found"
         - command: [/testbin/pcs, resource, enable, virtual-ip]
           environ: *env-def
           rc: 1
@@ -177,7 +237,7 @@ test_cases:
           environ: *env-def
           rc: 1
           out: ""
-          err: ""
+          err: "Error: resource or tag id 'virtual-ip' not found"
         - command: [/testbin/pcs, resource, disable, virtual-ip]
           environ: *env-def
           rc: 1

--- a/tests/unit/plugins/modules/test_pacemaker_resource.yaml
+++ b/tests/unit/plugins/modules/test_pacemaker_resource.yaml
@@ -124,7 +124,7 @@ test_cases:
           environ: *env-def
           rc: 1
           out: ""
-          err: ""
+          err: "Error: resource 'virtual-ip' is not running on any node"
         - command: [/testbin/pcs, resource, status, virtual-ip]
           environ: *env-def
           rc: 0

--- a/tests/unit/plugins/modules/test_pacemaker_resource.yaml
+++ b/tests/unit/plugins/modules/test_pacemaker_resource.yaml
@@ -145,6 +145,16 @@ test_cases:
           rc: 1
           out: ""
           err: "Error: resource or tag id 'virtual-ip' not found"
+        - command: [/testbin/pcs, property, config]
+          environ: *env-def
+          rc: 1
+          out: |
+            Cluster Properties: cib-bootstrap-options
+            cluster-infrastructure=corosync
+            cluster-name=hacluster
+            dc-version=2.1.9-1.fc41-7188dbf
+            have-watchdog=false
+          err: ""
         - command: [/testbin/pcs, resource, remove, virtual-ip]
           environ: *env-def
           rc: 1
@@ -170,11 +180,57 @@ test_cases:
           rc: 0
           out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
           err: ""
+        - command: [/testbin/pcs, property, config]
+          environ: *env-def
+          rc: 1
+          out: |
+            Cluster Properties: cib-bootstrap-options
+            cluster-infrastructure=corosync
+            cluster-name=hacluster
+            dc-version=2.1.9-1.fc41-7188dbf
+            have-watchdog=false
+          err: ""
         - command: [/testbin/pcs, resource, remove, virtual-ip]
           environ: *env-def
           rc: 0
           out: ""
           err: "Attempting to stop: virtual-ip... Stopped\n"
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 1
+          out: ""
+          err: "Error: resource or tag id 'virtual-ip' not found"
+  - id: test_absent_minimal_input_maintenance_mode
+    input:
+      state: absent
+      name: virtual-ip
+    output:
+      changed: true
+      previous_value: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
+      value: null
+    mocks:
+      run_command:
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
+          err: ""
+        - command: [/testbin/pcs, property, config]
+          environ: *env-def
+          rc: 0
+          out: |
+            Cluster Properties: cib-bootstrap-options
+            cluster-infrastructure=corosync
+            cluster-name=hacluster
+            dc-version=2.1.9-1.fc41-7188dbf
+            have-watchdog=false
+            maintenance-mode=true
+          err: ""
+        - command: [/testbin/pcs, resource, remove, virtual-ip, --force]
+          environ: *env-def
+          rc: 0
+          out: ""
+          err: "Deleting Resource (and group) - virtual-ip"
         - command: [/testbin/pcs, resource, status, virtual-ip]
           environ: *env-def
           rc: 1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Adds check for pacemaker cluster maintenance mode
* Ignores cluster resource lifecycle if maintenance mode is enabled
  * Deleting, enabling, or disabling resources can still be managed by user during maintenance mode

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #10180 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
`pacemaker_resource`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Error Replication:
* Create a pacemaker cluster
* Enable pacemaker maintenance mode: `pcs property set maintenance-mode=true`
* Create any pacemaker resource
  * Which will error out as no resource can start by pacemaker lifecycle on any mode while maintenance mode is enabled

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
