### PR TITLE
Add dad-timeout feature for nmcli

### DIFF
--- a/changelogs/fragments/10844-nmcli-dad-timeout-support.yml
+++ b/changelogs/fragments/10844-nmcli-dad-timeout-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmcli - add support for duplicate address detection (DAD) timeout configuration via new parameters ``dad_timeout4`` and ``dad_timeout6`` which map to the ``ipv4.dad-timeout`` and ``ipv6.dad-timeout`` NetworkManager properties (https://github.com/ansible-collections/community.general/pull/XXXX).


### PR DESCRIPTION
##### SUMMARY
Add support for setting IPv4 and IPv6 duplicate address detection (DAD) timeout parameters in the community.general.nmcli module. This enables users to configure NetworkManager's `ipv4.dad-timeout` and `ipv6.dad-timeout` settings directly through Ansible, providing better control over network configuration and preventing IP address conflicts in automated environments.

This feature adds two new parameters:
- `dad_timeout4`: Integer value in milliseconds for IPv4 DAD timeout
- `dad_timeout6`: Integer value in milliseconds for IPv6 DAD timeout

Fixes #10843

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
nmcli

##### ADDITIONAL INFORMATION
**Background:**
Duplicate address detection is a critical network safety feature that prevents IP conflicts. The default DAD timeout is -1 (disabled) for IPv4, leaving networks vulnerable to address conflicts. Currently, users must resort to raw nmcli commands or shell modules to set these parameters, breaking Ansible's idempotency model.

**Use Cases:**
- Automated server provisioning where static IP assignment must be conflict-free
- Container orchestration platforms requiring guaranteed unique IP addresses
- Network automation in enterprise environments with strict IP management policies
- Recovery scenarios where services must fail-fast on network conflicts

**Implementation Details:**
- Added `dad_timeout4` and `dad_timeout6` parameters to module argument specification
- Added corresponding instance variables in the Nmcli class constructor
- Mapped parameters to NetworkManager properties `ipv4.dad-timeout` and `ipv6.dad-timeout`
- Added parameters to the integer type validation list
- Updated module documentation with parameter descriptions and usage example
- Created changelog fragment following project conventions

**Example Usage:**
```yaml
- name: Configure connection with duplicate address detection
  community.general.nmcli:
    conn_name: ens192
    type: ethernet
    ip4: 192.168.1.100/24
    state: present
    dad_timeout4: 3000  # Enable IPv4 DAD with 3-second timeout
    may_fail4: false