### PR TITLE
Configure LUKS encrypted volume using crypttab

### DIFF
--- a/plugins/modules/crypttab.py
+++ b/plugins/modules/crypttab.py
@@ -73,6 +73,14 @@ EXAMPLES = r"""
     opts: discard
   loop: '{{ ansible_mounts }}'
   when: "'/dev/mapper/luks-' in item.device"
+
+- name: Add entry to /etc/crypttab for luks-home with password file
+  community.general.crypttab:
+        name: luks-home
+        backing_device: UUID=123e4567-e89b-12d3-a456-426614174000
+        password: /root/keys/luks-home.key
+        opts: discard,cipher=aes-cbc-essiv:sha256
+        state: present
 """
 
 import os


### PR DESCRIPTION
##### SUMMARY
Adds a crypttab entry for the `luks-home` encrypted volume using the `community.general.crypttab` module.  
This ensures the device is configured to auto-decrypt at boot using a provided password file, with options like `discard` and AES ciphering enabled.


##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
crypttab (community.general)

