### PR TITLE
Lenovo XCC Raw:PatchResource requests fail with "ETag missing" (#11261)

### DIFF
--- a/changelogs/fragments/11261-redfish-etags.yml
+++ b/changelogs/fragments/11261-redfish-etags.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redfish_utils module utils - fix PATCH request header to `ETag` (https://github.com/ansible-collections/community.general/pull/11270).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -270,7 +270,7 @@ class RedfishUtils:
             if etag:
                 if self.strip_etag_quotes:
                     etag = etag.strip('"')
-                req_headers["If-Match"] = etag
+                req_headers["ETag"] = etag
 
         if check_pyld:
             # Check the payload with the current settings to see if changes


### PR DESCRIPTION
##### SUMMARY

This PR Fixes #11261 where the usage of `If-Match` header is observed to cause `HTTP/412` error when performing `PATCH` requests to RedFish endpoints on newer Lenovo systems. 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

redfish_utils module utils

##### ADDITIONAL INFORMATION

More info in relevant ticket, but in short:

```
  tasks:
    - name: Power-on restore
      community.general.xcc_redfish_command:
        category: Raw
        command: PatchResource
        resource_uri: "/redfish/v1/Chassis/1/Power"
        request_body:
          Oem: { "Lenovo": { PowerRestorePolicy: "Restore" } }
```

Before:

```
$ ansible-playbook ./playbooks/xcc_poweronrestore.yml --limit wn060 

PLAY [XCC Power-on Restore] *********************************************************************************

TASK [Power-on restore] *********************************************************************************************************
[ERROR]: Task failed: Module failed: HTTP Error 412 on PATCH request to 'https://<redacted>/redfish/v1/Chassis/1/Power', extended message: 'The ETag supplied did not match the ETag required to change this resource.'
Origin: /<redacted>/playbooks/xcc_poweronrestore.yml:48:7

46
47   tasks:
48     - name: Power-on restore
         ^ column 7

fatal: [wn060]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/<redacted>/.venv/bin/python3.13"}, "changed": false, "msg": "HTTP Error 412 on PATCH request to 'https://<redacted>/redfish/v1/Chassis/1/Power', extended message: 'The ETag supplied did not match the ETag required to change this resource.'"}

PLAY RECAP **********************************************************************************************************************
wn060                      : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

After:

```
$ ansible-playbook ./playbooks/xcc_poweronrestore.yml --limit wn060 

PLAY [XCC Power-on Restore] *********************************************************************************

TASK [Power-on restore] *********************************************************************************************************
changed: [wn060]

TASK [meta] *********************************************************************************************************************

PLAY RECAP **********************************************************************************************************************
wn060                      : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```