### PR TITLE
dconf: add feature to populate a subpath from file

### DIFF
--- a/changelogs/fragments/10432-dconf-load-subpath.yml
+++ b/changelogs/fragments/10432-dconf-load-subpath.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - dconf - adds support of `load` to populate a subpath from file  
+  - dconf - adds support of `load` to populate a subpath from file

--- a/changelogs/fragments/10432-dconf-load-subpath.yml
+++ b/changelogs/fragments/10432-dconf-load-subpath.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - dconf - adds support of `load` to populate a subpath from file
+  - dconf - adds support of ``load`` to populate a subpath from file (https://github.com/ansible-collections/community.general/pull/10432).

--- a/changelogs/fragments/10432-dconf-load-subpath.yml
+++ b/changelogs/fragments/10432-dconf-load-subpath.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - dconf - adds support of `load` to populate a subpath from file  

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -440,7 +440,7 @@ class DconfPreference(object):
         except IOError as ex:
             self.module.fail_json(msg='Failed while reading configuration file %s with error: %s' % (path, ex))
 
-        # Parse configuratoin file
+        # Parse configuration file
         config = ConfigParser()
         try:
             config.read_string(raw_config)

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -444,11 +444,11 @@ class DconfPreference(object):
         changed = any(
             not self.variants_are_equal(self.read("%s%s/%s" % (root_dir, sub_dir, k)), v)
             for sub_dir in config.sections()
-                for k, v in config[sub_dir].items()
+            for k, v in config[sub_dir].items()
         )
 
         if self.check_mode or not changed:
-            return changed 
+            return changed
 
         # Set-up command to run. Since DBus is needed for write operation, wrap
         # dconf command dbus-launch.
@@ -460,10 +460,11 @@ class DconfPreference(object):
 
         if rc != 0:
             self.module.fail_json(msg='dconf failed while load config %s, root dir %s with error: %s' % (path, root_dir, err),
-                                        out=out,
-                                        err=err)
+                                  out=out,
+                                  err=err)
         # Value was changed.
-        return changed 
+        return changed
+
 
 def main():
     # Setup the Ansible module

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -438,7 +438,7 @@ class DconfPreference(object):
             with open(path, 'r') as fd:
                 raw_config = fd.read()
         except IOError as ex:
-            self.module.fail_json(msg='dconf failed while reading configuration file with error: %s' % ex)
+            self.module.fail_json(msg='Failed while reading configuration file %s with error: %s' % (path, ex))
 
         # Parse configuratoin file
         config = ConfigParser()

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -445,7 +445,7 @@ class DconfPreference(object):
         try:
             config.read_string(raw_config)
         except Exception as e:
-            self.module.fail_json(msg='dconf failed while reading config with error: %s' % e)
+            self.module.fail_json(msg='Failed while parsing config with error: %s' % e)
 
         # For each sub-directory, check if at least one change is needed
         changed = any(

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -480,8 +480,8 @@ def main():
             state=dict(default='present', choices=['present', 'absent', 'read']),
             key=dict(required=True, type='str', no_log=False),
             # Converted to str below after special handling of bool.
-            value=dict(required=False, default=None, type='raw'),
-            path=dict(required=False, default=None, type='path'),
+            value=dict(type='raw'),
+            path=dict(type='path'),
         ),
         supports_check_mode=True,
         required_if=[

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -481,6 +481,9 @@ def main():
             ('state', 'present', ['value']),
             ('state', 'load', ['path']),
         ],
+        mutually_exclusive=[
+            ['value', 'path']
+        ],
     )
 
     if Variant is None:

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -440,7 +440,7 @@ class DconfPreference(object):
         except Exception as e:
             self.module.fail_json(msg='dconf failed while reading config with error: %s' % e)
 
