### PR TITLE
binary_file lookup: automatically unvault vaulted files (closes #10799)

### DIFF
--- a/plugins/lookup/binary_file.py
+++ b/plugins/lookup/binary_file.py
@@ -105,10 +105,6 @@ class LookupModule(LookupBase):
                     continue
                 raise AnsibleLookupError(f"Could not locate file in community.general.binary_file lookup: {term}")
 
-            try:
-                with open(path, "rb") as f:
-                    result.append(base64.b64encode(f.read()).decode("utf-8"))
-            except Exception as exc:
-                raise AnsibleLookupError(f"Error while reading {path}: {exc}")
+            result.append(base64.b64encode(self._loader._get_file_contents(path)[0]).decode("utf-8"))
 
         return result


### PR DESCRIPTION
this matches the behavior of the builtin file lookup

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `binary_file` plugin now automatically unvaults vaulted files, matching the behavior of the built-in `file` plugin. I realize that `DataLoader._get_file_contents` is technically not public due to the underscore in front, but the alternative would be to either access `DataLoader._vault`, which is also not public, or using `DataLoader.get_real_file`, which creates an unnecessary temporary file.

Fixes #10799.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
`binary_file` lookup

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
