### PR TITLE
ansible-core 2.20: avoid deprecated functionality

### DIFF
--- a/changelogs/fragments/10687-deprecations.yml
+++ b/changelogs/fragments/10687-deprecations.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Avoid deprecated functionality in ansible-core 2.20 (https://github.com/ansible-collections/community.general/pull/10687)."

--- a/plugins/become/machinectl.py
+++ b/plugins/become/machinectl.py
@@ -94,7 +94,7 @@ EXAMPLES = r"""
 from re import compile as re_compile
 
 from ansible.plugins.become import BecomeBase
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 ansi_color_codes = re_compile(to_bytes(r'\x1B\[[0-9;]+m'))

--- a/plugins/become/run0.py
+++ b/plugins/become/run0.py
@@ -80,7 +80,7 @@ EXAMPLES = r"""
 from re import compile as re_compile
 
 from ansible.plugins.become import BecomeBase
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 ansi_color_codes = re_compile(to_bytes(r"\x1B\[[0-9;]+m"))
 

--- a/plugins/cache/memcached.py
+++ b/plugins/cache/memcached.py
@@ -54,7 +54,7 @@ from multiprocessing import Lock
 from itertools import chain
 
 from ansible.errors import AnsibleError
-from ansible.module_utils.common._collections_compat import MutableSet
+from collections.abc import MutableSet
 from ansible.plugins.cache import BaseCacheModule
 from ansible.utils.display import Display
 

--- a/plugins/callback/dense.py
+++ b/plugins/callback/dense.py
@@ -28,7 +28,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.six import binary_type, text_type
-from ansible.module_utils.common._collections_compat import MutableMapping, MutableSequence
+from collections.abc import MutableMapping, MutableSequence
 from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
 from ansible.utils.color import colorize, hostcolor
 from ansible.utils.display import Display

--- a/plugins/callback/log_plays.py
+++ b/plugins/callback/log_plays.py
@@ -34,7 +34,7 @@ import json
 
 from ansible.utils.path import makedirs_safe
 from ansible.module_utils.common.text.converters import to_bytes
-from ansible.module_utils.common._collections_compat import MutableMapping
+from collections.abc import MutableMapping
 from ansible.parsing.ajson import AnsibleJSONEncoder
 from ansible.plugins.callback import CallbackBase
 

--- a/plugins/connection/incus.py
+++ b/plugins/connection/incus.py
@@ -80,7 +80,7 @@ from subprocess import call, Popen, PIPE
 
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
 from ansible.module_utils.common.process import get_bin_path
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.plugins.connection import ConnectionBase
 
 

--- a/plugins/filter/counter.py
+++ b/plugins/filter/counter.py
@@ -36,7 +36,7 @@ _value:
 """
 
 from ansible.errors import AnsibleFilterError
-from ansible.module_utils.common._collections_compat import Sequence
+from collections.abc import Sequence
 from collections import Counter
 
 

--- a/plugins/filter/groupby_as_dict.py
+++ b/plugins/filter/groupby_as_dict.py
@@ -54,7 +54,7 @@ _value:
 """
 
 from ansible.errors import AnsibleFilterError
-from ansible.module_utils.common._collections_compat import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 
 def groupby_as_dict(sequence, attribute):

--- a/plugins/filter/lists_mergeby.py
+++ b/plugins/filter/lists_mergeby.py
@@ -197,7 +197,7 @@ _value:
 
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils.six import string_types
-from ansible.module_utils.common._collections_compat import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from ansible.utils.vars import merge_hash
 
 from collections import defaultdict

--- a/plugins/filter/to_ini.py
+++ b/plugins/filter/to_ini.py
@@ -51,7 +51,7 @@ _value:
 
 
 from ansible.errors import AnsibleFilterError
-from ansible.module_utils.common._collections_compat import Mapping
+from collections.abc import Mapping
 from ansible.module_utils.six.moves import StringIO
 from ansible.module_utils.six.moves.configparser import ConfigParser
 

--- a/plugins/filter/to_prettytable.py
+++ b/plugins/filter/to_prettytable.py
@@ -116,7 +116,7 @@ except ImportError:
     HAS_PRETTYTABLE = False
 
 from ansible.errors import AnsibleFilterError
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.six import string_types
 
 

--- a/plugins/inventory/virtualbox.py
+++ b/plugins/inventory/virtualbox.py
@@ -78,7 +78,7 @@ from subprocess import Popen, PIPE
 
 from ansible.errors import AnsibleParserError
 from ansible.module_utils.common.text.converters import to_bytes, to_text
-from ansible.module_utils.common._collections_compat import MutableMapping
+from collections.abc import MutableMapping
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.module_utils.common.process import get_bin_path
 

--- a/plugins/lookup/dependent.py
+++ b/plugins/lookup/dependent.py
@@ -121,7 +121,7 @@ _list:
 """
 
 from ansible.errors import AnsibleLookupError
-from ansible.module_utils.common._collections_compat import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from ansible.module_utils.six import string_types
 from ansible.plugins.lookup import LookupBase
 from ansible.template import Templar

--- a/plugins/module_utils/oneview.py
+++ b/plugins/module_utils/oneview.py
@@ -29,7 +29,7 @@ except ImportError:
 from ansible.module_utils import six
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
-from ansible.module_utils.common._collections_compat import Mapping
+from ansible.module_utils.six.moves.collections_abc import Mapping
 
 
 def transform_list_to_dict(list_):

--- a/plugins/modules/xml.py
+++ b/plugins/modules/xml.py
@@ -377,8 +377,8 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule, json_dict_bytes_to_unicode, missing_required_lib
 from ansible.module_utils.six import iteritems, string_types
+from ansible.module_utils.six.moves.collections_abc import MutableMapping
 from ansible.module_utils.common.text.converters import to_bytes, to_native
-from ansible.module_utils.common._collections_compat import MutableMapping
 
 _IDENT = r"[a-zA-Z-][a-zA-Z0-9_\-\.]*"
 _NSIDENT = _IDENT + "|" + _IDENT + ":" + _IDENT

--- a/plugins/plugin_utils/ansible_type.py
+++ b/plugins/plugin_utils/ansible_type.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.errors import AnsibleFilterError
-from ansible.module_utils.common._collections_compat import Mapping
+from collections.abc import Mapping
 
 try:
     # Introduced with Data Tagging (https://github.com/ansible/ansible/pull/84621):

--- a/plugins/plugin_utils/keys_filter.py
+++ b/plugins/plugin_utils/keys_filter.py
@@ -10,7 +10,7 @@ import re
 
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils.six import string_types
-from ansible.module_utils.common._collections_compat import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 
 def _keys_filter_params(data, matching_parameter):

--- a/plugins/plugin_utils/unsafe.py
+++ b/plugins/plugin_utils/unsafe.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 import re
 
 from ansible.module_utils.six import binary_type, text_type
-from ansible.module_utils.common._collections_compat import Mapping, Set
+from collections.abc import Mapping, Set
 from ansible.module_utils.common.collections import is_sequence
 from ansible.utils.unsafe_proxy import (
     AnsibleUnsafe,

--- a/plugins/test/ansible_type.py
+++ b/plugins/test/ansible_type.py
@@ -224,7 +224,7 @@ _value:
 '''
 
 from ansible.errors import AnsibleFilterError
-from ansible.module_utils.common._collections_compat import Sequence
+from ansible.module_utils.six.moves.collections_abc import Sequence
 from ansible_collections.community.general.plugins.plugin_utils.ansible_type import _ansible_type
 
 

--- a/tests/unit/plugins/modules/conftest.py
+++ b/tests/unit/plugins/modules/conftest.py
@@ -11,7 +11,7 @@ import json
 import pytest
 
 from ansible.module_utils.six import string_types
-from ansible.module_utils.common._collections_compat import MutableMapping
+from ansible.module_utils.six.moves.collections_abc import MutableMapping
 
 from ansible_collections.community.general.plugins.module_utils import deps
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import set_module_args as _set_module_args

--- a/tests/unit/plugins/modules/test_jenkins_plugin.py
+++ b/tests/unit/plugins/modules/test_jenkins_plugin.py
@@ -10,7 +10,7 @@ import json
 from collections import OrderedDict
 
 from ansible_collections.community.general.plugins.modules.jenkins_plugin import JenkinsPlugin
-from ansible.module_utils.common._collections_compat import Mapping
+from ansible.module_utils.six.moves.collections_abc import Mapping
 from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
     MagicMock,
     patch,


### PR DESCRIPTION
##### SUMMARY
ansible.module_utils._text and ansible.module_utils.common._collections_compat have been deprecated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
various
