### PR TITLE
ssh_config tests: remove paramiko version restriction

### DIFF
--- a/tests/integration/targets/ssh_config/tasks/main.yml
+++ b/tests/integration/targets/ssh_config/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: Install required libs
   pip:
     name:
-      - 'paramiko<3.0.0'
+      - paramiko
     state: present
     extra_args: "-c {{ remote_constraints }}"
 


### PR DESCRIPTION
##### SUMMARY
This was introduced in #5868, but causes harm on Debian Trixie. Let's see whether it's still needed.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
ssh_config
