### PR TITLE
time-command.py: make sure seconds is an int

### DIFF
--- a/.azure-pipelines/scripts/time-command.py
+++ b/.azure-pipelines/scripts/time-command.py
@@ -19,7 +19,7 @@ def main():
     sys.stdout.reconfigure(errors="surrogateescape")
 
     for line in sys.stdin:
-        seconds = time.time() - start
+        seconds = int(time.time() - start)
         sys.stdout.write(f"{seconds // 60:02}:{seconds % 60:02} {line}")
         sys.stdout.flush()
 


### PR DESCRIPTION
##### SUMMARY
When refactoring this script in #11379 (turned `%` formatting to f-string), the behavior changed. Since `seconds` is a float, we now have output like `5.0:57.38101887702942` instead of `05:57`.

This PR restores the original behavior.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
