### PR TITLE
xfs_quota: command args as list rather than string

### DIFF
--- a/changelogs/fragments/10609-xfs-quota-cmd-list.yml
+++ b/changelogs/fragments/10609-xfs-quota-cmd-list.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - xfs_quota - using safer mechanism to run external command (https://github.com/ansible-collections/community.general/pull/10609).

--- a/plugins/modules/xfs_quota.py
+++ b/plugins/modules/xfs_quota.py
@@ -457,8 +457,8 @@ def quota_report(module, xfs_quota_bin, mountpoint, name, quota_type, used_type)
 
 
 def exec_quota(module, xfs_quota_bin, cmd, mountpoint):
-    cmd = [xfs_quota_bin, "-x", "-c"] + [cmd, mountpoint]
-    (rc, stdout, stderr) = module.run_command(cmd, use_unsafe_shell=True)
+    cmd = [xfs_quota_bin, "-x", "-c", cmd, mountpoint]
+    (rc, stdout, stderr) = module.run_command(cmd)
     if (
         "XFS_GETQUOTA: Operation not permitted" in stderr.split("\n")
         or rc == 1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
~~Pass args to run_command as list.~~ Do not use unsafe shell in `run_command()`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
xfs_quota