### PR TITLE
[stable-9] [stable-10] Disable pipelining for doas and machinectl on ansible-core 2.19+ (#10537) (#10561)

### DIFF
--- a/changelogs/fragments/become-pipelining.yml
+++ b/changelogs/fragments/become-pipelining.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "doas become plugin - disable pipelining on ansible-core 2.19+. The plugin does not work with pipelining, and since ansible-core 2.19 become plugins can indicate that they do not work with pipelining (https://github.com/ansible-collections/community.general/issues/9977, https://github.com/ansible-collections/community.general/pull/10537)."
+  - "machinectl become plugin - disable pipelining on ansible-core 2.19+. The plugin does not work with pipelining, and since ansible-core 2.19 become plugins can indicate that they do not work with pipelining (https://github.com/ansible-collections/community.general/pull/10537)."

--- a/plugins/become/doas.py
+++ b/plugins/become/doas.py
@@ -84,6 +84,9 @@ DOCUMENTATION = '''
               - name: ansible_doas_prompt_l10n
             env:
               - name: ANSIBLE_DOAS_PROMPT_L10N
+    notes:
+      - This become plugin does not work when connection pipelining is enabled. With ansible-core 2.19+, using it automatically
+        disables pipelining. On ansible-core 2.18 and before, pipelining must explicitly be disabled by the user.
 '''
 
 import re
@@ -99,6 +102,10 @@ class BecomeModule(BecomeBase):
     # messages for detecting prompted password issues
     fail = ('Permission denied',)
     missing = ('Authorization required',)
+
+    # See https://github.com/ansible-collections/community.general/issues/9977,
+    # https://github.com/ansible/ansible/pull/78111
+    pipelining = False
 
     def check_password_prompt(self, b_output):
         ''' checks if the expected password prompt exists in b_output '''

--- a/plugins/become/machinectl.py
+++ b/plugins/become/machinectl.py
@@ -77,6 +77,8 @@ DOCUMENTATION = '''
         if the user is allowed to perform the action (take a look at the examples section).
         If such a rule is not present the plugin only work if it is used in context with the root user,
         because then no further prompt will be shown by machinectl.
+      - This become plugin does not work when connection pipelining is enabled. With ansible-core 2.19+, using it automatically
+        disables pipelining. On ansible-core 2.18 and before, pipelining must explicitly be disabled by the user.
 '''
 
 EXAMPLES = r'''
@@ -108,6 +110,10 @@ class BecomeModule(BecomeBase):
     fail = ('==== AUTHENTICATION FAILED ====',)
     success = ('==== AUTHENTICATION COMPLETE ====',)
     require_tty = True  # see https://github.com/ansible-collections/community.general/issues/6932
+
+    # See https://github.com/ansible/ansible/issues/81254,
+    # https://github.com/ansible/ansible/pull/78111
+    pipelining = False
 
     @staticmethod
     def remove_ansi_codes(line):


### PR DESCRIPTION
##### SUMMARY
Backport of #10561 to stable-9.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
doas become plugin
machinectl become plugin