### PR TITLE
filesystem: xfs resize: minimal required increment

### DIFF
--- a/changelogs/fragments/filesystem-xfs-resize-slack.yml
+++ b/changelogs/fragments/filesystem-xfs-resize-slack.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - filesystem - avoid false positive change detection on XFS resize due to unusable slack space (https://github.com/ansible-collections/community.general/pull/11033).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

filesystem: avoid false positive change detection on xfs resize due to unusable slack space at certain device sizes.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
filesystem

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Internally XFS uses allocation groups. Allocation groups have a maximum size of 1 TiB - 1 block. For devices >= 4 TiB XFS uses max size allocation groups. If a filesystem is extended and the last allocation group is already at max size, a new allocation group is added. An allocation group seems to require at least 64 4 KiB blocks.

For devices with integer TiB size (>4), this creates a filesystem that has initially has 1 unused block per TiB size. The `resize` option detects this unused space, and tries to resize the filesystem.  The xfs_growfs call is successful (exit 0), but does not increase the file system size. This is detected as repeated change in the task.

Test case:
```
- hosts: localhost
  tasks:
    - ansible.builtin.command:
        cmd: truncate -s 4T /media/xfs.img
        creates: /media/xfs.img
      notify: loopdev xfs

    - ansible.builtin.meta: flush_handlers

    - name: pickup xfs.img resize
      ansible.builtin.command:
        cmd: losetup -c /dev/loop0
      changed_when: false

    - community.general.filesystem:
        dev: "/dev/loop0"
        fstype: "xfs"

    - ansible.posix.mount:
        src: "/dev/loop0"
        fstype: "xfs"
        path: "/media/xfs"
        state: "mounted"

    # always shows a diff even for newly created filesystems
    - community.general.filesystem:
        dev: "/dev/loop0"
        fstype: "xfs"
        resizefs: true

  handlers:
    - name: loopdev xfs
      ansible.builtin.command:
        cmd: losetup /dev/loop0 /media/xfs.img
```

NB: If the last allocation group is not yet at max size, the filesystem can be resized. Detecting this requires considering the XFS topology. Other filesystems (at least ext4) also seem to require a minimum increment after the initial device size, but seem to use the entire device after initial creation.

Fun observation: creating a 64(+) TiB filesystem leaves a 64(+) block gap at the end, that is allocated in a subsequent xfs_growfs call.
