### PR TITLE
Keycloak idp well known url support

### DIFF
--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -2581,24 +2581,23 @@ class KeycloakAPI(object):
             self.fail_request(e, msg='Could not obtain list of identity provider mappers for idp %s in realm %s: %s'
                                      % (alias, realm, str(e)))
 
-    def fetch_idp_endpoints_import_config_url(self, fromUrl, realm='master'):
-        """
-        Import an identity provider on a Keycloak server form url.
+    def fetch_idp_endpoints_import_config_url(self, fromUrl, providerId='oidc', realm='master'):
+        """ Import an identity provider configuration through Keycloak server from a well-known URL.
         :param fromUrl: URL to import the identity provider configuration from.
+        "param providerId: Provider ID of the identity provider to import, default 'oidc'.
         :param realm: Realm
-        :return: Actual representation of the idp created.
+        :return: IDP endpoins.
         """
         try:
-            payload = dict(
-                providerId='oidc',
-                fromUrl=fromUrl
-            )
+            payload = {
+                "providerId": providerId,
+                "fromUrl": fromUrl
+            }
             idps_url = URL_IDENTITY_PROVIDER_IMPORT.format(url=self.baseurl, realm=realm)
             return self._request_and_deserialize(idps_url, method='POST', data=json.dumps(payload))
         except Exception as e:
-            self.fail_request(e, msg='Could not import the IdP config in realm %s: %s'
-                                      % (realm, str(e)))
-            
+            self.fail_request(e, msg='Could not import the IdP config in realm %s: %s' % (realm, str(e)))
+
     def get_identity_provider_mapper(self, mid, alias, realm='master'):
         """ Fetch identity provider representation from a realm using the idp's alias.
         If the identity provider does not exist, None is returned.

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -104,6 +104,7 @@ URL_IDENTITY_PROVIDERS = "{url}/admin/realms/{realm}/identity-provider/instances
 URL_IDENTITY_PROVIDER = "{url}/admin/realms/{realm}/identity-provider/instances/{alias}"
 URL_IDENTITY_PROVIDER_MAPPERS = "{url}/admin/realms/{realm}/identity-provider/instances/{alias}/mappers"
 URL_IDENTITY_PROVIDER_MAPPER = "{url}/admin/realms/{realm}/identity-provider/instances/{alias}/mappers/{id}"
+URL_IDENTITY_PROVIDER_IMPORT = "{url}/admin/realms/{realm}/identity-provider/import-config"
 
 URL_COMPONENTS = "{url}/admin/realms/{realm}/components"
 URL_COMPONENT = "{url}/admin/realms/{realm}/components/{id}"
@@ -2580,6 +2581,24 @@ class KeycloakAPI(object):
             self.fail_request(e, msg='Could not obtain list of identity provider mappers for idp %s in realm %s: %s'
                                      % (alias, realm, str(e)))
 
+    def fetch_idp_endpoints_import_config_url(self, fromUrl, realm='master'):
+        """
+        Import an identity provider on a Keycloak server form url.
+        :param fromUrl: URL to import the identity provider configuration from.
+        :param realm: Realm
+        :return: Actual representation of the idp created.
+        """
+        try:
+            payload = dict(
+                providerId='oidc',
+                fromUrl=fromUrl
+            )
+            idps_url = URL_IDENTITY_PROVIDER_IMPORT.format(url=self.baseurl, realm=realm)
+            return self._request_and_deserialize(idps_url, method='POST', data=json.dumps(payload))
+        except Exception as e:
+            self.fail_request(e, msg='Could not import the IdP config in realm %s: %s'
+                                      % (realm, str(e)))
+            
     def get_identity_provider_mapper(self, mid, alias, realm='master'):
         """ Fetch identity provider representation from a realm using the idp's alias.
         If the identity provider does not exist, None is returned.

--- a/plugins/modules/keycloak_identity_provider.py
+++ b/plugins/modules/keycloak_identity_provider.py
@@ -326,6 +326,24 @@ EXAMPLES = r"""
           user.attribute: last_name
           syncMode: INHERIT
 
+- name: Create OIDC identity provider, with well-known configuration URL
+  community.general.keycloak_identity_provider:
+    state: present
+    auth_keycloak_url: https://auth.example.com/auth
+    auth_realm: master
+    auth_username: admin
+    auth_password: admin
+    realm: myrealm
+    alias: oidc-idp
+    display_name: OpenID Connect IdP
+    enabled: true
+    provider_id: oidc
+    config:
+      fromUrl: https://the-idp.example.com/auth/realms/idprealm/.well-known/openid-configuration
+      clientAuthMethod: client_secret_post
+      clientId: my-client
+      clientSecret: secret
+
 - name: Create SAML identity provider, authentication with credentials
   community.general.keycloak_identity_provider:
     state: present

--- a/tests/integration/targets/keycloak_identity_provider/README.md
+++ b/tests/integration/targets/keycloak_identity_provider/README.md
@@ -1,0 +1,20 @@
+<!--
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+# Running keycloak_identity_provider module integration test
+
+To run Keycloak component info module's integration test, start a keycloak server using Docker:
+
+    docker run -d --rm --name mykeycloak -p 8080:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=password quay.io/keycloak/keycloak:latest start-dev --http-relative-path /auth
+
+Run integration tests:
+
+    ansible-test integration -v keycloak_identity_provider --allow-unsupported --docker fedora35 --docker-network host
+
+Cleanup:
+
+    docker stop mykeycloak
+
+

