### PR TITLE
Keycloak realm add support for some missing options

### DIFF
--- a/changelogs/fragments/10538-keycloak-realm-add-support-client-options.yml
+++ b/changelogs/fragments/10538-keycloak-realm-add-support-client-options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak_realm - add support for client-related options and Oauth2 device (https://github.com/ansible-collections/community.general/pull/10538).

--- a/plugins/modules/keycloak_realm.py
+++ b/plugins/modules/keycloak_realm.py
@@ -510,6 +510,48 @@ options:
     aliases:
       - waitIncrementSeconds
     type: int
+  client_session_idle_timeout:
+    description:
+      - All Clients will inherit from this setting, time a session is allowed to be idle before it expires.
+    aliases:
+      - clientSessionIdleTimeout
+    type: int
+    version_added: 11.2.0
+  client_session_max_lifespan:
+    description:
+      - All Clients will inherit from this setting, max time before a session is expired.
+    aliases:
+      - clientSessionMaxLifespan
+    type: int
+    version_added: 11.2.0
+  client_offline_session_idle_timeout:
+    description:
+      - All Clients will inherit from this setting, time an offline session is allowed to be idle before it expires.
+    aliases:
+      - clientOfflineSessionIdleTimeout
+    type: int
+    version_added: 11.2.0
+  client_offline_session_max_lifespan:
+    description:
+      - All Clients will inherit from this setting, max time before an offline session is expired regardless of activity.
+    aliases:
+      - clientOfflineSessionMaxLifespan
+    type: int
+    version_added: 11.2.0
+  oauth2_device_code_lifespan:
+    description:
+      - Max time before the device code and user code are expired.
+    aliases:
+      - oauth2DeviceCodeLifespan
+    type: int
+    version_added: 11.2.0
+  oauth2_device_polling_interval:
+    description:
+      - The minimum amount of time in seconds that the client should wait between polling requests to the token endpoint.
+    aliases:
+      - oauth2DevicePollingInterval
+    type: int
+    version_added: 11.2.0
 
 extends_documentation_fragment:
   - community.general.keycloak
@@ -710,6 +752,12 @@ def main():
         user_managed_access_allowed=dict(type='bool', aliases=['userManagedAccessAllowed']),
         verify_email=dict(type='bool', aliases=['verifyEmail']),
         wait_increment_seconds=dict(type='int', aliases=['waitIncrementSeconds']),
+        client_session_idle_timeout=dict(type='int', aliases=['clientSessionIdleTimeout']),
+        client_session_max_lifespan=dict(type='int', aliases=['clientSessionMaxLifespan']),
+        client_offline_session_idle_timeout=dict(type='int', aliases=['clientOfflineSessionIdleTimeout']),
+        client_offline_session_max_lifespan=dict(type='int', aliases=['clientOfflineSessionMaxLifespan']),
+        oauth2_device_code_lifespan=dict(type='int', aliases=['oauth2DeviceCodeLifespan']),
+        oauth2_device_polling_interval=dict(type='int', aliases=['oauth2DevicePollingInterval']),
     )
 
     argument_spec.update(meta_args)

--- a/tests/integration/targets/keycloak_realm/README.md
+++ b/tests/integration/targets/keycloak_realm/README.md
@@ -1,0 +1,20 @@
+<!--
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+# Running keycloak_realm module integration test
+
+To run Keycloak component info module's integration test, start a keycloak server using Docker:
+
+    docker run -d --rm --name mykeycloak -p 8080:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=password quay.io/keycloak/keycloak:latest start-dev --http-relative-path /auth
+
+Run integration tests:
+
+    ansible-test integration -v keycloak_realm --allow-unsupported --docker fedora35 --docker-network host
+
+Cleanup:
+
+    docker stop mykeycloak
+
+

--- a/tests/integration/targets/keycloak_realm/aliases
+++ b/tests/integration/targets/keycloak_realm/aliases
@@ -1,0 +1,5 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+unsupported

