### PR TITLE
simplify string formatting in some modules

### DIFF
--- a/plugins/modules/filesize.py
+++ b/plugins/modules/filesize.py
@@ -304,7 +304,7 @@ def split_size_unit(string, isint=False):
        Support optional space(s) between the numeric value and the unit.
     """
     unit = re.sub(r'(\d|\.)', r'', string).strip()
-    value = float(re.sub(r'%s' % unit, r'', string).strip())
+    value = float(re.sub(unit, r'', string).strip())
     if isint and unit in ('B', ''):
         if int(value) != value:
             raise AssertionError("invalid blocksize value: bytes require an integer value")

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -414,7 +414,7 @@ def main():
         COMMANDARGS.extend(['--table', table])
 
     if wait is not None:
-        TESTCOMMAND.extend(['--wait', '%s' % wait])
+        TESTCOMMAND.extend(['--wait', '%d' % wait])
 
     if modprobe is not None:
         b_modprobe = to_bytes(modprobe, errors='surrogate_or_strict')
@@ -502,7 +502,7 @@ def main():
     MAINCOMMAND.insert(0, bin_iptables_restore)
 
     if wait is not None:
-        MAINCOMMAND.extend(['--wait', '%s' % wait])
+        MAINCOMMAND.extend(['--wait', '%d' % wait])
 
     if _back is not None:
         b_back = to_bytes(_back, errors='surrogate_or_strict')

--- a/plugins/modules/manageiq_group.py
+++ b/plugins/modules/manageiq_group.py
@@ -251,7 +251,7 @@ class ManageIQgroup(object):
                 if not tenant_res:
                     self.module.fail_json(msg="Tenant '%s' not found in manageiq" % tenant_name)
                 if len(tenant_res) > 1:
-                    self.module.fail_json(msg="Multiple tenants found in manageiq with name '%s" % tenant_name)
+                    self.module.fail_json(msg="Multiple tenants found in manageiq with name '%s'" % tenant_name)
                 tenant = tenant_res[0]
                 return tenant
             else:
@@ -276,7 +276,7 @@ class ManageIQgroup(object):
                 if not role_res:
                     self.module.fail_json(msg="Role '%s' not found in manageiq" % role_name)
                 if len(role_res) > 1:
-                    self.module.fail_json(msg="Multiple roles found in manageiq with name '%s" % role_name)
+                    self.module.fail_json(msg="Multiple roles found in manageiq with name '%s'" % role_name)
                 return role_res[0]
             else:
                 # No role name or role id supplied

--- a/plugins/modules/manageiq_tenant.py
+++ b/plugins/modules/manageiq_tenant.py
@@ -214,7 +214,7 @@ class ManageIQTenant(object):
                     self.module.fail_json(msg="Parent tenant '%s' not found in manageiq" % parent)
 
                 if len(parent_tenant_res) > 1:
-                    self.module.fail_json(msg="Multiple parent tenants not found in manageiq with name '%s" % parent)
+                    self.module.fail_json(msg="Multiple parent tenants not found in manageiq with name '%s'" % parent)
 
                 parent_tenant = parent_tenant_res[0]
                 parent_id = int(parent_tenant['id'])

--- a/plugins/modules/mssql_db.py
+++ b/plugins/modules/mssql_db.py
@@ -210,7 +210,7 @@ def main():
             rc, stdout, stderr = db_import(conn, cursor, module, db, target)
 
             if rc != 0:
-                module.fail_json(msg="%s" % stderr)
+                module.fail_json(msg=stderr)
             else:
                 module.exit_json(changed=True, db=db, msg=stdout)
     else:
@@ -229,7 +229,7 @@ def main():
             rc, stdout, stderr = db_import(conn, cursor, module, db, target)
 
             if rc != 0:
-                module.fail_json(msg="%s" % stderr)
+                module.fail_json(msg=stderr)
             else:
                 module.exit_json(changed=True, db=db, msg=stdout)
 

--- a/plugins/modules/openbsd_pkg.py
+++ b/plugins/modules/openbsd_pkg.py
@@ -536,7 +536,7 @@ def upgrade_packages(pkg_spec, module):
     pkg_spec['*'] = {}
 
     # Attempt to upgrade all packages.
-    pkg_spec['*']['rc'], pkg_spec['*']['stdout'], pkg_spec['*']['stderr'] = execute_command("%s" % upgrade_cmd, module)
+    pkg_spec['*']['rc'], pkg_spec['*']['stdout'], pkg_spec['*']['stderr'] = execute_command(upgrade_cmd, module)
 
     # Try to find any occurrence of a package changing version like:
     # "bzip2-1.0.6->1.0.6p0: ok".

--- a/plugins/modules/ufw.py
+++ b/plugins/modules/ufw.py
@@ -546,7 +546,7 @@ def main():
                         insert_to = None
                 cmd.append([insert_to is not None, "insert %s" % insert_to])
             cmd.append([value])
-            cmd.append([params['direction'], "%s" % params['direction']])
+            cmd.append([params['direction'], params['direction']])
             cmd.append([params['interface'], "on %s" % params['interface']])
             cmd.append([params['interface_in'], "in on %s" % params['interface_in']])
             cmd.append([params['interface_out'], "out on %s" % params['interface_out']])

--- a/plugins/modules/xenserver_facts.py
+++ b/plugins/modules/xenserver_facts.py
@@ -178,7 +178,7 @@ def main():
     try:
         session = get_xenapi_session()
     except XenAPI.Failure as e:
-        module.fail_json(msg='%s' % e)
+        module.fail_json(msg=str(e))
 
     data = {
         'xenserver_version': obj.version,

--- a/plugins/modules/zfs_facts.py
+++ b/plugins/modules/zfs_facts.py
@@ -188,9 +188,9 @@ class ZFSFacts(object):
             cmd.append('-p')
         if self.recurse:
             cmd.append('-r')
-        if int(self.depth) != 0:
+        if self.depth != 0:
             cmd.append('-d')
-            cmd.append('%s' % self.depth)
+            cmd.append('%d' % self.depth)
         if self.type:
             cmd.append('-t')
             cmd.append(','.join(self.type))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Simplify string formatting for cases like `"%s" % var` when `var` is of type `str`, by using `var` directly.
While doing that, bumped into couple of modules where `var` was an `int`, in which case changed to `"%d" % var`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/modules/filesize.py
plugins/modules/iptables_state.py
plugins/modules/manageiq_group.py
plugins/modules/manageiq_tenant.py
plugins/modules/mssql_db.py
plugins/modules/openbsd_pkg.py
plugins/modules/ufw.py
plugins/modules/xenserver_facts.py
plugins/modules/zfs_facts.py
