### PR TITLE
keycloak: add support for client_credentials authentication

### DIFF
--- a/changelogs/fragments/10231-keycloak-add-client-credentials-authentication.yml
+++ b/changelogs/fragments/10231-keycloak-add-client-credentials-authentication.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - keycloak - add support for `client_credentials` `grant_type` to all keycloak modules, so that specifying `auth_client_id` and `auth_client_secret` is sufficient for authentication
+  - keycloak - add support for ``grant_type=client_credentials`` to all keycloak modules, so that specifying ``auth_client_id`` and ``auth_client_secret`` is sufficient for authentication (https://github.com/ansible-collections/community.general/pull/10231).

--- a/changelogs/fragments/10231-keycloak-add-client-credentials-authentication.yml
+++ b/changelogs/fragments/10231-keycloak-add-client-credentials-authentication.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak - add support for `client_credentials` `grant_type` to all keycloak modules, so that specifying `auth_client_id` and `auth_client_secret` is sufficient for authentication

--- a/plugins/modules/keycloak_authentication.py
+++ b/plugins/modules/keycloak_authentication.py
@@ -360,8 +360,8 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_authentication_required_actions.py
+++ b/plugins/modules/keycloak_authentication_required_actions.py
@@ -237,8 +237,8 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password']]),
-        required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+        required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+        required_together=([['auth_username', 'auth_password']]),
         required_by={'refresh_token': 'auth_realm'},
     )
 

