### PR TITLE
nagios: make services param a list

### DIFF
--- a/changelogs/fragments/10493-nagios-services.yml
+++ b/changelogs/fragments/10493-nagios-services.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nagios - make parameter ``services`` a ``list`` instead of a ``str`` (https://github.com/ansible-collections/community.general/pull/10493).

--- a/plugins/modules/nagios.py
+++ b/plugins/modules/nagios.py
@@ -83,12 +83,14 @@ options:
     description:
       - What to manage downtime/alerts for. Separate multiple services with commas.
       - 'B(Required) option when O(action) is one of: V(downtime), V(acknowledge), V(forced_check), V(enable_alerts), V(disable_alerts).'
-      - You can specify multiple services at once by separating them with commas, for example O(services=httpd,nfs,puppet).
       - When specifying what O(services) to handle there is a special service value, V(host), which handles alerts/downtime/acknowledge
         for the I(host itself), for example O(services=host). This keyword may not be given with other services at the same
         time. B(Setting alerts/downtime/acknowledge for a host does not affect alerts/downtime/acknowledge for any of the
         services running on it.) To schedule downtime for all O(services) on particular host use keyword V(all), for example
         O(services=all).
+      - Before community.general 11.2.0, one could specify multiple services at once by separating them with commas, for example
+        O(services=httpd,nfs,puppet). Since community.general 11.2.0, there can be spaces around the commas, and an actual
+        list can be provided.
     aliases: ["service"]
     type: list
     elements: str
@@ -224,7 +226,9 @@ EXAMPLES = r"""
 - name: Disable httpd and nfs alerts
   community.general.nagios:
     action: disable_alerts
-    service: httpd,nfs
+    service:
+      - httpd
+      - nfs
     host: '{{ inventory_hostname }}'
 
 - name: Disable HOST alerts


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Parameter `services` can receive multiple values separated by commas, but little things like whitespaces around commas are not handled. Instead of adding extra logic to do that, it is better to make it a list.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
nagios