### PR TITLE
Fix typo on tests for module lvm_pv

### DIFF
--- a/tests/integration/targets/lvm_pv/tasks/main.yml
+++ b/tests/integration/targets/lvm_pv/tasks/main.yml
@@ -15,7 +15,7 @@
     name: lvm2
     state: present
 
-- name: Testing lvg_pv module
+- name: Testing lvm_pv module
   block:
     - import_tasks: creation.yml
 


### PR DESCRIPTION
##### SUMMARY
This PR fixes a typo in the name of the `lvm_pv` module tests, which was introduced in PR #10070

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
`lvm_pv`

##### ADDITIONAL INFORMATION
The name of the task `Testing **lvg_pv** module` at https://github.com/ansible-collections/community.general/blob/main/tests/integration/targets/lvm_pv/tasks/main.yml#L18C9-L18C30 is wrong and it should be `Testing **lvm_pv** module` instead.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Before: `- name: Testing lvg_pv module`
After: `- name: Testing lvm_pv module`
```
