### PR TITLE
nmcli: allow VxLan multicast and bridge port

### DIFF
--- a/changelogs/fragments/11182-vxlan-parent-bridging.yml
+++ b/changelogs/fragments/11182-vxlan-parent-bridging.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmcli module - add ``vxlan_parent`` option required for multicast ``vxlan_remote`` addresses; add ``vxlan`` to list of bridgeable devices (https://github.com/ansible-collections/community.general/pull/11182).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -530,6 +530,11 @@ options:
     description:
       - This is only used with VXLAN - VXLAN destination IP address.
     type: str
+  vxlan_parent:
+    description:
+      - This is only used with VXLAN - VXLAN parent device (required when using a multicast remote address).
+    type: str
+    version_added: 12.2.0
   vxlan_local:
     description:
       - This is only used with VXLAN - VXLAN local IP address.
@@ -1454,6 +1459,17 @@ EXAMPLES = r"""
         vxlan_local: 192.168.1.2
         vxlan_remote: 192.168.1.5
 
+    - name: Add VxLan via multicast on a bridge
+      community.general.nmcli:
+        type: vxlan
+        conn_name: vxlan_test2
+        vxlan_id: 17
+        vxlan_parent: eth1
+        vxlan_local: 192.168.1.2
+        vxlan_remote: 239.192.0.17
+        slave_type: bridge
+        master: br0
+
     - name: Add gre
       community.general.nmcli:
         type: gre
@@ -1784,6 +1800,7 @@ class Nmcli:
         self.ingress = module.params["ingress"]
         self.egress = module.params["egress"]
         self.vxlan_id = module.params["vxlan_id"]
+        self.vxlan_parent = module.params["vxlan_parent"]
         self.vxlan_local = module.params["vxlan_local"]
         self.vxlan_remote = module.params["vxlan_remote"]
         self.ip_tunnel_dev = module.params["ip_tunnel_dev"]
@@ -2041,6 +2058,7 @@ class Nmcli:
             options.update(
                 {
                     "vxlan.id": self.vxlan_id,
+                    "vxlan.parent": self.vxlan_parent,
                     "vxlan.local": self.vxlan_local,
                     "vxlan.remote": self.vxlan_remote,
                 }
@@ -2256,6 +2274,7 @@ class Nmcli:
             "infiniband",
             "ovs-port",
             "ovs-interface",
+            "vxlan",
         )
 
     @property
@@ -2825,6 +2844,7 @@ def create_module() -> AnsibleModule:
             egress=dict(type="str"),
             # vxlan specific vars
             vxlan_id=dict(type="int"),
+            vxlan_parent=dict(type="str"),
             vxlan_local=dict(type="str"),
             vxlan_remote=dict(type="str"),
             # ip-tunnel specific vars


### PR DESCRIPTION
VxLan virtual devices can be added to bridge ports, like any other devices. And when using multicast remote addresses, NetworkManager need to know the parent device as well.

##### SUMMARY

Adds a `vxlan_parent` attribute to `nmcli` to support multicast remote VxLan addresses.
Enables `slave_type` and `master` for `vxlan` types to permit adding the vxlan device to a bridge.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->

- Feature Pull Request

##### COMPONENT NAME

nmcli

