### PR TITLE
[stable-10] Replace devel with stable-2.20

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -57,14 +57,14 @@ pool: Standard
 
 stages:
 ### Sanity
-  - stage: Sanity_devel
-    displayName: Sanity devel
+  - stage: Sanity_2_20
+    displayName: Sanity 2.20
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Test {0}
-          testFormat: devel/sanity/{0}
+          testFormat: 2.20/sanity/{0}
           targets:
             - test: 1
             - test: 2
@@ -123,14 +123,14 @@ stages:
             - test: 3
             - test: 4
 ### Units
-  - stage: Units_devel
-    displayName: Units devel
+  - stage: Units_2_20
+    displayName: Units 2.20
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: devel/units/{0}/1
+          testFormat: 2.20/units/{0}/1
           targets:
             - test: 3.9
             - test: '3.10'
@@ -188,13 +188,13 @@ stages:
             - test: "3.11"
 
 ## Remote
-  - stage: Remote_devel_extra_vms
-    displayName: Remote devel extra VMs
+  - stage: Remote_2_20_extra_vms
+    displayName: Remote 2.20 extra VMs
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/{0}
+          testFormat: 2.20/{0}
           targets:
             - name: Alpine 3.22
               test: alpine/3.22
@@ -206,13 +206,13 @@ stages:
               test: ubuntu/24.04
           groups:
             - vm
-  - stage: Remote_devel
-    displayName: Remote devel
+  - stage: Remote_2_20
+    displayName: Remote 2.20
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/{0}
+          testFormat: 2.20/{0}
           targets:
             - name: macOS 15.3
               test: macos/15.3
@@ -304,13 +304,13 @@ stages:
             - 3
 
 ### Docker
-  - stage: Docker_devel
-    displayName: Docker devel
+  - stage: Docker_2_20
+    displayName: Docker 2.20
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/linux/{0}
+          testFormat: 2.20/linux/{0}
           targets:
             - name: Fedora 42
               test: fedora42
@@ -398,13 +398,13 @@ stages:
             - 3
 
 ### Community Docker
-  - stage: Docker_community_devel
-    displayName: Docker (community images) devel
+  - stage: Docker_community_2_20
+    displayName: Docker (community images) 2.20
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/linux-community/{0}
+          testFormat: 2.20/linux-community/{0}
           targets:
             - name: Debian 11 Bullseye
               test: debian-bullseye/3.9
@@ -421,14 +421,14 @@ stages:
 
 ### Generic
 # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
-#  - stage: Generic_devel
-#    displayName: Generic devel
+#  - stage: Generic_2_20
+#    displayName: Generic 2.20
 #    dependsOn: []
 #    jobs:
 #      - template: templates/matrix.yml
 #        parameters:
 #          nameFormat: Python {0}
-#          testFormat: devel/generic/{0}/1
+#          testFormat: 2.20/generic/{0}/1
 #          targets:
 #            - test: '3.9'
 #            - test: '3.12'
@@ -482,30 +482,30 @@ stages:
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
-      - Sanity_devel
+      - Sanity_2_20
       - Sanity_2_19
       - Sanity_2_18
       - Sanity_2_17
       - Sanity_2_16
-      - Units_devel
+      - Units_2_20
       - Units_2_19
       - Units_2_18
       - Units_2_17
       - Units_2_16
-      - Remote_devel_extra_vms
-      - Remote_devel
+      - Remote_2_20_extra_vms
+      - Remote_2_20
       - Remote_2_19
       - Remote_2_18
       - Remote_2_17
       - Remote_2_16
-      - Docker_devel
+      - Docker_2_20
       - Docker_2_19
       - Docker_2_18
       - Docker_2_17
       - Docker_2_16
-      - Docker_community_devel
+      - Docker_community_2_20
 # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
