### PR TITLE
Migrate 1 RTD URLs to docs.ansible.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ If you find any inconsistencies or places in this document which can be improved
 
 ## Format code; and run sanity or unit tests locally (with antsibull-nox)
 
-The easiest way to format the code, and to run sanity and unit tests locally is to use [antsibull-nox](https://ansible.readthedocs.io/projects/antsibull-nox/).
+The easiest way to format the code, and to run sanity and unit tests locally is to use [antsibull-nox](https://docs.ansible.com/projects/antsibull-nox/).
 (If you have [nox](https://nox.thea.codes/en/stable/) installed, it will automatically install antsibull-nox in a virtual environment for you.)
 
 ### Format code


### PR DESCRIPTION
## Summary

This PR updates 1 `ansible.readthedocs.io` URLs to their `docs.ansible.com` equivalents as part of the Read the Docs migration.

For more details, see the Forum post [We're moving to Read The Docs](https://forum.ansible.com/t/we-re-moving-to-read-the-docs/43519).

## Changes Made

- Replaced `ansible.readthedocs.io` with `docs.ansible.com` in documentation links
- All URLs have been validated to ensure they work correctly

## URL Changes

- https://ansible.readthedocs.io/projects/antsibull-nox/ → https://docs.ansible.com/projects/antsibull-nox/

## Testing

- URLs have been validated before replacement
- Target URLs return HTTP 200 responses
- No broken links introduced

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>