### PR TITLE
Fix crash in module_utils.datetime.fromtimestamp()

### DIFF
--- a/changelogs/fragments/11206-datetime.yml
+++ b/changelogs/fragments/11206-datetime.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "datetime module utils - fix bug in ``fromtimestamp()`` that caused the function to crash.
+     This function is not used in community.general (https://github.com/ansible-collections/community.general/pull/11206)."

--- a/plugins/module_utils/datetime.py
+++ b/plugins/module_utils/datetime.py
@@ -15,7 +15,7 @@ def ensure_timezone_info(value):
 
 
 def fromtimestamp(value):
-    return _datetime.fromtimestamp(value, tz=_datetime.timezone.utc)
+    return _datetime.datetime.fromtimestamp(value, tz=_datetime.timezone.utc)
 
 
 def now():


### PR DESCRIPTION
##### SUMMARY
This function isn't used in community.general (anymore), but it's broken.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
datetime module utils
