### PR TITLE
[stable-9] docs: add notes that dnf_* modules do not work with dnf5 (#10238)

### DIFF
--- a/plugins/modules/dnf_config_manager.py
+++ b/plugins/modules/dnf_config_manager.py
@@ -40,6 +40,8 @@ options:
     required: false
     type: str
     choices: [enabled, disabled]
+notes:
+  - Does not work with C(dnf5).
 seealso:
   - module: ansible.builtin.dnf
   - module: ansible.builtin.yum_repository

--- a/plugins/modules/dnf_versionlock.py
+++ b/plugins/modules/dnf_versionlock.py
@@ -74,6 +74,7 @@ notes:
     guess as close as possible to the behaviour inferred from its code.
   - For most of cases where you want to lock and unlock specific versions of a
     package, this works fairly well.
+  - Does not work with C(dnf5).
 requirements:
   - dnf
   - dnf-plugin-versionlock


### PR DESCRIPTION
##### SUMMARY
Backport of #10238 to stable-9.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
dnf_config_manager
dnf_versionlock
