### PR TITLE
merge_variables lookup: avoid deprecated Templar.set_temporary_context

### DIFF
--- a/changelogs/fragments/10566-merge_variables.yml
+++ b/changelogs/fragments/10566-merge_variables.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "merge_variables lookup plugin - avoid deprecated functionality from ansible-core 2.19 (https://github.com/ansible-collections/community.general/pull/10566)."

--- a/plugins/lookup/merge_variables.py
+++ b/plugins/lookup/merge_variables.py
@@ -193,8 +193,8 @@ class LookupModule(LookupBase):
             result = initial_value
 
         for var_name in var_merge_names:
-            with self._templar.set_temporary_context(available_variables=variables):  # tmp. switch renderer to context of current variables
-                var_value = self._templar.template(variables[var_name])  # Render jinja2 templates
+            temp_templar = self._templar.copy_with_new_env(available_variables=variables)  # tmp. switch renderer to context of current variables
+            var_value = temp_templar.template(variables[var_name])  # Render jinja2 templates
             var_type = _verify_and_get_type(var_value)
 
             if prev_var_type is None:


### PR DESCRIPTION
##### SUMMARY
Fixes #10542.

(`Templar.copy_with_new_env()` is there since at least ansible-core 2.13+, which is the minimum ansible-core requirement of community.general 9.x.y.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
merge_variables lookup
