### PR TITLE
Add tasks_only callback

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -92,6 +92,8 @@ files:
     maintainers: ryancurrah
   $callbacks/syslog_json.py:
     maintainers: imjoseangel
+  $callbacks/tasks_only.py:
+    maintainers: felixfontein
   $callbacks/timestamp.py:
     maintainers: kurokobo
   $callbacks/unixy.py:

--- a/plugins/callback/tasks_only.py
+++ b/plugins/callback/tasks_only.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2025, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+DOCUMENTATION = r"""
+author: Felix Fontein (@felixfontein)
+name: tasks_only
+type: stdout
+version_added: 11.1.0
+short_description: Only show tasks
+description:
+  - Removes play start and stats marker from P(ansible.builtin.default#callback)'s output.
+  - Can be used to generate output for documentation examples.
+    For this, the O(column_width) option should be set to an explicit value.
+extends_documentation_fragment:
+  - default_callback
+options:
+  column_width:
+    description:
+      - Sets the column width for Ansible's display.
+    type: int
+    env:
+      - name: ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH
+"""
+
+EXAMPLES = r"""
+# Enable callback in ansible.cfg:
+ansible_config: |-
+  [defaults]
+  stdout_callback = community.general.tasks_only
+
+# Enable callback with environment variables:
+environment_variable: |-
+  ANSIBLE_STDOUT_CALLBACK=community.general.tasks_only
+"""
+
+from ansible.plugins.callback.default import CallbackModule as Default
+
+
+class CallbackModule(Default):
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'community.general.tasks_only'
+
+    def v2_playbook_on_play_start(self, play):
+        pass
+
+    def v2_playbook_on_stats(self, stats):
+        pass
+
+    def set_options(self, *args, **kwargs):
+        result = super(CallbackModule, self).set_options(*args, **kwargs)
+        self.column_width = self.get_option("column_width")
+        if self.column_width is not None:
+            self._display.columns = self.column_width
+        return result

--- a/tests/integration/targets/callback_tasks_only/aliases
+++ b/tests/integration/targets/callback_tasks_only/aliases
@@ -1,0 +1,6 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+azp/posix/3
+needs/target/callback

--- a/tests/integration/targets/callback_tasks_only/tasks/main.yml
+++ b/tests/integration/targets/callback_tasks_only/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- block:
+    - name: Create temporary file
+      tempfile:
+      register: tempfile
+
+    - name: Run tests
+      include_role:
+        name: callback
+      vars:
+        tests:
+          - name: Basic file diff
+            environment:
+              ANSIBLE_NOCOLOR: 'true'
+              ANSIBLE_FORCE_COLOR: 'false'
+              ANSIBLE_PYTHON_INTERPRETER: "{{ ansible_python_interpreter }}"
+              ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
+            playbook: |
+              - hosts: testhost
+                gather_facts: true
+                tasks:
+                  - name: Create file
+                    copy:
+                      dest: "{{ tempfile.path }}"
+                      content: |
+                        Foo bar
+
+                  - name: Modify file
+                    copy:
+                      dest: "{{ tempfile.path }}"
+                      content: |
+                        Foo bar
+                        Bar baz bam!
+            expected_output:
+              - ""
+              - "TASK [Gathering Facts] *********************************************************"
+              - "ok: [testhost]"
+              - ""
+              - "TASK [Create file] *************************************************************"
+              - "changed: [testhost]"
+              - ""
+              - "TASK [Modify file] *************************************************************"
+              - "changed: [testhost]"
+
+  always:
+    - name: Clean up temp file
+      file:
+        path: "{{ tempfile.path }}"
+        state: absent


### PR DESCRIPTION
##### SUMMARY
Adds a new callback plugin, `community.general.tasks_only`, which removes the play and recap sections from the default output.

This is useful when generating output for documentation.

I'm currently working on a tool that allows to render Ansible output directly into RST docs. For example, adding
```diff
--- a/docs/docsite/rst/filter_guide_working_with_versions.rst
+++ b/docs/docsite/rst/filter_guide_working_with_versions.rst
@@ -23,6 +23,26 @@ If you need to sort a list of version numbers, the Jinja ``sort`` filter is prob
 
 This produces:
 
+.. ansible-output-data::
+
+    env:
+      ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
+      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "90"
+    playbook: |-
+      - hosts: localhost
+        gather_facts: false
+        tasks:
+          - name: Sort list by version number
+            debug:
+              var: ansible_versions | community.general.version_sort
+            vars:
+              ansible_versions:
+                - '2.8.0'
+                - '2.11.0'
+                - '2.7.0'
+                - '2.10.0'
+                - '2.9.0'
+
 .. code-block:: ansible-output
 
     TASK [Sort list by version number] ********************************************************
```
to this collection allows the tool to re-generate the playbook output below that added directive automatically. Using the `community.general.tasks_only` callback and explicitly setting the number of columns (supported by this callback) allow to generate the expected task only, instead of also having to include play header and stats section, or having to manually edit the result.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
tasks_only callback
