### PR TITLE
Re-enable Copr integration tests

### DIFF
--- a/tests/integration/targets/copr/aliases
+++ b/tests/integration/targets/copr/aliases
@@ -8,4 +8,3 @@ skip/macos
 skip/osx
 skip/freebsd
 skip/rhel10.0  # FIXME
-disabled  # FIXME - https://github.com/ansible-collections/community.general/issues/10987


### PR DESCRIPTION
Fixes: https://github.com/ansible-collections/community.general/issues/10987

##### SUMMARY
Re-enable Copr integration tests. The underlying issue should be fixed now, and the tests passed when I ran them locally.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
copr
