### PR TITLE
cargo: add support for --features flag

### DIFF
--- a/changelogs/fragments/10198-cargo-features-parameter.yml
+++ b/changelogs/fragments/10198-cargo-features-parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cargo - add ``features`` parameter to allow activating specific features when installing Rust packages (https://github.com/ansible-collections/community.general/pull/10195).

--- a/changelogs/fragments/10198-cargo-features-parameter.yml
+++ b/changelogs/fragments/10198-cargo-features-parameter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - cargo - add ``features`` parameter to allow activating specific features when installing Rust packages (https://github.com/ansible-collections/community.general/pull/10195).
+  - cargo - add ``features`` parameter to allow activating specific features when installing Rust packages (https://github.com/ansible-collections/community.general/pull/10198).

--- a/plugins/modules/cargo.py
+++ b/plugins/modules/cargo.py
@@ -76,7 +76,7 @@ options:
     elements: str
     required: false
     default: []
-    version_added: 10.8.0
+    version_added: 11.0.0
 requirements:
   - cargo installed
 """

--- a/plugins/modules/cargo.py
+++ b/plugins/modules/cargo.py
@@ -68,6 +68,14 @@ options:
     type: path
     required: false
     version_added: 9.1.0
+  features:
+    description:
+      - List of features to activate.
+      - This is only used when installing packages.
+    type: list
+    elements: str
+    required: false
+    version_added: 10.8.0
 requirements:
   - cargo installed
 """
@@ -106,6 +114,11 @@ EXAMPLES = r"""
   community.general.cargo:
     name: ludusavi
     directory: /path/to/ludusavi/source
+
+- name: Install "serpl" Rust package with ast_grep feature
+  community.general.cargo:
+    name: serpl
+    features: [ast_grep]
 """
 
 import json
@@ -125,6 +138,7 @@ class Cargo(object):
         self.version = kwargs["version"]
         self.locked = kwargs["locked"]
         self.directory = kwargs["directory"]
+        self.features = kwargs["features"]
 
     @property
     def path(self):
@@ -176,6 +190,8 @@ class Cargo(object):
         if self.directory:
             cmd.append("--path")
             cmd.append(self.directory)
+        if self.features:
+            cmd += ["--features", ",".join(self.features)]
         return self._exec(cmd)
 
     def is_outdated(self, name):
@@ -236,6 +252,7 @@ def main():
         version=dict(default=None, type="str"),
         locked=dict(default=False, type="bool"),
         directory=dict(default=None, type="path"),
+        features=dict(default=[], required=False, type="list", elements="str"),
     )
     module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
 

--- a/plugins/modules/cargo.py
+++ b/plugins/modules/cargo.py
@@ -75,6 +75,7 @@ options:
     type: list
     elements: str
     required: false
+    default: []
     version_added: 10.8.0
 requirements:
   - cargo installed

--- a/plugins/modules/cargo.py
+++ b/plugins/modules/cargo.py
@@ -119,7 +119,8 @@ EXAMPLES = r"""
 - name: Install "serpl" Rust package with ast_grep feature
   community.general.cargo:
     name: serpl
-    features: [ast_grep]
+    features:
+      - ast_grep
 """
 
 import json


### PR DESCRIPTION
##### SUMMARY

Hi! I'm using currently cargo module to install many cargo binaries. This is my example [vars/config/main.yaml](https://github.com/Psyhackological/my-ansible/blob/main/collections/konradkon/popos/roles/rustup/vars/main.yaml)

```yaml
---
rustup_cargo_list:
  - name: alacritty
    dependencies:
      - cmake
      - g++
      - pkg-config
      - libfontconfig1-dev
      - libxcb-xfixes0-dev
      - libxkbcommon-dev
      - python3
```

You get the idea, then the logic is in the playbooks so name is passed through `community.general.cargo` and apt packages to `ansible.builtin.apt` module. However in the cargo install there is a `--features` flag that allows:
> Cargo “features” provide a mechanism to express [conditional compilation](https://doc.rust-lang.org/reference/conditional-compilation.html) and [optional dependencies](https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies).
[Features - The Cargo Book](https://doc.rust-lang.org/cargo/reference/features.html)

which is needed for some packages and I would like to pass it for example to my vars (`rustup_cargo_list`):
```yaml
  - name: serpl
    features: [ast_grep]
```

so it's later passed into an example command `cargo install serpl --features ast_grep`. The features can be found in the [`Cargo.toml`](https://github.com/yassinebridi/serpl/blob/main/Cargo.toml#L12) file in the specific repo.

The changelog:
```yaml
minor_changes:
  - cargo - add `features` parameter to allow activating specific features when installing Rust packages (https://github.com/ansible-collections/community.general/pull/10198).
```

##### ISSUE TYPE - Feature Pull Request
Adds `--features` flag to cargo module.

##### COMPONENT NAME - cargo module
and its `features` parameter
```bash
Feature Selection:
  -F, --features <FEATURES>  Space or comma separated list of features to activate
```
I decided to use comma separated list approach:
```python
        if self.features:
            cmd += ["--features", ",".join(self.features)]
```

##### ADDITIONAL INFORMATION - before and after example playbook

###### Example playbook

```yaml
---
- name: Test cargo module features parameter - serpl example
  hosts: localhost
  gather_facts: false

  tasks:
    - name: "BEFORE: Install serpl with ast_grep feature using command module"
      ansible.builtin.command: cargo install serpl --features ast_grep
      register: before_install
      changed_when: "'Installing' in before_install.stderr"  # for some reason it lands into stderr
      tags: before

    - name: "Remove serpl for clean test"
      community.general.cargo:
        name: serpl
        state: absent
      tags: cleanup

    - name: "AFTER: Install serpl with ast_grep feature using cargo module"
      community.general.cargo:
        name: serpl
        features: [ast_grep]
        state: present
      tags: after

    - name: "VERIFY: Check that serpl is installed"
      ansible.builtin.command: cargo install --list
      register: installed_packages
      changed_when: false
      tags: verify

    - name: "VERIFY: Show serpl installation"
      ansible.builtin.debug:
        msg: "{{ installed_packages.stdout_lines | select('match', '.*serpl.*') | list }}"
      tags: verify
```

###### Before

```text
PLAY [Test cargo module features parameter - serpl example] **************************************************************************************************************************

TASK [BEFORE: Install serpl with ast_grep feature using command module] **************************************************************************************************************
ok: [localhost]

TASK [Remove serpl for clean test] ***************************************************************************************************************************************************
changed: [localhost]
```
###### After

```text
TASK [AFTER: Install serpl with ast_grep feature using cargo module] *****************************************************************************************************************
changed: [localhost]

TASK [VERIFY: Check that serpl is installed] *****************************************************************************************************************************************
ok: [localhost]

TASK [VERIFY: Show serpl installation] ***********************************************************************************************************************************************
ok: [localhost] => {
    "msg": [
        "serpl v0.3.4:",
        "    serpl"
    ]
}

PLAY RECAP ***************************************************************************************************************************************************************************
localhost                  : ok=5    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

###### Testing

I would love to verify if the feature is really installed but I don't see any way `cargo install --list` doesn't show it. Other than that you can use [`cargo info serpl`](https://gitlab.com/imp/cargo-info) to see the available features:
```bash
cargo info serpl
Updating crates.io index
serpl
A simple terminal UI for search and replace, ala VS Code
version: 0.3.4
license: MIT
rust-version: unknown
documentation: https://docs.rs/serpl/0.3.4
repository: https://github.com/yassinebridi/serpl
crates.io: https://crates.io/crates/serpl/0.3.4
features:
  ast_grep = []
```

##### Credits
Thanks @colin-nolan and @radek-sprta for this module.