### PR TITLE
Fix issue #10299

### DIFF
--- a/changelogs/fragments/10299-github_app_access_token-lookup.yml
+++ b/changelogs/fragments/10299-github_app_access_token-lookup.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - github_app_access_token lookup plugin - avoid using jwt library requirement that conflicts with other modules requirements (https://github.com/ansible-collections/community.general/issues/10299)
+breaking_changes:
+  - github_app_access_token lookup plugin - depends now on pyjwt rather than jwt (https://github.com/ansible-collections/community.general/issues/10299)


### PR DESCRIPTION
##### SUMMARY
Change community.general.github_app_access_token lookup to use PyJWT (https://pypi.org/project/PyJWT/) rather than jwt (https://github.com/GehirnInc/python-jwt). 

Fixes #10299 
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
github_app_access_token

##### ADDITIONAL INFORMATION
Change the implementation to use pyjwt, rather than  jwt that causes conflits elsewhere in the Ansible ecosystem.
