### PR TITLE
sysrc jail tests: FreeBSD 14.1 stopped working

### DIFF
--- a/tests/integration/targets/sysrc/tasks/main.yml
+++ b/tests/integration/targets/sysrc/tasks/main.yml
@@ -141,12 +141,12 @@
       #
       # NOTE: currently fails with FreeBSD 12 with minor version less than 4
       # NOTE: currently fails with FreeBSD 13 with minor version less than 4
-      # NOTE: currently fails with FreeBSD 14 with minor version less than 1
+      # NOTE: currently fails with FreeBSD 14 with minor version less than 2
       #
       when: >-
         ansible_distribution_version is version('12.4', '>=') and ansible_distribution_version is version('13', '<')
         or ansible_distribution_version is version('13.4', '>=') and ansible_distribution_version is version('14', '<')
-        or ansible_distribution_version is version('14.1', '>=')
+        or ansible_distribution_version is version('14.2', '>=')
       block:
         - name: Setup testjail
           include_tasks: setup-testjail.yml


### PR DESCRIPTION
##### SUMMARY
See for example https://dev.azure.com/ansible/community.general/_build/results?buildId=148985&view=logs&j=15b15ff5-e25d-5a85-feff-f9fd657743a6&t=f55d911f-2bf9-585b-8bc7-9e61a21207bc&l=6316.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
sysrc
