### PR TITLE
pacemaker_resource: Fix resource_type parameter

### DIFF
--- a/plugins/module_utils/pacemaker.py
+++ b/plugins/module_utils/pacemaker.py
@@ -24,7 +24,7 @@ _state_map = {
 
 
 def fmt_resource_type(value):
-    return [value[k] for k in ['resource_standard', 'resource_provider', 'resource_name'] if value.get(k) is not None]
+    return [":".join(value[k] for k in ['resource_standard', 'resource_provider', 'resource_name'] if value.get(k) is not None)]
 
 
 def fmt_resource_operation(value):

--- a/tests/unit/plugins/modules/test_pacemaker_resource.yaml
+++ b/tests/unit/plugins/modules/test_pacemaker_resource.yaml
@@ -57,6 +57,8 @@ test_cases:
       name: virtual-ip
       resource_type:
         resource_name: IPaddr2
+        resource_standard: ocf
+        resource_provider: heartbeat
       resource_option:
         - "ip=[192.168.2.1]"
       resource_operation:
@@ -98,10 +100,10 @@ test_cases:
             dc-version=2.1.9-1.fc41-7188dbf
             have-watchdog=false
           err: ""
-        - command: [/testbin/pcs, resource, create, virtual-ip, IPaddr2, "ip=[192.168.2.1]", op, start, timeout=1200, op, stop, timeout=1200, op, monitor, timeout=1200, meta, test_meta1=123, meta, test_meta2=456, --group, test_group, --wait=200]
+        - command: [/testbin/pcs, resource, create, virtual-ip, ocf:heartbeat:IPaddr2, "ip=[192.168.2.1]", op, start, timeout=1200, op, stop, timeout=1200, op, monitor, timeout=1200, meta, test_meta1=123, meta, test_meta2=456, --group, test_group, --wait=200]
           environ: *env-def
           rc: 0
-          out: "Assumed agent name 'ocf:heartbeat:IPaddr2' (deduced from 'IPAddr2')"
+          out: "Assumed agent name 'ocf:heartbeat:IPaddr2'"
           err: ""
         - command: [/testbin/pcs, resource, status, virtual-ip]
           environ: *env-def


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Current implementation of `pacemaker_resource` does not format the `resource_type` successfully for the Pacemaker CLI. This PR corrects the format to be: `resource_standard:resource_provider:resource_name`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #10426
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
pacemaker_resource

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
