### PR TITLE
Inventory plugins: remove deprecated disable_lookups parameter (which was set to its default anyway)

### DIFF
--- a/changelogs/fragments/10271--disable_lookups.yml
+++ b/changelogs/fragments/10271--disable_lookups.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "icinga2 inventory plugin - avoid using deprecated option when templating options (https://github.com/ansible-collections/community.general/pull/10271)."
+  - "linode inventory plugin - avoid using deprecated option when templating options (https://github.com/ansible-collections/community.general/pull/10271)."

--- a/plugins/inventory/icinga2.py
+++ b/plugins/inventory/icinga2.py
@@ -291,11 +291,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self.group_by_hostgroups = self.get_option('group_by_hostgroups')
 
         if self.templar.is_template(self.icinga2_url):
-            self.icinga2_url = self.templar.template(variable=self.icinga2_url, disable_lookups=False)
+            self.icinga2_url = self.templar.template(variable=self.icinga2_url)
         if self.templar.is_template(self.icinga2_user):
-            self.icinga2_user = self.templar.template(variable=self.icinga2_user, disable_lookups=False)
+            self.icinga2_user = self.templar.template(variable=self.icinga2_user)
         if self.templar.is_template(self.icinga2_password):
-            self.icinga2_password = self.templar.template(variable=self.icinga2_password, disable_lookups=False)
+            self.icinga2_password = self.templar.template(variable=self.icinga2_password)
 
         self.icinga2_url = f"{self.icinga2_url.rstrip('/')}/v1"
 

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -150,7 +150,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         access_token = self.get_option('access_token')
         if self.templar.is_template(access_token):
-            access_token = self.templar.template(variable=access_token, disable_lookups=False)
+            access_token = self.templar.template(variable=access_token)
 
         if access_token is None:
             raise AnsibleError((


### PR DESCRIPTION
##### SUMMARY
`Templar.template`'s parameter `disable_lookups` has been deprecated in ansible-core 2.19 (https://github.com/ansible/ansible/blob/34abc83822a4ee118cc813862ecdb8d2a6a1538b/lib/ansible/template/__init__.py#L273-L279). Inventory plugins have been using it (probably copied around from a common source), but they always set it to `False`, which happened to be the default since at least 2017 (I didn't bother to check back even more).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory plugins
