### PR TITLE
Change description of nopasswd parameter for sudoers to be more clear

### DIFF
--- a/plugins/modules/sudoers.py
+++ b/plugins/modules/sudoers.py
@@ -52,7 +52,7 @@ options:
     version_added: 8.4.0
   nopassword:
     description:
-      - Whether a password is required when command is run with sudo.
+      - Whether a password is not required when command is run with sudo.
     default: true
     type: bool
   setenv:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The description as currently written suggests that the `nopasswd` parameter determines whether a password *is required* -- true == needs a password, false == do not need a password. This conflicts with the semantics of the parameter (nopassword: true --> no password is required, vice versa). I changed the description to say "not required", which brings the description in line with the parameter's existing semantics.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
sudoers