--- a/tests/integration/targets/keycloak_realm/tasks/main.yml
+++ b/tests/integration/targets/keycloak_realm/tasks/main.yml
@@ -1,0 +1,98 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+- name: Wait for Keycloak
+  uri:
+    url: "{{ url }}/admin/"
+    status_code: 200
+    validate_certs: false
+  register: result
+  until: result.status == 200
+  retries: 10
+  delay: 10
+
+- name: Delete realm if exists
+  community.general.keycloak_realm:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    state: absent
+
+- name: Create realm
+  community.general.keycloak_realm:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    id: "{{ realm }}"
+    realm: "{{ realm }}"
+    state: present
+  register: result
+
+- name: Modify realm
+  community.general.keycloak_realm:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    id: "{{ realm }}"
+    realm: "{{ realm }}"
+    client_session_idle_timeout: 240
+    client_session_max_lifespan: 21600
+    client_offline_session_idle_timeout: 100
+    client_offline_session_max_lifespan: 200
+    oauth2_device_code_lifespan: 700
+    oauth2_device_polling_interval: 800
+    state: present
+  register: result
+
+- name: Assert result
+  assert:
+    that:
+      - result is changed
+      - result.end_state.clientSessionIdleTimeout == 240
+      - result.end_state.clientSessionMaxLifespan == 21600
+      - result.end_state.clientOfflineSessionIdleTimeout == 100
+      - result.end_state.clientOfflineSessionMaxLifespan == 200
+      - result.end_state.oauth2DeviceCodeLifespan == 700
+      - result.end_state.oauth2DevicePollingInterval == 800
+
+- name: Delete realm
+  community.general.keycloak_realm:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    state: absent
+
+- name: create realm
+  community.general.keycloak_realm:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    id: "{{ realm }}"
+    realm: "{{ realm }}"
+    client_session_idle_timeout: 240
+    client_session_max_lifespan: 21600
+    client_offline_session_idle_timeout: 100
+    client_offline_session_max_lifespan: 200
+    oauth2_device_code_lifespan: 700
+    oauth2_device_polling_interval: 800
+    state: present
+  register: result
+
+- name: Assert result
+  assert:
+    that:
+      - result is changed
+      - result.end_state.clientSessionIdleTimeout == 240
+      - result.end_state.clientSessionMaxLifespan == 21600
+      - result.end_state.clientOfflineSessionIdleTimeout == 100
+      - result.end_state.clientOfflineSessionMaxLifespan == 200
+      - result.end_state.oauth2DeviceCodeLifespan == 700
+      - result.end_state.oauth2DevicePollingInterval == 800

--- a/tests/integration/targets/keycloak_realm/vars/main.yml
+++ b/tests/integration/targets/keycloak_realm/vars/main.yml
@@ -8,5 +8,3 @@ admin_realm: master
 admin_user: admin
 admin_password: password
 realm: myrealm
-
-

--- a/tests/integration/targets/keycloak_realm/vars/main.yml
+++ b/tests/integration/targets/keycloak_realm/vars/main.yml
@@ -1,0 +1,12 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+url: http://localhost:8080/auth
+admin_realm: master
+admin_user: admin
+admin_password: password
+realm: myrealm
+
+


### PR DESCRIPTION
##### SUMMARY
This pull request adds support for client-related options in the `community.general.keycloak_realm` module. These options allow users to configure client session and device code settings at the realm level.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
keycloak_realm

##### ADDITIONAL INFORMATION
The following options have been added to the module:

- `client_session_idle_timeout`: Time a session is allowed to be idle before it expires for all clients.
- `client_session_max_lifespan`: Maximum lifespan of a session for all clients.
- `client_offline_session_idle_timeout`: Time an offline session can be idle before it expires for all clients.
- `client_offline_session_max_lifespan`: Maximum time before an offline session expires for all clients, regardless of activity.
- `oauth2_device_code_lifespan`: Maximum lifespan of the device code and user code.
- `oauth2_device_polling_interval`: Minimum interval (in seconds) between polling requests to the token endpoint.

All options are of type `int` and were added in version 11.2.0. Aliases for each option have also been included for compatibility.

