### PR TITLE
supervisorctl: remove unstable tag from integration tests

### DIFF
--- a/tests/integration/targets/supervisorctl/aliases
+++ b/tests/integration/targets/supervisorctl/aliases
@@ -7,4 +7,3 @@ destructive
 skip/aix
 skip/rhel  # TODO executables are installed in /usr/local/bin, which isn't part of $PATH
 skip/macos  # TODO executables are installed in /Library/Frameworks/Python.framework/Versions/3.11/bin, which isn't part of $PATH
-unstable # TODO fix!


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As a follow-up to #11057 , this PR removes the `unstable` tag in `aliases` for the integration test of supervisorctl.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
supervisorctl