### PR TITLE
random_string: Specify seed while generating random string

### DIFF
--- a/changelogs/fragments/random_string_seed.yml
+++ b/changelogs/fragments/random_string_seed.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+    - random_string - allow to specify seed while generating random string (https://github.com/ansible-collections/community.general/issues/5362, https://github.com/ansible-collections/community.general/pull/10710).

--- a/changelogs/fragments/random_string_seed.yml
+++ b/changelogs/fragments/random_string_seed.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-    - random_string - allow to specify seed while generating random string (https://github.com/ansible-collections/community.general/issues/5362, https://github.com/ansible-collections/community.general/pull/10710).
+    - random_string lookup plugin - allow to specify seed while generating random string (https://github.com/ansible-collections/community.general/issues/5362, https://github.com/ansible-collections/community.general/pull/10710).

--- a/plugins/lookup/random_string.py
+++ b/plugins/lookup/random_string.py
@@ -100,6 +100,9 @@ options:
   seed:
     description:
       - Seed for random string generator.
+      - B(Note) that this drastically reduces the security of this plugin. First, when O(seed) is provided, a non-cryptographic random number generator is used.
+        Second, if the seed does not contain enough entropy, the generated string is weak.
+        B(Do not use the generated string as a password or a secure token when using this option!)
     type: str
     version_added: 11.3.0
 """
@@ -114,6 +117,9 @@ EXAMPLES = r"""
   ansible.builtin.debug:
     var: lookup('community.general.random_string', seed=12345)
   # Example result: '6[~(2q5O'
+  # NOTE: Do **not** use this string as a password or a secure token,
+  #       unless you know exactly what you are doing!
+  #       Specifying seed uses a non-secure random number generator.
 
 - name: Generate random string with length 12
   ansible.builtin.debug:

--- a/tests/integration/targets/lookup_random_string/test.yml
+++ b/tests/integration/targets/lookup_random_string/test.yml
@@ -21,6 +21,8 @@
         result11: "{{ query('community.general.random_string', base64=true, length=8) }}"
         result12: "{{ query('community.general.random_string', upper=false, numbers=false, special=false) }}" # all lower case
         result13: "{{ query('community.general.random_string', override_all='0', length=2) }}"
+        result14: "{{ query('community.general.random_string', seed='1234') }}"
+        result15: "{{ query('community.general.random_string', seed='1234') }}"
 
     - name: Raise error when impossible constraints are provided
       set_fact:
@@ -51,3 +53,4 @@
           - result13[0] == '00'
           - impossible_result is failed
           - "'Available characters cannot' in impossible_result.msg"
+          - result15[0] == result14[0]


### PR DESCRIPTION
##### SUMMARY

* Allow user to specify seed to generate random string

Fixes: #5362

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/random_string_seed.yml
plugins/lookup/random_string.py
tests/integration/targets/lookup_random_string/test.yml


