### PR TITLE
Keycloak client scope support

### DIFF
--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -798,12 +798,12 @@ def normalise_cr(clientrep, remove_ids=False):
     else:
         clientrep['attributes'] = []
 
-    if 'webOrigins' in clientrep: 
+    if 'webOrigins' in clientrep:
         clientrep['webOrigins'] = sorted(clientrep['webOrigins'])
     else:
         clientrep['webOrigins'] = []
 
-    if 'redirectUris' in clientrep: 
+    if 'redirectUris' in clientrep:
         clientrep['redirectUris'] = sorted(clientrep['redirectUris'])
     else:
         clientrep['redirectUris'] = []
@@ -899,7 +899,7 @@ def find_match(iterable, attribut, name):
     """
     Search for an element in a list of dictionaries based on a given attribute and value.
 
-    This function iterates over the elements of an iterable (typically a list of dictionaries) 
+    This function iterates over the elements of an iterable (typically a list of dictionaries)
     and returns the first element whose value for the specified attribute matches `name`.
 
     :param iterable:

--- a/tests/integration/targets/keycloak_client/tasks/main.yml
+++ b/tests/integration/targets/keycloak_client/tasks/main.yml
@@ -2,6 +2,15 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
+- name: Install required packages
+  pip:
+    name:
+      - jmespath
+  register: result
+  until: result is success
+  environment:
+    https_proxy: http://proxy.reg00.rtss.qc.ca:8080/
+
 - name: Wait for Keycloak
   uri:
     url: "{{ url }}/admin/"
@@ -71,7 +80,7 @@
     state: present
     redirect_uris: '{{redirect_uris1}}'
     attributes: '{{client_attributes1}}'
-    protocol_mappers: '{{protocol_mappers1}}'
+    protocol_mappers: '{{protocol_mappers2_unordered}}'
     authorization_services_enabled: false
   check_mode: true
   register: check_client_when_present_and_same
@@ -103,6 +112,37 @@
   assert:
     that:
       - check_client_when_present_and_changed is changed
+
+- name: Check client with modified protocol_mappers idempotence
+  community.general.keycloak_client:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    client_id: "{{ client_id }}"
+    state: present
+    redirect_uris: '{{redirect_uris1}}'
+    attributes: '{{client_attributes1}}'
+    protocol_mappers: '{{protocol_mappers3_modifed}}'
+    authorization_services_enabled: false
+    service_accounts_enabled: true
+  register: check_client_protocol_mappers_idempotence
+
+- name: Assert idempotence changes to protocol_mappers
+  assert:
+    that:
+      - check_client_protocol_mappers_idempotence is changed
+      - end_state.protocolMappers | length == 3
+      - end_state.protocolMappers | community.general.json_query("[?name == 'email_verified']") | length == 0
+      - end_state.protocolMappers | community.general.json_query("[?name == 'address']") | length == 1
+      - end_state.protocolMappers | community.general.json_query("[?name == 'email']") | length == 1
+      - end_state.protocolMappers | community.general.json_query("[?name == 'family_name']") | length == 1
+      - email.config is defined
+      - email.config['access.token.claim'] == "false"
+  vars:
+    end_state: "{{ check_client_protocol_mappers_idempotence.end_state }}"
+    email: "{{ end_state.protocolMappers | community.general.json_query('[?name == `email`]') | first | d({}) }}"
 
 - name: Desire client with flow binding overrides
   community.general.keycloak_client:
@@ -231,3 +271,117 @@
       - "'authenticationFlowBindingOverrides' in desire_client_with_flow_binding_overrides.end_state"
       - "'browser' not in desire_client_with_flow_binding_overrides.end_state.authenticationFlowBindingOverrides"
       - "'direct_grant' not in desire_client_with_flow_binding_overrides.end_state.authenticationFlowBindingOverrides"
+
+- name: Create a scope1 client scope
+  community.general.keycloak_clientscope:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: scope1
+    description: "test 1"
+    protocol: openid-connect
+
+- name: Create a scope2 client scope
+  community.general.keycloak_clientscope:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: scope2
+    description: "test 2"
+    protocol: openid-connect
+
+- name: Create a scope3 client scope
+  community.general.keycloak_clientscope:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: scope3
+    description: "test 3"
+    protocol: openid-connect
+
+- name: Create Keycloak client with default_client_scopes
+  community.general.keycloak_client:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    default_client_scopes: ['scope1']
+    optional_client_scopes: ['scope2']
+    client_id: testSD-bug
+    state: present
+  register: desire_client_with_default_client_scopes
+
+- name: Assert default_client_scopes
+  assert:
+    that:
+      - desire_client_with_default_client_scopes is changed
+      - '"scope1" in end_state.defaultClientScopes'
+      - '"scope2" in end_state.optionalClientScopes'
+      - end_state.defaultClientScopes | length == 1
+      - end_state.optionalClientScopes | length == 1
+  vars:
+    end_state: "{{ desire_client_with_default_client_scopes.end_state }}"
+
+- name: Update Keycloak client with empty default_client_scopes
+  community.general.keycloak_client:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    default_client_scopes: []
+    optional_client_scopes: ['scope3']
+    client_id: testSD-bug
+    state: present
+  register: desire_client_with_default_client_scopes
+
+- name: Assert default_client_scopes
+  assert:
+    that:
+      - desire_client_with_default_client_scopes is changed
+      - end_state.defaultClientScopes | length == 0
+      - end_state.optionalClientScopes | length == 1
+      - '"scope3" in end_state.optionalClientScopes'
+  vars:
+    end_state: "{{ desire_client_with_default_client_scopes.end_state }}"
+
+- name: Create client with attributes
+  community.general.keycloak_client:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    client_id: "{{ client_id_2 }}"
+    state: present
+    attributes: '{{ client_attributes1 }}'
+  register: check_client_when_present_and_attributes_modified
+      
+- name: Modify attributes
+  community.general.keycloak_client:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    client_id: "{{ client_id_2 }}"
+    state: present
+    attributes: '{{ client_attributes2 }}'
+  register: check_client_when_present_and_attributes_modified
+
+- name: Assert attributes modified
+  assert:
+    that:
+      - check_client_when_present_and_attributes_modified is changed
+      - end_state.attributes["backchannel.logout.revoke.offline.tokens"] == 'false'
+      - end_state.attributes["backchannel.logout.session.required"] == 'false'
+      - end_state.attributes["oauth2.device.authorization.grant.enabled"] == 'false'
+  vars:
+    end_state: "{{ check_client_when_present_and_attributes_modified.end_state }}"

--- a/tests/integration/targets/keycloak_client/tasks/main.yml
+++ b/tests/integration/targets/keycloak_client/tasks/main.yml
@@ -8,8 +8,6 @@
       - jmespath
   register: result
   until: result is success
-  environment:
-    https_proxy: http://proxy.reg00.rtss.qc.ca:8080/
 
 - name: Wait for Keycloak
   uri:

--- a/tests/integration/targets/keycloak_client/vars/main.yml
+++ b/tests/integration/targets/keycloak_client/vars/main.yml
@@ -9,6 +9,7 @@ admin_user: admin
 admin_password: password
 realm: myrealm
 client_id: myclient
+client_id_2: mynewclient
 role: myrole
 description_1: desc 1
 description_2: desc 2
@@ -24,7 +25,9 @@ redirect_uris1:
   - "http://example.b.com/"
   - "http://example.a.com/"
 
-client_attributes1: {"backchannel.logout.session.required": true, "backchannel.logout.revoke.offline.tokens": false, "client.secret.creation.time": 0}
+client_attributes1: {"backchannel.logout.session.required": true, "backchannel.logout.revoke.offline.tokens": false, "oauth2.device.authorization.grant.enabled": true, "client.secret.creation.time": 0}
+
+client_attributes2: {"backchannel.logout.session.required": false, "oauth2.device.authorization.grant.enabled": false, "client.secret.creation.time": 0}
 
 protocol_mappers1:
   - name: 'email'
@@ -59,3 +62,36 @@ protocol_mappers1:
       "id.token.claim": "true"
       "access.token.claim": "true"
       "userinfo.token.claim": "true"
+
+protocol_mappers2_unordered:
+  - "{{ protocol_mappers1[2] }}"
+  - "{{ protocol_mappers1[1] }}"
+  - "{{ protocol_mappers1[0] }}"
+
+protocol_mappers3_modifed:
+  - "{{ protocol_mappers1[2] }}"
+  - name: address
+    protocol: openid-connect
+    protocolMapper: oidc-address-mapper
+    consentRequired: false
+    config:
+      user.attribute.formatted: formatted
+      user.attribute.country: country
+      introspection.token.claim: 'true'
+      user.attribute.postal_code: postal_code
+      userinfo.token.claim: 'true'
+      user.attribute.street: street
+      id.token.claim: 'true'
+      user.attribute.region: region
+      access.token.claim: 'true'
+      user.attribute.locality: locality
+  - name: 'email'
+    protocol: 'openid-connect'
+    protocolMapper: 'oidc-usermodel-property-mapper'
+    config:
+      "claim.name": "email"
+      "user.attribute": "email"
+      "jsonType.label": "String"
+      "id.token.claim": true
+      "access.token.claim": False
+      "userinfo.token.claim": true


### PR DESCRIPTION
##### SUMMARY
Add support for assigning both **default** and **optional** scopes to clients.  
Also fixes somes issues related to change detection.

Fixes #5495

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
keycloak_client

##### ADDITIONAL INFORMATION
This change allows users to manage client scopes with keycloak_client.  
It also improves the reliability of the `changed` status returned by the module, ensuring more predictable playbook behavior.
