### PR TITLE
YAML callback: remove 12.0.0 already

### DIFF
--- a/changelogs/fragments/10213-yaml-deprecation.yml
+++ b/changelogs/fragments/10213-yaml-deprecation.yml
@@ -1,0 +1,5 @@
+deprecated_features:
+  - "yaml callback plugin - the YAML callback plugin was deprecated for removal in community.general 13.0.0.
+     Since it needs to use ansible-core internals since ansible-core 2.19 that are changing a lot,
+     we will remove this plugin already from community.general 12.0.0 to ease the maintenance burden
+     (https://github.com/ansible-collections/community.general/pull/10213)."

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -86,7 +86,7 @@ plugin_routing:
           = yes' option.
     yaml:
       deprecation:
-        removal_version: 13.0.0
+        removal_version: 12.0.0
         warning_text: >-
           The plugin has been superseded by the the option `result_format=yaml` in callback plugin ansible.builtin.default from ansible-core 2.13 onwards.
   connection:

--- a/plugins/callback/yaml.py
+++ b/plugins/callback/yaml.py
@@ -12,7 +12,7 @@ name: yaml
 type: stdout
 short_description: YAML-ized Ansible screen output
 deprecated:
-  removed_in: 13.0.0
+  removed_in: 12.0.0
   why: Starting in ansible-core 2.13, the P(ansible.builtin.default#callback) callback has support for printing output in
     YAML format.
   alternative: Use O(ansible.builtin.default#callback:result_format=yaml).


### PR DESCRIPTION
##### SUMMARY
I'd like to move the removal of the YAML callback from 13.0.0 to 12.0.0. The latest set of breaking changes in the ansible-core internals we have to use since ansible-core 2.19 shows that we should get rid of this plugin as soon as possible.

Removing it from 11.0.0 already might be a bit too extreme, but I really don't want to keep it around much longer...

(CI will fail because #10212 isn't merged yet.)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
yaml callback
