### PR TITLE
[stable-11] Move ansible-core 2.17 to EOL CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -108,19 +108,6 @@ stages:
             - test: 2
             - test: 3
             - test: 4
-  - stage: Sanity_2_17
-    displayName: Sanity 2.17
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Test {0}
-          testFormat: 2.17/sanity/{0}
-          targets:
-            - test: 1
-            - test: 2
-            - test: 3
-            - test: 4
 ### Units
   - stage: Units_devel
     displayName: Units devel
@@ -173,18 +160,6 @@ stages:
             - test: 3.8
             - test: "3.11"
             - test: "3.13"
-  - stage: Units_2_17
-    displayName: Units 2.17
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.17/units/{0}/1
-          targets:
-            - test: 3.7
-            - test: "3.10"
-            - test: "3.12"
 
 ## Remote
   - stage: Remote_devel_extra_vms
@@ -279,22 +254,6 @@ stages:
             - 1
             - 2
             - 3
-  - stage: Remote_2_17
-    displayName: Remote 2.17
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.17/{0}
-          targets:
-            - name: FreeBSD 13.5
-              test: freebsd/13.5
-            - name: RHEL 9.3
-              test: rhel/9.3
-          groups:
-            - 1
-            - 2
-            - 3
 
 ### Docker
   - stage: Docker_devel
@@ -363,24 +322,6 @@ stages:
               test: alpine320
             - name: Ubuntu 24.04
               test: ubuntu2404
-          groups:
-            - 1
-            - 2
-            - 3
-  - stage: Docker_2_17
-    displayName: Docker 2.17
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.17/linux/{0}
-          targets:
-            - name: Fedora 39
-              test: fedora39
-            - name: Alpine 3.19
-              test: alpine319
-            - name: Ubuntu 20.04
-              test: ubuntu2004
           groups:
             - 1
             - 2
@@ -455,17 +396,6 @@ stages:
 #          targets:
 #            - test: '3.8'
 #            - test: '3.13'
-#  - stage: Generic_2_17
-#    displayName: Generic 2.17
-#    dependsOn: []
-#    jobs:
-#      - template: templates/matrix.yml
-#        parameters:
-#          nameFormat: Python {0}
-#          testFormat: 2.17/generic/{0}/1
-#          targets:
-#            - test: '3.7'
-#            - test: '3.12'
 
   - stage: Summary
     condition: succeededOrFailed()
@@ -474,29 +404,24 @@ stages:
       - Sanity_2_20
       - Sanity_2_19
       - Sanity_2_18
-      - Sanity_2_17
       - Units_devel
       - Units_2_20
       - Units_2_19
       - Units_2_18
-      - Units_2_17
       - Remote_devel_extra_vms
       - Remote_devel
       - Remote_2_20
       - Remote_2_19
       - Remote_2_18
-      - Remote_2_17
       - Docker_devel
       - Docker_2_20
       - Docker_2_19
       - Docker_2_18
-      - Docker_2_17
       - Docker_community_devel
 # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
 #      - Generic_devel
 #      - Generic_2_20
 #      - Generic_2_19
 #      - Generic_2_18
-#      - Generic_2_17
     jobs:
       - template: templates/coverage.yml

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -30,6 +30,7 @@ jobs:
       matrix:
         ansible:
           - '2.16'
+          - '2.17'
     runs-on: ubuntu-latest
     steps:
       - name: Perform sanity testing
@@ -63,6 +64,12 @@ jobs:
             python: '3.6'
           - ansible: '2.16'
             python: '3.11'
+          - ansible: '2.17'
+            python: '3.7'
+          - ansible: '2.17'
+            python: '3.10'
+          - ansible: '2.17'
+            python: '3.12'
 
     steps:
       - name: >-
@@ -136,19 +143,43 @@ jobs:
             docker: alpine3
             python: ''
             target: azp/posix/3/
-          # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
-          # - ansible: '2.16'
-          #   docker: default
-          #   python: '2.7'
-          #   target: azp/generic/1/
-          # - ansible: '2.16'
-          #   docker: default
-          #   python: '3.6'
-          #   target: azp/generic/1/
-          # - ansible: '2.16'
-          #   docker: default
-          #   python: '3.11'
-          #   target: azp/generic/1/
+          # 2.17
+          - ansible: '2.17'
+            docker: fedora39
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.17'
+            docker: fedora39
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.17'
+            docker: fedora39
+            python: ''
+            target: azp/posix/3/
+          - ansible: '2.17'
+            docker: alpine319
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.17'
+            docker: alpine319
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.17'
+            docker: alpine319
+            python: ''
+            target: azp/posix/3/
+          - ansible: '2.17'
+            docker: ubuntu2004
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.17'
+            docker: ubuntu2004
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.17'
+            docker: ubuntu2004
+            python: ''
+            target: azp/posix/3/
 
     steps:
       - name: >-


### PR DESCRIPTION
##### SUMMARY
ansible-core 2.17 is EOL.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
