### PR TITLE
Fix(zpool): Ensure consistent device path normalization for idempotency

### DIFF
--- a/changelogs/fragments/11020-zpool-device-path-idempotency.yaml
+++ b/changelogs/fragments/11020-zpool-device-path-idempotency.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - zpool - idempotency failed when canonical device IDs were used; the fix now ensures consistent device path normalization (https://github.com/ansible-collections/community.general/pull/11020).
+  - zpool - idempotency failed when canonical device IDs were used; the fix now ensures consistent device path normalization (https://github.com/ansible-collections/community.general/issues/10771, https://github.com/ansible-collections/community.general/issues/10744, https://github.com/ansible-collections/community.general/pull/11020).

--- a/changelogs/fragments/11020-zpool-device-path-idempotency.yaml
+++ b/changelogs/fragments/11020-zpool-device-path-idempotency.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zpool - idempotency failed when canonical device IDs were used; the fix now ensures consistent device path normalization (https://github.com/ansible-collections/community.general/pull/11020).

--- a/plugins/modules/zpool.py
+++ b/plugins/modules/zpool.py
@@ -309,7 +309,7 @@ class Zpool(object):
         match = re.match(r'^(/dev/(?:sd|vd)[a-z])\d+$', device)
         if match:
             return match.group(1)
-        
+
         # disk/by-id drives
         match = re.match(r'^(/dev/disk/by-id/(.*))-part\d+$', device)
         if match:

--- a/plugins/modules/zpool.py
+++ b/plugins/modules/zpool.py
@@ -309,12 +309,17 @@ class Zpool(object):
         match = re.match(r'^(/dev/(?:sd|vd)[a-z])\d+$', device)
         if match:
             return match.group(1)
+        
+        # disk/by-id drives
+        match = re.match(r'^(/dev/disk/by-id/(.*))-part\d+$', device)
+        if match:
+            return match.group(1)
 
         return device
 
     def get_current_layout(self):
-        with self.zpool_runner('subcommand full_paths real_paths name', check_rc=True) as ctx:
-            rc, stdout, stderr = ctx.run(subcommand='status', full_paths=True, real_paths=True)
+        with self.zpool_runner('subcommand full_paths name', check_rc=True) as ctx:
+            rc, stdout, stderr = ctx.run(subcommand='status', full_paths=True)
 
         vdevs = []
         current = None
@@ -433,8 +438,8 @@ class Zpool(object):
             return {'prepared': stdout}
 
     def list_vdevs_with_names(self):
-        with self.zpool_runner('subcommand full_paths real_paths name', check_rc=True) as ctx:
-            rc, stdout, stderr = ctx.run(subcommand='status', full_paths=True, real_paths=True)
+        with self.zpool_runner('subcommand full_paths name', check_rc=True) as ctx:
+            rc, stdout, stderr = ctx.run(subcommand='status', full_paths=True)
         in_cfg = False
         saw_pool = False
         vdevs = []


### PR DESCRIPTION
##### SUMMARY
This fix resolves an idempotency failure that occurs when defining zpool vdevs using canonical device IDs (e.g., /dev/disk/by-id/...).

The underlying issue was two-fold:
1. The base_device parsing logic was insufficient to strip partition suffixes (-partN) from these specific canonical paths.
2. The concurrent use of the 'real_paths=True' flag in zpool status output complicated path comparison.

This patch implements the solution by:
a) Enhancing the base_device function to correctly normalize /dev/disk/by-id/ paths. b) Removing the redundant 'real_paths=True' flag to stabilize path reporting.

This solution was developed and implemented entirely by the Author of this commit.

Fixes #10771
Fixes #10744
Ref https://github.com/ansible-collections/community.general/pull/10146#issuecomment-3342219496

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zpool
