### PR TITLE
New feature for lvol: calculate size for logical volume based on the main memory. 

### DIFF
--- a/plugins/modules/lvol.py
+++ b/plugins/modules/lvol.py
@@ -306,13 +306,15 @@ def get_lvm_version(module):
         return None
     return mkversion(m.group(1), m.group(2), m.group(3))
 
+
 def get_mem_size_in_mb():
     with open('/proc/meminfo', 'r') as file:
         for line in file:
             parts = line.split()
             if parts[0] == "MemTotal:":
-                return int(parts[1])/1000
+                return int(parts[1]) / 1000
     return 0
+
 
 def main():
     module = AnsibleModule(


### PR DESCRIPTION

##### SUMMARY
Calculate size for logical volume based on the main memory. 
In some cases (swap, some SAP server partitions), it is very helpful to calculate the LV size based on the size of the main memory.

The syntax is:  `size: <multiplier>ram`

This is also possible to resize the logical volume:
```
size: [+-]<multiplier>ram
```
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lvol

