### PR TITLE
gitlab_*_access_token: add missing scopes

### DIFF
--- a/changelogs/fragments/10785-gitlab-token-add-missing-scopes.yml
+++ b/changelogs/fragments/10785-gitlab-token-add-missing-scopes.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - gitlab_group_access_token - add missing scopes (https://github.com/ansible-collections/community.general/pull/10785).
+  - gitlab_project_access_token - add missing scopes (https://github.com/ansible-collections/community.general/pull/10785).

--- a/plugins/modules/gitlab_group_access_token.py
+++ b/plugins/modules/gitlab_group_access_token.py
@@ -51,6 +51,7 @@ options:
   scopes:
     description:
       - Scope of the access token.
+      - The values V(read_virtual_registry), V(write_virtual_registry), V(manage_runner), and V(self_rotate) were added in community.general 11.3.0.
     required: true
     type: list
     elements: str
@@ -60,11 +61,15 @@ options:
       - read_api
       - read_registry
       - write_registry
+      - read_virtual_registry
+      - write_virtual_registry
       - read_repository
       - write_repository
       - create_runner
+      - manage_runner
       - ai_features
       - k8s_proxy
+      - self_rotate
   access_level:
     description:
       - Access level of the access token.
@@ -241,11 +246,15 @@ def main():
                              'read_api',
                              'read_registry',
                              'write_registry',
+                             'read_virtual_registry',
+                             'write_virtual_registry',
                              'read_repository',
                              'write_repository',
                              'create_runner',
+                             'manage_runner',
                              'ai_features',
-                             'k8s_proxy']),
+                             'k8s_proxy',
+                             'self_rotate']),
         access_level=dict(type='str', default='maintainer', choices=['guest', 'planner', 'reporter', 'developer', 'maintainer', 'owner']),
         expires_at=dict(type='str', required=True),
         recreate=dict(type='str', default='never', choices=['never', 'always', 'state_change'])

--- a/plugins/modules/gitlab_project_access_token.py
+++ b/plugins/modules/gitlab_project_access_token.py
@@ -51,6 +51,7 @@ options:
   scopes:
     description:
       - Scope of the access token.
+      - The values V(manage_runner) and V(self_rotate) were added in community.general 11.3.0.
     required: true
     type: list
     elements: str
@@ -63,8 +64,10 @@ options:
       - read_repository
       - write_repository
       - create_runner
+      - manage_runner
       - ai_features
       - k8s_proxy
+      - self_rotate
   access_level:
     description:
       - Access level of the access token.
@@ -242,8 +245,10 @@ def main():
                              'read_repository',
                              'write_repository',
                              'create_runner',
+                             'manage_runner',
                              'ai_features',
-                             'k8s_proxy']),
+                             'k8s_proxy',
+                             'self_rotate']),
         access_level=dict(type='str', default='maintainer', choices=['guest', 'planner', 'reporter', 'developer', 'maintainer', 'owner']),
         expires_at=dict(type='str', required=True),
         recreate=dict(type='str', default='never', choices=['never', 'always', 'state_change'])


### PR DESCRIPTION
##### SUMMARY

Add project and group access token scopes available in the GitLab API but not yet available in this collection.
I'm in here to add self_rotate, but may as well add all other missing scopes while I'm here.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
gitlab_project_access_token, gitlab_group_access_token

##### ADDITIONAL INFORMATION
* https://docs.gitlab.com/user/project/settings/project_access_tokens/#scopes-for-a-project-access-token
* https://docs.gitlab.com/user/group/settings/group_access_tokens/#scopes-for-a-group-access-token
