### PR TITLE
Fix/failling to assign role to user

### DIFF
--- a/plugins/modules/keycloak_user_rolemapping.py
+++ b/plugins/modules/keycloak_user_rolemapping.py
@@ -351,7 +351,9 @@ def main():
             # Fetch missing role_name
             else:
                 if cid is None:
-                    role["name"] = kc.get_realm_user_rolemapping_by_id(uid=uid, rid=role.get("id"), realm=realm)["name"]
+                    role_rep = kc.get_realm_user_rolemapping_by_id(uid=uid, rid=role.get("id"), realm=realm)
+                    if role_rep is not None:
+                      role["name"] = role_rep["name"]
                 else:
                     role["name"] = kc.get_client_user_rolemapping_by_id(
                         uid=uid, cid=cid, rid=role.get("id"), realm=realm


### PR DESCRIPTION
##### SUMMARY

Fix: the module can now correctly assign roles to users.

##### ISSUE TYPE

Bug: previously, if a user did not already have the role, the module crashed with `TypeError: NoneType`.

##### COMPONENT NAME
plugins/modules/keycloak_user_rolemapping.py
