### PR TITLE
reduce collection build time with build_ignore

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -20,6 +20,4 @@ documentation: https://docs.ansible.com/projects/ansible/latest/collections/comm
 homepage: https://github.com/ansible-collections/community.general
 issues: https://github.com/ansible-collections/community.general/issues
 build_ignore:
-  - .git
-  - .github
   - .nox


### PR DESCRIPTION
##### SUMMARY

Reduce collection build time by using `build_ignore` (https://docs.ansible.com/projects/ansible/latest/dev_guide/developing_collections_distributing.html#build-ignore)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`galaxy.yml`

##### ADDITIONAL INFORMATION
Pre and post build time.

```
$ time ansible-galaxy collection build -f .
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
[WARNING]: Skipping '[...]/community.general/.nox/codeqa/collection-root/ansible_collections/community/internal_test_tools' as it is a symbolic link to a directory outside the collection
[WARNING]: Skipping '[...]/community.general/.nox/typing/collection-root/ansible_collections/community/internal_test_tools' as it is a symbolic link to a directory outside the collection
Created collection for community.general at [...]/community.general/community-general-12.4.0.tar.gz

real    1m31,371s
user    1m28,258s
sys     0m3,099s
```

```sh
$ time ansible-galaxy collection build -f .
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
Created collection for community.general at [...]/community.general/community-general-12.4.0.tar.gz

real    0m2,443s
user    0m2,171s
sys     0m0,270s
```
