### PR TITLE
CI: Make sure to install Java in Debian Bullseye

### DIFF
--- a/tests/integration/targets/setup_java_keytool/vars/Debian.yml
+++ b/tests/integration/targets/setup_java_keytool/vars/Debian.yml
@@ -5,3 +5,4 @@
 
 keytool_package_names:
   - ca-certificates-java
+  - openjdk-11-jre-headless


### PR DESCRIPTION
##### SUMMARY
Currently the tests fail consistently only on stable-9, but not on stable-10 or stable-11.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
setup_java_keytool integration role
