### PR TITLE
Fix lookup GitHub app access token

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -283,7 +283,7 @@ files:
     maintainers: dagwieers
   $lookups/flattened.py: {}
   $lookups/github_app_access_token.py:
-    maintainers: weisheng-p
+    maintainers: weisheng-p blavoie
   $lookups/hiera.py:
     maintainers: jparrill
   $lookups/keyring.py: {}

--- a/changelogs/fragments/10299-github_app_access_token-lookup.yml
+++ b/changelogs/fragments/10299-github_app_access_token-lookup.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - github_app_access_token lookup plugin - avoid using jwt library requirement that conflicts with other modules requirements (https://github.com/ansible-collections/community.general/issues/10299)
+breaking_changes:
+  - github_app_access_token lookup plugin - depends now on pyjwt rather than jwt (https://github.com/ansible-collections/community.general/issues/10299)

--- a/plugins/lookup/github_app_access_token.py
+++ b/plugins/lookup/github_app_access_token.py
@@ -139,12 +139,10 @@ def post_request(generated_jwt, installation_id):
         raise AnsibleError(f"Error while dencoding JSON respone from github: {e}")
     return json_data.get('token')
 
-
 def get_token(key_path, app_id, installation_id, private_key, expiry=600):
     jwk = read_key(key_path, private_key)
     generated_jwt = encode_jwt(app_id, jwk, exp=expiry)
     return post_request(generated_jwt, installation_id)
-
 
 class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):

--- a/plugins/lookup/github_app_access_token.py
+++ b/plugins/lookup/github_app_access_token.py
@@ -90,6 +90,7 @@ from ansible.utils.display import Display
 
 display = Display()
 
+
 def read_key(path, private_key=None):
     try:
         if private_key:
@@ -100,6 +101,7 @@ def read_key(path, private_key=None):
         return serialization.load_pem_private_key(key_bytes, password=None)
     except Exception as e:
         raise AnsibleError(f"Error while parsing key file: {e}")
+
 
 def encode_jwt(app_id, private_key_obj, exp=600):
     now = int(time.time())
@@ -112,6 +114,7 @@ def encode_jwt(app_id, private_key_obj, exp=600):
         return jwt.encode(payload, private_key_obj, algorithm='RS256')
     except Exception as e:
         raise AnsibleError(f"Error while encoding jwt: {e}")
+
 
 def post_request(generated_jwt, installation_id):
     github_api_url = f'https://api.github.com/app/installations/{installation_id}/access_tokens'
@@ -139,10 +142,12 @@ def post_request(generated_jwt, installation_id):
         raise AnsibleError(f"Error while dencoding JSON respone from github: {e}")
     return json_data.get('token')
 
+
 def get_token(key_path, app_id, installation_id, private_key, expiry=600):
     jwk = read_key(key_path, private_key)
     generated_jwt = encode_jwt(app_id, jwk, exp=expiry)
     return post_request(generated_jwt, installation_id)
+
 
 class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):


### PR DESCRIPTION
##### SUMMARY
Change community.general.github_app_access_token lookup to use PyJWT (https://pypi.org/project/PyJWT/) rather than jwt (https://github.com/GehirnInc/python-jwt).

Fixes #10299

this is a continuation of #10332

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
github_app_access_token

##### ADDITIONAL INFORMATION
Change the implementation to use pyjwt, rather than jwt that causes conflits elsewhere in the Ansible ecosystem.

thank you @blavoie  for the intial commit and fixes. This pr would include both the compatibility issue and (hopefully) the required test cases

Im not too sure about how deprecation warning are usually shown in this collection, I've make used of `display.deprecated` function with a magic version number, any direction on this would be appreciated 