-        # For each sub-directory, check if at least on change is needed
+        # For each sub-directory, check if at least one change is needed
         changed = any(
             not self.variants_are_equal(self.read("%s%s/%s" % (root_dir, sub_dir, k)), v)
             for sub_dir in config.sections()

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -66,7 +66,7 @@ options:
         particular are handled properly even when specified as booleans rather than strings (in fact, handling booleans properly
         is why the type of this parameter is "raw").
   path:
-    type: str
+    type: path
     required: false
     description:
       - Remote path to the configuration to apply.

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -437,7 +437,7 @@ class DconfPreference(object):
         try:
             with open(path, 'r') as fd:
                 raw_config = fd.read()
-        except FileNotFoundError as ex:
+        except IOError as ex:
             self.module.fail_json(msg='dconf failed while reading configuration file with error: %s' % ex)
 
         # Parse configuratoin file

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -488,7 +488,7 @@ def main():
             ('state', 'present', ['value', 'path'], True),
         ],
         mutually_exclusive=[
-            ['value', 'path']
+            ['value', 'path'],
         ],
     )
 

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -141,7 +141,7 @@ EXAMPLES = r"""
 import os
 import sys
 
-from configparser import ConfigParser
+from ansible.module_utils.six.moves.configparser import ConfigParser
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.respawn import (

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -61,7 +61,7 @@ options:
     description:
       - Value to set for the specified dconf key. Value should be specified in GVariant format. Due to complexity of this
         format, it is best to have a look at existing values in the dconf database.
-      - Required for O(state=present). If provided, O(path) is not required.
+      - One of O(value) and O(path) are required for O(state=present).
       - Although the type is specified as "raw", it should typically be specified as a string. However, boolean values in
         particular are handled properly even when specified as booleans rather than strings (in fact, handling booleans properly
         is why the type of this parameter is "raw").

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -67,7 +67,6 @@ options:
         is why the type of this parameter is "raw").
   path:
     type: path
-    required: false
     description:
       - Remote path to the configuration to apply.
       - One of O(value) and O(path) are required for O(state=present).
@@ -557,12 +556,6 @@ def main():
             # Use 'dconf write' to modify the key
             changed = dconf.write(module.params['key'], module.params['value'])
             module.exit_json(changed=changed)
-        else:
-            # NOTE: This case shouldn't happen yet as 'key' and 'path' are
-            #       required with 'state=present'
-            # TODO: if 'key' ends with '/' then 'dconf list' should be used
-            #       else, 'dconf read'
-            module.fail_json(msg="'key' or 'path' must be defined.")
     elif module.params['state'] == 'absent':
         changed = dconf.reset(module.params['key'])
         module.exit_json(changed=changed)

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -70,7 +70,7 @@ options:
     required: false
     description:
       - Remote path to the configuration to apply.
-      - Required for O(state=present). If provided, O(value) is not required.
+      - One of O(value) and O(path) are required for O(state=present).
 
   state:
     type: str

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -421,6 +421,13 @@ class DconfPreference(object):
 
         :returns: bool -- True if a change was made, False if no change was required.
         """
+        def _create_dconf_key(root, sub_dir, key):
+            # Root should end with '/'
+            if sub_dir == "/":
+                # No sub directory
+                return "%s%s" % (root, key)
+            return "%s%s/%s" % (root, sub_dir, key)
+
         # Ensure key refers to a directory, as required by dconf
         root_dir = key
         if not root_dir.endswith('/'):
@@ -442,7 +449,7 @@ class DconfPreference(object):
 
         # For each sub-directory, check if at least one change is needed
         changed = any(
-            not self.variants_are_equal(self.read("%s%s/%s" % (root_dir, sub_dir, k)), v)
+            not self.variants_are_equal(self.read(_create_dconf_key(root_dir, sub_dir, k)), v)
             for sub_dir in config.sections()
             for k, v in config[sub_dir].items()
         )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This merge request allows to populate a subpath from file by using `load` sub-command of the `dconf` binary. Below the changes that were made:
- `state: load` has been added to address the feature
- `path` is a new option working with the feature. It points to a file located in node which contains a subpath dump.
- `key` **remains unchanged** but, here, it refers to a root directory (instead of a dconf key) and must be '/' terminated

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
dconf

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Below a role using the newly `load` state, followed by the varbatim output:
```
- name: Apply profile for Gnome terminal
  ansible.builtin.dconf:
    key: "/org/gnome/terminal/legacy/profiles:/"
    path: "/tmp/solarized_dark.dump"
    state: load
```

```
changed: [192.168.1.1] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "key": "/org/gnome/terminal/legacy/profiles:/",
            "path": "/tmp/solarized_dark.dump",
            "state": "load",
            "value": null
        }
    }
}
```

The content of the `path` file is:
```
[:b1daa9dd-6252-4d8d-a863-c897e6d619b9]
background-color='rgb(0,43,54)'
bold-is-bright=false
foreground-color='rgb(131,148,150)'
palette=['rgb(7,54,66)', 'rgb(220,50,47)', 'rgb(133,153,0)', 'rgb(181,137,0)', 'rgb(38,139,210)', 'rgb(211,54,130)', 'rgb(42,161,152)', 'rgb(238,232,213)', 'rgb(0,43,54)', 'rgb(203,75,22)', 'rgb(88,110,117)', 'rgb(101,123,131)', 'rgb(131,148,150)', 'rgb(108,113,196)', 'rgb(147,161,161)', 'rgb(253,246,227)']
use-theme-colors=false
```
