### PR TITLE
zypper_repository: fix usage of removed method ConfigParser.readfp()

### DIFF
--- a/changelogs/fragments/10222-zypper_repository-readfp.yml
+++ b/changelogs/fragments/10222-zypper_repository-readfp.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zypper_repository - fix usage of removed method ConfigParser.readfp()

--- a/plugins/modules/zypper_repository.py
+++ b/plugins/modules/zypper_repository.py
@@ -142,6 +142,7 @@ from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils.common.text.converters import to_text
+from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import configparser, StringIO
 from io import open
 
@@ -407,7 +408,10 @@ def main():
 
         repofile = configparser.ConfigParser()
         try:
-            repofile.readfp(StringIO(repofile_text))
+            if PY3:
+                repofile.read_file(StringIO(repofile_text))
+            else:
+                repofile.readfp(StringIO(repofile_text))
         except configparser.Error:
             module.fail_json(msg='Invalid format, .repo file could not be parsed')
 


### PR DESCRIPTION
##### SUMMARY

ConfigParser.readfp() has been removed in python 3.12. See similar fix e.g. in https://github.com/ansible/ansible/pull/81657

Fixes #10222

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zypper_repository
