### PR TITLE
[stable-11] python_requirements_info: use importlib.metadata when available (#11495)

### DIFF
--- a/changelogs/fragments/11492-python_requires_info.yml
+++ b/changelogs/fragments/11492-python_requires_info.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "python_requirements_info - use ``importlib.metadata`` if ``pkg_resources`` from ``setuptools`` cannot be imported.
+     That module has been removed from setuptools 82.0.0
+     (https://github.com/ansible-collections/community.general/issues/11491, https://github.com/ansible-collections/community.general/pull/11492)."


### PR DESCRIPTION
##### SUMMARY
Backport of #11495 to stable-11.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
python_requirements_info
