### PR TITLE
Start opentelemetry spans on host start instead of task start

### DIFF
--- a/changelogs/fragments/11434-opentelemetry-spans.yml
+++ b/changelogs/fragments/11434-opentelemetry-spans.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - opentelemetry callback plugin - set span start to the actual start time of the task for the given host instead of the task start time for the first host of that task (https://github.com/ansible-collections/community.general/pull/11434).

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -185,7 +185,7 @@ class TaskData:
                 # concatenate task include output from multiple items
                 host.result = f"{self.host_data[host.uuid].result}\n{host.result}"
             else:
-                self.host_data[host.uuid].update(host)
+                self.host_data[host.uuid].update(host.status, host.result)
                 return
 
         self.host_data[host.uuid] = host
@@ -196,20 +196,18 @@ class HostData:
     Data about an individual host.
     """
 
-    def __init__(self, uuid, name, status, result, start=None):
+    def __init__(self, uuid, name, status, result):
         self.uuid = uuid
         self.name = name
         self.status = status
         self.result = result
-        self.finish = time_ns()
-        self.start = start
+        self.finish = None
+        self.start = time_ns()
 
-    def update(self, host):
-        self.status = host.status
-        self.result = host.result
-        self.finish = host.finish
-        if host.start is not None:
-            self.start = host.start
+    def update(self, status, result):
+        self.status = status
+        self.result = result
+        self.finish = time_ns()
 
 
 class OpenTelemetrySource:
@@ -230,17 +228,14 @@ class OpenTelemetrySource:
         carrier["traceparent"] = traceparent
         return TraceContextTextMapPropagator().extract(carrier=carrier)
 
-    def start_task(self, tasks_data, hide_task_arguments, play_name, task, host=None):
+    def start_task(self, tasks_data, hide_task_arguments, play_name, task, host):
         """record the start of a task for one or more hosts"""
 
         uuid = task._uuid
 
         if uuid in tasks_data:
-            if host:
-                tasks_data[uuid].add_host(HostData(host._uuid, host.name, "started", None, time_ns()))
-                return
-            else:
-                return
+            tasks_data[uuid].add_host(HostData(host._uuid, host.name, "started", None))
+            return
 
         name = task.get_name().strip()
         path = task.get_path()
@@ -251,8 +246,7 @@ class OpenTelemetrySource:
             args = task.args
 
         tasks_data[uuid] = TaskData(uuid, name, path, play_name, action, args)
-        if host:
-            tasks_data[uuid].add_host(HostData(host._uuid, host.name, "started", None, time_ns()))
+        tasks_data[uuid].add_host(HostData(host._uuid, host.name, "started", None))
 
     def finish_task(self, tasks_data, status, result, dump):
         """record the results of a task for a single host"""
@@ -575,20 +569,8 @@ class CallbackModule(CallbackBase):
     def v2_playbook_on_play_start(self, play):
         self.play_name = play.get_name()
 
-    def v2_runner_on_no_hosts(self, task):
-        self.opentelemetry.start_task(self.tasks_data, self.hide_task_arguments, self.play_name, task)
-
-    def v2_playbook_on_task_start(self, task, is_conditional):
-        self.opentelemetry.start_task(self.tasks_data, self.hide_task_arguments, self.play_name, task)
-
     def v2_runner_on_start(self, host, task):
         self.opentelemetry.start_task(self.tasks_data, self.hide_task_arguments, self.play_name, task, host)
-
-    def v2_playbook_on_cleanup_task_start(self, task):
-        self.opentelemetry.start_task(self.tasks_data, self.hide_task_arguments, self.play_name, task)
-
-    def v2_playbook_on_handler_task_start(self, task):
-        self.opentelemetry.start_task(self.tasks_data, self.hide_task_arguments, self.play_name, task)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
         if ignore_errors:

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -37,19 +37,6 @@ class TestOpentelemetry(unittest.TestCase):
             host=self.mock_host, task=self.mock_task, return_data={}, task_fields=self.task_fields
         )
 
-    def test_start_task(self):
-        tasks_data = OrderedDict()
-
-        self.opentelemetry.start_task(tasks_data, False, "myplay", self.mock_task)
-
-        task_data = tasks_data["myuuid"]
-        self.assertEqual(task_data.uuid, "myuuid")
-        self.assertEqual(task_data.name, "mytask")
-        self.assertEqual(task_data.path, "/mypath")
-        self.assertEqual(task_data.play, "myplay")
-        self.assertEqual(task_data.action, "myaction")
-        self.assertEqual(task_data.args, {})
-
     def test_run_task_with_host(self):
         tasks_data = OrderedDict()
 

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, Mock, patch
 from ansible.executor.task_result import TaskResult
 from ansible.playbook.task import Task
 
-from ansible_collections.community.general.plugins.callback.opentelemetry import OpenTelemetrySource, TaskData, HostData
+from ansible_collections.community.general.plugins.callback.opentelemetry import HostData, OpenTelemetrySource, TaskData
 
 
 class TestOpentelemetry(unittest.TestCase):

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, Mock, patch
 from ansible.executor.task_result import TaskResult
 from ansible.playbook.task import Task
 
-from ansible_collections.community.general.plugins.callback.opentelemetry import OpenTelemetrySource, TaskData
+from ansible_collections.community.general.plugins.callback.opentelemetry import OpenTelemetrySource, TaskData, HostData
 
 
 class TestOpentelemetry(unittest.TestCase):
@@ -36,6 +36,10 @@ class TestOpentelemetry(unittest.TestCase):
         self.my_task_result = TaskResult(
             host=self.mock_host, task=self.mock_task, return_data={}, task_fields=self.task_fields
         )
+        self.mock_span = Mock("MockSpan")
+        self.mock_span.set_status = MagicMock()
+        self.mock_span.set_attributes = MagicMock()
+        self.mock_span.end = MagicMock()
 
     def test_run_task_with_host(self):
         tasks_data = OrderedDict()
@@ -82,6 +86,13 @@ class TestOpentelemetry(unittest.TestCase):
         self.assertEqual(host_data.uuid, "include")
         self.assertEqual(host_data.name, "include")
         self.assertEqual(host_data.status, "ok")
+
+    @patch("ansible_collections.community.general.plugins.callback.opentelemetry.Status", create=True)
+    @patch("ansible_collections.community.general.plugins.callback.opentelemetry.StatusCode", create=True)
+    def test_update_span_data(self, mock_status_code, mock_status):
+        unfinished_host = HostData("myhost_uuid", "myhost", "unreachable")
+        self.opentelemetry.update_span_data(self.mock_task, unfinished_host, self.mock_span, True, True)
+        self.mock_span.end.assert_called()
 
     def test_get_error_message(self):
         test_cases = (

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -50,6 +50,27 @@ class TestOpentelemetry(unittest.TestCase):
         self.assertEqual(task_data.action, "myaction")
         self.assertEqual(task_data.args, {})
 
+    def test_run_task_with_host(self):
+        tasks_data = OrderedDict()
+
+        self.opentelemetry.start_task(tasks_data, False, "myplay", self.mock_task, self.mock_host)
+
+        task_data = tasks_data["myuuid"]
+        self.assertEqual(task_data.uuid, "myuuid")
+        self.assertEqual(task_data.name, "mytask")
+        self.assertEqual(task_data.path, "/mypath")
+        self.assertEqual(task_data.play, "myplay")
+        self.assertEqual(task_data.action, "myaction")
+        self.assertEqual(task_data.args, {})
+
+        host_data = task_data.host_data["myhost_uuid"]
+        self.assertEqual(host_data.uuid, "myhost_uuid")
+        self.assertEqual(host_data.name, "myhost")
+        self.assertIsNotNone(host_data.start)
+
+        self.opentelemetry.finish_task(tasks_data, "ok", self.my_task_result, "")
+        self.assertEqual(host_data.status, "ok")
+
     def test_finish_task_with_a_host_match(self):
         tasks_data = OrderedDict()
         tasks_data["myuuid"] = self.my_task


### PR DESCRIPTION
##### SUMMARY
v2_playbook_on_task_start does not have the host information, so spans would always start at the same time for every host in that task, even if they started at different times, like when hosts > forks with strategy host_pinned. This also hides the duration of the task for that host.

This change uses the newer v2_runner_on_start callback and adds the acutal host start time to the span. The change is backwards compatible with ansible versions that do not have v2_runner_on_start and makes no assumptions around the ordering of v2_runner_on_start and v2_playbook_on_task_start.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.general.opentelemetry

##### ADDITIONAL INFORMATION
Before:
<img width="1241" height="113" alt="image" src="https://github.com/user-attachments/assets/0777db0e-2c9c-45a9-971d-cca867f59258" />

After:
<img width="1241" height="113" alt="image" src="https://github.com/user-attachments/assets/6e1e25dc-6d10-44ce-a735-fc0e4840dc41" />


```ansible
---
- name: Update web servers
  hosts: hostlist
  gather_facts: false
  strategy: host_pinned
  tasks:
  # executed with forks=1
  - name: Sleep for 4 seconds and continue with play
    ansible.builtin.wait_for:
      timeout: 4
    delegate_to: localhost

```