--- a/plugins/modules/keycloak_authz_authorization_scope.py
+++ b/plugins/modules/keycloak_authz_authorization_scope.py
@@ -153,8 +153,8 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
                            required_one_of=(
-                               [['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                               [['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_authz_custom_policy.py
+++ b/plugins/modules/keycloak_authz_custom_policy.py
@@ -139,8 +139,8 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
                            required_one_of=(
-                               [['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                               [['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_authz_permission.py
+++ b/plugins/modules/keycloak_authz_permission.py
@@ -253,8 +253,8 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
                            required_one_of=(
-                               [['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                               [['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_authz_permission_info.py
+++ b/plugins/modules/keycloak_authz_permission_info.py
@@ -134,8 +134,8 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
                            required_one_of=(
-                               [['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                               [['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -941,8 +941,8 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
                            required_one_of=([['client_id', 'id'],
-                                             ['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                                             ['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_client_rolemapping.py
+++ b/plugins/modules/keycloak_client_rolemapping.py
@@ -268,8 +268,8 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_clientscope.py
+++ b/plugins/modules/keycloak_clientscope.py
@@ -354,8 +354,8 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
                            required_one_of=([['id', 'name'],
-                                             ['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                                             ['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_clientscope_type.py
+++ b/plugins/modules/keycloak_clientscope_type.py
@@ -145,10 +145,10 @@ def keycloak_clientscope_type_module():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_one_of=([
-            ['token', 'auth_realm', 'auth_username', 'auth_password'],
+            ['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret'],
             ['default_clientscopes', 'optional_clientscopes']
         ]),
-        required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+        required_together=([['auth_username', 'auth_password']]),
         required_by={'refresh_token': 'auth_realm'},
         mutually_exclusive=[
             ['token', 'auth_realm'],

--- a/plugins/modules/keycloak_clienttemplate.py
+++ b/plugins/modules/keycloak_clienttemplate.py
@@ -296,8 +296,8 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
                            required_one_of=([['id', 'name'],
-                                             ['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                                             ['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_component.py
+++ b/plugins/modules/keycloak_component.py
@@ -155,7 +155,7 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secrect']]),
+                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
                            required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )

--- a/plugins/modules/keycloak_component.py
+++ b/plugins/modules/keycloak_component.py
@@ -155,8 +155,8 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secrect']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_group.py
+++ b/plugins/modules/keycloak_group.py
@@ -334,8 +334,8 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
                            required_one_of=([['id', 'name'],
-                                             ['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                                             ['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_identity_provider.py
+++ b/plugins/modules/keycloak_identity_provider.py
@@ -497,8 +497,8 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secred']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_identity_provider.py
+++ b/plugins/modules/keycloak_identity_provider.py
@@ -497,7 +497,7 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secred']]),
+                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
                            required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )

--- a/plugins/modules/keycloak_realm.py
+++ b/plugins/modules/keycloak_realm.py
@@ -705,8 +705,8 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
                            required_one_of=([['id', 'realm', 'enabled'],
-                                             ['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                                             ['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_realm_key.py
+++ b/plugins/modules/keycloak_realm_key.py
@@ -263,8 +263,8 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_realm_keys_metadata_info.py
+++ b/plugins/modules/keycloak_realm_keys_metadata_info.py
@@ -104,8 +104,8 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_one_of=([["token", "auth_realm", "auth_username", "auth_password"]]),
-        required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+        required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+        required_together=([['auth_username', 'auth_password']]),
         required_by={'refresh_token': 'auth_realm'},
     )
 

--- a/plugins/modules/keycloak_realm_rolemapping.py
+++ b/plugins/modules/keycloak_realm_rolemapping.py
@@ -252,8 +252,8 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_role.py
+++ b/plugins/modules/keycloak_role.py
@@ -247,8 +247,8 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -410,8 +410,8 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -838,8 +838,8 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
                            required_one_of=([['id', 'name'],
-                                             ['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                                             ['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_user_rolemapping.py
+++ b/plugins/modules/keycloak_user_rolemapping.py
@@ -242,9 +242,9 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password'],
+                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret'],
                                              ['uid', 'target_username', 'service_account_user_client_id']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/plugins/modules/keycloak_userprofile.py
+++ b/plugins/modules/keycloak_userprofile.py
@@ -533,8 +533,8 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']]),
+                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password', 'auth_client_id', 'auth_client_secret']]),
+                           required_together=([['auth_username', 'auth_password']]),
                            required_by={'refresh_token': 'auth_realm'},
                            )
 

--- a/tests/integration/targets/keycloak_modules_authentication/tasks/main.yml
+++ b/tests/integration/targets/keycloak_modules_authentication/tasks/main.yml
@@ -3,6 +3,19 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+- name: Reset public login in master admin-cli (if potentially previous test failed)
+  community.general.keycloak_client:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    auth_client_id: "admin-cli"
+    auth_client_secret: "{{ client_secret }}"
+    client_id: "admin-cli"
+    secret: "{{ client_secret }}"
+    public_client: true
+    state: present
+
 - name: Create realm
   community.general.keycloak_realm:
     auth_keycloak_url: "{{ url }}"
@@ -201,6 +214,89 @@
   debug:
     var: result
 
+- name: PREPARE - Temporarily disable public login in master admin-cli
+  community.general.keycloak_client:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    auth_client_id: "admin-cli"
+    auth_client_secret: "{{ client_secret }}"
+    client_id: "admin-cli"
+    secret: "{{ client_secret }}"
+    public_client: false
+    service_accounts_enabled: true
+    client_authenticator_type: "client-secret"
+    state: present
+
+- name: PREPARE - Get admin role id
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    auth_client_id: "admin-cli"
+    auth_client_secret: "{{ client_secret }}"
+    name: "admin"
+  register: admin_role
+
+- name: PREPARE - Assign admin role to admin-cli in master
+  community.general.keycloak_user_rolemapping:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    auth_client_id: "admin-cli"
+    auth_client_secret: "{{ client_secret }}"
+    realm: "master"
+    roles:
+      - name: "admin"
+    service_account_user_client_id: "admin-cli"
+
+- name: Create new realm role with valid client_id and client_secret
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_client_id: "admin-cli"
+    auth_client_secret: "{{ client_secret }}"
+    realm: "{{ realm }}"
+    name: "{{ role }}"
+    description: "{{ keycloak_role_description }}"
+    state: present
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Reset temporarily disabled public login in master admin-cli
+  community.general.keycloak_client:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    auth_client_id: "admin-cli"
+    auth_client_secret: "{{ client_secret }}"
+    client_id: "admin-cli"
+    secret: "{{ client_secret }}"
+    public_client: true
+    state: present
+
+- name: Remove created realm role
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: "{{ role }}"
+    state: absent
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
 ### Unhappy path tests
 
 - name: Fail to create new realm role with invalid username/password
@@ -215,7 +311,6 @@
     state: present
   register: result
   failed_when: >
-    (result.exception is not defined) or
     ("HTTP Error 401: Unauthorized" not in result.msg)
 
 - name: Fail to create new realm role with invalid auth token
@@ -228,7 +323,6 @@
     state: present
   register: result
   failed_when: >
-    (result.exception is not defined) or
     ("HTTP Error 401: Unauthorized" not in result.msg)
 
 - name: Fail to create new realm role with invalid auth and refresh tokens, and invalid username/password
@@ -245,5 +339,4 @@
     state: present
   register: result
   failed_when: >
-    (result.exception is not defined) or
     ("HTTP Error 401: Unauthorized" not in result.msg)

--- a/tests/integration/targets/keycloak_modules_authentication/vars/main.yml
+++ b/tests/integration/targets/keycloak_modules_authentication/vars/main.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-url: http://keycloak-test:8080/auth
+url: http://localhost:8080/auth
 admin_realm: master
 admin_user: admin
 admin_password: password

--- a/tests/integration/targets/keycloak_modules_authentication/vars/main.yml
+++ b/tests/integration/targets/keycloak_modules_authentication/vars/main.yml
@@ -3,12 +3,13 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-url: http://localhost:8080/auth
+url: http://keycloak-test:8080/auth
 admin_realm: master
 admin_user: admin
 admin_password: password
 realm: myrealm
 client_id: myclient
+client_secret: myclientsecret
 role: myrole
 
 keycloak_role_name: test


### PR DESCRIPTION
##### SUMMARY
Adds support for client_credentials authentication to all keycloak modules. Applying these changes allows authentication solely with `auth_client_id` and `auth_client_secret` to non-public keycloak realms, which is a common pattern for keycloak configurations in production environments.


Resolves:
- #9561
- #8829 
- #7469 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
keycloak

##### ADDITIONAL INFORMATION
A test case including preparation of keycloak with the appropriate configuration has been added in `tests/integration/targets/keycloak_modules_authentication/tasks/main.yml`.

In general, the keycloak modules did not at all support the `grant_type=client_credentials`, though it was written at different places in the documentation.

```
        'grant_type': 'client_credentials',
        'client_id': client_id,
        'client_secret': client_secret,
```

Reason is, that in most modules `auth_realm` is expected to be configured `together` with `auth_username` and `auth_password`. Furthermore, the `grant_type` was simply not supported in the `keycloak.py`. I now added missing functionality and updated all modules to ensure the feature is working everywhere.

Furthermore, I executed tests of all modules. Unfortunately, several tests are also not working without this PR, because of several reasons. I did not fix them as part of this PR. Working tests are also working with this PR included anyway.