### PR TITLE
uthelper: make str and repr generic in base class

### DIFF
--- a/tests/unit/plugins/modules/uthelper.py
+++ b/tests/unit/plugins/modules/uthelper.py
@@ -203,13 +203,11 @@ class TestCaseMock:
     def build_mock(cls, mock_specs):
         return cls(mock_specs)
 
-    @classmethod
-    def __str__(cls):
-        return f"<{cls.__name__} specs={self.mock_specs}>"
+    def __str__(self):
+        return f"<{self.__class__.__name__} specs={self.mock_specs}>"
 
-    @classmethod
-    def __repr__(cls):
-        return f"{cls.__name__}({self.mock_specs})"
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.mock_specs})"
 
     def __init__(self, mock_specs):
         self.mock_specs = mock_specs


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Make generic versions of the methods `__str__` and `__repr__` for UTHelper's TestCaseMock classes.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
tests/unit/plugins/modules/uthelper.py