### PR TITLE
keycloak_userprofile: support attributes.defaultValue

### DIFF
--- a/plugins/modules/keycloak_userprofile.py
+++ b/plugins/modules/keycloak_userprofile.py
@@ -99,6 +99,14 @@ options:
                 type: str
                 required: true
 
+              default_value:
+                description:
+                  - The default value for the attribute.
+                aliases:
+                  - defaultValue
+                type: str
+                required: false
+
               validations:
                 description:
                   - The validations to be applied to the attribute.
@@ -542,6 +550,7 @@ def main():
                             options={
                                 "name": dict(type="str", required=True),
                                 "display_name": dict(type="str", aliases=["displayName"], required=True),
+                                "default_value": dict(type="str", aliases=["defaultValue"]),
                                 "validations": dict(
                                     type="dict",
                                     options={


### PR DESCRIPTION
##### SUMMARY

This change adds missing support for the defaultValue field in Keycloak  UserProfileAttributeMetadata:

* https://www.keycloak.org/docs-api/latest/rest-api/index.html#UserProfileAttributeMetadata

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

* keycloak_userprofile

##### ADDITIONAL INFORMATION

This change was tested using a slightly older ~12.0.1 version of community.general (HEAD^1 at a9a4f89033dd133). It should work just fine on latest "main" branch as well.