### PR TITLE
tasks_only callback: add result_format_callback docs fragment

### DIFF
--- a/changelogs/fragments/10422-tasks_only-result_format.yml
+++ b/changelogs/fragments/10422-tasks_only-result_format.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "tasks_only callback plugin - add ``result_format`` and ``pretty_results`` options similarly to the default callback (https://github.com/ansible-collections/community.general/pull/10422)."

--- a/plugins/callback/tasks_only.py
+++ b/plugins/callback/tasks_only.py
@@ -17,7 +17,8 @@ description:
   - Can be used to generate output for documentation examples.
     For this, the O(number_of_columns) option should be set to an explicit value.
 extends_documentation_fragment:
-  - default_callback
+  - ansible.builtin.default_callback
+  - ansible.builtin.result_format_callback
 options:
   number_of_columns:
     description:
@@ -25,6 +26,12 @@ options:
     type: int
     env:
       - name: ANSIBLE_COLLECTIONS_TASKS_ONLY_NUMBER_OF_COLUMNS
+  result_format:
+    # Part of the ansible.builtin.result_format_callback doc fragment
+    version_added: 11.2.0
+  pretty_results:
+    # Part of the ansible.builtin.result_format_callback doc fragment
+    version_added: 11.2.0
 """
 
 EXAMPLES = r"""


### PR DESCRIPTION
##### SUMMARY
This allows to configure the output format (YAML vs. JSON) and whether to pretty-format the output (relevant for JSON).

Basically enables these features from ansible-core...

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
tasks_only callback
