### PR TITLE
seport: Add support for dccp and sctp protocols

### DIFF
--- a/changelogs/fragments/11486-seport-dccp-sctp.yaml
+++ b/changelogs/fragments/11486-seport-dccp-sctp.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - seport - adds support for DCCP and SCTP protocols (https://github.com/ansible-collections/community.general/pull/11486).

--- a/plugins/modules/seport.py
+++ b/plugins/modules/seport.py
@@ -29,9 +29,10 @@ options:
   proto:
     description:
       - Protocol for the specified port.
+      - Support for V(dccp) and V(sctp) has been added in community.general 12.4.0.
     type: str
     required: true
-    choices: [tcp, udp]
+    choices: [tcp, udp, dccp, sctp]
   setype:
     description:
       - SELinux type for the specified port.
@@ -145,7 +146,7 @@ def semanage_port_get_ports(seport, setype, proto, local):
     :param setype: SELinux type.
 
     :type proto: str
-    :param proto: Protocol ('tcp' or 'udp')
+    :param proto: Protocol ('tcp', 'udp', 'dccp', 'sctp')
 
     :rtype: list
     :return: List of ports that have the specified SELinux type.
@@ -166,7 +167,7 @@ def semanage_port_get_type(seport, port, proto):
     :param port: Port or port range (example: "8080", "8080-9090")
 
     :type proto: str
-    :param proto: Protocol ('tcp' or 'udp')
+    :param proto: Protocol ('tcp', 'udp', 'dccp', 'sctp')
 
     :rtype: tuple
     :return: Tuple containing the SELinux type and MLS/MCS level, or None if not found.
@@ -194,7 +195,7 @@ def semanage_port_add(module, ports, proto, setype, do_reload, serange="s0", ses
     :param ports: List of ports and port ranges to add (e.g. ["8080", "8080-9090"])
 
     :type proto: str
-    :param proto: Protocol ('tcp' or 'udp')
+    :param proto: Protocol ('tcp', 'udp', 'dccp', 'sctp')
 
     :type setype: str
     :param setype: SELinux type
@@ -245,7 +246,7 @@ def semanage_port_del(module, ports, proto, setype, do_reload, sestore="", local
     :param ports: List of ports and port ranges to delete (e.g. ["8080", "8080-9090"])
 
     :type proto: str
-    :param proto: Protocol ('tcp' or 'udp')
+    :param proto: Protocol ('tcp', 'udp', 'dccp', 'sctp')
 
     :type setype: str
     :param setype: SELinux type.
@@ -281,7 +282,7 @@ def main():
         argument_spec=dict(
             ignore_selinux_state=dict(type="bool", default=False),
             ports=dict(type="list", elements="str", required=True),
-            proto=dict(type="str", required=True, choices=["tcp", "udp"]),
+            proto=dict(type="str", required=True, choices=["tcp", "udp", "dccp", "sctp"]),
             setype=dict(type="str", required=True),
             state=dict(type="str", default="present", choices=["absent", "present"]),
             reload=dict(type="bool", default=True),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Support for dccp and sctp protocols were added to SELinux userspace python libraries in 3.0 version release in November 2019.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

seport

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```
$ sudo ansible localhost -m community.general.seport -a "ports=7745 proto=dccp setype=reserved_port_t state=present"
[ERROR]: Task failed: Module failed: value of proto must be one of: tcp, udp, got: dccp
Origin: <adhoc 'community.general.seport' task>

{'action': 'community.general.seport', 'args': {'ports': '7745', 'proto': 'dccp', 'setype': 'reserved_port_t', [...]

localhost | FAILED! => {
    "changed": false,
    "msg": "value of proto must be one of: tcp, udp, got: dccp"
}
```

After
```
$ sudo ansible localhost -m community.general.seport -a "ports=7745 proto=dccp setype=reserved_port_t state=present"
localhost | CHANGED => {
    "changed": true,
    "ports": [
        "7745"
    ],
    "proto": "dccp",
    "setype": "reserved_port_t",
    "state": "present"
}
```
