### PR TITLE
community.general.easy_install :  use of the virtualenv_command parameter

### DIFF
--- a/plugins/modules/easy_install.py
+++ b/plugins/modules/easy_install.py
@@ -74,6 +74,12 @@ EXAMPLES = r"""
   community.general.easy_install:
     name: bottle
     virtualenv: /webapps/myapp/venv
+    
+- name: Install requests using pyvenv as the virtualenv tool
+  community.general.easy_install:
+    name: requests
+    virtualenv: /opt/myenv
+    virtualenv_command: pyvenv
 """
 
 import os

--- a/plugins/modules/easy_install.py
+++ b/plugins/modules/easy_install.py
@@ -74,10 +74,10 @@ EXAMPLES = r"""
   community.general.easy_install:
     name: bottle
     virtualenv: /webapps/myapp/venv
-    
-- name: Install requests using pyvenv as the virtualenv tool
+
+- name: Install a python package using pyvenv as the virtualenv tool
   community.general.easy_install:
-    name: requests
+    name: package_name
     virtualenv: /opt/myenv
     virtualenv_command: pyvenv
 """


### PR DESCRIPTION
##### SUMMARY
- Adds a new task demonstrating usage of the `virtualenv_command` parameter in the `community.general.easy_install` module.  
- This task installs a Python library into a virtual environment using `pyvenv` instead of the default `virtualenv` tool.  

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`community.general.easy_install` 
