### PR TITLE
Extend failure message for merge_variables type detection

### DIFF
--- a/changelogs/fragments/11107-extend-merge-variables-failure-message.yml
+++ b/changelogs/fragments/11107-extend-merge-variables-failure-message.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - merge_variables - extend type detection failure message to allow users for easier failure debugging (https://github.com/ansible-collections/community.general/pull/11107).

--- a/plugins/lookup/merge_variables.py
+++ b/plugins/lookup/merge_variables.py
@@ -129,7 +129,7 @@ def _verify_and_get_type(variable):
     elif isinstance(variable, dict):
         return "dict"
     else:
-        raise AnsibleError("Not supported type detected, variable must be a list or a dict")
+        raise AnsibleError(f"Not supported type detected, variable must be a list or a dict: '{variable}'")
 
 
 class LookupModule(LookupBase):


### PR DESCRIPTION
Update the error message for the merge_variables lookup plugin in case an unsupported type is passed.

##### SUMMARY

Improve the failure message in case an not-allowed type is specified.
This allows our users to find errors in plugins early on (e.g. where an input variable with an undefined jinja2 filter is passed).

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

Not sure whether it is docs or bugfix, since it is mainly inline documentation.

##### COMPONENT NAME
merge_variables

##### ADDITIONAL INFORMATION
N.A.