### PR TITLE
fix(docs): missing info on id when creating realms

### DIFF
--- a/plugins/modules/keycloak_realm.py
+++ b/plugins/modules/keycloak_realm.py
@@ -47,7 +47,6 @@ options:
     description:
       - Unique identifier for the realm.
       - This field is required when creating a new realm but can be omitted otherwise.
-    required: true
     type: str
   realm:
     description:


### PR DESCRIPTION
##### SUMMARY

This PR updates the Keycloak realm module documentation to clarify that the id field is required when creating a new realm.