### PR TITLE
apache2_module: updated cgi action conditions

### DIFF
--- a/changelogs/fragments/10423-apache_module-condition.yml
+++ b/changelogs/fragments/10423-apache_module-condition.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - apache2_module - check the cgi module restrictions only during activation (https://github.com/ansible-collections/community.general/pull/10423)
+  - apache2_module - check the ``cgi`` module restrictions only during activation (https://github.com/ansible-collections/community.general/pull/10423).

--- a/changelogs/fragments/10423-apache_module-condition.yml
+++ b/changelogs/fragments/10423-apache_module-condition.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apache2_module - check the cgi module restrictions only during activation (https://github.com/ansible-collections/community.general/pull/10423)

--- a/plugins/modules/apache2_module.py
+++ b/plugins/modules/apache2_module.py
@@ -258,8 +258,8 @@ def main():
     )
 
     name = module.params['name']
-    if name == 'cgi' and _run_threaded(module):
-        module.fail_json(msg="Your MPM seems to be threaded. No automatic actions on module cgi possible.")
+    if name == 'cgi' and module.params['state'] == 'present' and _run_threaded(module):
+        module.fail_json(msg="Your MPM seems to be threaded, therefore enabling cgi module is not allowed.")
 
     if not module.params['identifier']:
         module.params['identifier'] = create_apache_identifier(module.params['name'])


### PR DESCRIPTION
Only the activation of the cgi module in threaded mode should be a restriction due to apache2 limitations, not the deactivation. Especially when the cgi module isn't enabled yet at all.

* bug(fix): apache2_module fails to disable cgi module

##### SUMMARY

Trying to disable the cgi module while running in mpm_event module will result in a failure, even when cgi module is already disabled.

Disabling the `cgi` module with `community.general.apache2_module` will fail with the error message `Your MPM seems to be threaded. No automatic actions on module cgi possible.`. Doing the same on the commandline with `a2dismod cgi` will result with the correct messaage `cgi is already disabled`.

Fixes #9140

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

community.general.apache2_module

##### ADDITIONAL INFORMATION

Steps to reproduce and discussion
* https://github.com/ansible-collections/community.general/issues/9140#issuecomment-3056179126