### PR TITLE
Fix incorrect nmcli up/down/conn_reload version_added

### DIFF
--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -36,7 +36,7 @@ options:
       - Whether the device should exist or not, taking action if the state is different from what is stated.
       - Using O(state=present) creates connection set to be brought up automatically.
       - Using O(state=up) and O(state=down) does not modify connection with other parameters. These states have been added
-        in community.general 9.5.0.
+        in community.general 10.0.0.
     type: str
     required: true
     choices: [absent, present, up, down]
@@ -67,7 +67,7 @@ options:
     type: bool
     required: false
     default: false
-    version_added: 9.5.0
+    version_added: 10.0.0
   ifname:
     description:
       - The interface to bind the connection to.


### PR DESCRIPTION
##### SUMMARY
Fixes the documentation stating that up/down/conn_reload functionality was added in `9.5.0` even though it wasn't added until `10.0.0`.

[The CHANGELOG shows that this functionality was not added until version `10.0.0`.](https://github.com/ansible-collections/community.general/blob/stable-10/CHANGELOG.md#v1000)

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
[plugins/modules/nmcli.py](https://github.com/ansible-collections/community.general/blob/main/plugins/modules/nmcli.py)

##### ADDITIONAL INFORMATION
The incorrect version number was introduced when the up/down/conn_reload code was added in https://github.com/ansible-collections/community.general/commit/d4fb6bf8a65afabe3576b49af906585425571ac3.
