### PR TITLE
jc filter: remove redundant noqa comment

### DIFF
--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -79,7 +79,7 @@ from ansible.errors import AnsibleError, AnsibleFilterError
 import importlib
 
 try:
-    import jc  # noqa: F401, pylint: disable=unused-import
+    import jc
     HAS_LIB = True
 except ImportError:
     HAS_LIB = False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Comment became redundant at some point.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/filter/jc.py