-#      - Generic_devel
+#      - Generic_2_20
 #      - Generic_2_19
 #      - Generic_2_18
 #      - Generic_2_17

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For more information about communication, see the [Ansible communication guide](
 
 ## Tested with Ansible
 
-Tested with the current ansible-core 2.15, ansible-core 2.16, ansible-core 2.17, ansible-core 2.18, ansible-core 2.19 releases and the current development version of ansible-core. Ansible-core versions before 2.15.0 are not supported. This includes all ansible-base 2.10 and Ansible 2.9 releases.
+Tested with the current ansible-core 2.15, ansible-core 2.16, ansible-core 2.17, ansible-core 2.18, ansible-core 2.19, and ansible-core 2.20 releases. Ansible-core versions before 2.15.0 are not supported. This includes all ansible-base 2.10 and Ansible 2.9 releases.
 
 ## External requirements
 

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,64 +1,14 @@
-plugins/module_utils/csv.py pylint:ansible-bad-import-from
-plugins/module_utils/gitlab.py pylint:ansible-bad-import-from
-plugins/module_utils/homebrew.py pylint:ansible-bad-import-from
-plugins/module_utils/ipa.py pylint:ansible-bad-import-from
-plugins/module_utils/net_tools/pritunl/api.py pylint:ansible-bad-import-from
-plugins/module_utils/opennebula.py pylint:ansible-bad-import-from
-plugins/module_utils/oracle/oci_utils.py pylint:ansible-bad-import-from
-plugins/module_utils/pkg_req.py pylint:ansible-bad-import-from
-plugins/module_utils/redfish_utils.py pylint:ansible-bad-import-from
-plugins/module_utils/saslprep.py pylint:ansible-bad-import-from
 plugins/module_utils/univention_umc.py pylint:use-yield-from  # suggested construct does not work with Python 2
-plugins/modules/apache2_mod_proxy.py pylint:ansible-bad-import-from
-plugins/modules/circonus_annotation.py pylint:ansible-bad-import-from
-plugins/modules/cobbler_system.py pylint:ansible-bad-import-from
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
-plugins/modules/dnsmadeeasy.py pylint:ansible-bad-import-from
-plugins/modules/homebrew.py pylint:ansible-bad-import-from
-plugins/modules/homebrew_cask.py pylint:ansible-bad-import-from
 plugins/modules/homectl.py import-3.11  # Uses deprecated stdlib library 'crypt'
 plugins/modules/homectl.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
-plugins/modules/java_keystore.py pylint:ansible-bad-import-from
-plugins/modules/jenkins_plugin.py pylint:ansible-bad-import-from
-plugins/modules/ldap_search.py pylint:ansible-bad-import-from
 plugins/modules/lxc_container.py validate-modules:use-run-command-not-popen
-plugins/modules/mail.py pylint:ansible-bad-import-from
-plugins/modules/make.py pylint:ansible-bad-import-from
-plugins/modules/monit.py pylint:ansible-bad-import-from
-plugins/modules/osx_defaults.py pylint:ansible-bad-import-from
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rhevm.py validate-modules:parameter-state-invalid-choice
-plugins/modules/sl_vm.py pylint:ansible-bad-import-from
-plugins/modules/ssh_config.py pylint:ansible-bad-import-from
-plugins/modules/terraform.py pylint:ansible-bad-import-from
-plugins/modules/timezone.py pylint:ansible-bad-import-from
 plugins/modules/udm_user.py import-3.11  # Uses deprecated stdlib library 'crypt'
 plugins/modules/udm_user.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/xfconf.py validate-modules:return-syntax-error
-plugins/modules/xml.py pylint:ansible-bad-import-from
-plugins/modules/zpool_facts.py pylint:ansible-bad-import-from
-plugins/modules/zypper_repository.py pylint:ansible-bad-import-from
-tests/unit/plugins/module_utils/identity/keycloak/test_keycloak_connect.py pylint:ansible-bad-import-from
-tests/unit/plugins/module_utils/net_tools/pritunl/test_api.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/conftest.py pylint:ansible-bad-import-from
 tests/unit/plugins/modules/uthelper.py pylint:use-yield-from  # suggested construct does not work with Python 2
 tests/unit/plugins/modules/test_gio_mime.yaml no-smart-quotes
-tests/unit/plugins/modules/test_keycloak_authentication.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/test_keycloak_authentication_required_actions.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/test_keycloak_client.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/test_keycloak_client_rolemapping.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/test_keycloak_clientscope.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/test_keycloak_component.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/test_keycloak_identity_provider.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/test_keycloak_realm.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/test_keycloak_realm_info.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/test_keycloak_realm_keys.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/test_keycloak_realm_keys_metadata_info.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/test_keycloak_role.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/test_keycloak_user.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/test_keycloak_user_federation.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/test_keycloak_userprofile.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/test_pritunl_org.py pylint:ansible-bad-import-from
-tests/unit/plugins/modules/test_pritunl_user.py pylint:ansible-bad-import-from


### PR DESCRIPTION
##### SUMMARY
Now that ansible-core 2.20.0rc1 is out, and the devel branch is bumped to 2.21.0.dev0, replace devel with stable-2.20.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI, README
