### PR TITLE
Add a scaleway group to be able to use module_defaults

### DIFF
--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -79,6 +79,11 @@ exclusions = [
 ]
 doc_fragment = "community.general.keycloak.actiongroup_keycloak"
 
+[[sessions.extra_checks.action_groups_config]]
+name = "scaleway"
+pattern = "^scaleway_.*$"
+doc_fragment = "community.general.scaleway.actiongroup_scaleway"
+
 [sessions.build_import_check]
 run_galaxy_importer = true
 

--- a/changelogs/fragments/10647-scaleway-module-defaults.yml
+++ b/changelogs/fragments/10647-scaleway-module-defaults.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - scaleway modules - add a ``scaleway`` group to use ``module_defaults`` (https://github.com/ansible-collections/community.general/pull/10647).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -46,6 +46,36 @@ action_groups:
     - keycloak_user_federation
     - keycloak_user_rolemapping
     - keycloak_userprofile
+  scaleway:
+    - scaleway_compute
+    - scaleway_compute_private_network
+    - scaleway_container
+    - scaleway_container_info
+    - scaleway_container_namespace
+    - scaleway_container_namespace_info
+    - scaleway_container_registry
+    - scaleway_container_registry_info
+    - scaleway_database_backup
+    - scaleway_function
+    - scaleway_function_info
+    - scaleway_function_namespace
+    - scaleway_function_namespace_info
+    - scaleway_image_info
+    - scaleway_ip
+    - scaleway_ip_info
+    - scaleway_lb
+    - scaleway_organization_info
+    - scaleway_private_network
+    - scaleway_security_group
+    - scaleway_security_group_info
+    - scaleway_security_group_rule
+    - scaleway_server_info
+    - scaleway_snapshot_info
+    - scaleway_sshkey
+    - scaleway_user_data
+    - scaleway_volume
+    - scaleway_volume_info
+
 plugin_routing:
   callback:
     actionable:

--- a/plugins/doc_fragments/scaleway.py
+++ b/plugins/doc_fragments/scaleway.py
@@ -47,3 +47,13 @@ notes:
     E(SCW_TOKEN), E(SCW_API_KEY), E(SCW_OAUTH_TOKEN) or E(SCW_API_TOKEN).
   - If one wants to use a different O(api_url) one can also set the E(SCW_API_URL) environment variable.
 """
+
+    ACTIONGROUP_SCALEWAY = r"""
+options: {}
+attributes:
+  action_group:
+    description: Use C(group/community.general.scaleway) in C(module_defaults) to set defaults for this module.
+    support: full
+    membership:
+      - community.general.scaleway
+"""

--- a/plugins/modules/scaleway_compute.py
+++ b/plugins/modules/scaleway_compute.py
@@ -22,12 +22,15 @@ description:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
 
 attributes:
   check_mode:
     support: full
   diff_mode:
     support: none
+  action_group:
+    version_added: 11.3.0
 
 options:
 

--- a/plugins/modules/scaleway_compute_private_network.py
+++ b/plugins/modules/scaleway_compute_private_network.py
@@ -21,12 +21,15 @@ description:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
 
 attributes:
   check_mode:
     support: full
   diff_mode:
     support: none
+  action_group:
+    version_added: 11.3.0
 
 options:
   state:

--- a/plugins/modules/scaleway_container.py
+++ b/plugins/modules/scaleway_container.py
@@ -22,6 +22,7 @@ extends_documentation_fragment:
   - community.general.scaleway
   - community.general.scaleway_waitable_resource
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
 requirements:
   - passlib[argon2] >= 1.7.4
 
@@ -30,6 +31,8 @@ attributes:
     support: full
   diff_mode:
     support: none
+  action_group:
+    version_added: 11.3.0
 
 options:
   state:

--- a/plugins/modules/scaleway_container_info.py
+++ b/plugins/modules/scaleway_container_info.py
@@ -21,7 +21,12 @@ description:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
   - community.general.attributes.info_module
+
+attributes:
+  action_group:
+    version_added: 11.3.0
 
 options:
   namespace_id:

--- a/plugins/modules/scaleway_container_namespace.py
+++ b/plugins/modules/scaleway_container_namespace.py
@@ -22,6 +22,7 @@ extends_documentation_fragment:
   - community.general.scaleway
   - community.general.scaleway_waitable_resource
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
 requirements:
   - passlib[argon2] >= 1.7.4
 
@@ -30,6 +31,8 @@ attributes:
     support: full
   diff_mode:
     support: none
+  action_group:
+    version_added: 11.3.0
 
 options:
   state:

--- a/plugins/modules/scaleway_container_namespace_info.py
+++ b/plugins/modules/scaleway_container_namespace_info.py
@@ -21,7 +21,12 @@ description:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
   - community.general.attributes.info_module
+
+attributes:
+  action_group:
+    version_added: 11.3.0
 
 options:
   project_id:

--- a/plugins/modules/scaleway_container_registry.py
+++ b/plugins/modules/scaleway_container_registry.py
@@ -22,12 +22,15 @@ extends_documentation_fragment:
   - community.general.scaleway
   - community.general.scaleway_waitable_resource
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
 
 attributes:
   check_mode:
     support: full
   diff_mode:
     support: none
+  action_group:
+    version_added: 11.3.0
 
 options:
   state:

--- a/plugins/modules/scaleway_container_registry_info.py
+++ b/plugins/modules/scaleway_container_registry_info.py
@@ -21,7 +21,12 @@ description:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
   - community.general.attributes.info_module
+
+attributes:
+  action_group:
+    version_added: 11.3.0
 
 options:
   project_id:

--- a/plugins/modules/scaleway_database_backup.py
+++ b/plugins/modules/scaleway_database_backup.py
@@ -22,11 +22,15 @@ description:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
 attributes:
   check_mode:
     support: full
   diff_mode:
     support: none
+  action_group:
+    version_added: 11.3.0
+
 options:
   state:
     description:

--- a/plugins/modules/scaleway_function.py
+++ b/plugins/modules/scaleway_function.py
@@ -22,6 +22,7 @@ extends_documentation_fragment:
   - community.general.scaleway
   - community.general.scaleway_waitable_resource
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
 requirements:
   - passlib[argon2] >= 1.7.4
 
@@ -30,6 +31,8 @@ attributes:
     support: full
   diff_mode:
     support: none
+  action_group:
+    version_added: 11.3.0
 
 options:
   state:

--- a/plugins/modules/scaleway_function_info.py
+++ b/plugins/modules/scaleway_function_info.py
@@ -21,7 +21,12 @@ description:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
   - community.general.attributes.info_module
+
+attributes:
+  action_group:
+    version_added: 11.3.0
 
 options:
   namespace_id:

--- a/plugins/modules/scaleway_function_namespace.py
+++ b/plugins/modules/scaleway_function_namespace.py
@@ -22,6 +22,7 @@ extends_documentation_fragment:
   - community.general.scaleway
   - community.general.scaleway_waitable_resource
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
 requirements:
   - passlib[argon2] >= 1.7.4
 
@@ -30,6 +31,8 @@ attributes:
     support: full
   diff_mode:
     support: none
+  action_group:
+    version_added: 11.3.0
 
 options:
   state:

--- a/plugins/modules/scaleway_function_namespace_info.py
+++ b/plugins/modules/scaleway_function_namespace_info.py
@@ -21,7 +21,12 @@ description:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
   - community.general.attributes.info_module
+
+attributes:
+  action_group:
+    version_added: 11.3.0
 
 options:
   project_id:

--- a/plugins/modules/scaleway_image_info.py
+++ b/plugins/modules/scaleway_image_info.py
@@ -19,7 +19,12 @@ author:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
   - community.general.attributes.info_module
+
+attributes:
+  action_group:
+    version_added: 11.3.0
 
 options:
   region:

--- a/plugins/modules/scaleway_ip.py
+++ b/plugins/modules/scaleway_ip.py
@@ -20,12 +20,15 @@ description:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
 
 attributes:
   check_mode:
     support: full
   diff_mode:
     support: none
+  action_group:
+    version_added: 11.3.0
 
 options:
   state:

--- a/plugins/modules/scaleway_ip_info.py
+++ b/plugins/modules/scaleway_ip_info.py
@@ -19,7 +19,12 @@ author:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
   - community.general.attributes.info_module
+
+attributes:
+  action_group:
+    version_added: 11.3.0
 
 options:
   region:

--- a/plugins/modules/scaleway_lb.py
+++ b/plugins/modules/scaleway_lb.py
@@ -22,12 +22,15 @@ description:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
 
 attributes:
   check_mode:
     support: full
   diff_mode:
     support: none
+  action_group:
+    version_added: 11.3.0
 
 options:
 

--- a/plugins/modules/scaleway_organization_info.py
+++ b/plugins/modules/scaleway_organization_info.py
@@ -16,6 +16,11 @@ description:
 author:
   - "Yanis Guenane (@Spredzy)"
   - "Remy Leone (@remyleone)"
+
+attributes:
+  action_group:
+    version_added: 11.3.0
+
 options:
   api_url:
     description:
@@ -25,6 +30,7 @@ options:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
   - community.general.attributes.info_module
 """
 

--- a/plugins/modules/scaleway_private_network.py
+++ b/plugins/modules/scaleway_private_network.py
@@ -21,12 +21,15 @@ description:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
 
 attributes:
   check_mode:
     support: full
   diff_mode:
     support: none
+  action_group:
+    version_added: 11.3.0
 
 options:
   state:

--- a/plugins/modules/scaleway_security_group.py
+++ b/plugins/modules/scaleway_security_group.py
@@ -21,12 +21,15 @@ description:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
 
 attributes:
   check_mode:
     support: full
   diff_mode:
     support: none
+  action_group:
+    version_added: 11.3.0
 
 options:
   state:

--- a/plugins/modules/scaleway_security_group_info.py
+++ b/plugins/modules/scaleway_security_group_info.py
@@ -16,6 +16,11 @@ description:
 author:
   - "Yanis Guenane (@Spredzy)"
   - "Remy Leone (@remyleone)"
+
+attributes:
+  action_group:
+    version_added: 11.3.0
+
 options:
   region:
     type: str
@@ -39,6 +44,7 @@ options:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
   - community.general.attributes.info_module
 """
 

--- a/plugins/modules/scaleway_security_group_rule.py
+++ b/plugins/modules/scaleway_security_group_rule.py
@@ -21,12 +21,15 @@ description:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
 
 attributes:
   check_mode:
     support: full
   diff_mode:
     support: none
+  action_group:
+    version_added: 11.3.0
 
 options:
   state:

--- a/plugins/modules/scaleway_server_info.py
+++ b/plugins/modules/scaleway_server_info.py
@@ -19,7 +19,12 @@ author:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
   - community.general.attributes.info_module
+
+attributes:
+  action_group:
+    version_added: 11.3.0
 
 options:
   region:

--- a/plugins/modules/scaleway_snapshot_info.py
+++ b/plugins/modules/scaleway_snapshot_info.py
@@ -19,7 +19,12 @@ author:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
   - community.general.attributes.info_module
+
+attributes:
+  action_group:
+    version_added: 11.3.0
 
 options:
   region:

--- a/plugins/modules/scaleway_sshkey.py
+++ b/plugins/modules/scaleway_sshkey.py
@@ -22,12 +22,15 @@ description:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
 
 attributes:
   check_mode:
     support: full
   diff_mode:
     support: none
+  action_group:
+    version_added: 11.3.0
 
 options:
   state:

--- a/plugins/modules/scaleway_user_data.py
+++ b/plugins/modules/scaleway_user_data.py
@@ -23,12 +23,15 @@ description:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
 
 attributes:
   check_mode:
     support: full
   diff_mode:
     support: none
+  action_group:
+    version_added: 11.3.0
 
 options:
 

--- a/plugins/modules/scaleway_volume.py
+++ b/plugins/modules/scaleway_volume.py
@@ -21,12 +21,15 @@ description:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
 
 attributes:
   check_mode:
     support: full
   diff_mode:
     support: none
+  action_group:
+    version_added: 11.3.0
 
 options:
   state:

--- a/plugins/modules/scaleway_volume_info.py
+++ b/plugins/modules/scaleway_volume_info.py
@@ -19,7 +19,12 @@ author:
 extends_documentation_fragment:
   - community.general.scaleway
   - community.general.attributes
+  - community.general.scaleway.actiongroup_scaleway
   - community.general.attributes.info_module
+
+attributes:
+  action_group:
+    version_added: 11.3.0
 
 options:
   region:


### PR DESCRIPTION
##### SUMMARY
Add a scaleway group to be able to use module_defaults

Since all modules requires the use of a api_key and various others repeated arguments, being able to use module_defaults allow to write cleaner roles.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
all scaleway
