### PR TITLE
Extra docs: normalize code block language

### DIFF
--- a/docs/docsite/rst/guide_vardict.rst
+++ b/docs/docsite/rst/guide_vardict.rst
@@ -51,7 +51,7 @@ And by the time the module is about to exit:
 
 That makes the return value of the module:
 
-.. code-block:: javascript
+.. code-block:: json
 
     {
         "abc": 123,


### PR DESCRIPTION
##### SUMMARY
This should be `json`, not `javascript`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/guide_vardict.rst
