### PR TITLE
CI: add checks for code block types in extra docs

### DIFF
--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -19,11 +19,13 @@ validate_collection_refs="all"
 codeblocks_restrict_types = [
     "ansible-output",
     "console",
+    "ini",
     "json",
     "python",
     "shell",
     "yaml",
     "yaml+jinja",
+    "text",
 ]
 codeblocks_restrict_type_exact_case = true
 codeblocks_allow_without_type = false

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -16,6 +16,18 @@
 
 [sessions.docs_check]
 validate_collection_refs="all"
+codeblocks_restrict_types = [
+    "ansible-output",
+    "console",
+    "json",
+    "python",
+    "shell",
+    "yaml",
+    "yaml+jinja",
+]
+codeblocks_restrict_type_exact_case = true
+codeblocks_allow_without_type = false
+codeblocks_allow_literal_blocks = false
 
 [sessions.license_check]
 


### PR DESCRIPTION
##### SUMMARY
antsibull-nox allows to validate code block languages. This ensures that we stick to a certain set of languages (which can always be updated if we need more). Also the config disallows code blocks without languages, and the usage of `::` (which can cause problems with rstcheck, and can result in random formatting since the syntax highlighting for these is configured on a global level).

##### ISSUE TYPE
- Docs Pull Request
- Test Pull Request

##### COMPONENT NAME
CI
