### PR TITLE
Improve capabilities module by detecting /sbin/getcap error message and stop early with a meaningful error message

### DIFF
--- a/changelogs/fragments/10455-capabilities-improve-error-detection.yml
+++ b/changelogs/fragments/10455-capabilities-improve-error-detection.yml
@@ -1,2 +1,2 @@
 bugfixes:
-    - capabilities - Using invalid path (symlink/directory/...) would return unrelated and incoherent error messages (https://github.com/ansible-collections/community.general/issues/5649)
+    - capabilities - using invalid path (symlink/directory/...) returned unrelated and incoherent error messages (https://github.com/ansible-collections/community.general/issues/5649, https://github.com/ansible-collections/community.general/pull/10455).

--- a/changelogs/fragments/10455-capabilities-improve-error-detection.yml
+++ b/changelogs/fragments/10455-capabilities-improve-error-detection.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - capabilities - Using invalid path (symlink/directory/...) would return unrelated and incoherent error messages (https://github.com/ansible-collections/community.general/issues/5649)

--- a/plugins/modules/capabilities.py
+++ b/plugins/modules/capabilities.py
@@ -123,6 +123,8 @@ class CapabilitiesModule(object):
             if ' =' in stdout:
                 # process output of an older version of libcap
                 caps = stdout.split(' =')[1].strip().split()
+            elif stdout.strip().endswith(")"): # '/foo (Error Message)'
+                self.module.fail_json(msg="Unable to get capabilities of %s" % path, stdout=stdout.strip(), stderr=stderr)
             else:
                 # otherwise, we have a newer version here
                 # see original commit message of cap/v0.2.40-18-g177cd41 in libcap.git

--- a/plugins/modules/capabilities.py
+++ b/plugins/modules/capabilities.py
@@ -123,7 +123,7 @@ class CapabilitiesModule(object):
             if ' =' in stdout:
                 # process output of an older version of libcap
                 caps = stdout.split(' =')[1].strip().split()
-            elif stdout.strip().endswith(")"): # '/foo (Error Message)'
+            elif stdout.strip().endswith(")"):  # '/foo (Error Message)'
                 self.module.fail_json(msg="Unable to get capabilities of %s" % path, stdout=stdout.strip(), stderr=stderr)
             else:
                 # otherwise, we have a newer version here


### PR DESCRIPTION
##### SUMMARY

Improve `capabilities` module by detecting `/sbin/getcap` error message and stop early with a meaningful error message.

Fix #5649

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

capabilities

##### ADDITIONAL INFORMATION

The `capabilities` module rely on executing `/sbin/getcap` to retrieve the current capabilities of a path.
The `/sbin/getcap` always returns with an `rc == 0` even when the path does not exist or is a symlink:

```
(Pdb) self.module.run_command('/sbin/getcap -v /usr/bin/python3.11')
(0, '/usr/bin/python3.11 cap_net_bind_service=eip\n', '')

(Pdb) self.module.run_command('/sbin/getcap -v /usr/bin/python3')
(0, '/usr/bin/python3 (Not a regular file)\n', '')

(Pdb) self.module.run_command('/sbin/getcap -v /usr/bin/python3_NOT_FOUND')
(0, '', '/usr/bin/python3_NOT_FOUND (No such file or directory)\n')
```
The code checking the stdout, does not currently check for an error message and will try to interpret it as a valid capabilities string. Thus passing `(Not` to `_parse_cap`.
This means that the module will fail with an incoherent error message: `Couldn't find operator (one of: ('=', '-', '+'))`.

The fix detect the error message (by detecting `)`) and fail early with the complete stdout of `getcap`.

```
{"stdout": "/usr/bin/python3 (Not a regular file)", "stderr": "", "failed": true, "msg": "Unable to get capabilities of /usr/bin/python3", "invocation": {"module_args": {"path": "/usr/bin/python3", "capability": "cap_net_bind_service=eip", "state": "present"}}}
```