### PR TITLE
[keycloak] fix call of non-existent method in backported code

### DIFF
--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -2236,14 +2236,17 @@ class KeycloakAPI(object):
         """
         try:
             # Send a DELETE request to remove the specified authentication config from the Keycloak server.
-            self._request(
+            open_url(
                 URL_AUTHENTICATION_CONFIG.format(
                     url=self.baseurl,
                     realm=realm,
                     id=configId),
-                method='DELETE')
+                method='DELETE',
+                http_agent=self.http_agent, headers=self.restheaders,
+                timeout=self.connection_timeout,
+                validate_certs=self.validate_certs)
         except Exception as e:
-            self.fail_request(e, msg="Unable to delete authentication config %s: %s" % (configId, str(e)))
+            self.fail_open_url(e, msg="Unable to delete authentication config %s: %s" % (configId, str(e)))
 
     def create_subflow(self, subflowName, flowAlias, realm='master', flowType='basic-flow'):
         """ Create new sublow on the flow


### PR DESCRIPTION
##### SUMMARY
Commit 8b1a193a backported into stable-9 contains calls to `_request` and `_fail_request` methods which were created as part of api calls refactoring in main/stable-10 but does not exist in stable-9.

This commit replaces the calls with the previous implementation (open_url method).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
keycloak_authentication

##### ADDITIONAL INFORMATION

none
