### PR TITLE
keycloak_authentication_required_actions: fix examples

### DIFF
--- a/plugins/modules/keycloak_authentication_required_actions.py
+++ b/plugins/modules/keycloak_authentication_required_actions.py
@@ -91,7 +91,7 @@ EXAMPLES = r"""
     auth_realm: "master"
     auth_username: "admin"
     realm: "master"
-    required_action:
+    required_actions:
       - alias: "TERMS_AND_CONDITIONS"
         name: "Terms and conditions"
         providerId: "TERMS_AND_CONDITIONS"
@@ -106,7 +106,7 @@ EXAMPLES = r"""
     auth_realm: "master"
     auth_username: "admin"
     realm: "master"
-    required_action:
+    required_actions:
       - alias: "TERMS_AND_CONDITIONS"
         enabled: false
     state: "present"
@@ -119,7 +119,7 @@ EXAMPLES = r"""
     auth_realm: "master"
     auth_username: "admin"
     realm: "master"
-    required_action:
+    required_actions:
       - alias: "TERMS_AND_CONDITIONS"
     state: "absent"
 """


### PR DESCRIPTION
The correct parameter name is "required_actions" (plural).

##### SUMMARY

The example tasks use parameter "required_action", which is invalid. Instead one needs to plural, "required_actions" as described elsewhere in the documentation.

##### ISSUE TYPE

- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME

keycloak_authentication_required_actions