### PR TITLE
Keycloak role fix changed status

### DIFF
--- a/changelogs/fragments/10829-fix-keycloak-role-changed-status.yml
+++ b/changelogs/fragments/10829-fix-keycloak-role-changed-status.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_role - Fixes an issue where `keycloak_role` incorrectly returns `"changed"` when using the alias `clientId` in composite roles (https://github.com/ansible-collections/community.general/pull/10829).

--- a/changelogs/fragments/10829-fix-keycloak-role-changed-status.yml
+++ b/changelogs/fragments/10829-fix-keycloak-role-changed-status.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - keycloak_role - Fixes an issue where `keycloak_role` incorrectly returns `"changed"` when using the alias `clientId` in composite roles (https://github.com/ansible-collections/community.general/pull/10829).
+  - keycloak_role - fixes an issue where the module incorrectly returns ``changed=true`` when using the alias ``clientId`` in composite roles (https://github.com/ansible-collections/community.general/pull/10829).

--- a/plugins/modules/keycloak_role.py
+++ b/plugins/modules/keycloak_role.py
@@ -361,7 +361,7 @@ def main():
 
     else:
         if state == 'present':
-            compare_exclude = []
+            compare_exclude = ['clientId']
             if 'composites' in desired_role and isinstance(desired_role['composites'], list) and len(desired_role['composites']) > 0:
                 composites = kc.get_role_composites(rolerep=before_role, clientid=clientid, realm=realm)
                 before_role['composites'] = []

--- a/tests/integration/targets/keycloak_role/README.md
+++ b/tests/integration/targets/keycloak_role/README.md
@@ -13,7 +13,7 @@ Source Ansible env-setup from ansible github repository
 
 Run integration tests:
 
-    ansible-test integration keycloak_role --python 3.10 --allow-unsupported
+    ansible-test integration -v keycloak_role --allow-unsupported --docker fedora35 --docker-network host
 
 Cleanup:
 

--- a/tests/integration/targets/keycloak_role/tasks/main.yml
+++ b/tests/integration/targets/keycloak_role/tasks/main.yml
@@ -3,6 +3,15 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+- name: Delete realm if exists
+  community.general.keycloak_realm:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    state: absent
+
 - name: Create realm
   community.general.keycloak_realm:
     auth_keycloak_url: "{{ url }}"
@@ -296,6 +305,29 @@
     that:
       - result is not changed
       - result.end_state.composites | length == 3
+
+- name: Change realm role with composites using aliases no change
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    name: "{{ keycloak_role_name }}"
+    realm: "{{ realm }}"
+    description: "{{ keycloak_role_description }}"
+    composite: "{{ keycloak_role_composite }}"
+    composites: "{{ keycloak_role_composites_with_aliases }}"
+    state: present
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert realm role with composites using aliases have not changed
+  assert:
+    that:
+      - result is not changed
 
 - name: Remove composite from realm role with composites
   community.general.keycloak_role:

--- a/tests/integration/targets/keycloak_role/vars/main.yml
+++ b/tests/integration/targets/keycloak_role/vars/main.yml
@@ -25,6 +25,15 @@ keycloak_role_composites:
     state: present
   - name: offline_access
     state: present
+keycloak_role_composites_with_aliases:
+  - name: view-clients
+    clientId: "realm-management"
+    state: present
+  - name: query-clients
+    clientId: "realm-management"
+    state: present
+  - name: offline_access
+    state: present
 keycloak_client_id: test-client
 keycloak_client_name: test-client
 keycloak_client_description: This is a client for testing purpose


### PR DESCRIPTION
##### SUMMARY

Fixes an issue where `keycloak_role` incorrectly returns `"changed"` when using the alias `clientId` in composite roles.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
keycloak_role

##### ADDITIONAL INFORMATION
```yaml
- name: Unchanged role with composites using aliases - should return no change
  community.general.keycloak_role:
    auth_keycloak_url: "{{ url }}"
    auth_realm: "{{ admin_realm }}"
    auth_username: "{{ admin_user }}"
    auth_password: "{{ admin_password }}"
    name: "Test"
    realm: "my-realm"
    description: "My composite role"
    composite: true
    composites:
      - name: view-clients
        clientId: "realm-management"
        state: present
      - name: query-clients
        clientId: "realm-management"
        state: present
    keycloak_client_id: test-client
    state: present
  register: result
