### PR TITLE
gem: fix soundness issue when uninstalling default gems on Ubuntu

### DIFF
--- a/tests/integration/targets/gem/tasks/main.yml
+++ b/tests/integration/targets/gem/tasks/main.yml
@@ -212,3 +212,20 @@
         that:
           - install_gem_result is changed
           - not gem_bindir_stat.stat.exists
+  
+    - name: Attempt to uninstall default gem 'json'
+      community.general.gem:
+        name: json
+        state: absent
+      when: ansible_distribution == "Ubuntu"
+      register: gem_result
+      ignore_errors: true
+
+    - name: Assert gem uninstall failed as expected
+      when: ansible_distribution == "Ubuntu"
+      assert:
+        that:
+          - gem_result is failed
+          - "'Gem could not be removed' == gem_result.msg"
+          - gem_result.state == "absent"
+          - gem_result.name == "json"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes incorrect reporting when uninstalling default gems on Ubuntu.  
Previously, the `gem` module reported `changed: true` even though default gems (e.g. `json`) cannot be removed.  
On Ubuntu, `gem uninstall` exits with code 0 but leaves the gem installed, misleading the module.  
With this patch, the module now re-checks after uninstall and fails if the gem is still present. I also added integration tests

Fixes #10451
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
gem
