### PR TITLE
Use correct kernel flavor for zfs kernel modules on alpine

### DIFF
--- a/tests/integration/targets/zpool/aliases
+++ b/tests/integration/targets/zpool/aliases
@@ -12,4 +12,3 @@ skip/osx
 skip/macos
 skip/rhel
 skip/docker
-skip/alpine  # TODO: figure out what goes wrong

--- a/tests/integration/targets/zpool/tasks/install_requirements_alpine.yml
+++ b/tests/integration/targets/zpool/tasks/install_requirements_alpine.yml
@@ -9,9 +9,6 @@
       - zfs
       - "zfs-{{ ansible_kernel.split('-')[-1] }}"
 
-- name: Check content of /lib/modules/6.12.38-0-virt/
-  ansible.builtin.command: ls -l /lib/modules/6.12.38-0-virt/
-
 - name: Load zfs module
   community.general.modprobe:
     name: zfs

--- a/tests/integration/targets/zpool/tasks/install_requirements_alpine.yml
+++ b/tests/integration/targets/zpool/tasks/install_requirements_alpine.yml
@@ -8,3 +8,8 @@
     name:
       - zfs
       - "zfs-{{ ansible_kernel.split('-')[-1] }}"
+
+- name: Load zfs module
+  community.general.modprobe:
+    name: zfs
+    state: present

--- a/tests/integration/targets/zpool/tasks/install_requirements_alpine.yml
+++ b/tests/integration/targets/zpool/tasks/install_requirements_alpine.yml
@@ -7,7 +7,7 @@
   community.general.apk:
     name:
       - zfs
-      - zfs-lts
+      - "zfs-{{ ansible_kernel.split('-')[-1] }}"
 
 - name: Load zfs module
   community.general.modprobe:

--- a/tests/integration/targets/zpool/tasks/install_requirements_alpine.yml
+++ b/tests/integration/targets/zpool/tasks/install_requirements_alpine.yml
@@ -9,6 +9,9 @@
       - zfs
       - "zfs-{{ ansible_kernel.split('-')[-1] }}"
 
+- name: Check content of /lib/modules/6.12.38-0-virt/
+  ansible.builtin.command: ls -l /lib/modules/6.12.38-0-virt/
+
 - name: Load zfs module
   community.general.modprobe:
     name: zfs

--- a/tests/integration/targets/zpool/tasks/install_requirements_alpine.yml
+++ b/tests/integration/targets/zpool/tasks/install_requirements_alpine.yml
@@ -8,8 +8,3 @@
     name:
       - zfs
       - "zfs-{{ ansible_kernel.split('-')[-1] }}"
-
-- name: Load zfs module
-  community.general.modprobe:
-    name: zfs
-    state: present


### PR DESCRIPTION
##### SUMMARY
Use the correct kernel flavor from the ansible_kernel fact to ensure the correct zfs modules are installed for integration testing.

Fixes #10453 

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
zpool
