### PR TITLE
[PR #10960][stable-12] Fix: failling to assign role to user

### DIFF
--- a/plugins/modules/keycloak_user_rolemapping.py
+++ b/plugins/modules/keycloak_user_rolemapping.py
@@ -353,7 +353,7 @@ def main():
                 if cid is None:
                     role_rep = kc.get_realm_user_rolemapping_by_id(uid=uid, rid=role.get("id"), realm=realm)
                     if role_rep is not None:
-                      role["name"] = role_rep["name"]
+                        role["name"] = role_rep["name"]
                 else:
                     role["name"] = kc.get_client_user_rolemapping_by_id(
                         uid=uid, cid=cid, rid=role.get("id"), realm=realm


### PR DESCRIPTION
Fix for #10960 for merge into stable-12

##### SUMMARY

Fix: the module can now correctly assign roles to users.

##### ISSUE TYPE

Bug: previously, if a user did not already have the role, the module crashed with `TypeError: NoneType`.

##### COMPONENT NAME
plugins/modules/keycloak_user_rolemapping.py
