### PR TITLE
mas: Fix parsing on mas 3.0.0+.

### DIFF
--- a/changelogs/fragments/11179-mas-list-parsing.yml
+++ b/changelogs/fragments/11179-mas-list-parsing.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - mas - Parse CLI output correctly when listing installed apps (https://github.com/ansible-collections/community.general/pull/11179).
+  - mas - parse CLI output correctly when listing installed apps with mas 3.0.0+ (https://github.com/ansible-collections/community.general/pull/11179).

--- a/plugins/modules/mas.py
+++ b/plugins/modules/mas.py
@@ -195,7 +195,11 @@ class Mas:
             rows = []
         apps = []
         for r in rows:
-            # Format example:
+            # mas 2.3.0 and older:
+            # 123456789  App Name         (version)
+            # 4567890    App Name Longer  (version)
+            #
+            # mas 3.0.0 and newer:
             # 123456789  App Name         (version)
             #   4567890  App Name Longer  (version)
             r = r.strip().split(" ", 1)


### PR DESCRIPTION
##### SUMMARY
`mas` changed the formatting of `mas list` with version 3, which breaks the parsing this module uses to determine which apps are installed.  In particular, app IDs may now have leading space, which causes us to split the string too early.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mas

##### ADDITIONAL INFORMATION
Prior to this change, users may see ansible runs with something like the following:

```
TASK [macos/all : Install App Store Apps] **************************************
[ERROR]: Task failed: Module failed: invalid literal for int() with base 10: ''
Origin: <redacted>/roles/macos/all/tasks/packages.yml:70:3

68     - "buildifer"
69
70 - name: Install App Store Apps
     ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: Module failed: invalid literal for int() with base 10: ''"}
```

The root cause is the format change in new versions of the `mas` CLI.  For example:

```
$ mas list
1440147259  AdGuard for Safari  (1.11.24)
1037126344  Apple Configurator  (2.19)
1151217174  Banner Hunter       (1.2.1)
6452017315  Cookie              (8.0)
 682658836  GarageBand          (10.4.12)
 408981434  iMovie              (10.4.3)
1136220934  Infuse              (8.3.1)
 409183694  Keynote             (14.4)
 409203825  Numbers             (14.4)
 409201541  Pages               (14.4)
 747648890  Telegram            (12.2)
 497799835  Xcode               (26.1.1)
```

With this change (and `mas` 3.0.1), I now get clean runs of the same task:

```
TASK [macos/all : Install App Store Apps] **************************************
ok: [localhost]
```