### PR TITLE
Tests: adjust to ansible-core devel changes

### DIFF
--- a/tests/integration/targets/alternatives/tasks/subcommands.yml
+++ b/tests/integration/targets/alternatives/tasks/subcommands.yml
@@ -89,7 +89,7 @@
   assert:
     that:
       - cmd.rc == 2
-      - '"No such file" in cmd.msg'
+      - '"No such file" in cmd.msg or "Error executing command." == cmd.msg'
 
 - name: Get dummymain alternatives output
   command:
@@ -172,7 +172,7 @@
   assert:
     that:
       - cmd.rc == 2
-      - '"No such file" in cmd.msg'
+      - '"No such file" in cmd.msg or "Error executing command." == cmd.msg'
 
 - name: Get dummymain alternatives output
   command:

--- a/tests/integration/targets/cmd_runner/vars/main.yml
+++ b/tests/integration/targets/cmd_runner/vars/main.yml
@@ -253,3 +253,5 @@ cmd_echo_tests:
     assertions:
       - >
         "No such file or directory" in test_result.msg
+        or
+        "Error executing command." == test_result.msg


### PR DESCRIPTION
##### SUMMARY
Apparently the error message returned by AnsibleModule.run_command() when trying to execute a non-existing executable changed. This makes some of the integration tests fail.

Ref: https://github.com/ansible/ansible/commit/600c1e67b488ecaf92554f7b73b0335a8ec768f8

(There are some more CI breakages, I will take a look in another PR.)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
alternatives integration tests
cmd_runner integration tests
