### PR TITLE
lvg: add docs example for preserving existing PVs in a volume group using `remove_extra_pvs: false`

### DIFF
--- a/plugins/modules/lvg.py
+++ b/plugins/modules/lvg.py
@@ -146,6 +146,13 @@ EXAMPLES = r"""
     state: active
     vg: vg.services
 
+- name: Add new PVs to volume group without removing existing ones
+  community.general.lvg:
+    vg: vg.services
+    pvs: /dev/sdb1,/dev/sdc1
+    remove_extra_pvs: false
+    state: present
+
 - name: Reset a volume group UUID
   community.general.lvg:
     state: inactive


### PR DESCRIPTION
##### SUMMARY
-  `community.general.lvg` module demonstrating the use of `remove_extra_pvs: false`.

- how to safely add new physical volumes (PVs) to an existing volume group (VG) without removing previously added PVs. 

##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
lvg (community.general)

