### PR TITLE
fix typo in ipa_dnsrecord module examples

### DIFF
--- a/plugins/modules/ipa_dnsrecord.py
+++ b/plugins/modules/ipa_dnsrecord.py
@@ -167,7 +167,7 @@ EXAMPLES = r"""
     state: absent
 
 - name: Ensure an NS record for a subdomain is present
-  community,general.ipa_dnsrecord:
+  community.general.ipa_dnsrecord:
     name: subdomain
     zone_name: example.com
     record_type: 'NS'


### PR DESCRIPTION
Simple comma instead of a period, easy mistake.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Very simple typo correction in the module documentation, no changes to features nor functions.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
ipa_dnsrecord

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