--- a/tests/integration/targets/keycloak_identity_provider/tasks/main.yml
+++ b/tests/integration/targets/keycloak_identity_provider/tasks/main.yml
@@ -3,6 +3,15 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+- name: Delete realm if exists
+  community.general.keycloak_realm:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    state: absent
+
 - name: Create realm
   community.general.keycloak_realm:
     auth_keycloak_url: "{{ url }}"
@@ -62,7 +71,7 @@
       - result.existing == {}
       - result.end_state.alias == "{{ idp }}"
       - result.end_state.mappers != []
-      - result.end_state.config.client_secret = "**********"
+      - result.end_state.config.clientSecret == "**********"
 
 - name: Update existing identity provider (no change)
   community.general.keycloak_identity_provider:
@@ -277,3 +286,79 @@
     that:
       - result is not changed
       - result.end_state == {}
+
+- name: Create IDP realm
+  community.general.keycloak_realm:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    id: "{{ idp_realm }}"
+    realm: "{{ idp_realm }}"
+    state: present
+
+- name: Create new identity provider with fromUrl
+  community.general.keycloak_identity_provider:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    alias: "{{ idp_fromurl }}"
+    display_name: OpenID Connect IdP from url
+    enabled: true
+    provider_id: oidc
+    config:
+      fromUrl: "{{ url }}/realms/{{ idp_realm }}/.well-known/openid-configuration"
+      clientAuthMethod: client_secret_post
+      clientId: clientid
+      clientSecret: clientsecret
+      syncMode: FORCE
+    state: present
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert identity provider created with IDP endpoints
+  assert:
+    that:
+      - result is changed
+      - result.end_state.config.authorizationUrl == "{{ url }}/realms/{{ idp_realm }}/protocol/openid-connect/auth"
+      - result.end_state.config.issuer == "{{ url }}/realms/{{ idp_realm }}"
+      - result.end_state.config.jwksUrl == "{{ url }}/realms/{{ idp_realm }}/protocol/openid-connect/certs"
+      - result.end_state.config.logoutUrl ==  "{{ url }}/realms/{{ idp_realm }}/protocol/openid-connect/logout"
+      - result.end_state.config.tokenUrl == "{{ url }}/realms/{{ idp_realm }}/protocol/openid-connect/token"
+      - result.end_state.config.userInfoUrl == "{{ url }}/realms/{{ idp_realm }}/protocol/openid-connect/userinfo"
+
+- name: Create new identity provider with fromUrl and exclusion should fail
+  community.general.keycloak_identity_provider:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    alias: "mustfail"
+    display_name: Failed OpenID Connect IdP from url
+    enabled: true
+    provider_id: oidc
+    config: "{{ config | combine(endpoint) }}"
+    state: present
+  vars:
+    config:
+      fromUrl: "{{ url }}/realms/{{ idp_realm }}/.well-known/openid-configuration"
+      clientAuthMethod: client_secret_post
+      clientId: clientid
+      clientSecret: clientsecret
+    endpoint: "{{ '{\"' + item + '\": \"' + url + '/realms/' + idp_realm + '/protocol/openid-connect/' + item + '\"}' }}"
+  with_items: ['userInfoUrl', 'authorizationUrl', 'tokenUrl', 'logoutUrl', 'issuer', 'jwksUrl']
+  register: result
+  ignore_errors: true
+
+- name: Check failure of identity provider creation with fromUrl and userInfoUrl
+  assert:
+    that:
+      - result is not changed
+      - result is failed
+      - result.results | selectattr('failed', 'equalto', false) | list | length == 0

--- a/tests/integration/targets/keycloak_identity_provider/vars/main.yml
+++ b/tests/integration/targets/keycloak_identity_provider/vars/main.yml
@@ -9,3 +9,6 @@ admin_user: admin
 admin_password: password
 realm: myrealm
 idp: myidp
+
+idp_realm: myidprealm
+idp_fromurl: myidpfromurl


### PR DESCRIPTION
##### SUMMARY
This pull request adds support for the OpenID Connect Discovery endpoint to the `community.general.keycloak_identity_provider` module.  
A new function, `fetch_identity_provider_wellknown_config`, is introduced to automatically fetch and populate required endpoints (`userInfoUrl`, `authorizationUrl`, `tokenUrl`, `logoutUrl`, `issuer`, `jwksUrl`) from the well-known configuration URL (`fromUrl`).  
This simplifies the configuration of OIDC identity providers and prevents manual endpoint conflicts.  

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
keycloak_identity_provider

##### ADDITIONAL INFORMATION
- Only `oidc` providers are supported for automatic discovery.
- If `fromUrl` is provided, manual specification of endpoints is not allowed.
- The configuration dictionary is updated in-place and `fromUrl` is removed after processing.
- Endpoint fetching is handled via the `fetch_idp_endpoints_import_config_url` method of the Keycloak API client.

**Testing steps:**
1. Create an OIDC identity provider using only the `fromUrl` parameter.
2. Verify that all endpoints are correctly populated in the configuration.
3. Attempt to use `fromUrl` with a non-oidc provider, and confirm an error is raised.
4. Attempt to use both `fromUrl` and manual endpoints, and confirm an error is raised.