### PR TITLE
docs: add notes that dnf_* modules do not work with dnf5

### DIFF
--- a/plugins/modules/dnf_config_manager.py
+++ b/plugins/modules/dnf_config_manager.py
@@ -40,7 +40,7 @@ options:
     type: str
     choices: [enabled, disabled]
 notes:
-  - Does not work with dnf5.
+  - Does not work with C(dnf5).
 seealso:
   - module: ansible.builtin.dnf
   - module: ansible.builtin.yum_repository

--- a/plugins/modules/dnf_config_manager.py
+++ b/plugins/modules/dnf_config_manager.py
@@ -39,6 +39,8 @@ options:
     required: false
     type: str
     choices: [enabled, disabled]
+notes:
+  - Does not work with dnf5.
 seealso:
   - module: ansible.builtin.dnf
   - module: ansible.builtin.yum_repository

--- a/plugins/modules/dnf_versionlock.py
+++ b/plugins/modules/dnf_versionlock.py
@@ -60,7 +60,7 @@ notes:
   - In an ideal world, the C(versionlock) plugin would have a dry-run option to know for sure what is going to happen. So
     far we have to work with a best guess as close as possible to the behaviour inferred from its code.
   - For most of cases where you want to lock and unlock specific versions of a package, this works fairly well.
-  - Does not work with dnf5.
+  - Does not work with C(dnf5).
 requirements:
   - dnf
   - dnf-plugin-versionlock

--- a/plugins/modules/dnf_versionlock.py
+++ b/plugins/modules/dnf_versionlock.py
@@ -60,6 +60,7 @@ notes:
   - In an ideal world, the C(versionlock) plugin would have a dry-run option to know for sure what is going to happen. So
     far we have to work with a best guess as close as possible to the behaviour inferred from its code.
   - For most of cases where you want to lock and unlock specific versions of a package, this works fairly well.
+  - Does not work with dnf5.
 requirements:
   - dnf
   - dnf-plugin-versionlock


### PR DESCRIPTION
##### SUMMARY
The dnf_* modules do not work with dnf5. Since it doesn't look like anyone is fixing them, let's note this in the docs.

Ref: #10237
Ref: #9127

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
dnf_config_manager
dnf_versionlock
