### PR TITLE
pacemaker: Add regex checking for maintenance-mode

### DIFF
--- a/changelogs/fragments/10707-pacemaker-maintenance-mode-regex.yml
+++ b/changelogs/fragments/10707-pacemaker-maintenance-mode-regex.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - "pacemaker - Use regex for matching ``maintenance-mode`` output to determine cluster maintenance status (https://github.com/ansible-collections/community.general/issues/10426, https://github.com/ansible-collections/community.general/pull/10707)."
+
+minor_changes:
+  - "pacemaker_resource - Additional unit test for handling different Pacemaker CLI output for ``maintenance-mode`` (https://github.com/ansible-collections/community.general/issues/10426, https://github.com/ansible-collections/community.general/pull/10707)."
+  - "pacemaker_cluster - Additional unit test for handling different Pacemaker CLI output for ``maintenance-mode`` (https://github.com/ansible-collections/community.general/issues/10426, https://github.com/ansible-collections/community.general/pull/10707)."

--- a/changelogs/fragments/10707-pacemaker-maintenance-mode-regex.yml
+++ b/changelogs/fragments/10707-pacemaker-maintenance-mode-regex.yml
@@ -1,6 +1,2 @@
 bugfixes:
-  - "pacemaker - Use regex for matching ``maintenance-mode`` output to determine cluster maintenance status (https://github.com/ansible-collections/community.general/issues/10426, https://github.com/ansible-collections/community.general/pull/10707)."
-
-minor_changes:
-  - "pacemaker_resource - Additional unit test for handling different Pacemaker CLI output for ``maintenance-mode`` (https://github.com/ansible-collections/community.general/issues/10426, https://github.com/ansible-collections/community.general/pull/10707)."
-  - "pacemaker_cluster - Additional unit test for handling different Pacemaker CLI output for ``maintenance-mode`` (https://github.com/ansible-collections/community.general/issues/10426, https://github.com/ansible-collections/community.general/pull/10707)."
+  - "pacemaker - use regex for matching ``maintenance-mode`` output to determine cluster maintenance status (https://github.com/ansible-collections/community.general/issues/10426, https://github.com/ansible-collections/community.general/pull/10707)."

--- a/plugins/module_utils/pacemaker.py
+++ b/plugins/module_utils/pacemaker.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible_collections.community.general.plugins.module_utils.cmd_runner import CmdRunner, cmd_runner_fmt
-
+import re
 
 _state_map = {
     "present": "create",
@@ -45,7 +45,7 @@ def fmt_resource_argument(value):
 def get_pacemaker_maintenance_mode(runner):
     with runner("cli_action config") as ctx:
         rc, out, err = ctx.run(cli_action="property")
-        maintenance_mode_output = list(filter(lambda string: "maintenance-mode=true" in string.lower(), out.splitlines()))
+        maintenance_mode_output = list(filter(lambda string: bool(re.search("maintenance-mode.*true", string, re.IGNORECASE)), out.splitlines()))
         return bool(maintenance_mode_output)
 
 

--- a/plugins/module_utils/pacemaker.py
+++ b/plugins/module_utils/pacemaker.py
@@ -6,8 +6,9 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from ansible_collections.community.general.plugins.module_utils.cmd_runner import CmdRunner, cmd_runner_fmt
 import re
+
+from ansible_collections.community.general.plugins.module_utils.cmd_runner import CmdRunner, cmd_runner_fmt
 
 _state_map = {
     "present": "create",
@@ -45,7 +46,8 @@ def fmt_resource_argument(value):
 def get_pacemaker_maintenance_mode(runner):
     with runner("cli_action config") as ctx:
         rc, out, err = ctx.run(cli_action="property")
-        maintenance_mode_output = list(filter(lambda string: bool(re.search("maintenance-mode.*true", string, re.IGNORECASE)), out.splitlines()))
+        maint_mode_re = re.compile(r"maintenance-mode.*true", re.IGNORECASE)
+        maintenance_mode_output = [line for line in out.splitlines() if maint_mode_re.search(line)]
         return bool(maintenance_mode_output)
 
 

--- a/tests/unit/plugins/modules/test_pacemaker_cluster.yaml
+++ b/tests/unit/plugins/modules/test_pacemaker_cluster.yaml
@@ -371,6 +371,30 @@ test_cases:
           rc: 0
           out: 'maintenance-mode=true'
           err: ""
+  - id: test_maintenance_minimal_input_initial_online_version_change
+    input:
+      state: maintenance
+    output:
+      changed: true
+      previous_value: 'maintenance-mode: false'
+      value: 'maintenance-mode: true'
+    mocks:
+      run_command:
+        - command: [/testbin/pcs, property, config, maintenance-mode]
+          environ: *env-def
+          rc: 0
+          out: 'maintenance-mode: false'
+          err: ""
+        - command: [/testbin/pcs, property, set, maintenance-mode=true]
+          environ: *env-def
+          rc: 0
+          out: ""
+          err: ""
+        - command: [/testbin/pcs, property, config, maintenance-mode]
+          environ: *env-def
+          rc: 0
+          out: 'maintenance-mode: true'
+          err: ""
   - id: test_maintenance_minimal_input_initial_offline
     input:
       state: maintenance

--- a/tests/unit/plugins/modules/test_pacemaker_resource.yaml
+++ b/tests/unit/plugins/modules/test_pacemaker_resource.yaml
@@ -189,6 +189,46 @@ test_cases:
           rc: 0
           out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Stopped"
           err: ""
+  - id: test_present_minimal_input_resource_maintenance_mode_version_change
+    input:
+      state: present
+      name: virtual-ip
+      resource_type:
+        resource_name: IPaddr2
+      resource_option:
+        - "ip=[192.168.2.1]"
+    output:
+      changed: true
+      previous_value: null
+      value: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Stopped"
+    mocks:
+      run_command:
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 1
+          out: ""
+          err: ""
+        - command: [/testbin/pcs, property, config]
+          environ: *env-def
+          rc: 0
+          out: |
+            Cluster Properties: cib-bootstrap-options
+            cluster-infrastructure: corosync
+            cluster-name: hacluster
+            dc-version: 2.1.9-1.fc41-7188dbf
+            have-watchdog: false
+            maintenance-mode: true
+          err: ""
+        - command: [/testbin/pcs, resource, create, virtual-ip, IPaddr2, "ip=[192.168.2.1]", --wait=300]
+          environ: *env-def
+          rc: 1
+          out: ""
+          err: "Error: resource 'virtual-ip' is not running on any node"
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Stopped"
+          err: ""
   - id: test_absent_minimal_input_resource_not_exist
     input:
       state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add regex matching for `maintenance-mode` for determining maintenance-mode status. Additional unit tests for affected modules.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #10426
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
pacemaker
pacemaker_resource
pacemaker_cluster
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Depending on OS version, `maintenance-mode` value can be defined such as: `maintenance-mode=true` or `maintenance-mode: true` when performing a `pcs property config`.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
