### PR TITLE
Speed up tests in android_sdk module

### DIFF
--- a/tests/integration/targets/android_sdk/tasks/default-tests.yml
+++ b/tests/integration/targets/android_sdk/tasks/default-tests.yml
@@ -8,35 +8,35 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: Install build-tools;34.0.0
+- name: Install skiaparser;1
   android_sdk:
     accept_licenses: true
-    name: build-tools;34.0.0
+    name: skiaparser;1
     state: present
-  register: build_tools_installed
+  register: skiaparser_1_installed
 
-- name: Install build-tools;34.0.0 second time
+- name: Install skiaparser;1 second time
   android_sdk:
-    name: build-tools;34.0.0
+    name: skiaparser;1
     state: present
-  register: build_tools_installed2
+  register: skiaparser_1_installed_2
 
-- name: Stat build-tools
+- name: Stat skiaparser;1
   stat:
-    path: "{{ android_sdk_location }}/build-tools/34.0.0"
-  register: build_tools_34_0_0
+    path: "{{ android_sdk_location }}/skiaparser/1"
+  register: skiaparser_1_stat
 
-- name: Delete build-tools;34.0.0
+- name: Delete skiaparser;1
   android_sdk:
-    name: build-tools;34.0.0
+    name: skiaparser;1
     state: absent
-  register: build_tools_deleted
+  register: skiaparser_1_deleted
 
-- name: Delete build-tools;34.0.0 second time
+- name: Delete skiaparser;1 second time
   android_sdk:
-    name: build-tools;34.0.0
+    name: skiaparser;1
     state: absent
-  register: build_tools_deleted2
+  register: skiaparser_1_deleted_2
 
 - name: Download old platform-tools
   unarchive:
@@ -59,7 +59,7 @@
 
 - name: Install a package to a new root
   android_sdk:
-    name: build-tools;34.0.0
+    name: skiaparser;1
     accept_licenses: true
     state: present
     sdk_root: "{{ remote_tmp_dir }}"
@@ -67,12 +67,12 @@
 
 - name: Check package is installed
   stat:
-    path: "{{ remote_tmp_dir }}/build-tools/34.0.0"
+    path: "{{ remote_tmp_dir }}/skiaparser/1"
   register: new_root_package_stat
 
 - name: Install a package from canary channel
   android_sdk:
-    name: build-tools;33.0.0
+    name: skiaparser;1
     state: present
     channel: canary
   register: package_canary
@@ -80,11 +80,11 @@
 - name: Run tests
   assert:
     that:
-      - build_tools_34_0_0.stat.exists
-      - build_tools_installed is changed
-      - build_tools_installed2 is not changed
-      - build_tools_deleted is changed
-      - build_tools_deleted2 is not changed
+      - skiaparser_1_stat.stat.exists
+      - skiaparser_1_installed is changed
+      - skiaparser_1_installed_2 is not changed
+      - skiaparser_1_deleted is changed
+      - skiaparser_1_deleted_2 is not changed
       - platform_tools_present is not changed
       - platform_tools_updated is changed
       - new_root_package is changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Related to https://github.com/ansible-collections/community.general/issues/10811

This PR changes the dependency that is downloaded by "sdkmanager" as part of the testing suite. The previous dependency was ~100MB, the new one is ~6MB, which should speed up the tests a bit. No changes in how the tests run and the scope they test are expected.
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
android_sdk