### PR TITLE
zypper_repository: handle repositories without <url/> element

### DIFF
--- a/changelogs/fragments/10224-zypper_repository-metalink.yml
+++ b/changelogs/fragments/10224-zypper_repository-metalink.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zypper_repository - use metalink attribute to identify repositories without <url/> element

--- a/plugins/modules/zypper_repository.py
+++ b/plugins/modules/zypper_repository.py
@@ -173,7 +173,10 @@ def _parse_repos(module):
             opts = {}
             for o in REPO_OPTS:
                 opts[o] = repo.getAttribute(o)
-            opts['url'] = repo.getElementsByTagName('url')[0].firstChild.data
+            try:
+                opts['url'] = repo.getElementsByTagName('url')[0].firstChild.data
+            except IndexError:
+                opts['url'] = repo.getAttribute('metalink')
             # A repo can be uniquely identified by an alias + url
             repos.append(opts)
         return repos


### PR DESCRIPTION
##### SUMMARY

zypper_repository identifies repos using a combination of "alias" and "url". Recently, openSUE has begun using "metalink" attributes instead of "url" elements, causing errors.
Fix this by using the "metalink" attribute for identifying repositories.

Fixes #10224

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

zypper_repository
