### PR TITLE
Using add_keys_to_agent in ssh_config module

### DIFF
--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -162,6 +162,16 @@ EXAMPLES = r"""
     other_options:
       serveraliveinterval: '30'
 
+- name: Add SSH config with key auto-added to agent
+  community.general.ssh_config:
+    user: devops
+    host: "example.com"
+    hostname: "staging.example.com"
+    identity_file: "/home/devops/.ssh/id_rsa"
+    add_keys_to_agent: true
+    state: present
+
+
 - name: Delete a host from the configuration
   community.general.ssh_config:
     ssh_config_file: "{{ ssh_config_test }}"


### PR DESCRIPTION
##### SUMMARY
- Usage of  add_keys_to_agent parameter in the community.general.ssh_config module. 
- This parameter, introduced in version 8.2.0, was previously undocumented  


##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
community.general.ssh_config
