### PR TITLE
Deprecate unused module utils

### DIFF
--- a/changelogs/fragments/11205-module_utils.yml
+++ b/changelogs/fragments/11205-module_utils.yml
@@ -1,0 +1,9 @@
+deprecated_features:
+  - "cloud module utils - this module utils is not used by community.general and will thus be removed from community.general 13.0.0.
+     If you are using it from another collection, please copy it over (https://github.com/ansible-collections/community.general/pull/11205)."
+  - "database module utils - this module utils is not used by community.general and will thus be removed from community.general 13.0.0.
+     If you are using it from another collection, please copy it over (https://github.com/ansible-collections/community.general/pull/11205)."
+  - "known_hosts module utils - this module utils is not used by community.general and will thus be removed from community.general 13.0.0.
+     If you are using it from another collection, please copy it over (https://github.com/ansible-collections/community.general/pull/11205)."
+  - "saslprep module utils - this module utils is not used by community.general and will thus be removed from community.general 13.0.0.
+     If you are using it from another collection, please copy it over (https://github.com/ansible-collections/community.general/pull/11205)."

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1146,6 +1146,14 @@ plugin_routing:
         warning_text: This doc fragment was used by rax modules, that relied on the deprecated
           package pyrax.
   module_utils:
+    cloud:
+      deprecation:
+        removal_version: 13.0.0
+        warning_text: This code is not used by community.general. If you want to use it in another collection, please copy it over.
+    database:
+      deprecation:
+        removal_version: 13.0.0
+        warning_text: This code is not used by community.general. If you want to use it in another collection, please copy it over.
     dimensiondata:
       deprecation:
         removal_version: 13.0.0
@@ -1162,6 +1170,10 @@ plugin_routing:
       redirect: community.google.gcp
     hetzner:
       redirect: community.hrobot.robot
+    known_hosts:
+      deprecation:
+        removal_version: 13.0.0
+        warning_text: This code is not used by community.general. If you want to use it in another collection, please copy it over.
     kubevirt:
       redirect: community.kubevirt.kubevirt
     net_tools.nios.api:
@@ -1193,6 +1205,10 @@ plugin_routing:
       redirect: dellemc.openmanage.dellemc_idrac
     remote_management.dellemc.ome:
       redirect: dellemc.openmanage.ome
+    saslprep:
+      deprecation:
+        removal_version: 13.0.0
+        warning_text: This code is not used by community.general. If you want to use it in another collection, please copy it over.
   inventory:
     docker_machine:
       redirect: community.docker.docker_machine

--- a/plugins/module_utils/cloud.py
+++ b/plugins/module_utils/cloud.py
@@ -3,6 +3,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# This module utils is deprecated and will be removed in community.general 13.0.0
+
 from __future__ import annotations
 
 

--- a/plugins/module_utils/database.py
+++ b/plugins/module_utils/database.py
@@ -9,6 +9,8 @@
 # Simplified BSD License (see LICENSES/BSD-2-Clause.txt or https://opensource.org/licenses/BSD-2-Clause)
 # SPDX-License-Identifier: BSD-2-Clause
 
+# This module utils is deprecated and will be removed in community.general 13.0.0
+
 from __future__ import annotations
 
 import re

--- a/plugins/module_utils/known_hosts.py
+++ b/plugins/module_utils/known_hosts.py
@@ -9,6 +9,8 @@
 # Simplified BSD License (see LICENSES/BSD-2-Clause.txt or https://opensource.org/licenses/BSD-2-Clause)
 # SPDX-License-Identifier: BSD-2-Clause
 
+# This module utils is deprecated and will be removed in community.general 13.0.0
+
 from __future__ import annotations
 
 import os

--- a/plugins/module_utils/saslprep.py
+++ b/plugins/module_utils/saslprep.py
@@ -9,6 +9,8 @@
 # Simplified BSD License (see LICENSES/BSD-2-Clause.txt or https://opensource.org/licenses/BSD-2-Clause)
 # SPDX-License-Identifier: BSD-2-Clause
 
+# This module utils is deprecated and will be removed in community.general 13.0.0
+
 from __future__ import annotations
 
 from stringprep import (


### PR DESCRIPTION
##### SUMMARY
While starting to add more type hints I noticed that some module utils aren't used *at all*. Let's deprecate them so we can remove them soon.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/cloud.py
plugins/module_utils/database.py
plugins/module_utils/known_hosts.py
plugins/module_utils/saslprep.py
