### PR TITLE
flatpak: add docs example for install using custom executable path

### DIFF
--- a/plugins/modules/flatpak.py
+++ b/plugins/modules/flatpak.py
@@ -107,6 +107,12 @@ EXAMPLES = r"""
     state: present
     remote: gnome
 
+- name: Install GIMP using custom flatpak binary path
+  community.general.flatpak:
+    name: org.gimp.GIMP
+    state: present
+    executable: /usr/local/bin/flatpak-dev
+
 - name: Install multiple packages
   community.general.flatpak:
     name:


### PR DESCRIPTION
##### SUMMARY
- Adds a new usage for the `community.general.flatpak` module demonstrating the `executable` parameter, which allows users to specify a custom path to the `flatpak` binary.
- This can be useful in development or testing environments where the system binary is overridden or unavailable.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
flatpak (community.general)

