### PR TITLE
Docs: use :anscollection:

### DIFF
--- a/docs/docsite/rst/filter_guide.rst
+++ b/docs/docsite/rst/filter_guide.rst
@@ -8,7 +8,7 @@
 community.general Filter Guide
 ==============================
 
-The :ref:`community.general collection <plugins_in_community.general>` offers several useful filter plugins.
+The :anscollection:`community.general collection <community.general#collection>` offers several useful filter plugins.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/docsite/rst/test_guide.rst
+++ b/docs/docsite/rst/test_guide.rst
@@ -8,7 +8,7 @@
 community.general Test (Plugin) Guide
 =====================================
 
-The :ref:`community.general collection <plugins_in_community.general>` offers currently one test plugin.
+The :anscollection:`community.general collection <community.general#collection>` offers currently one test plugin.
 
 .. contents:: Topics
 


### PR DESCRIPTION
##### SUMMARY
antsibull-docs 2.18.0 has a new role: `:anscollection:`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
extra docs
