### PR TITLE
pacemaker_cluster: deprecate cleanup state

### DIFF
--- a/plugins/modules/pacemaker_cluster.py
+++ b/plugins/modules/pacemaker_cluster.py
@@ -99,6 +99,13 @@ class PacemakerCluster(StateModuleHelper):
         self.vars.set('previous_value', self._get()['out'])
         self.vars.set('value', self.vars.previous_value, change=True, diff=True)
 
+        if self.module.params['state'] == "cleanup":
+            self.module.deprecate(
+                'The value `cleanup` for "state" is being deprecated',
+                version='12.0.0',
+                collection_name='community.general'
+            )
+
         if not self.module.params['state']:
             self.module.deprecate(
                 'Parameter "state" values not set is being deprecated. Make sure to provide a value for "state"',

--- a/plugins/modules/pacemaker_resource.py
+++ b/plugins/modules/pacemaker_resource.py
@@ -27,13 +27,14 @@ options:
   state:
     description:
       - Indicate desired state for cluster resource.
-    choices: [present, absent, enabled, disabled]
-    default: present
+      - The state V(cleanup) has been added in community.general 12.0.0.
+    choices: [present, absent, enabled, disabled, cleanup]
+    required: true
     type: str
   name:
     description:
       - Specify the resource name to create.
-    required: true
+      - This is required if O(state=present), O(state=absent), O(state=enabled), or O(state=disabled).
     type: str
   resource_type:
     description:
@@ -140,9 +141,9 @@ from ansible_collections.community.general.plugins.module_utils.pacemaker import
 class PacemakerResource(StateModuleHelper):
     module = dict(
         argument_spec=dict(
-            state=dict(type='str', default='present', choices=[
-                'present', 'absent', 'enabled', 'disabled']),
-            name=dict(type='str', required=True),
+            state=dict(type='str', required=True, choices=[
+                'present', 'absent', 'enabled', 'disabled', 'cleanup']),
+            name=dict(type='str'),
             resource_type=dict(type='dict', options=dict(
                 resource_name=dict(type='str'),
                 resource_standard=dict(type='str'),
@@ -160,7 +161,13 @@ class PacemakerResource(StateModuleHelper):
             )),
             wait=dict(type='int', default=300),
         ),
-        required_if=[('state', 'present', ['resource_type', 'resource_option'])],
+        required_if=[
+            ('state', 'present', ['resource_type', 'resource_option', 'name']),
+            ('state', 'absent', ['name']),
+            ('state', 'enabled', ['name']),
+            ('state', 'disabled', ['name']),
+            ('state', ['present', 'absent', 'enabled', 'disabled'], ['name']),
+        ],
         supports_check_mode=True,
     )
 
@@ -206,6 +213,13 @@ class PacemakerResource(StateModuleHelper):
 
     def state_disabled(self):
         with self.runner('cli_action state name', output_process=self._process_command_output(True, "Stopped"), check_mode_skip=True) as ctx:
+            ctx.run(cli_action='resource')
+
+    def state_cleanup(self):
+        runner_args = ['cli_action', 'state']
+        if self.module.params['name']:
+            runner_args.append('name')
+        with self.runner(runner_args, output_process=self._process_command_output(True, "Clean"), check_mode_skip=True) as ctx:
             ctx.run(cli_action='resource')
 
 

--- a/tests/unit/plugins/modules/test_pacemaker_resource.yaml
+++ b/tests/unit/plugins/modules/test_pacemaker_resource.yaml
@@ -11,7 +11,7 @@ test_cases:
     input: {}
     output:
       failed: true
-      msg: "missing required arguments: name"
+      msg: "missing required arguments: state"
   - id: test_present_minimal_input_resource_not_exist
     input:
       state: present
@@ -380,4 +380,77 @@ test_cases:
           environ: *env-def
           rc: 0
           out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Stopped (disabled)"
+          err: ""
+  - id: test_cleanup_minimal_input_initial_resources_not_exist
+    input:
+      state: cleanup
+    output:
+      changed: false
+      previous_value: "NO resources configured"
+      value: "NO resources configured"
+    mocks:
+      run_command:
+        - command: [/testbin/pcs, resource, status]
+          environ: *env-def
+          rc: 0
+          out: "NO resources configured"
+          err: ""
+        - command: [/testbin/pcs, resource, cleanup]
+          environ: *env-def
+          rc: 0
+          out: "Cleaned up all resources on all nodes"
+          err: ""
+        - command: [/testbin/pcs, resource, status]
+          environ: *env-def
+          rc: 0
+          out: "NO resources configured"
+          err: ""
+  - id: test_cleanup_minimal_input_initial_resources_exists
+    input:
+      state: cleanup
+    output:
+      changed: true
+      previous_value: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
+      value: "NO resources configured"
+    mocks:
+      run_command:
+        - command: [/testbin/pcs, resource, status]
+          environ: *env-def
+          rc: 0
+          out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
+          err: ""
+        - command: [/testbin/pcs, resource, cleanup]
+          environ: *env-def
+          rc: 0
+          out: "Cleaned up all resources on all nodes"
+          err: ""
+        - command: [/testbin/pcs, resource, status]
+          environ: *env-def
+          rc: 0
+          out: "NO resources configured"
+          err: ""
+  - id: test_cleanup_specific_minimal_input_initial_resources_exists
+    input:
+      state: cleanup
+      name: virtual-ip
+    output:
+      changed: true
+      previous_value: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
+      value: "NO resources configured"
+    mocks:
+      run_command:
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
+          err: ""
+        - command: [/testbin/pcs, resource, cleanup, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: "Cleaned up virtual-ip on X"
+          err: ""
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: "NO resources configured"
           err: ""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `pacemaker_cluster` module currently has a `state=cleanup` which would be more appropriate for the `pacemaker_resource` module.
* Add deprecation for `state=cleanup` for `pacemaker_cluster`
* Add `state=cleanup` for `pacemaker_resource`
* `pacemaker_resource` parameter for `name` is no longer required as input for certain states (`O(state=cleanup`)
* `pacemaker_resource` parameter for `state` is required as input

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
`pacemaker_resource`
`pacemaker_cluster`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
