### PR TITLE
keycloak module utils: group search optimization

### DIFF
--- a/changelogs/fragments/11503-keycloak-group-search-optimization.yml
+++ b/changelogs/fragments/11503-keycloak-group-search-optimization.yml
@@ -1,4 +1,3 @@
 ---
 minor_changes:
-  - keycloak_* modules - optimize retrieval of groups by name to use Keycloak search API with exact matching instead of fetching all groups (https://github.com/ansible-collections/community.general/pull/11503).
-    This improves speed on group related modules like `keycloak_client_rolemapping`. `keycloak_realm_rolemapping` and `keycloak_group`.
+  - keycloak_client_rolemapping, keycloak_realm_rolemapping, keycloak_group - optimize retrieval of groups by name to use Keycloak search API with exact matching instead of fetching all groups (https://github.com/ansible-collections/community.general/pull/11503).

--- a/changelogs/fragments/11503-keycloak-group-search-optimization.yml
+++ b/changelogs/fragments/11503-keycloak-group-search-optimization.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
   - keycloak_* modules - optimize retrieval of groups by name to use Keycloak search API with exact matching instead of fetching all groups (https://github.com/ansible-collections/community.general/pull/11503).
+    This improves speed on group related modules like `keycloak_client_rolemapping`. `keycloak_realm_rolemapping` and `keycloak_group`.

--- a/changelogs/fragments/11503-keycloak-group-search-optimization.yml
+++ b/changelogs/fragments/11503-keycloak-group-search-optimization.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - keycloak - optimize ``get_group_by_name`` to use Keycloak search API with exact matching instead of fetching all groups (https://github.com/ansible-collections/community.general/pull/11503).

--- a/changelogs/fragments/11503-keycloak-group-search-optimization.yml
+++ b/changelogs/fragments/11503-keycloak-group-search-optimization.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - keycloak - optimize ``get_group_by_name`` to use Keycloak search API with exact matching instead of fetching all groups (https://github.com/ansible-collections/community.general/pull/11503).
+  - keycloak_* modules - optimize retrieval of groups by name to use Keycloak search API with exact matching instead of fetching all groups (https://github.com/ansible-collections/community.general/pull/11503).

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1655,13 +1655,12 @@ class KeycloakAPI:
                 # For subgroups: use children endpoint with search parameter
                 search_url = "{url}?search={name}&exact=true".format(
                     url=URL_GROUP_CHILDREN.format(url=self.baseurl, realm=realm, groupid=parent["id"]),
-                    name=quote(name, safe='')
+                    name=quote(name, safe=""),
                 )
             else:
                 # For top-level groups: use groups endpoint with search parameter
                 search_url = "{url}?search={name}&exact=true".format(
-                    url=URL_GROUPS.format(url=self.baseurl, realm=realm),
-                    name=quote(name, safe='')
+                    url=URL_GROUPS.format(url=self.baseurl, realm=realm), name=quote(name, safe="")
                 )
 
             groups = self._request_and_deserialize(search_url, method="GET")


### PR DESCRIPTION
##### SUMMARY

When using Keycloak with Active Directory (AD) federation, the number of groups can be very large. In our setup we have over 6,000 groups. The original implementation of `get_group_by_name` fetched **all** groups from Keycloak and then filtered locally by name. With large group counts, Keycloak took several minutes to return the full group list, while also fully saturating one CPU core.

This change replaces the full group listing with a targeted search using Keycloak's `?search=<name>&exact=true` query parameter, both for top-level groups and subgroups (via the children endpoint). This reduces the API response to typically one or zero results, making group lookups near-instant even with thousands of groups.

The change should be backwards-compatible with older Keycloak versions that do not support the `search` parameter — those versions will simply ignore the unknown query parameter, fall back to returning all groups, and the existing name-matching loop will still find the correct group.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
keycloak module utils (`plugins/module_utils/identity/keycloak/keycloak.py`)

##### ADDITIONAL INFORMATION

**Before:** `get_group_by_name` calls `get_groups()` which fetches all groups, then iterates to find the match. With 6,000+ groups (AD-federated), this caused multi-minute response times and high CPU load on the Keycloak server.

**After:** `get_group_by_name` uses the Keycloak search API (`?search=<name>&exact=true`), returning only matching groups. Lookup completes in milliseconds.

```paste below
# Example: before (slow)
GET /admin/realms/{realm}/groups
→ returns 6000+ groups, takes several minutes

# Example: after (fast)
GET /admin/realms/{realm}/groups?search={name}&exact=true
→ returns 0-1 groups, completes instantly