### PR TITLE
listen_ports_facts: Avoid crash when required commands are missing

### DIFF
--- a/changelogs/fragments/10458-listen_port_facts-prevent-Type-error-crash.yml
+++ b/changelogs/fragments/10458-listen_port_facts-prevent-Type-error-crash.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "listen-port-facts - Avoid crash when required commands are missing  (https://github.com/ansible-collections/community.general/issues/10457, https://github.com/ansible-collections/community.general/pull/10458).

--- a/changelogs/fragments/10458-listen_port_facts-prevent-Type-error-crash.yml
+++ b/changelogs/fragments/10458-listen_port_facts-prevent-Type-error-crash.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - "listen-port-facts - Avoid crash when required commands are missing  (https://github.com/ansible-collections/community.general/issues/10457, https://github.com/ansible-collections/community.general/pull/10458).

--- a/changelogs/fragments/10458-listen_port_facts-prevent-type-error.yml
+++ b/changelogs/fragments/10458-listen_port_facts-prevent-type-error.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "listen-port-facts - Avoid crash when required commands are missing  (https://github.com/ansible-collections/community.general/issues/10457, https://github.com/ansible-collections/community.general/pull/10458).
+  - "listen-port-facts - Avoid crash when required commands are missing  (https://github.com/ansible-collections/community.general/issues/10457, https://github.com/ansible-collections/community.general/pull/10458)."

--- a/changelogs/fragments/10458-listen_port_facts-prevent-type-error.yml
+++ b/changelogs/fragments/10458-listen_port_facts-prevent-type-error.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "listen-port-facts - Avoid crash when required commands are missing  (https://github.com/ansible-collections/community.general/issues/10457, https://github.com/ansible-collections/community.general/pull/10458)."
+  - "listen_port_facts - avoid crash when required commands are missing (https://github.com/ansible-collections/community.general/issues/10457, https://github.com/ansible-collections/community.general/pull/10458)."

--- a/changelogs/fragments/10458-listen_port_facts-prevent-type-error.yml
+++ b/changelogs/fragments/10458-listen_port_facts-prevent-type-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "listen-port-facts - Avoid crash when required commands are missing  (https://github.com/ansible-collections/community.general/issues/10457, https://github.com/ansible-collections/community.general/pull/10458).

--- a/plugins/modules/listen_ports_facts.py
+++ b/plugins/modules/listen_ports_facts.py
@@ -397,7 +397,7 @@ def main():
                     break
 
         if bin_path is None:
-            raise EnvironmentError(msg='Unable to find any of the supported commands in PATH: {0}'.format(", ".join(sorted(commands_map))))
+            raise EnvironmentError('Unable to find any of the supported commands in PATH: {0}'.format(", ".join(sorted(commands_map))))
 
         # which ports are listening for connections?
         args = commands_map[command]['args']

--- a/tests/integration/targets/listen_ports_facts/tasks/main.yml
+++ b/tests/integration/targets/listen_ports_facts/tasks/main.yml
@@ -110,3 +110,34 @@
   loop: "{{ [tcp_listen, udp_listen]|flatten }}"
   when: item.name == 'nc'
   ignore_errors: true
+
+
+- name: Remove netstat and ss dependencies to simulate missing executables
+  ansible.builtin.package:
+    name:
+      - net-tools
+      - iproute2
+    state: absent
+  ignore_errors: true
+  when: ansible_os_family == "Debian"
+
+- name: Trigger listen_ports_facts with missing tools
+  community.general.listen_ports_facts:
+  register: listen_ports_failure_result
+  ignore_errors: true
+  when: ansible_os_family == "Debian"
+
+- name: Assert graceful failure when dependencies are missing
+  ansible.builtin.assert:
+    that:
+      - listen_ports_failure_result.failed
+      - "'Unable to find any of the supported commands' in listen_ports_failure_result.msg"
+  when: ansible_os_family == "Debian"
+
+- name: Reinstall netstat and ss dependencies after test
+  ansible.builtin.package:
+    name:
+      - net-tools
+      - iproute2
+    state: present
+  when: ansible_os_family == "Debian"

--- a/tests/integration/targets/listen_ports_facts/tasks/main.yml
+++ b/tests/integration/targets/listen_ports_facts/tasks/main.yml
@@ -112,32 +112,30 @@
   ignore_errors: true
 
 
-- name: Remove netstat and ss dependencies to simulate missing executables
-  ansible.builtin.package:
-    name:
-      - net-tools
-      - iproute2
-    state: absent
-  ignore_errors: true
-  when: ansible_os_family == "Debian"
+- when: ansible_os_family == "Debian"
+  block:
+    - name: Remove netstat and ss dependencies to simulate missing executables
+      ansible.builtin.package:
+        name:
+          - net-tools
+          - iproute2
+        state: absent
+      ignore_errors: true
 
-- name: Trigger listen_ports_facts with missing tools
-  community.general.listen_ports_facts:
-  register: listen_ports_failure_result
-  ignore_errors: true
-  when: ansible_os_family == "Debian"
+    - name: Trigger listen_ports_facts with missing tools
+      community.general.listen_ports_facts:
+      register: listen_ports_failure_result
+      ignore_errors: true
 
-- name: Assert graceful failure when dependencies are missing
-  ansible.builtin.assert:
-    that:
-      - listen_ports_failure_result.failed
-      - "'Unable to find any of the supported commands' in listen_ports_failure_result.msg"
-  when: ansible_os_family == "Debian"
+    - name: Assert graceful failure when dependencies are missing
+      ansible.builtin.assert:
+        that:
+          - listen_ports_failure_result is failed
+          - "'Unable to find any of the supported commands' in listen_ports_failure_result.msg"
 
-- name: Reinstall netstat and ss dependencies after test
-  ansible.builtin.package:
-    name:
-      - net-tools
-      - iproute2
-    state: present
-  when: ansible_os_family == "Debian"
+    - name: Reinstall netstat and ss dependencies after test
+      ansible.builtin.package:
+        name:
+          - net-tools
+          - iproute2
+        state: present


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The module `listen_ports_facts` would crash with a TypeError when required executables were not present. This fix ensures missing dependencies raise a valid OSError without keyword arguments. I also added integration tests.

Fixes  #10457


##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
listen_ports_facts

