### PR TITLE
django module utils: remove deprecated function arg `ignore_value_none`

### DIFF
--- a/plugins/module_utils/django.py
+++ b/plugins/module_utils/django.py
@@ -55,11 +55,11 @@ class _DjangoRunner(PythonRunner):
 
         super(_DjangoRunner, self).__init__(module, ["-m", "django"], arg_formats=arg_fmts, **kwargs)
 
-    def __call__(self, output_process=None, ignore_value_none=True, check_mode_skip=False, check_mode_return=None, **kwargs):
+    def __call__(self, output_process=None, check_mode_skip=False, check_mode_return=None, **kwargs):
         args_order = (
             ("command", "no_color", "settings", "pythonpath", "traceback", "verbosity", "skip_checks") + self._prepare_args_order(self.default_args_order)
         )
-        return super(_DjangoRunner, self).__call__(args_order, output_process, ignore_value_none, check_mode_skip, check_mode_return, **kwargs)
+        return super(_DjangoRunner, self).__call__(args_order, output_process, check_mode_skip, check_mode_return, **kwargs)
 
     def bare_context(self, *args, **kwargs):
         return super(_DjangoRunner, self).__call__(*args, **kwargs)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove argument `ignore_value_none` from `_DjangoRunner`, preventing the deprecation message for it.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #10541 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/module_utils/django.py