### PR TITLE
dependent lookup: avoid deprecated ansible-core 2.19 functionality

### DIFF
--- a/changelogs/fragments/10359-dependent.yml
+++ b/changelogs/fragments/10359-dependent.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "dependent lookup plugin - avoid deprecated ansible-core 2.19 functionality (https://github.com/ansible-collections/community.general/pull/10359)."

--- a/plugins/lookup/dependent.py
+++ b/plugins/lookup/dependent.py
@@ -197,7 +197,10 @@ class LookupModule(LookupBase):
 
         result = []
         if len(terms) > 0:
-            templar = Templar(loader=self._templar._loader)
+            if HAS_DATATAGGING:
+                templar = self._templar.copy_with_new_env(available_variables={})
+            else:
+                templar = Templar(loader=self._templar._loader)
             data = []
             vars_so_far = set()
             for index, term in enumerate(terms):

--- a/tests/unit/plugins/lookup/test_dependent.py
+++ b/tests/unit/plugins/lookup/test_dependent.py
@@ -9,10 +9,9 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
+from ansible.template import Templar
+
 from ansible_collections.community.internal_test_tools.tests.unit.compat.unittest import TestCase
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
-    MagicMock,
-)
 from ansible_collections.community.internal_test_tools.tests.unit.utils.trust import make_trusted
 
 from ansible.plugins.loader import lookup_loader
@@ -20,8 +19,7 @@ from ansible.plugins.loader import lookup_loader
 
 class TestLookupModule(TestCase):
     def setUp(self):
-        templar = MagicMock()
-        templar._loader = None
+        templar = Templar(loader=None)
         self.lookup = lookup_loader.get("community.general.dependent", templar=templar)
 
     def test_empty(self):


### PR DESCRIPTION
##### SUMMARY
Randomly found this when running some playbook...

Ref: https://github.com/ansible/ansible/issues/85436

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
dependent lookup plugin
