### PR TITLE
irc: fix wrap_socket() call when validate_certs=true and use_tls=true

### DIFF
--- a/changelogs/fragments/10491-irc.yml
+++ b/changelogs/fragments/10491-irc.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "irc - pass hostname to ``wrap_socket()`` if ``use_tls=true`` and ``validate_certs=true`` (https://github.com/ansible-collections/community.general/issues/10472, https://github.com/ansible-collections/community.general/pull/10491)."

--- a/plugins/modules/irc.py
+++ b/plugins/modules/irc.py
@@ -232,9 +232,11 @@ def send_msg(msg, server='localhost', port='6667', channel=None, nick_to=None, k
 
     irc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     if use_tls:
+        kwargs = {}
         if validate_certs:
             try:
                 context = ssl.create_default_context()
+                kwargs["server_hostname"] = server
             except AttributeError:
                 raise Exception('Need at least Python 2.7.9 for SSL certificate validation')
         else:
@@ -244,7 +246,7 @@ def send_msg(msg, server='localhost', port='6667', channel=None, nick_to=None, k
             else:
                 context = ssl.SSLContext()
             context.verify_mode = ssl.CERT_NONE
-        irc = context.wrap_socket(irc)
+        irc = context.wrap_socket(irc, **kwargs)
     irc.connect((server, int(port)))
 
     if passwd:


### PR DESCRIPTION
##### SUMMARY
Fixes #10472.

This was introduced in #7550 when `validate_certs` was added.

I'm backporting this to stable-9 as well since this can be seen as a security relevant issue.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
irc
