### PR TITLE
lvm_pv - Fixes #10444 - Partition device not found

### DIFF
--- a/changelogs/fragments/lvm_pv.yml
+++ b/changelogs/fragments/lvm_pv.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - lvm_pv - properly detect SCSI or NVMe devices to rescan (https://github.com/ansible-collections/community.general/pull/10596).

--- a/changelogs/fragments/lvm_pv.yml
+++ b/changelogs/fragments/lvm_pv.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-    - lvm_pv - properly detect SCSI or NVMe devices to rescan (https://github.com/ansible-collections/community.general/pull/10596).
+    - lvm_pv - properly detect SCSI or NVMe devices to rescan (https://github.com/ansible-collections/community.general/issues/10444, https://github.com/ansible-collections/community.general/pull/10596).

--- a/plugins/modules/lvm_pv.py
+++ b/plugins/modules/lvm_pv.py
@@ -91,10 +91,22 @@ def get_pv_size(module, device):
 
 def rescan_device(module, device):
     """Perform storage rescan for the device."""
-    # Extract the base device name (e.g., /dev/sdb -> sdb)
     base_device = os.path.basename(device)
-    rescan_path = "/sys/block/{0}/device/rescan".format(base_device)
-    pv_partition = "/sys/class/block/{0}/partition".format(base_device)
+    is_partition = "/sys/class/block/{0}/partition".format(base_device)
+
+    # Determine parent device if partition exists
+    parent_device = base_device
+    if os.path.exists(is_partition):
+        parent_device = (
+            base_device.rpartition('p')[0] if base_device.startswith('nvme')
+            else base_device.rstrip('0123456789')
+        )
+
+    # Determine rescan path
+    rescan_path = "/sys/block/{0}/device/{1}".format(
+        parent_device,
+        "rescan_controller" if base_device.startswith('nvme') else "rescan"
+    )
 
     if os.path.exists(rescan_path):
         try:
@@ -103,11 +115,8 @@ def rescan_device(module, device):
             return True
         except IOError as e:
             module.warn("Failed to rescan device {0}: {1}".format(device, str(e)))
-            return False
-    elif os.path.exists(pv_partition):
-        return False
     else:
-        module.warn("Rescan path not found for device {0}".format(device))
+        module.warn("Rescan path does not exist for device {0}".format(device))
         return False
 
 

--- a/plugins/modules/lvm_pv.py
+++ b/plugins/modules/lvm_pv.py
@@ -94,6 +94,7 @@ def rescan_device(module, device):
     # Extract the base device name (e.g., /dev/sdb -> sdb)
     base_device = os.path.basename(device)
     rescan_path = "/sys/block/{0}/device/rescan".format(base_device)
+    pv_partition = "/sys/class/block/{0}/partition".format(base_device)
 
     if os.path.exists(rescan_path):
         try:
@@ -103,6 +104,8 @@ def rescan_device(module, device):
         except IOError as e:
             module.warn("Failed to rescan device {0}: {1}".format(device, str(e)))
             return False
+    elif os.path.exists(pv_partition):
+        return False
     else:
         module.warn("Rescan path not found for device {0}".format(device))
         return False


### PR DESCRIPTION
##### SUMMARY
This change improves error handling by gracefully skipping the rescan operation when dealing with partition devices, avoiding misleading warning messages.

Fixes #10444

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lvm_pv
