### PR TITLE
CI: remove no longer necessary skip/ lines

### DIFF
--- a/tests/integration/targets/django_command/aliases
+++ b/tests/integration/targets/django_command/aliases
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python2
 skip/freebsd
 skip/macos
 skip/osx

--- a/tests/integration/targets/django_manage/aliases
+++ b/tests/integration/targets/django_manage/aliases
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python2
 skip/freebsd
 skip/macos
 skip/osx

--- a/tests/integration/targets/filter_jc/aliases
+++ b/tests/integration/targets/filter_jc/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python2.7  # jc only supports python3.x

--- a/tests/integration/targets/pipx/aliases
+++ b/tests/integration/targets/pipx/aliases
@@ -4,5 +4,3 @@
 
 azp/posix/2
 destructive
-skip/python2
-skip/python3.5

--- a/tests/integration/targets/pipx_info/aliases
+++ b/tests/integration/targets/pipx_info/aliases
@@ -4,5 +4,3 @@
 
 azp/posix/3
 destructive
-skip/python2
-skip/python3.5

--- a/tests/integration/targets/ssh_config/aliases
+++ b/tests/integration/targets/ssh_config/aliases
@@ -4,5 +4,4 @@
 
 azp/posix/2
 destructive
-skip/python2.7  # stromssh only supports python3
 skip/freebsd # stromssh installation fails on freebsd

--- a/tests/integration/targets/terraform/aliases
+++ b/tests/integration/targets/terraform/aliases
@@ -8,4 +8,3 @@ skip/aix
 skip/osx
 skip/macos
 skip/freebsd
-skip/python2


### PR DESCRIPTION
##### SUMMARY
Python 2 and 3.5 are no longer supported by the collection's `main` branch.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
integration tests
