### PR TITLE
Fix cronvar crash when parent dir of cron_file is missing

### DIFF
--- a/changelogs/fragments/10461-cronvar-non-existent-dir-crash-fix.yml
+++ b/changelogs/fragments/10461-cronvar-non-existent-dir-crash-fix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "cronvar - Fix crash on missing cron_file parent directories (https://github.com/ansible-collections/community.general/issues/10460, https://github.com/ansible-collections/community.general/pull/10461)."
+  - "cronvar - fix crash on missing ``cron_file`` parent directories (https://github.com/ansible-collections/community.general/issues/10460, https://github.com/ansible-collections/community.general/pull/10461)."

--- a/changelogs/fragments/10461-cronvar-non-existent-dir-crash-fix.yml
+++ b/changelogs/fragments/10461-cronvar-non-existent-dir-crash-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "cronvar - Fix crash on missing cron_file parent directories (https://github.com/ansible-collections/community.general/issues/10460, https://github.com/ansible-collections/community.general/pull/10461)."

--- a/plugins/modules/cronvar.py
+++ b/plugins/modules/cronvar.py
@@ -135,7 +135,7 @@ class CronVar(object):
                 self.cron_file = cron_file
             else:
                 self.cron_file = os.path.join('/etc/cron.d', cron_file)
-            parent_dir = os.path.dirname(cron_file) 
+            parent_dir = os.path.dirname(self.cron_file) 
             if not os.path.isdir(parent_dir):
                 module.fail_json(msg=f"Parent directory '{parent_dir}' does not exist for cron_file: '{cron_file}'")
         else:

--- a/plugins/modules/cronvar.py
+++ b/plugins/modules/cronvar.py
@@ -135,7 +135,7 @@ class CronVar(object):
                 self.cron_file = cron_file
             else:
                 self.cron_file = os.path.join('/etc/cron.d', cron_file)
-            parent_dir = os.path.dirname(self.cron_file) 
+            parent_dir = os.path.dirname(self.cron_file)
             if not os.path.isdir(parent_dir):
                 module.fail_json(msg=f"Parent directory '{parent_dir}' does not exist for cron_file: '{cron_file}'")
         else:

--- a/plugins/modules/cronvar.py
+++ b/plugins/modules/cronvar.py
@@ -136,7 +136,7 @@ class CronVar(object):
             else:
                 self.cron_file = os.path.join('/etc/cron.d', cron_file)
             parent_dir = os.path.dirname(self.cron_file)
-            if not os.path.isdir(parent_dir):
+            if parent_dir and not os.path.isdir(parent_dir):
                 module.fail_json(msg="Parent directory '{}' does not exist for cron_file: '{}'".format(parent_dir, cron_file))
         else:
             self.cron_file = None

--- a/plugins/modules/cronvar.py
+++ b/plugins/modules/cronvar.py
@@ -137,7 +137,7 @@ class CronVar(object):
                 self.cron_file = os.path.join('/etc/cron.d', cron_file)
             parent_dir = os.path.dirname(self.cron_file)
             if not os.path.isdir(parent_dir):
-                module.fail_json(msg=f"Parent directory '{parent_dir}' does not exist for cron_file: '{cron_file}'")
+                module.fail_json(msg="Parent directory '{}' does not exist for cron_file: '{}'".format(parent_dir, cron_file))
         else:
             self.cron_file = None
 

--- a/plugins/modules/cronvar.py
+++ b/plugins/modules/cronvar.py
@@ -135,6 +135,9 @@ class CronVar(object):
                 self.cron_file = cron_file
             else:
                 self.cron_file = os.path.join('/etc/cron.d', cron_file)
+            parent_dir = os.path.dirname(cron_file) 
+            if not os.path.isdir(parent_dir):
+                module.fail_json(msg=f"Parent directory '{parent_dir}' does not exist for cron_file: '{cron_file}'")
         else:
             self.cron_file = None
 

--- a/tests/integration/targets/cronvar/tasks/main.yml
+++ b/tests/integration/targets/cronvar/tasks/main.yml
@@ -127,7 +127,7 @@
   cronvar:
     name: NOPARENT_VAR
     value: noparentval
-    cron_file:  /nonexistent/foo
+    cron_file: /nonexistent/foo
     user: root
   register: invalid_directory_cronvar_result
   ignore_errors: true

--- a/tests/integration/targets/cronvar/tasks/main.yml
+++ b/tests/integration/targets/cronvar/tasks/main.yml
@@ -122,3 +122,19 @@
       - custom_varcheck1.stdout == '1'
       - custom_varcheck2.stdout == '1'
       - custom_varcheck3.stdout == '0'
+
+- name: Attempt to add cron variable to non-existent parent directory
+  cronvar:
+    name: NOPARENT_VAR
+    value: noparentval
+    cron_file:  /nonexistent/foo
+    user: root
+  register: invalid_directory_cronvar_result
+  ignore_errors: true
+
+- name: Assert that the cronvar task failed due to invalid directory
+  ansible.builtin.assert:
+    that:
+      - invalid_directory_cronvar_result is failed
+      - >-
+       "Parent directory '/nonexistent' does not exist for cron_file: '/nonexistent/foo'" == invalid_directory_cronvar_result.msg


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix crash in cronvar module when cron_file is under a non-existent parent directory by validating with os.path.isdir() and returning a clear error.

Fixes #10460 

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
cronvar

