### PR TITLE
Ensure apk handles empty name strings properly

### DIFF
--- a/changelogs/fragments/10442-apk-fix-empty-names.yml
+++ b/changelogs/fragments/10442-apk-fix-empty-names.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - apk -  apk handles empty name strings properly
-    (https://github.com/ansible-collections/community.general/pull/10442).
+  - apk - handle empty name strings properly
+    (https://github.com/ansible-collections/community.general/issues/10441, https://github.com/ansible-collections/community.general/pull/10442).

--- a/changelogs/fragments/10442-apk-fix-empty-names.yml
+++ b/changelogs/fragments/10442-apk-fix-empty-names.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - apk -  apk handles empty name strings properly
+    (https://github.com/ansible-collections/community.general/pull/10442).

--- a/plugins/modules/apk.py
+++ b/plugins/modules/apk.py
@@ -371,6 +371,12 @@ def main():
     if p['upgrade']:
         upgrade_packages(module, p['available'])
 
+    if all(not name.strip() for name in p['name']):
+        if len(p['name']) == 1:
+            module.fail_json(msg="Package name cannot be empty or whitespace-only")
+        else:
+            module.fail_json(msg="Package names cannot be empty or whitespace-only")
+
     if p['state'] in ['present', 'latest']:
         install_packages(module, p['name'], p['state'], p['world'])
     elif p['state'] == 'absent':

--- a/plugins/modules/apk.py
+++ b/plugins/modules/apk.py
@@ -351,6 +351,9 @@ def main():
 
     p = module.params
 
+    if all(not name.strip() for name in p['name']):
+        module.fail_json(msg="Package name(s) cannot be empty or whitespace-only")
+
     if p['no_cache']:
         APK_PATH = "%s --no-cache" % (APK_PATH, )
 
@@ -370,9 +373,6 @@ def main():
 
     if p['upgrade']:
         upgrade_packages(module, p['available'])
-
-    if all(not name.strip() for name in p['name']):
-        module.fail_json(msg="Package name(s) cannot be empty or whitespace-only")
 
     if p['state'] in ['present', 'latest']:
         install_packages(module, p['name'], p['state'], p['world'])

--- a/plugins/modules/apk.py
+++ b/plugins/modules/apk.py
@@ -372,10 +372,7 @@ def main():
         upgrade_packages(module, p['available'])
 
     if all(not name.strip() for name in p['name']):
-        if len(p['name']) == 1:
-            module.fail_json(msg="Package name cannot be empty or whitespace-only")
-        else:
-            module.fail_json(msg="Package names cannot be empty or whitespace-only")
+        module.fail_json(msg="Package name(s) cannot be empty or whitespace-only")
 
     if p['state'] in ['present', 'latest']:
         install_packages(module, p['name'], p['state'], p['world'])

--- a/tests/integration/targets/apk/tasks/main.yml
+++ b/tests/integration/targets/apk/tasks/main.yml
@@ -169,7 +169,7 @@
       ansible.builtin.assert:
         that:
           - result_empty is failed
-          - "'Package name(s) cannot be empty' in result_empty.msg"
+          - "'Package name(s) cannot be empty or whitespace-only' == result_empty.msg"
 
     - name: Install package name with only spaces
       community.general.apk:
@@ -181,7 +181,7 @@
       ansible.builtin.assert:
         that:
           - result_spaces is failed
-          - "'Package name(s) cannot be empty' in result_spaces.msg"
+          - "'Package name(s) cannot be empty or whitespace-only' == result_spaces.msg"
 
     - name: Accept list with valid and empty string
       community.general.apk:
@@ -204,4 +204,17 @@
       ansible.builtin.assert:
         that:
           - result_multiple_empty is failed
-          - "'Package name(s) cannot be empty' in result_multiple_empty.msg"
+          - "'Package name(s) cannot be empty or whitespace-only' == result_multiple_empty.msg"
+
+    - name: Reject empty package name with update_cache parameter
+      community.general.apk:
+        name: ""
+        update_cache: true
+      register: result_empty_package_with_update_cache
+      ignore_errors: true
+
+    - name: Assert failure due to all package names being empty or whitespace
+      ansible.builtin.assert:
+        that:
+          - result_empty_package_with_update_cache is failed
+          - "'Package name(s) cannot be empty or whitespace-only' == result_empty_package_with_update_cache.msg"

--- a/tests/integration/targets/apk/tasks/main.yml
+++ b/tests/integration/targets/apk/tasks/main.yml
@@ -158,3 +158,52 @@
         that:
           - results is not changed
           - (results.packages | default([]) | length) == 0
+
+    - name: Install package with empty name
+      community.general.apk:
+        name: ""
+      register: result_empty
+      ignore_errors: true
+
+    - name: Assert failure due to empty package name
+      ansible.builtin.assert:
+        that:
+          - result_empty is failed
+          - "'Package name cannot be empty' in result_empty.msg"
+
+    - name: Install package name with only spaces
+      community.general.apk:
+        name: ["   "]
+      register: result_spaces
+      ignore_errors: true
+      
+
+    - name: Assert failure due to whitespace-only package name
+      ansible.builtin.assert:
+        that:
+          - result_spaces is failed
+          - "'Package name cannot be empty' in result_spaces.msg"
+
+    - name: Accept list with valid and empty string
+      community.general.apk:
+        name: ["busybox", ""]
+      register: result_valid_mixed
+      ignore_errors: true
+
+    - name: Assert success with mixed package list
+      ansible.builtin.assert:
+        that:
+          - result_valid_mixed is not failed
+
+    - name: Reject package name list with multiple empty/whitespace-only strings
+      community.general.apk:
+        name: ["", "   "]
+      register: result_multiple_empty
+      ignore_errors: true
+
+    - name: Assert failure due to all package names being empty or whitespace
+      ansible.builtin.assert:
+        that:
+          - result_multiple_empty is failed
+          - "'All package names are empty or whitespace' in result_multiple_empty.msg"
+      ignore_errors: true

--- a/tests/integration/targets/apk/tasks/main.yml
+++ b/tests/integration/targets/apk/tasks/main.yml
@@ -176,7 +176,6 @@
         name: ["   "]
       register: result_spaces
       ignore_errors: true
-      
 
     - name: Assert failure due to whitespace-only package name
       ansible.builtin.assert:

--- a/tests/integration/targets/apk/tasks/main.yml
+++ b/tests/integration/targets/apk/tasks/main.yml
@@ -169,7 +169,7 @@
       ansible.builtin.assert:
         that:
           - result_empty is failed
-          - "'Package name cannot be empty' in result_empty.msg"
+          - "'Package name(s) cannot be empty' in result_empty.msg"
 
     - name: Install package name with only spaces
       community.general.apk:
@@ -181,7 +181,7 @@
       ansible.builtin.assert:
         that:
           - result_spaces is failed
-          - "'Package name cannot be empty' in result_spaces.msg"
+          - "'Package name(s) cannot be empty' in result_spaces.msg"
 
     - name: Accept list with valid and empty string
       community.general.apk:
@@ -204,5 +204,5 @@
       ansible.builtin.assert:
         that:
           - result_multiple_empty is failed
-          - "'All package names are empty or whitespace' in result_multiple_empty.msg"
+          - "'Package name(s) cannot be empty' in result_multiple_empty.msg"
       ignore_errors: true

--- a/tests/integration/targets/apk/tasks/main.yml
+++ b/tests/integration/targets/apk/tasks/main.yml
@@ -205,4 +205,3 @@
         that:
           - result_multiple_empty is failed
           - "'Package name(s) cannot be empty' in result_multiple_empty.msg"
-      ignore_errors: true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR ensures the apk module rejects empty or whitespace-only package names, which previously led to misleading `status:changed` reports despite no action being taken. 
I also added integration tests to cover various related cases.

Fixes #10441

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
apk
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
