### PR TITLE
zpool: fix broken example

### DIFF
--- a/plugins/modules/zpool.py
+++ b/plugins/modules/zpool.py
@@ -125,9 +125,7 @@ EXAMPLES = r"""
 - name: Set pool and filesystem properties
   community.general.zpool:
     name: tank
-    pool_properties:
     ashift: 12
-    filesystem_properties:
     compression: lz4
     vdevs:
       - disks:


### PR DESCRIPTION
##### SUMMARY
`pool_properties` and `filesystem_properties` accept a dictionary, but not `None`, which the example is passing to them.

Ref: #10766.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zpool
