### PR TITLE
CI: Disable zpool tests on Alpine

### DIFF
--- a/tests/integration/targets/zpool/aliases
+++ b/tests/integration/targets/zpool/aliases
@@ -12,3 +12,4 @@ skip/osx
 skip/macos
 skip/rhel
 skip/docker
+skip/alpine  # TODO: figure out what goes wrong


### PR DESCRIPTION
##### SUMMARY
These currently fail due to zfs module not being there.

Example run:
- https://dev.azure.com/ansible/community.general/_build/results?buildId=152245&view=logs&j=4a3db1d6-9138-5151-c46d-05bec78b43c6&t=3a5d6d32-7711-5b90-4da3-38a87efde932

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
zpool
