### PR TITLE
Fix ansible-core 2.19 deprecations

### DIFF
--- a/changelogs/fragments/10459-deprecations.yml
+++ b/changelogs/fragments/10459-deprecations.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - "apache2_module - avoid ansible-core 2.19 deprecation (https://github.com/ansible-collections/community.general/pull/10459)."
+  - "htpasswd - avoid ansible-core 2.19 deprecation (https://github.com/ansible-collections/community.general/pull/10459)."
+  - "syspatch - avoid ansible-core 2.19 deprecation (https://github.com/ansible-collections/community.general/pull/10459)."
+  - "sysupgrade - avoid ansible-core 2.19 deprecation (https://github.com/ansible-collections/community.general/pull/10459)."
+  - "zypper_repository - avoid ansible-core 2.19 deprecation (https://github.com/ansible-collections/community.general/pull/10459)."

--- a/plugins/modules/apache2_module.py
+++ b/plugins/modules/apache2_module.py
@@ -164,12 +164,12 @@ def _module_is_enabled(module):
         if module.params['ignore_configcheck']:
             if 'AH00534' in stderr and 'mpm_' in module.params['name']:
                 if module.params['warn_mpm_absent']:
-                    module.warnings.append(
+                    module.warn(
                         "No MPM module loaded! apache2 reload AND other module actions"
                         " will fail if no MPM module is loaded immediately."
                     )
             else:
-                module.warnings.append(error_msg)
+                module.warn(error_msg)
             return False
         else:
             module.fail_json(msg=error_msg)
@@ -224,9 +224,7 @@ def _set_state(module, state):
 
     if _module_is_enabled(module) != want_enabled:
         if module.check_mode:
-            module.exit_json(changed=True,
-                             result=success_msg,
-                             warnings=module.warnings)
+            module.exit_json(changed=True, result=success_msg)
 
         a2mod_binary_path = module.get_bin_path(a2mod_binary)
         if a2mod_binary_path is None:
@@ -241,9 +239,7 @@ def _set_state(module, state):
         result, stdout, stderr = module.run_command(a2mod_binary_cmd + [name])
 
         if _module_is_enabled(module) == want_enabled:
-            module.exit_json(changed=True,
-                             result=success_msg,
-                             warnings=module.warnings)
+            module.exit_json(changed=True, result=success_msg)
         else:
             msg = (
                 'Failed to set module {name} to {state}:\n'
@@ -261,9 +257,7 @@ def _set_state(module, state):
                              stdout=stdout,
                              stderr=stderr)
     else:
-        module.exit_json(changed=False,
-                         result=success_msg,
-                         warnings=module.warnings)
+        module.exit_json(changed=False, result=success_msg)
 
 
 def main():
@@ -278,8 +272,6 @@ def main():
         ),
         supports_check_mode=True,
     )
-
-    module.warnings = []
 
     name = module.params['name']
     if name == 'cgi' and _run_threaded(module):

--- a/plugins/modules/htpasswd.py
+++ b/plugins/modules/htpasswd.py
@@ -241,8 +241,8 @@ def main():
             (msg, changed) = present(path, username, password, hash_scheme, create, check_mode)
         elif state == 'absent':
             if not os.path.exists(path):
-                module.exit_json(msg="%s not present" % username,
-                                 warnings="%s does not exist" % path, changed=False)
+                module.warn("%s does not exist" % path)
+                module.exit_json(msg="%s not present" % username, changed=False)
             (msg, changed) = absent(path, username, check_mode)
         else:
             module.fail_json(msg="Invalid state: %s" % state)

--- a/plugins/modules/syspatch.py
+++ b/plugins/modules/syspatch.py
@@ -103,7 +103,6 @@ def syspatch_run(module):
     cmd = module.get_bin_path('syspatch', True)
     changed = False
     reboot_needed = False
-    warnings = []
 
     # Set safe defaults for run_flag and check_flag
     run_flag = ['-c']
@@ -145,11 +144,11 @@ def syspatch_run(module):
             # Kernel update applied
             reboot_needed = True
         elif out.lower().find('syspatch updated itself') >= 0:
-            warnings.append('Syspatch was updated. Please run syspatch again.')
+            module.warn('Syspatch was updated. Please run syspatch again.')
 
         # If no stdout, then warn user
         if len(out) == 0:
-            warnings.append('syspatch had suggested changes, but stdout was empty.')
+            module.warn('syspatch had suggested changes, but stdout was empty.')
 
         changed = True
     else:
@@ -161,7 +160,6 @@ def syspatch_run(module):
         rc=rc,
         stderr=err,
         stdout=out,
-        warnings=warnings
     )
 
 

--- a/plugins/modules/sysupgrade.py
+++ b/plugins/modules/sysupgrade.py
@@ -102,7 +102,6 @@ def sysupgrade_run(module):
     sysupgrade_bin = module.get_bin_path('/usr/sbin/sysupgrade', required=True)
     cmd = [sysupgrade_bin]
     changed = False
-    warnings = []
 
     # Setup command flags
     if module.params['snapshot']:
@@ -138,7 +137,6 @@ def sysupgrade_run(module):
         rc=rc,
         stderr=err,
         stdout=out,
-        warnings=warnings
     )
 
 


### PR DESCRIPTION
##### SUMMARY
I randomly noticed that returning `warnings` in `exit_json()` is deprecated in community.routeros, and when grepping for more occasions I found some modules in community.general.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
various
