### PR TITLE
gitlab_*_variable: add `description` option

### DIFF
--- a/changelogs/fragments/10812-gitlab-variable-add-description.yml
+++ b/changelogs/fragments/10812-gitlab-variable-add-description.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - gitlab_group_variable - add ``description`` option (https://github.com/ansible-collections/community.general/pull/10812).
+  - gitlab_instance_variable - add ``description`` option (https://github.com/ansible-collections/community.general/pull/10812).
+  - gitlab_project_variable - add ``description`` option (https://github.com/ansible-collections/community.general/pull/10812, https://github.com/ansible-collections/community.general/issues/8584, https://github.com/ansible-collections/community.general/issues/10809).

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -134,7 +134,7 @@ def gitlab_authentication(module, min_version=None):
 def filter_returned_variables(gitlab_variables):
     # pop properties we don't know
     existing_variables = [dict(x.attributes) for x in gitlab_variables]
-    KNOWN = ['key', 'value', 'masked', 'hidden', 'protected', 'variable_type', 'environment_scope', 'raw']
+    KNOWN = ['key', 'value', 'description', 'masked', 'hidden', 'protected', 'variable_type', 'environment_scope', 'raw']
     for item in existing_variables:
         for key in list(item.keys()):
             if key not in KNOWN:
@@ -151,6 +151,7 @@ def vars_to_variables(vars, module):
                 {
                     "name": item,
                     "value": str(value),
+                    "description": None,
                     "masked": False,
                     "protected": False,
                     "hidden": False,
@@ -163,6 +164,7 @@ def vars_to_variables(vars, module):
             new_item = {
                 "name": item,
                 "value": value.get('value'),
+                "description": value.get('description'),
                 "masked": value.get('masked'),
                 "hidden": value.get('hidden'),
                 "protected": value.get('protected'),

--- a/plugins/modules/gitlab_group_variable.py
+++ b/plugins/modules/gitlab_group_variable.py
@@ -87,6 +87,12 @@ options:
           - The variable value.
           - Required when O(state=present).
         type: str
+      description:
+        description:
+          - A description for the variable.
+          - Support for descriptions requires GitLab >= 16.2.
+        type: str
+        version_added: '11.4.0'
       masked:
         description:
           - Whether variable value is masked or not.
@@ -240,6 +246,7 @@ class GitlabGroupVariables(object):
         var = {
             "key": var_obj.get('key'),
             "value": var_obj.get('value'),
+            "description": var_obj.get('description'),
             "masked": var_obj.get('masked'),
             "masked_and_hidden": var_obj.get('hidden'),
             "protected": var_obj.get('protected'),
@@ -348,14 +355,13 @@ def native_python_main(this_gitlab, purge, requested_variables, state, module):
                     return_value['removed'].append(item)
 
     elif state == 'absent':
-        # value does not matter on removing variables.
-        # key and environment scope are sufficient
-        for item in existing_variables:
-            item.pop('value')
-            item.pop('variable_type')
-        for item in requested_variables:
-            item.pop('value')
-            item.pop('variable_type')
+        # value, type, and description do not matter on removing variables.
+        keys_ignored_on_deletion = ['value', 'variable_type', 'description']
+        for key in keys_ignored_on_deletion:
+            for item in existing_variables:
+                item.pop(key)
+            for item in requested_variables:
+                item.pop(key)
 
         if not purge:
             remove_requested = [x for x in requested_variables if x in existing_variables]
@@ -392,6 +398,7 @@ def main():
         variables=dict(type='list', elements='dict', default=list(), options=dict(
             name=dict(type='str', required=True),
             value=dict(type='str', no_log=True),
+            description=dict(type='str'),
             masked=dict(type='bool', default=False),
             hidden=dict(type='bool', default=False),
             protected=dict(type='bool', default=False),

--- a/plugins/modules/gitlab_project_variable.py
+++ b/plugins/modules/gitlab_project_variable.py
@@ -86,6 +86,12 @@ options:
           - The variable value.
           - Required when O(state=present).
         type: str
+      description:
+        description:
+          - A description for the variable.
+          - Support for descriptions requires GitLab >= 16.2.
+        type: str
+        version_added: '11.4.0'
       masked:
         description:
           - Whether variable value is masked or not.
@@ -260,6 +266,7 @@ class GitlabProjectVariables(object):
         var = {
             "key": var_obj.get('key'),
             "value": var_obj.get('value'),
+            "description": var_obj.get('description'),
             "masked": var_obj.get('masked'),
             "masked_and_hidden": var_obj.get('hidden'),
             "protected": var_obj.get('protected'),
@@ -370,14 +377,13 @@ def native_python_main(this_gitlab, purge, requested_variables, state, module):
                     return_value['removed'].append(item)
 
     elif state == 'absent':
-        # value does not matter on removing variables.
-        # key and environment scope are sufficient
-        for item in existing_variables:
-            item.pop('value')
-            item.pop('variable_type')
-        for item in requested_variables:
-            item.pop('value')
-            item.pop('variable_type')
+        # value, type, and description do not matter on removing variables.
+        keys_ignored_on_deletion = ['value', 'variable_type', 'description']
+        for key in keys_ignored_on_deletion:
+            for item in existing_variables:
+                item.pop(key)
+            for item in requested_variables:
+                item.pop(key)
 
         if not purge:
             remove_requested = [x for x in requested_variables if x in existing_variables]
@@ -414,6 +420,7 @@ def main():
         variables=dict(type='list', elements='dict', default=list(), options=dict(
             name=dict(type='str', required=True),
             value=dict(type='str', no_log=True),
+            description=dict(type='str'),
             masked=dict(type='bool', default=False),
             hidden=dict(type='bool', default=False),
             protected=dict(type='bool', default=False),


### PR DESCRIPTION
##### SUMMARY
Add the ability to configure the description field for group, project, and instance variables.

In addition, `description` is not considered when deleting with `state=absent`. Unsure if this needs to be docced.

I noticed all three modules, when deleting, construct match objects by popping parameters that aren't required to be equal. I suspect `raw`, `masked` etc. were missed from this. I know `hidden` was missed by mistake. I wonder if it's better to construct comparison objects directly from the name and environment scope, rather than subtracting 3+ fields. AFAIK the GitLab API rejects duplicate variables based on variable name and environment scope, so our deletion should probably follow this convention.

Fixes #8584.
Fixes #10809.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
gitlab_group_variable, gitlab_instance_variable, gitlab_project_variable