### PR TITLE
parted: join command list for fail_json message

### DIFF
--- a/plugins/modules/parted.py
+++ b/plugins/modules/parted.py
@@ -572,7 +572,7 @@ def parted(script, device, align):
 
         if rc != 0:
             module.fail_json(
-                msg="Error while running parted script: %s" % command.strip(),
+                msg="Error while running parted script: %s" % " ".join(command).strip(),
                 rc=rc, out=out, err=err
             )
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When the `parted` command fails, the call to `fail_json()` was handling the var `command` as `str` when it should be a `list`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #10817 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
parted