### PR TITLE
Fix keycloak sub-group search

### DIFF
--- a/changelogs/fragments/10830-fix-keycloak-subgroup-search-realm.yml
+++ b/changelogs/fragments/10830-fix-keycloak-subgroup-search-realm.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - keycloak_group - fixes an issue where module ignores realm when searching subgroups by name (https://github.com/ansible-collections/community.general/pull/10830).

--- a/changelogs/fragments/10840-fix-keycloak-subgroup-search-realm.yml
+++ b/changelogs/fragments/10840-fix-keycloak-subgroup-search-realm.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_group - fixes an issue where module ignores realm when searching subgroups by name (https://github.com/ansible-collections/community.general/pull/10840).


### PR DESCRIPTION
##### SUMMARY

Under certain conditions processing of subgroups in Keycloak fails, because module implementation does not take realm into account - failure comes from API reporting the group.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
keycloak_group

##### ADDITIONAL INFORMATION

Sorry, we resolved this on our side weeks ago, I don't have a working test case anymore to provide exact steps to reproduce. Fix is so trivial that  I hope the problem will be obvious just from looking at the code.

We have tested at Red Hat build of Keycloak 26.0.13