### PR TITLE
community.general.copr: clarify includepkgs/excludepkgs

### DIFF
--- a/plugins/modules/copr.py
+++ b/plugins/modules/copr.py
@@ -50,12 +50,14 @@ options:
         is run.
     type: str
   includepkgs:
-    description: List of packages to include.
+    description:
+      - List of packages to include in all operations.  Inverse of O(excludepkgs), DNF will exclude any package in
+        the repository that does not match this list.  Matches a name or a glob.
     type: list
     elements: str
     version_added: 9.4.0
   excludepkgs:
-    description: List of packages to exclude.
+    description: List of packages in this repository to exclude from all operations.  Matches a name or a glob.
     type: list
     elements: str
     version_added: 9.4.0
@@ -74,12 +76,14 @@ EXAMPLES = r"""
     state: absent
     name: '@copr/integration_tests'
 
-- name: Install Caddy
+- name: Install a repo where only packages starting with "python" that do not have i386 are seen by DNF
   community.general.copr:
-    name: '@caddy/caddy'
+    name: '@sample/repo'
     chroot: fedora-rawhide-{{ ansible_facts.architecture }}
     includepkgs:
-      - caddy
+      - 'python*'
+    excludepkgs:
+      - '*.i386'
 """
 
 RETURN = r"""


### PR DESCRIPTION
##### SUMMARY

At first glance, includepkgs seems to be something that would install the package name from the given copr repo.  This isn't helped by the example that says "Install caddy" which very much looks like it is installing the package from the repo.  Not only did I, a human, hallucinate this behaviour, so did a large search engine's AI responses to related queries.

In fact these are labels to vary what packages DNF sees.  Clarify this by using wording and examples closer to the upstream documentation [1]

[1] https://dnf.readthedocs.io/en/latest/conf_ref.html

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
`community.general.copr`