### PR TITLE
keycloak_identity_provider: add claims example for oidc-advanced-group-idp-mapper

### DIFF
--- a/plugins/modules/keycloak_identity_provider.py
+++ b/plugins/modules/keycloak_identity_provider.py
@@ -368,6 +368,35 @@ EXAMPLES = r"""
           attribute.friendly.name: User Roles
           attribute.name: roles
           syncMode: INHERIT
+
+- name: Create OIDC identity provider, authentication with credentials and advanced claim to group
+  community.general.keycloak_identity_provider:
+    state: present
+    auth_keycloak_url: https://auth.example.com/auth
+    auth_realm: master
+    auth_username: admin
+    auth_password: admin
+    realm: myrealm
+    alias: oidc-idp
+    display_name: OpenID Connect IdP
+    enabled: true
+    provider_id: oidc
+    config:
+      issuer: https://idp.example.com
+      authorizationUrl: https://idp.example.com/auth
+      tokenUrl: https://idp.example.com/token
+      userInfoUrl: https://idp.example.com/userinfo
+      clientAuthMethod: client_secret_post
+      clientId: my-client
+      clientSecret: secret
+      syncMode: FORCE
+    mappers:
+      - name: group_name
+        identityProviderMapper: oidc-advanced-group-idp-mapper
+        config:
+          claims: '[{"key":"my_key","value":"my_value"}]'
+          group: group_name
+          syncMode: INHERIT
 """
 
 RETURN = r"""


### PR DESCRIPTION
##### SUMMARY
For me it wasn't clear how to create claims using oidc-advanced-group-idp-mapper in the community.general.keycloak_identity_provider module, perhaps other people can benefit from the following example.


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
community.general.keycloak_identity_provider