### PR TITLE
[stable-11] docs: migrate RTD URLs to docs.ansible.com (#11109)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -146,7 +146,7 @@ body:
     attributes:
       label: Code of Conduct
       description: |
-        Read the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
+        Read the [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
       options:
         - label: I agree to follow the Ansible Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,7 +7,7 @@
 blank_issues_enabled: false  # default: true
 contact_links:
   - name: Security bug report
-    url: https://docs.ansible.com/ansible-core/devel/community/reporting_bugs_and_features.html?utm_medium=github&utm_source=issue_template_chooser_ansible_collections
+    url: https://docs.ansible.com/projects/ansible-core/devel/community/reporting_bugs_and_features.html?utm_medium=github&utm_source=issue_template_chooser_ansible_collections
     about: |
       Please learn how to report security vulnerabilities here.
 
@@ -16,12 +16,12 @@ contact_links:
       a prompt response.
 
       For more information, see
-      https://docs.ansible.com/ansible/latest/community/reporting_bugs_and_features.html
+      https://docs.ansible.com/projects/ansible/latest/community/reporting_bugs_and_features.html
   - name: Ansible Code of Conduct
-    url: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_template_chooser_ansible_collections
+    url: https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_template_chooser_ansible_collections
     about: Be nice to other members of the community.
   - name: Talks to the community
-    url: https://docs.ansible.com/ansible/latest/community/communication.html?utm_medium=github&utm_source=issue_template_chooser#mailing-list-information
+    url: https://docs.ansible.com/projects/ansible/latest/community/communication.html?utm_medium=github&utm_source=issue_template_chooser#mailing-list-information
     about: Please ask and answer usage questions here
   - name: Working groups
     url: https://github.com/ansible/community/wiki

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -122,7 +122,7 @@ body:
     attributes:
       label: Code of Conduct
       description: |
-        Read the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
+        Read the [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
       options:
         - label: I agree to follow the Ansible Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Code of Conduct
       description: |
-        Read the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
+        Read the [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
       options:
         - label: I agree to follow the Ansible Code of Conduct
           required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 <!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
 
 <!--- Please do not forget to include a changelog fragment:
-      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
+      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
       No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
       Read about more details in CONTRIBUTING.md.
       -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Contributing
 
-We follow [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html) in all our contributions and interactions within this repository.
+We follow [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html) in all our contributions and interactions within this repository.
 
 If you are a committer, also refer to the [collection's committer guidelines](https://github.com/ansible-collections/community.general/blob/main/commit-rights.md).
 
@@ -30,8 +30,8 @@ Also, consider taking up a valuable, reviewed, but abandoned pull request which 
 
 * Try committing your changes with an informative but short commit message.
 * Do not squash your commits and force-push to your branch if not needed. Reviews of your pull request are much easier with individual commits to comprehend the pull request history. All commits of your pull request branch will be squashed into one commit by GitHub upon merge.
-* Do not add merge commits to your PR. The bot will complain and you will have to rebase ([instructions for rebasing](https://docs.ansible.com/ansible/latest/dev_guide/developing_rebasing.html)) to remove them before your PR can be merged. To avoid that git automatically does merges during pulls, you can configure it to do rebases instead by running `git config pull.rebase true` inside the repository checkout.
-* Make sure your PR includes a [changelog fragment](https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-a-changelog-fragment).
+* Do not add merge commits to your PR. The bot will complain and you will have to rebase ([instructions for rebasing](https://docs.ansible.com/projects/ansible/latest/dev_guide/developing_rebasing.html)) to remove them before your PR can be merged. To avoid that git automatically does merges during pulls, you can configure it to do rebases instead by running `git config pull.rebase true` inside the repository checkout.
+* Make sure your PR includes a [changelog fragment](https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-a-changelog-fragment).
   * You must not include a fragment for new modules or new plugins. Also you shouldn't include one for docs-only changes. (If you're not sure, simply don't include one, we'll tell you whether one is needed or not :) )
   * Please always include a link to the pull request itself, and if the PR is about an issue, also a link to the issue. Also make sure the fragment ends with a period, and begins with a lower-case letter after `-`. (Again, if you don't do this, we'll add suggestions to fix it, so don't worry too much :) )
 * Avoid reformatting unrelated parts of the codebase in your PR. These types of changes will likely be requested for reversion, create additional work for reviewers, and may cause approval to be delayed.
@@ -188,9 +188,9 @@ Creating new modules and plugins requires a bit more work than other Pull Reques
 
 3. When creating a new module or plugin, please make sure that you follow various guidelines:
 
-   - Follow [development conventions](https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_best_practices.html);
-   - Follow [documentation standards](https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html) and
-     the [Ansible style guide](https://docs.ansible.com/ansible/devel/dev_guide/style_guide/index.html#style-guide);
+   - Follow [development conventions](https://docs.ansible.com/projects/ansible/devel/dev_guide/developing_modules_best_practices.html);
+   - Follow [documentation standards](https://docs.ansible.com/projects/ansible/devel/dev_guide/developing_modules_documenting.html) and
+     the [Ansible style guide](https://docs.ansible.com/projects/ansible/devel/dev_guide/style_guide/index.html#style-guide);
    - Make sure your modules and plugins are [GPL-3.0-or-later](https://www.gnu.org/licenses/gpl-3.0-standalone.html) licensed
      (new module_utils can also be [BSD-2-clause](https://opensource.org/licenses/BSD-2-Clause) licensed);
    - Make sure that new plugins and modules have tests (unit tests, integration tests, or both); it is preferable to have some tests

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Community General Collection
 
-[![Documentation](https://img.shields.io/badge/docs-brightgreen.svg)](https://docs.ansible.com/ansible/devel/collections/community/general/)
+[![Documentation](https://img.shields.io/badge/docs-brightgreen.svg)](https://docs.ansible.com/projects/ansible/devel/collections/community/general/)
 [![Build Status](https://dev.azure.com/ansible/community.general/_apis/build/status/CI?branchName=stable-11)](https://dev.azure.com/ansible/community.general/_build?definitionId=31)
 [![EOL CI](https://github.com/ansible-collections/community.general/actions/workflows/ansible-test.yml/badge.svg?branch=stable-11)](https://github.com/ansible-collections/community.general/actions)
 [![Nox CI](https://github.com/ansible-collections/community.general/actions/workflows/nox.yml/badge.svg?branch=stable-11)](https://github.com/ansible-collections/community.general/actions)
@@ -15,15 +15,15 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 This repository contains the `community.general` Ansible Collection. The collection is a part of the Ansible package and includes many modules and plugins supported by Ansible community which are not part of more specialized community collections.
 
-You can find [documentation for this collection on the Ansible docs site](https://docs.ansible.com/ansible/latest/collections/community/general/).
+You can find [documentation for this collection on the Ansible docs site](https://docs.ansible.com/projects/ansible/latest/collections/community/general/).
 
 Please note that this collection does **not** support Windows targets. Only connection plugins included in this collection might support Windows targets, and will explicitly mention that in their documentation if they do so.
 
 ## Code of Conduct
 
-We follow [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html) in all our interactions within this project.
+We follow [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html) in all our interactions within this project.
 
-If you encounter abusive behavior violating the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html), please refer to the [policy violations](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html#policy-violations) section of the Code of Conduct for information on how to raise a complaint.
+If you encounter abusive behavior violating the [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html), please refer to the [policy violations](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html#policy-violations) section of the Code of Conduct for information on how to raise a complaint.
 
 ## Communication
 
@@ -33,9 +33,9 @@ If you encounter abusive behavior violating the [Ansible Code of Conduct](https:
   * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
   * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
 
-* The Ansible [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn): used to announce releases and important changes.
+* The Ansible [Bullhorn newsletter](https://docs.ansible.com/projects/ansible/devel/community/communication.html#the-bullhorn): used to announce releases and important changes.
 
-For more information about communication, see the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
+For more information about communication, see the [Ansible communication guide](https://docs.ansible.com/projects/ansible/devel/community/communication.html).
 
 ## Tested with Ansible
 
@@ -47,7 +47,7 @@ Some modules and plugins require external libraries. Please check the requiremen
 
 ## Included content
 
-Please check the included content on the [Ansible Galaxy page for this collection](https://galaxy.ansible.com/ui/repo/published/community/general/) or the [documentation on the Ansible docs site](https://docs.ansible.com/ansible/latest/collections/community/general/).
+Please check the included content on the [Ansible Galaxy page for this collection](https://galaxy.ansible.com/ui/repo/published/community/general/) or the [documentation on the Ansible docs site](https://docs.ansible.com/projects/ansible/latest/collections/community/general/).
 
 ## Using this collection
 
@@ -76,7 +76,7 @@ You can also install a specific version of the collection, for example, if you n
 ansible-galaxy collection install community.general:==X.Y.Z
 ```
 
-See [Ansible Using collections](https://docs.ansible.com/ansible/latest/user_guide/collections_using.html) for more details.
+See [Ansible Using collections](https://docs.ansible.com/projects/ansible/latest/user_guide/collections_using.html) for more details.
 
 ## Contributing to this collection
 
@@ -90,13 +90,13 @@ You don't know how to start? Refer to our [contribution guide](https://github.co
 
 The current maintainers are listed in the [commit-rights.md](https://github.com/ansible-collections/community.general/blob/main/commit-rights.md#people) file. If you have questions or need help, feel free to mention them in the proposals.
 
-You can find more information in the [developer guide for collections](https://docs.ansible.com/ansible/devel/dev_guide/developing_collections.html#contributing-to-collections), and in the [Ansible Community Guide](https://docs.ansible.com/ansible/latest/community/index.html).
+You can find more information in the [developer guide for collections](https://docs.ansible.com/projects/ansible/devel/dev_guide/developing_collections.html#contributing-to-collections), and in the [Ansible Community Guide](https://docs.ansible.com/projects/ansible/latest/community/index.html).
 
 Also for some notes specific to this collection see [our CONTRIBUTING documentation](https://github.com/ansible-collections/community.general/blob/main/CONTRIBUTING.md).
 
 ### Running tests
 
-See [here](https://docs.ansible.com/ansible/devel/dev_guide/developing_collections.html#testing-collections).
+See [here](https://docs.ansible.com/projects/ansible/devel/dev_guide/developing_collections.html#testing-collections).
 
 ## Collection maintenance
 
@@ -110,7 +110,7 @@ It is necessary for maintainers of this collection to be subscribed to:
 * The collection itself (the `Watch` button → `All Activity` in the upper right corner of the repository's homepage).
 * The "Changes Impacting Collection Contributors and Maintainers" [issue](https://github.com/ansible-collections/overview/issues/45).
 
-They also should be subscribed to Ansible's [The Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn).
+They also should be subscribed to Ansible's [The Bullhorn newsletter](https://docs.ansible.com/projects/ansible/devel/community/communication.html#the-bullhorn).
 
 ## Publishing New Version
 
@@ -129,9 +129,9 @@ See [this issue](https://github.com/ansible-collections/community.general/issues
 ## More information
 
 - [Ansible Collection overview](https://github.com/ansible-collections/overview)
-- [Ansible User guide](https://docs.ansible.com/ansible/latest/user_guide/index.html)
-- [Ansible Developer guide](https://docs.ansible.com/ansible/latest/dev_guide/index.html)
-- [Ansible Community code of conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html)
+- [Ansible User guide](https://docs.ansible.com/projects/ansible/latest/user_guide/index.html)
+- [Ansible Developer guide](https://docs.ansible.com/projects/ansible/latest/dev_guide/index.html)
+- [Ansible Community code of conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html)
 
 ## Licensing
 

--- a/commit-rights.md
+++ b/commit-rights.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 Committers Guidelines for community.general
 ===========================================
 
-This document is based on the [Ansible committer guidelines](https://github.com/ansible/ansible/blob/b57444af14062ec96e0af75fdfc2098c74fe2d9a/docs/docsite/rst/community/committer_guidelines.rst) ([latest version](https://docs.ansible.com/ansible/devel/community/committer_guidelines.html)).
+This document is based on the [Ansible committer guidelines](https://github.com/ansible/ansible/blob/b57444af14062ec96e0af75fdfc2098c74fe2d9a/docs/docsite/rst/community/committer_guidelines.rst) ([latest version](https://docs.ansible.com/projects/ansible/devel/community/committer_guidelines.html)).
 
 These are the guidelines for people with commit privileges on the Ansible Community General Collection GitHub repository. Please read the guidelines before you commit.
 
@@ -45,7 +45,7 @@ Individuals with direct commit access to this collection repository are entruste
   - Do not commit directly.
   - Do not merge your own PRs. Someone else should have a chance to review and approve the PR merge. You have a small amount of leeway here for very minor changes.
   - Do not forget about non-standard / alternate environments. Consider the alternatives. Yes, people have bad/unusual/strange environments (like binaries from multiple init systems installed), but they are the ones who need us the most.
-  - Do not drag your community team members down. Discuss the technical merits of any pull requests you review. Avoid negativity and personal comments. For more guidance on being a good community member, read the [Ansible Community Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
+  - Do not drag your community team members down. Discuss the technical merits of any pull requests you review. Avoid negativity and personal comments. For more guidance on being a good community member, read the [Ansible Community Code of Conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html).
   - Do not forget about the maintenance burden. High-maintenance features may not be worth adding.
   - Do not break playbooks. Always keep backwards compatibility in mind.
   - Do not forget to keep it simple. Complexity breeds all kinds of problems.

--- a/docs/docsite/rst/guide_modulehelper.rst
+++ b/docs/docsite/rst/guide_modulehelper.rst
@@ -21,7 +21,7 @@ That is where ``ModuleHelper`` comes to assistance: a lot of that boilerplate co
 Quickstart
 """"""""""
 
-See the `example from Ansible documentation <https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html#creating-a-module>`_
+See the `example from Ansible documentation <https://docs.ansible.com/projects/ansible/latest/dev_guide/developing_modules_general.html#creating-a-module>`_
 written with ``ModuleHelper``.
 But bear in mind that it does not showcase all of MH's features:
 
@@ -550,9 +550,9 @@ The other option is to use the parameter ``value``, in which case the method wil
 References
 ^^^^^^^^^^
 
-- `Ansible Developer Guide <https://docs.ansible.com/ansible/latest/dev_guide/index.html>`_
-- `Creating a module <https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html#creating-a-module>`_
-- `Returning ansible facts <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#ansible-facts>`_
+- `Ansible Developer Guide <https://docs.ansible.com/projects/ansible/latest/dev_guide/index.html>`_
+- `Creating a module <https://docs.ansible.com/projects/ansible/latest/dev_guide/developing_modules_general.html#creating-a-module>`_
+- `Returning ansible facts <https://docs.ansible.com/projects/ansible/latest/reference_appendices/common_return_values.html#ansible-facts>`_
 - :ref:`ansible_collections.community.general.docsite.guide_vardict`
 
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,6 +16,6 @@ license_file: COPYING
 tags:
   - community
 repository: https://github.com/ansible-collections/community.general
-documentation: https://docs.ansible.com/ansible/latest/collections/community/general/
+documentation: https://docs.ansible.com/projects/ansible/latest/collections/community/general/
 homepage: https://github.com/ansible-collections/community.general
 issues: https://github.com/ansible-collections/community.general/issues

--- a/plugins/callback/diy.py
+++ b/plugins/callback/diy.py
@@ -39,7 +39,7 @@ notes:
 seealso:
   - name: default – default Ansible screen output
     description: The official documentation on the B(default) callback plugin.
-    link: https://docs.ansible.com/ansible/latest/plugins/callback/default.html
+    link: https://docs.ansible.com/projects/ansible/latest/plugins/callback/default.html
 requirements:
   - set as stdout_callback in configuration
 options:

--- a/plugins/modules/ansible_galaxy_install.py
+++ b/plugins/modules/ansible_galaxy_install.py
@@ -23,7 +23,7 @@ notes:
 seealso:
   - name: C(ansible-galaxy) command manual page
     description: Manual page for the command.
-    link: https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html
+    link: https://docs.ansible.com/projects/ansible/latest/cli/ansible-galaxy.html
 
 requirements:
   - ansible-core 2.11 or newer

--- a/plugins/modules/discord.py
+++ b/plugins/modules/discord.py
@@ -80,7 +80,7 @@ EXAMPLES = r"""
     webhook_token: "XXXYYY"
     content: "This is a message from ansible"
     username: Ansible
-    avatar_url: "https://docs.ansible.com/ansible/latest/_static/images/logo_invert.png"
+    avatar_url: "https://docs.ansible.com/favicon/favicon-32x32.png"
 
 - name: Send a embedded message to the Discord channel
   community.general.discord:
@@ -92,7 +92,7 @@ EXAMPLES = r"""
         footer:
           text: "Author: Ansible"
         image:
-          url: "https://docs.ansible.com/ansible/latest/_static/images/logo_invert.png"
+          url: "https://docs.ansible.com/favicon/favicon-32x32.png"
 
 - name: Send two embedded messages
   community.general.discord:
@@ -104,12 +104,12 @@ EXAMPLES = r"""
         footer:
           text: "Author: Ansible"
         image:
-          url: "https://docs.ansible.com/ansible/latest/_static/images/logo_invert.png"
+          url: "https://docs.ansible.com/favicon/favicon-32x32.png"
       - title: "Second message"
         description: "This is my first second message"
         footer:
           text: "Author: Ansible"
-          icon_url: "https://docs.ansible.com/ansible/latest/_static/images/logo_invert.png"
+          icon_url: "https://docs.ansible.com/favicon/favicon-32x32.png"
         fields:
           - name: "Field 1"
             value: "Value of my first field"


### PR DESCRIPTION
##### SUMMARY
Backport of #11109 to stable-11.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
various
