### PR TITLE
[stable-11] Fix crash in module_utils.datetime.fromtimestamp() (#11206)

### DIFF
--- a/changelogs/fragments/11206-datetime.yml
+++ b/changelogs/fragments/11206-datetime.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "datetime module utils - fix bug in ``fromtimestamp()`` that caused the function to crash.
+     This function is not used in community.general (https://github.com/ansible-collections/community.general/pull/11206)."

--- a/plugins/module_utils/datetime.py
+++ b/plugins/module_utils/datetime.py
@@ -22,8 +22,8 @@ def ensure_timezone_info(value):
 
 def fromtimestamp(value):
     if _USE_TIMEZONE:
-        return _datetime.fromtimestamp(value, tz=_datetime.timezone.utc)
-    return _datetime.utcfromtimestamp(value)
+        return _datetime.datetime.fromtimestamp(value, tz=_datetime.timezone.utc)
+    return _datetime.datetime.utcfromtimestamp(value)
 
 
 def now():


### PR DESCRIPTION
##### SUMMARY
Backport of #11206 to stable-11.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
datetime module utils
