### PR TITLE
xfconf: update state=absent doc

### DIFF
--- a/plugins/modules/xfconf.py
+++ b/plugins/modules/xfconf.py
@@ -23,6 +23,10 @@ seealso:
     description: XFCE documentation for the Xfconf configuration system.
     link: 'https://docs.xfce.org/xfce/xfconf/start'
 
+  - name: xfce4-settings-editor - Settings Editor
+    description: XFCE documentation for the graphical editor for configuration settings.
+    link: https://docs.xfce.org/xfce/xfce4-settings/editor#change_properties
+
 extends_documentation_fragment:
   - community.general.attributes
 
@@ -69,6 +73,10 @@ options:
       - The action to take upon the property/value.
       - The state V(get) has been removed in community.general 5.0.0. Please use the module M(community.general.xfconf_info)
         instead.
+      - Xfce4 may, and usually does, have default values that come with the system packages.
+        You can set new values for these default properties and override the their values.
+        However, whey you use O(state=absent), the module executes the command C(xfconf-query reset) for the specified property and
+        that only removes user-configured properties, so those properties are B(not removed), but rather they go back to the default values.
     choices: [present, absent]
     default: "present"
   force_array:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It turns out that `xfconf-query reset` does not necessarily remove the property: it may have been defined with a default value in the system (varying with OS, distro, xfce version)
in which case the property will return to its default value when reset.

This PR updates the documentation to be more clear about this behaviour.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
xfconf