### PR TITLE
CI: Add yamllint for YAML files, plugin/module docs, and YAML in extra docs

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,52 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+extends: default
+
+ignore: |
+  /changelogs/
+
+rules:
+  line-length:
+    max: 1000
+    level: error
+  document-start: disable
+  document-end: disable
+  truthy:
+    level: error
+    allowed-values:
+      - 'true'
+      - 'false'
+  indentation:
+    spaces: 2
+    indent-sequences: true
+  key-duplicates: enable
+  trailing-spaces: enable
+  new-line-at-end-of-file: disable
+  hyphens:
+    max-spaces-after: 1
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 0
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -14,6 +14,17 @@
 
 [sessions]
 
+[sessions.lint]
+run_isort = false
+run_black = false
+run_flake8 = false
+run_pylint = false
+run_yamllint = true
+yamllint_config = ".yamllint"
+# yamllint_config_plugins = ".yamllint-docs"
+# yamllint_config_plugins_examples = ".yamllint-examples"
+run_mypy = false
+
 [sessions.docs_check]
 validate_collection_refs="all"
 


### PR DESCRIPTION
##### SUMMARY
This adds a basic yamllint config together with antsibull-nox configuration to use it for various places where YAML appears.

antsibull-nox allows to configure different yamllint configs for different contexts (YAML files, plugin/module docs, plugin/module examples, extra docs), for now I'd suggest to use the same "generic" (and not too strict) one for everything.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
