### PR TITLE
jboss: deprecation

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -378,6 +378,10 @@ plugin_routing:
         warning_text: Use community.general.idrac_redfish_info instead.
     idrac_server_config_profile:
       redirect: dellemc.openmanage.idrac_server_config_profile
+    jboss:
+      deprecation:
+        removal_version: 14.0.0
+        warning_text: Use role middleware_automation.wildfly.wildfly_app_deploy instead.
     jenkins_job_facts:
       tombstone:
         removal_version: 3.0.0

--- a/plugins/modules/jboss.py
+++ b/plugins/modules/jboss.py
@@ -11,6 +11,12 @@ module: jboss
 short_description: Deploy applications to JBoss
 description:
   - Deploy applications to JBoss standalone using the filesystem.
+deprecated:
+  removed_in: 14.0.0
+  why: The module has not been very actively maintained and there is a better alternative.
+  alternative: >-
+    Use the C(middleware_automation.wildfly.wildfly_app_deploy) role to deploy applications in JBoss or WildFly.
+    See U(https://galaxy.ansible.com/ui/repo/published/middleware_automation/wildfly/content/role/wildfly_app_deploy/) for details.
 extends_documentation_fragment:
   - community.general.attributes
 attributes:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Application deployment module in JBoss is not actively maintained. The middleware_automation.wildfly.wildfly_app_deploy role provides a more modern solution for WildFly (name JBoss has been rebranded to).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
jboss