### PR TITLE
Add module to manage Python versions using uv

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1425,6 +1425,10 @@ files:
   $modules/utm_proxy_exception.py:
     keywords: sophos utm
     maintainers: $team_e_spirit RickS-C137
+  $modules/uv_python.py:
+    labels: uv python
+    keywords: uv python
+    maintainers: mriamah
   $modules/vdo.py:
     maintainers: rhawalsh bgurney-rh
   $modules/vertica_:

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1426,7 +1426,6 @@ files:
     keywords: sophos utm
     maintainers: $team_e_spirit RickS-C137
   $modules/uv_python.py:
-    labels: uv python
     keywords: uv python
     maintainers: mriamah
   $modules/vdo.py:

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -146,17 +146,19 @@ def main():
         msg="",
     )
     state = module.params["state"]
-    uv = UV(module)
 
-    if state == "present":
-      result["changed"], result["msg"] = uv.install_python()
-    elif state == "absent":
-      result["changed"], result["msg"] = uv.uninstall_python()
-    elif state == "latest":
-      result["changed"], result["msg"] = uv.upgrade_python()
+    try:
+      uv = UV(module)
+      if state == "present":
+        result["changed"], result["msg"] = uv.install_python()
+      elif state == "absent":
+        result["changed"], result["msg"] = uv.uninstall_python()
+      elif state == "latest":
+        result["changed"], result["msg"] = uv.upgrade_python()
 
-    module.exit_json(**result)
-
+      module.exit_json(**result)
+    except Exception as e:
+      module.fail_json(msg=str(e))
 
 if __name__ == "__main__":
     main()

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -101,10 +101,11 @@ class UV:
     def upgrade_python(self):
       rc, out, _ = self._find_python("--show-version")
       detected_version = out.split()[0]
-      if rc == 0 and detected_version == self._get_latest_patch_release():
+      latest_version = self._get_latest_patch_release()
+      if rc == 0 and detected_version == latest_version:
           return False, out
       if self.module.check_mode:
-          return True, ""
+          return True, latest_version
       
       cmd = [self.module.get_bin_path("uv", required=True), "python", "upgrade", self.python_version_str]
       rc, out, _ = self.module.run_command(cmd, check_rc=True)

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -107,8 +107,8 @@ class UV:
       if self.module.check_mode:
           return True, latest_version
       
-      cmd = [self.module.get_bin_path("uv", required=True), "python", "upgrade", self.python_version_str]
-      rc, out, _ = self.module.run_command(cmd, check_rc=True)
+      cmd = [self.module.get_bin_path("uv", required=True), "python", "install", latest_version]
+      _, out, _ = self.module.run_command(cmd, check_rc=True)
       return True, out
 
     def _find_python(self, *args):

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -72,7 +72,7 @@ class UV:
           module.fail_json(
             msg=(
                 f"Invalid version '{python_version}'. "
-                "Expected X.Y or X.Y.Z."
+                "Expected formats are X.Y or X.Y.Z"
             )
           )
 
@@ -97,14 +97,26 @@ class UV:
       cmd = [self.module.get_bin_path("uv", required=True), "python", "uninstall", self.python_version_str]
       _, out, _ = self.module.run_command(cmd, check_rc=True)
       return True, out
+    
+    def upgrade_python(self):
+      rc, out, _ = self._find_python("--show-version")
+      detected_version = out.split()[0]
+      if rc == 0 and detected_version == self._get_latest_patch_release():
+          return False, out
+      if self.module.check_mode:
+          return True, ""
+      
+      cmd = [self.module.get_bin_path("uv", required=True), "python", "upgrade", self.python_version_str]
+      rc, out, _ = self.module.run_command(cmd, check_rc=True)
+      return True, out
 
-    def _find_python(self):
-      cmd = [self.module.get_bin_path("uv", required=True), "python", "find", self.python_version_str]
+    def _find_python(self, *args):
+      # if multiple similar minor versions exist, find returns the one used by default if inside a virtualenv otherwise it returns latest installed patch version
+      cmd = [self.module.get_bin_path("uv", required=True), "python", "find", self.python_version_str, *args]
       rc, out, err = self.module.run_command(cmd)
       return rc, out, err
     
     def _list_python(self):
-      # By default, only the latest patch version is shown for each minor version.
       # https://docs.astral.sh/uv/reference/cli/#uv-python-list
       cmd = [self.module.get_bin_path("uv", required=True), "python", "list", self.python_version_str, "--output-format", "json"]
       rc, out, err = self.module.run_command(cmd)
@@ -113,14 +125,14 @@ class UV:
     def _get_latest_patch_release(self):
       _, out, _ = self._list_python()
       result = json.loads(out)
-      return result[-1]["version"]
+      return result[0]["version"] # uv orders versions in descending order
     
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
             version=dict(type='str', required=True),
-            state=dict(type='str', default='present', choices=['present', 'absent']),
+            state=dict(type='str', default='present', choices=['present', 'absent', 'latest']),
         ),
         supports_check_mode=True
     )
@@ -136,6 +148,8 @@ def main():
       result["changed"], result["msg"] = uv.install_python()
     elif state == "absent":
       result["changed"], result["msg"] = uv.uninstall_python()
+    elif state == "latest":
+      result["changed"], result["msg"] = uv.upgrade_python()
 
     module.exit_json(**result)
 

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -149,13 +149,13 @@ class UV:
       if not latest_version:
          self.module.fail_json(msg=f"Version {self.python_version_str} is not available.")
       if rc == 0 and out.strip() == latest_version:
-          return False, latest_version, "", rc
+          return False, "", "", rc, [latest_version]
       if self.module.check_mode:
-          return True, latest_version, "", 0
+          return True, "", "", 0, [latest_version]
       
       cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "install", latest_version]
-      rc, _, err = self.module.run_command(cmd, check_rc=True)
-      return True, latest_version, err, rc
+      rc, out, err = self.module.run_command(cmd, check_rc=True)
+      return True, out, err, rc, [latest_version]
 
     def _find_python(self, *args):
       """
@@ -212,18 +212,18 @@ def main():
         stdout="",
         stderr="",
         rc=0,
-        python_version=[],
+        python_versions=[],
         failed=False
     )
     state = module.params["state"]
 
     uv = UV(module)
     if state == "present":
-      result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_version"] = uv.install_python()
+      result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_versions"] = uv.install_python()
     elif state == "absent":
-      result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_version"] = uv.uninstall_python()
+      result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_versions"] = uv.uninstall_python()
     elif state == "latest":
-      result["changed"], result["stdout"], result["stderr"], result["rc"] = uv.upgrade_python()
+      result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_versions"] = uv.upgrade_python()
 
     module.exit_json(**result)
 

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -92,7 +92,7 @@ class UV:
       if rc != 0:
           return False, out
       if self.module.check_mode:
-          return True, ""
+          return True, out
       
       cmd = [self.module.get_bin_path("uv", required=True), "python", "uninstall", self.python_version_str]
       _, out, _ = self.module.run_command(cmd, check_rc=True)

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -12,7 +12,6 @@ description:
 version_added: "12.5.0"
 requirements:
   - uv must be installed and available in PATH and uv version must be >= 0.8.0.
-  - Python 3.9 or higher is required on the target system.
 extends_documentation_fragment:
   - community.general.attributes
 attributes:

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -200,7 +200,6 @@ class UV:
         """
         Runs command 'uv python install X.Y.Z' with latest patch version available.
         Returns:
-          tuple [bool, str, str, int, list, list]
           - boolean to indicate if method changed state
           - command's stdout
           - command's stderr
@@ -232,9 +231,6 @@ class UV:
           command (str): uv python subcommand (e.g. "install", "uninstall", "find").
           *args: Additional positional arguments passed to the command.
           check_rc (bool): Whether to fail if the command exits with non-zero return code.
-        Returns:
-          tuple[int, str, str]:
-            A tuple containing (rc, stdout, stderr).
         """
         cmd = [self.bin_path, "python", command, python_version, "--color", "never", *args]
         rc, out, err = self.module.run_command(cmd, check_rc=check_rc)
@@ -248,9 +244,6 @@ class UV:
         Args:
           *args: Additional positional arguments passed to _exec.
           check_rc (bool): Whether to fail if the command exits with non-zero return code.
-        Returns:
-          tuple[int, str, str]:
-            A tuple containing (rc, stdout, stderr).
         """
         rc, out, err = self._exec(self.python_version_str, "find", *args, check_rc=check_rc)
         if rc == 0:
@@ -264,9 +257,6 @@ class UV:
         Args:
           *args: Additional positional arguments passed to _exec.
           check_rc (bool): Whether to fail if the command exits with non-zero return code.
-        Returns:
-          tuple[int, list, str]
-            A tuple containing (rc, stdout, stderr).
         """
         rc, out, err = self._exec(self.python_version_str, "list", "--output-format", "json", *args, check_rc=check_rc)
         pythons_installed = []
@@ -283,7 +273,6 @@ class UV:
         Args:
           *args: Additional positional arguments passed to _list_python.
         Returns:
-          tuple[str, str]:
             - latest found patch version in format X.Y.Z
             - installation path of latest patch version if version exists
         """
@@ -303,7 +292,6 @@ class UV:
         Args:
           *args: Additional positional arguments passed to _list_python.
         Returns:
-          tuple[list, list]:
             - list of latest found patch versions
             - list of installation paths of installed versions
         """

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -111,6 +111,7 @@ rc:
 """
 
 import json
+import re
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.compat.version import LooseVersion, StrictVersion
@@ -141,13 +142,16 @@ class UV:
     def _ensure_min_uv_version(self) -> None:
         cmd = [self.bin_path, "--version", "--color", "never"]
         dummy_rc, out, dummy_err = self.module.run_command(cmd, check_rc=True)
-        detected = out.strip().split()[-1]
-        if LooseVersion(detected) < LooseVersion(MINIMUM_UV_VERSION):
-            self.module.fail_json(
-                msg=f"uv_python module requires uv >= {MINIMUM_UV_VERSION}",
-                detected_version=detected,
-                required_version=MINIMUM_UV_VERSION,
-            )
+        try:
+            detected = re.search(r"\b\d+(?:\.\d+)+\b", out).group()  # type: ignore[union-attr]
+            if LooseVersion(detected) < LooseVersion(MINIMUM_UV_VERSION):
+                self.module.fail_json(
+                    msg=f"uv_python module requires uv >= {MINIMUM_UV_VERSION}",
+                    detected_version=detected,
+                    required_version=MINIMUM_UV_VERSION,
+                )
+        except AttributeError:
+            self.module.warn("Could not get installed uv version, skipping uv version check")
 
     def install_python(self) -> tuple[bool, str, str, int, list[str], list[str]]:
         """

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -70,41 +70,60 @@ class UV:
           self.python_version = StrictVersion(python_version)
           self.python_version_str = self.python_version.__str__()
         except ValueError:
-          module.fail_json(
+          self.module.fail_json(
             msg=(
-                f"Invalid version '{python_version}'. "
+                f"Invalid version {python_version}. "
                 "Expected formats are X.Y or X.Y.Z"
             )
           )
 
     def install_python(self):
-        rc, out, _ = self._find_python("--show-version") 
-        if rc == 0:
-          return False, out.split()[0]
-        if self.module.check_mode:
-          return True, self.python_version_str
-
-        cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "install", self.python_version_str]
-        self.module.run_command(cmd, check_rc=True)
+      """
+        Runs command 'uv python install X.Y.Z' which installs specified python version.
+        If patch version is not specified uv installs latest available patch version.
+        Returns: tuple with following elements 
+          - boolean to indicate if method changed state
+          - installed version
+      """
+      rc, out, _ = self._find_python("--show-version") 
+      if rc == 0:
+        return False, out.split()[0]
+      if self.module.check_mode:
         return True, self.python_version_str
+
+      cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "install", self.python_version_str]
+      self.module.run_command(cmd, check_rc=True)
+      return True, self.python_version_str
     
     def uninstall_python(self):
-      rc, out, _ = self._find_python()
+      """
+        Runs command 'uv python uninstall X.Y.Z' which removes specified python version from environment.
+        If patch version is not specified all correspending installed patch versions are removed.
+        Returns: tuple with following elements 
+          - boolean to indicate if method changed state
+          - removed version
+      """
+      rc, _, _ = self._find_python("--show-version")
+      # if "uv python find" fails, it means specified version does not exist
       if rc != 0:
-          return False, out
+          return False, ""
       if self.module.check_mode:
-          return True, ""
+        return True, self.python_version_str
       
       cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "uninstall", self.python_version_str]
       self.module.run_command(cmd, check_rc=True)
-      return True, ""
+      return True, self.python_version_str
     
     def upgrade_python(self):
+      """
+        Runs command 'uv python install X.Y.Z' which installs specified python version.
+        Returns: tuple with following elements 
+          - boolean to indicate if method changed state
+          - installed version
+      """
       rc, out, _ = self._find_python("--show-version")
       latest_version = self._get_latest_patch_release()
-      if rc == 0:
-        detected_version = out.split()[0]
-        if detected_version == latest_version:
+      if rc == 0 and out.split()[0] == latest_version:
           return False, latest_version
       if self.module.check_mode:
           return True, latest_version
@@ -114,23 +133,50 @@ class UV:
       return True, latest_version
 
     def _find_python(self, *args):
-      # if multiple similar minor versions exist, "uv python find" returns the one used by default if inside a virtualenv otherwise it returns latest installed patch version
+      """
+        Runs command 'uv python find' which returns path of installed patch releases for a given python version.
+        If multiple patch versions are installed, "uv python find" returns the one used by default if inside a virtualenv otherwise it returns latest installed patch version.
+        Returns: tuple with following elements 
+          - return code of executed command
+          - stdout of command
+          - stderr of command
+      """
       cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "find", self.python_version_str, *args]
       rc, out, err = self.module.run_command(cmd)
       return rc, out, err
     
     def _list_python(self):
+      """
+        Runs command 'uv python list' which returns list of installed patch releases for a given python version.
+        Returns: tuple with following elements 
+          - return code of executed command
+          - stdout of command
+          - stderr of command
+      """
       # https://docs.astral.sh/uv/reference/cli/#uv-python-list
       cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "list", self.python_version_str, "--output-format", "json"]
       rc, out, err = self.module.run_command(cmd)
       return rc, out, err
 
     def _get_latest_patch_release(self):
+      """
+        Returns latest available patch release for a given python version.
+        Fails when no available release exists for the specified version.
+      """
       _, out, _ = self._list_python() # uv returns versions in descending order but we sort them just in case future uv behavior changes
-      results = json.loads(out)
-      versions = [StrictVersion(result["version"]) for result in results]
-      return max(versions).__str__()
-    
+      latest_version = ""
+      try:
+        results = json.loads(out)
+        versions = [StrictVersion(result["version"]) for result in results]
+        latest_version = max(versions).__str__()
+      except ValueError:
+        self.module.fail_json(
+          msg=(
+              f"Version {self.python_version_str} is not available. "
+          )
+        )
+      return latest_version
+
 
 def main():
     module = AnsibleModule(

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -89,6 +89,13 @@ class UV:
       if rc == 0:
         return False, out.split()[0]
       if self.module.check_mode:
+        _, versions_available, _ = self._list_python()
+        # when uv does not find any available patch version the install command will fail
+        try:
+          if not json.loads(versions_available):
+            self.module.fail_json(msg=(f"Version {self.python_version_str} is not available."))
+        except json.decoder.JSONDecodeError as e:
+          self.module.fail_json(msg=f"Failed to parse 'uv python list' output with error {str(e)}")
         return True, self.python_version_str
 
       cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "install", self.python_version_str]
@@ -123,6 +130,8 @@ class UV:
       """
       rc, out, _ = self._find_python("--show-version")
       latest_version = self._get_latest_patch_release()
+      if not latest_version:
+         self.module.fail_json(msg=(f"Version {self.python_version_str} is not available."))
       if rc == 0 and out.split()[0] == latest_version:
           return False, latest_version
       if self.module.check_mode:
@@ -170,11 +179,7 @@ class UV:
         versions = [StrictVersion(result["version"]) for result in results]
         latest_version = max(versions).__str__()
       except ValueError:
-        self.module.fail_json(
-          msg=(
-              f"Version {self.python_version_str} is not available. "
-          )
-        )
+        pass
       return latest_version
 
 
@@ -190,21 +195,19 @@ def main():
     result = dict(
         changed=False,
         msg="",
+        failed=False
     )
     state = module.params["state"]
 
-    try:
-      uv = UV(module)
-      if state == "present":
-        result["changed"], result["msg"] = uv.install_python()
-      elif state == "absent":
-        result["changed"], result["msg"] = uv.uninstall_python()
-      elif state == "latest":
-        result["changed"], result["msg"] = uv.upgrade_python()
+    uv = UV(module)
+    if state == "present":
+      result["changed"], result["msg"] = uv.install_python()
+    elif state == "absent":
+      result["changed"], result["msg"] = uv.uninstall_python()
+    elif state == "latest":
+      result["changed"], result["msg"] = uv.upgrade_python()
 
-      module.exit_json(**result)
-    except Exception as e:
-      module.fail_json(msg=str(e))
+    module.exit_json(**result)
 
 if __name__ == "__main__":
     main()

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -8,8 +8,8 @@ DOCUMENTATION = r'''
 module: uv_python
 short_description: Manage Python versions and installations using uv.
 description:
-  - Install, remove or upgrade Python versions managed by uv. 
-version_added: "X.Y"
+  - Install, uninstall or upgrade Python versions managed by uv. 
+version_added: "1.0.0"
 requirements:
   - uv must be installed and available on PATH
   - uv version should be at least 0.8.0
@@ -105,7 +105,7 @@ class UV:
 
 
     def _ensure_min_uv_version(self):
-      cmd = [self.module.get_bin_path("uv", required=True), "--version"]
+      cmd = [self.module.get_bin_path("uv", required=True), "--version", "--color", "never"]
       _, out, _ = self.module.run_command(cmd, check_rc=True)
       detected = out.strip().split()[-1]
       if LooseVersion(detected) < LooseVersion(MINIMUM_UV_VERSION):
@@ -222,7 +222,7 @@ class UV:
           AnsibleModuleFailJson:
               If check_rc is True and the command exits with a non-zero return code.
       """
-      cmd = [self.module.get_bin_path("uv", required=True), "python", command, python_version, *args]
+      cmd = [self.module.get_bin_path("uv", required=True), "python", command, python_version, "--color", "never", *args]
       rc, out, err = self.module.run_command(cmd, check_rc=check_rc)
       return rc, out, err
 

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -5,7 +5,6 @@
 
 
 DOCUMENTATION = r"""
----
 module: uv_python
 short_description: Manage Python versions and installations using uv Python package manager
 description:
@@ -13,50 +12,46 @@ description:
 version_added: "12.5.0"
 requirements:
   - uv must be installed and available in PATH and uv version must be >= 0.8.0.
+  - Python 3.9 or higher is required on the target system.
+extends_documentation_fragment:
+  - community.general.attributes
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
 options:
   version:
     description:
       - Python version to manage.
-      - |
-        Not all canonical Python versions are supported in this release. Valid version numbers consist of two or three dot-separated numeric components,
-        with an optional 'pre-release' tag on the end such as C(3.12), C(3.12.3), C(3.15.0a5).
-      - Advanced uv selectors such as C(>=3.12,<3.13) or C(cpython@3.12) are not supported in this release.
-      - When you specify only a major.minor version, behavior depends on the O(state) parameter.
+      - "Not all canonical Python versions are supported in this release. Valid version numbers consist of two or three dot-separated
+        numeric components,\nwith an optional 'pre-release' tag at the end such as V(3.12), V(3.12.3), V(3.15.0a5)."
+      - Advanced uv selectors such as V(>=3.12,<3.13) or V(cpython@3.12) are not supported in this release.
+      - "When you specify only a major.minor version, make sure the number is enclosed in quotes so that it gets parsed correctly.\n\
+        Note that in case only a major.minor version are specified behavior depends on the O(state) parameter."
     type: str
     required: true
   state:
     description:
       - Desired state of the specified Python version.
-      - |
-        V(present) ensures the specified version is installed.
-        If you specify a full patch version (for example C(3.12.3)), that exact version will be installed if not already present.
-        If you only specify a minor version (for example C(3.12)), the latest available patch version for that minor release is installed only
-        if no patch version for that minor release is currently installed (including patch versions not managed by C(uv)).
-        RV(python_versions) and RV(python_paths) lengths are always equal to one for this state.
-      - |
-        V(absent) ensures the specified version is removed.
-        If you specify a full patch version, only that exact patch version is removed.
-        If you only specify a minor version (for example C(3.12)), all installed patch versions for that minor release are removed.
-        If you specify a version that is not installed, no changes are made.
-        RV(python_versions) and RV(python_paths) lengths can be higher or equal to one in this state.
-      - |
-        V(latest) ensures the latest available patch version for the specified version is installed.
-        If you only specify a minor version (for example C(3.12)), the latest available patch version for that minor release is always installed.
-        If another patch version is already installed but is not the latest, the latest patch version is installed.
-        The latest patch version installed depends on the C(uv) version, since available Python versions are frozen per C(uv) release.
-        RV(python_versions) and RV(python_paths) lengths are always equal to one in this state.
-        This state does not use C(uv python upgrade).
+      - "V(present) ensures the specified version is installed.\nIf you specify a full patch version (for example O(version=3.12.3)),
+        that exact version is be installed if not already present.\nIf you only specify a minor version (for example V(3.12)),
+        the latest available patch version for that minor release is installed only\nif no patch version for that minor release
+        is currently installed (including patch versions not managed by C(uv)).\nRV(python_versions) and RV(python_paths)
+        lengths are always equal to one for this state."
+      - "V(absent) ensures the specified version is removed.\nIf you specify a full patch version, only that exact patch version
+        is removed.\nIf you only specify a minor version (for example V(3.12)), all installed patch versions for that minor
+        release are removed.\nIf you specify a version that is not installed, no changes are made.\nRV(python_versions) and
+        RV(python_paths) lengths can be higher or equal to one in this state."
+      - "V(latest) ensures the latest available patch version for the specified version is installed.\nIf you only specify
+        a minor version (for example V(3.12)), the latest available patch version for that minor release is always installed.\n\
+        If another patch version is already installed but is not the latest, the latest patch version is installed.\nThe latest
+        patch version installed depends on the C(uv) version, since available Python versions are frozen per C(uv) release.\n\
+        RV(python_versions) and RV(python_paths) lengths are always equal to one in this state.\nThis state does not use C(uv
+        python upgrade)."
     type: str
     choices: [present, absent, latest]
     default: present
-attributes:
-  check_mode:
-    description: Can run in check_mode and return changed status prediction without modifying target.
-    support: full
-  diff_mode:
-    description: Returns details on what has changed (or possibly needs changing in check_mode), when in diff mode.
-    support: none
-notes:
 seealso:
   - name: uv documentation
     description: Python versions management with uv.
@@ -65,13 +60,17 @@ seealso:
     description: uv CLI reference guide.
     link: https://docs.astral.sh/uv/reference/cli/#uv-python
 author: Mariam Ahhttouche (@mriamah)
-
 """
 
 EXAMPLES = r"""
 - name: Install Python 3.14
   community.general.uv_python:
     version: "3.14"
+
+- name: Upgrade Python 3.14
+  community.general.uv_python:
+    version: "3.14"
+    state: latest
 
 - name: Remove Python 3.13.5
   community.general.uv_python:
@@ -117,11 +116,12 @@ class UV:
 
     def __init__(self, module):
         self.module = module
+        self.bin_path = self.module.get_bin_path("uv", required=True)
         self._ensure_min_uv_version()
-        python_version = module.params["version"]
         try:
+            python_version = module.params["version"]
             self.python_version = StrictVersion(python_version)
-            self.python_version_str = self.python_version.__str__()
+            self.python_version_str = str(self.python_version)
         except ValueError:
             self.module.fail_json(
                 msg="Unsupported version format. Valid version numbers consist of two or three dot-separated numeric components, \
@@ -129,7 +129,7 @@ class UV:
             )
 
     def _ensure_min_uv_version(self):
-        cmd = [self.module.get_bin_path("uv", required=True), "--version", "--color", "never"]
+        cmd = [self.bin_path, "--version", "--color", "never"]
         ignored_rc, out, ignored_err = self.module.run_command(cmd, check_rc=True)
         detected = out.strip().split()[-1]
         if LooseVersion(detected) < LooseVersion(MINIMUM_UV_VERSION):
@@ -139,7 +139,7 @@ class UV:
                 required_version=MINIMUM_UV_VERSION,
             )
 
-    def install_python(self):
+    def install_python(self) -> tuple[bool, str, str, int, list, list]:
         """
         Runs command 'uv python install X.Y.Z' which installs specified python version.
         If patch version is not specified uv installs latest available patch version.
@@ -151,10 +151,6 @@ class UV:
           - command's return code
           - list of installed versions
           - list of installation paths for each installed version
-        Raises:
-          AnsibleModuleFailJson:
-              If the install command exits with a non-zero return code.
-              If specified version is not available for download.
         """
         find_rc, existing_version, ignored_err = self._find_python("--show-version")
         if find_rc == 0:
@@ -170,7 +166,7 @@ class UV:
         latest_version, path = self._get_latest_patch_release("--only-installed", "--managed-python")
         return True, out, err, rc, [latest_version], [path]
 
-    def uninstall_python(self):
+    def uninstall_python(self) -> tuple[bool, str, str, int, list, list]:
         """
         Runs command 'uv python uninstall X.Y.Z' which removes specified python version from environment.
         If patch version is not specified all correspending installed patch versions are removed.
@@ -182,9 +178,6 @@ class UV:
           - command's return code
           - list of uninstalled versions
           - list of previous installation paths for each uninstalled version
-        Raises:
-          AnsibleModuleFailJson:
-              If the uninstall command exits with a non-zero return code.
         """
         installed_versions, install_paths = self._get_installed_versions("--managed-python")
         if not installed_versions:
@@ -194,7 +187,7 @@ class UV:
         rc, out, err = self._exec(self.python_version_str, "uninstall", check_rc=True)
         return True, out, err, rc, installed_versions, install_paths
 
-    def upgrade_python(self):
+    def upgrade_python(self) -> tuple[bool, str, str, int, list, list]:
         """
         Runs command 'uv python install X.Y.Z' with latest patch version available.
         Returns:
@@ -205,10 +198,6 @@ class UV:
           - command's return code
           - list of installed versions
           - list of installation paths for each installed version
-        Raises:
-          AnsibleModuleFailJson:
-              If the install command exits with a non-zero return code.
-              If resolved patch version is not available for download.
         """
         rc, installed_version_str, ignored_err = self._find_python("--show-version")
         installed_version = self._parse_version(installed_version_str)
@@ -226,7 +215,7 @@ class UV:
         latest_version_str, latest_path = self._get_latest_patch_release("--only-installed", "--managed-python")
         return True, out, err, rc, [latest_version_str], [latest_path]
 
-    def _exec(self, python_version, command, *args, check_rc=False):
+    def _exec(self, python_version, command, *args, check_rc=False) -> tuple[int, str, str]:
         """
         Execute a uv python subcommand.
         Args:
@@ -237,15 +226,12 @@ class UV:
         Returns:
           tuple[int, str, str]:
             A tuple containing (rc, stdout, stderr).
-        Raises:
-          AnsibleModuleFailJson:
-              If check_rc is True and the command exits with a non-zero return code.
         """
-        cmd = [self.module.get_bin_path("uv", required=True), "python", command, python_version, "--color", "never", *args]
+        cmd = [self.bin_path, "python", command, python_version, "--color", "never", *args]
         rc, out, err = self.module.run_command(cmd, check_rc=check_rc)
         return rc, out, err
 
-    def _find_python(self, *args, check_rc=False):
+    def _find_python(self, *args, check_rc=False) -> tuple[int, str, str]:
         """
         Runs command 'uv python find' which returns path of installed patch releases for a given python version.
         If multiple patch versions are installed, "uv python find" returns the one used by default
@@ -256,16 +242,13 @@ class UV:
         Returns:
           tuple[int, str, str]:
             A tuple containing (rc, stdout, stderr).
-        Raises:
-          AnsibleModuleFailJson:
-            If check_rc is True and the command exits with a non-zero return code.
         """
         rc, out, err = self._exec(self.python_version_str, "find", *args, check_rc=check_rc)
         if rc == 0:
             out = out.strip()
         return rc, out, err
 
-    def _list_python(self, *args, check_rc=False):
+    def _list_python(self, *args, check_rc=False) -> tuple[int, list, str]:
         """
         Runs command 'uv python list' (which returns list of installed patch releases for a given python version).
         Official documentation https://docs.astral.sh/uv/reference/cli/#uv-python-list
@@ -273,21 +256,19 @@ class UV:
           *args: Additional positional arguments passed to _exec.
           check_rc (bool): Whether to fail if the command exits with non-zero return code.
         Returns:
-          tuple[int, str, str]:
+          tuple[int, list, str]
             A tuple containing (rc, stdout, stderr).
-        Raises:
-          AnsibleModuleFailJson:
-            If check_rc is True and the command exits with a non-zero return code.
         """
         rc, out, err = self._exec(self.python_version_str, "list", "--output-format", "json", *args, check_rc=check_rc)
+        pythons_installed = []
         try:
-            out = json.loads(out)
+            pythons_installed = json.loads(out)
         except json.decoder.JSONDecodeError:
             # This happens when no version is found
             pass
-        return rc, out, err
+        return rc, pythons_installed, err
 
-    def _get_latest_patch_release(self, *args):
+    def _get_latest_patch_release(self, *args) -> tuple[str, str]:
         """
         Returns latest available patch release for a given python version.
         Args:
@@ -307,7 +288,7 @@ class UV:
             path = version.get("path", "")
         return latest_version, path
 
-    def _get_installed_versions(self, *args):
+    def _get_installed_versions(self, *args) -> tuple[list, list]:
         """
         Returns installed patch releases for a given python version.
         Args:
@@ -319,7 +300,7 @@ class UV:
         """
         ignored_rc, results, ignored_err = self._list_python("--only-installed", *args)
         if results:
-            return [result["version"] for result in results], [result["path"] for result in results]
+            return [result.get("version") for result in results], [result.get("path") for result in results]
         return [], []
 
     @staticmethod

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -1,0 +1,101 @@
+#!/usr/bin/python
+# Copyright (c) 2026 Mariam Ahhttouche <mariam.ahhttouche@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+DOCUMENTATION = r'''
+---
+module: uv_python
+short_description: Manage Python installations using uv
+description:
+  - Install or remove Python versions managed by uv.
+# requirements:
+#   - uv must be installed and available on PATH
+options:
+  version:
+    description: Python version to manage
+    type: str
+    required: true
+  state:
+    description: Desired state
+    type: str
+    choices: [present, absent]
+    default: present
+  force:
+    description: Force reinstall
+    type: bool
+    default: false
+  uv_path:
+    description: Path to uv binary
+    type: str
+    default: uv
+author:
+  - Your Name
+'''
+
+EXAMPLES = r'''
+- name: Install Python 3.12
+  uv_python:
+    version: "3.12"
+
+- name: Remove Python 3.11
+  uv_python:
+    version: "3.11"
+    state: absent
+'''
+
+RETURN = r'''
+python:
+  description: Installed Python info
+  returned: when state=present
+  type: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+class UV:
+    def __init__(self, module, **kwargs):
+        self.module = module
+
+    def install_python(self):
+        rc, out = self._find_python()
+        if rc == 0:
+          return False, out
+        if self.module.check_mode:
+          return True, ""
+        
+        cmd = [self.module.get_bin_path("uv", required=True), "python", "install", self.module.params["version"]]
+        _, out, _ = self.module.run_command(cmd, check_rc=True)
+        return True, out
+    
+    def _find_python(self):
+      cmd = [self.module.get_bin_path("uv", required=True), "python", "find", self.module.params["version"]]
+      rc, out, _ = self.module.run_command(cmd)
+      return rc, out
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            version=dict(type='str', required=True),
+            state=dict(type='str', default='present', choices=['present', 'absent']),
+        ),
+        supports_check_mode=True
+    )
+
+    result = dict(
+        changed=False,
+        msg="",
+    )
+    state = module.params["state"]
+    uv = UV(module)
+
+    if state == "present":
+        result["changed"], result["msg"] = uv.install_python()
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -6,13 +6,13 @@
 
 DOCUMENTATION = r"""
 module: uv_python
-short_description: Manage Python versions and installations using uv Python package manager
+short_description: Manage Python versions and installations using the C(uv) Python package manager
 description:
   - Install, uninstall or upgrade Python versions managed by C(uv).
 version_added: "12.5.0"
 requirements:
   - uv must be installed and available in PATH and uv version must be at least 0.8.0.
-  - Python version must be at least 3.9
+  - Python version must be at least 3.9.
 extends_documentation_fragment:
   - community.general.attributes
 attributes:
@@ -27,8 +27,8 @@ options:
       - "Not all canonical Python versions are supported in this release. Valid version numbers consist of two or three dot-separated
         numeric components, with an optional 'pre-release' tag at the end such as V(3.12), V(3.12.3), V(3.15.0a5)."
       - Advanced uv selectors such as V(>=3.12,<3.13) or V(cpython@3.12) are not supported in this release.
-      - "When you specify only a major.minor version, make sure the number is enclosed in quotes so that it gets parsed correctly.\n\
-        Note that in case only a major.minor version are specified behavior depends on the O(state) parameter."
+      - When you specify only a major.minor version, make sure the number is enclosed in quotes so that it gets parsed correctly.
+        Note that in case only a major.minor version are specified behavior depends on the O(state) parameter.
     type: str
     required: true
   state:
@@ -43,21 +43,20 @@ options:
         is removed. If you only specify a minor version (for example V(3.12)), all installed patch versions for that minor
         release are removed. If you specify a version that is not installed, no changes are made. RV(python_versions) and
         RV(python_paths) lengths can be higher or equal to one in this state."
-      - "V(latest) ensures the latest available patch version for the specified version is installed. If you only specify
-        a minor version (for example V(3.12)), the latest available patch version for that minor release is always installed. \
+      - V(latest) ensures the latest available patch version for the specified version is installed. If you only specify
+        a minor version (for example V(3.12)), the latest available patch version for that minor release is always installed.
         If another patch version is already installed but is not the latest, the latest patch version is installed. The latest
-        patch version installed depends on the C(uv) version, since available Python versions are frozen per C(uv) release. \
-        RV(python_versions) and RV(python_paths) lengths are always equal to one in this state. This state does not use C(uv
-        python upgrade)."
+        patch version installed depends on the C(uv) version, since available Python versions are frozen per C(uv) release.
+        RV(python_versions) and RV(python_paths) lengths are always equal to one in this state. This state does not use C(uv python upgrade).
     type: str
     choices: [present, absent, latest]
     default: present
 seealso:
-  - name: uv documentation
-    description: Python versions management with uv.
+  - name: C(uv) documentation
+    description: Python versions management with C(uv).
     link: https://docs.astral.sh/uv/concepts/python-versions/
-  - name: uv CLI documentation
-    description: uv CLI reference guide.
+  - name: C(uv) CLI documentation
+    description: C(uv) CLI reference guide.
     link: https://docs.astral.sh/uv/reference/cli/#uv-python
 author: Mariam Ahhttouche (@mriamah)
 """
@@ -123,8 +122,10 @@ class UV:
             self.python_version_str = str(self.python_version)
         except (ValueError, AttributeError):
             self.module.fail_json(
-                msg="Unsupported version format. Valid version numbers consist of two or three dot-separated numeric components, \
-                  with an optional 'pre-release' tag on the end (for example 3.12, 3.12.3, 3.15.0a5) are supported in this release."
+                msg=(
+                    "Unsupported version format. Valid version numbers consist of two or three dot-separated numeric components"
+                    " with an optional 'pre-release' tag on the end (for example 3.12, 3.12.3, 3.15.0a5) are supported in this release."
+                )
             )
 
     def _ensure_min_uv_version(self):
@@ -214,11 +215,11 @@ class UV:
         latest_version_str, latest_path = self._get_latest_patch_release("--only-installed", "--managed-python")
         return True, out, err, rc, [latest_version_str], [latest_path]
 
-    def _exec(self, python_version, command, *args, check_rc=False) -> tuple[int, str, str]:
+    def _exec(self, python_version: str, command, *args, check_rc=False) -> tuple[int, str, str]:
         """
         Execute a uv python subcommand.
         Args:
-          python_version (str): Python version specifier (e.g. "3.12", "3.12.3").
+          python_version: Python version specifier (e.g. "3.12", "3.12.3").
           command (str): uv python subcommand (e.g. "install", "uninstall", "find").
           *args: Additional positional arguments passed to the command.
           check_rc (bool): Whether to fail if the command exits with non-zero return code.

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -1,72 +1,89 @@
 #!/usr/bin/python
 # Copyright (c) 2026 Mariam Ahhttouche <mariam.ahhttouche@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
 ---
 module: uv_python
-short_description: Manage Python versions and installations using uv Python package manager.
+short_description: Manage Python versions and installations using uv Python package manager
 description:
   - Install, uninstall or upgrade Python versions managed by C(uv).
-version_added: "0.1.8"
+version_added: "12.5.0"
 requirements:
-  - uv must be installed and available in PATH.
-  - uv version must be at least 0.8.0.
+  - uv >= 0.8.0 must be installed and available in PATH
+  - packaging
 options:
   version:
     description:
       - Python version to manage.
       - Only L(canonical Python versions, https://peps.python.org/pep-0440/) are supported in this release such as C(3), C(3.12), C(3.12.3), C(3.15.0a5).
       - Advanced uv selectors such as C(>=3.12,<3.13) or C(cpython@3.12) are not supported in this release.
-      - When specifying only a major or major.minor version, behavior depends on the O(state) parameter.
+      - When you specify only a major or major.minor version, behavior depends on the O(state) parameter.
     type: str
     required: true
   state:
     description:
       - Desired state of the specified Python version.
-      - C(present) ensures the specified version is installed. If a full patch version is specified (for example C(3.12.3)), that exact version will be installed if not already present. If only a minor version is specified (for example 3.12), the latest available patch version for that minor release is installed only if no patch version for that minor release is currently installed (including patch versions not managed by C(uv)). RV(python_versions) and RV(python_paths) lengths are always equal to one for this state. Uses C(uv python install) command.
-      - C(absent) ensures the specified version is removed. If a full patch version is specified, only that exact patch version is removed. If only a minor version is specified (for example C(3.12)), all installed patch versions for that minor release are removed. If the specified version is not installed, no changes are made. RV(python_versions) and RV(python_paths) lengths can be higher or equal to one for this state. Uses C(uv python uninstall) command.
-      - C(latest) ensures the latest available patch version for the specified version is installed. If only a minor version is specified (for example C(3.12)), the latest available patch version for that minor release is always installed. If another patch version is already installed but is not the latest, the latest patch version is installed. The latest patch version installed depends on the C(uv) version, since available Python versions are frozen per C(uv) release. RV(python_versions) and RV(python_paths) lengths are always equal to one for this state. This state does not use C(uv python upgrade).
+      - |
+        V(present) ensures the specified version is installed.
+        If you specify a full patch version (for example C(3.12.3)), that exact version will be installed if not already present.
+        If you only specify a minor version (for example C(3.12)), the latest available patch version for that minor release is installed only
+        if no patch version for that minor release is currently installed (including patch versions not managed by C(uv)).
+        RV(python_versions) and RV(python_paths) lengths are always equal to one for this state.
+      - |
+        V(absent) ensures the specified version is removed.
+        If you specify a full patch version, only that exact patch version is removed.
+        If you only specify a minor version (for example C(3.12)), all installed patch versions for that minor release are removed.
+        If you specify a version that is not installed, no changes are made.
+        RV(python_versions) and RV(python_paths) lengths can be higher or equal to one in this state.
+      - |
+        V(latest) ensures the latest available patch version for the specified version is installed.
+        If you only specify a minor version (for example C(3.12)), the latest available patch version for that minor release is always installed.
+        If another patch version is already installed but is not the latest, the latest patch version is installed.
+        The latest patch version installed depends on the C(uv) version, since available Python versions are frozen per C(uv) release.
+        RV(python_versions) and RV(python_paths) lengths are always equal to one in this state.
+        This state does not use C(uv python upgrade).
     type: str
     choices: [present, absent, latest]
     default: present
 attributes:
   check_mode:
-      description: Can run in check_mode and return changed status prediction without modifying target.
-      support: full
+    description: Can run in check_mode and return changed status prediction without modifying target.
+    support: full
   diff_mode:
-      description: Returns details on what has changed (or possibly needs changing in check_mode), when in diff mode.
-      support: none
+    description: Returns details on what has changed (or possibly needs changing in check_mode), when in diff mode.
+    support: none
 notes:
 seealso:
-- name: uv documentation
-  description: Python versions management with uv.
-  link: https://docs.astral.sh/uv/concepts/python-versions/
-- name: uv CLI documentation
-  description: uv CLI reference guide.
-  link: https://docs.astral.sh/uv/reference/cli/#uv-python
+  - name: uv documentation
+    description: Python versions management with uv.
+    link: https://docs.astral.sh/uv/concepts/python-versions/
+  - name: uv CLI documentation
+    description: uv CLI reference guide.
+    link: https://docs.astral.sh/uv/reference/cli/#uv-python
 author: Mariam Ahhttouche (@mriamah)
 
-'''
+"""
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: Install Python 3.14
-  mriamah.uv_python:
+  community.general.uv_python:
     version: "3.14"
 
 - name: Remove Python 3.13.5
-  mriamah.uv_python:
+  community.general.uv_python:
     version: 3.13.5
     state: absent
 
-- name: Upgrade python 3
-  mriamah.uv_python:
+- name: Upgrade Python 3
+  community.general.uv_python:
     version: 3
     state: latest
-'''
+"""
 
-RETURN = r'''
+RETURN = r"""
 python_versions:
   description: List of Python versions changed.
   returned: success
@@ -87,28 +104,30 @@ rc:
   description: Return code of the executed command.
   returned: success
   type: int
-'''
+"""
 
 import json
 import traceback
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.compat.version import LooseVersion
-from ansible.module_utils.basic import missing_required_lib
 
 LIB_IMP_ERR = None
 HAS_LIB = False
 try:
     from packaging.version import Version, InvalidVersion
+
     HAS_LIB = True
-except:
+except ImportError:
     LIB_IMP_ERR = traceback.format_exc()
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.compat.version import LooseVersion
 
 
 MINIMUM_UV_VERSION = "0.8.0"
 
+
 class UV:
     """
-      Module for managing Python versions and installations using "uv python" command
+    Module for managing Python versions and installations using "uv python" command
     """
 
     def __init__(self, module):
@@ -116,30 +135,30 @@ class UV:
         self._ensure_min_uv_version()
         python_version = module.params["version"]
         try:
-          self.python_version = Version(python_version)
-          self.python_version_str = self.python_version.__str__()
+            self.python_version = Version(python_version)
+            self.python_version_str = self.python_version.__str__()
         except InvalidVersion:
-          self.module.fail_json(
-            msg="Unsupported version format. Only canonical Python versions (e.g. 3, 3.12, 3.12.3, 3.15.0a5) are supported in this release."
-          )
+            self.module.fail_json(
+                msg="Unsupported version format. Only canonical Python versions (e.g. 3, 3.12, 3.12.3, 3.15.0a5) are supported in this release."
+            )
 
     def _ensure_min_uv_version(self):
-      cmd = [self.module.get_bin_path("uv", required=True), "--version", "--color", "never"]
-      _, out, _ = self.module.run_command(cmd, check_rc=True)
-      detected = out.strip().split()[-1]
-      if LooseVersion(detected) < LooseVersion(MINIMUM_UV_VERSION):
-          self.module.fail_json(
-              msg=f"uv_python module requires uv >= {MINIMUM_UV_VERSION}",
-              detected_version=detected,
-              required_version=MINIMUM_UV_VERSION,
-          )
+        cmd = [self.module.get_bin_path("uv", required=True), "--version", "--color", "never"]
+        ignored_rc, out, ignored_err = self.module.run_command(cmd, check_rc=True)
+        detected = out.strip().split()[-1]
+        if LooseVersion(detected) < LooseVersion(MINIMUM_UV_VERSION):
+            self.module.fail_json(
+                msg=f"uv_python module requires uv >= {MINIMUM_UV_VERSION}",
+                detected_version=detected,
+                required_version=MINIMUM_UV_VERSION,
+            )
 
     def install_python(self):
-      """
+        """
         Runs command 'uv python install X.Y.Z' which installs specified python version.
         If patch version is not specified uv installs latest available patch version.
-        Returns: 
-          tuple [bool, str, str, int, list, list] 
+        Returns:
+          tuple [bool, str, str, int, list, list]
           - boolean to indicate if method changed state
           - command's stdout
           - command's stderr
@@ -150,27 +169,27 @@ class UV:
           AnsibleModuleFailJson:
               If the install command exits with a non-zero return code.
               If specified version is not available for download.
-      """
-      find_rc, existing_version, _ = self._find_python("--show-version")
-      if find_rc == 0:
-        _, version_path, _ = self._find_python()
-        return False, "", "", 0, [existing_version], [version_path]
-      if self.module.check_mode:
-        latest_version, _ = self._get_latest_patch_release("--managed-python")
-        # when uv does not find any available patch version the install command will fail
-        if not latest_version:
-          self.module.fail_json(msg=(f"Version {self.python_version_str} is not available."))
-        return True, "", "", 0, [latest_version], [""]
-      rc, out, err = self._exec(self.python_version_str, "install", check_rc=True)
-      latest_version, path = self._get_latest_patch_release("--only-installed", "--managed-python")
-      return True, out, err, rc, [latest_version], [path]
+        """
+        find_rc, existing_version, ignored_err = self._find_python("--show-version")
+        if find_rc == 0:
+            ignored_rc, version_path, ignored_err = self._find_python()
+            return False, "", "", 0, [existing_version], [version_path]
+        if self.module.check_mode:
+            latest_version, ignored_path = self._get_latest_patch_release("--managed-python")
+            # when uv does not find any available patch version the install command will fail
+            if not latest_version:
+                self.module.fail_json(msg=(f"Version {self.python_version_str} is not available."))
+            return True, "", "", 0, [latest_version], [""]
+        rc, out, err = self._exec(self.python_version_str, "install", check_rc=True)
+        latest_version, path = self._get_latest_patch_release("--only-installed", "--managed-python")
+        return True, out, err, rc, [latest_version], [path]
 
     def uninstall_python(self):
-      """
+        """
         Runs command 'uv python uninstall X.Y.Z' which removes specified python version from environment.
         If patch version is not specified all correspending installed patch versions are removed.
-        Returns: 
-          tuple [bool, str, str, int, list, list] 
+        Returns:
+          tuple [bool, str, str, int, list, list]
           - boolean to indicate if method changed state
           - command's stdout
           - command's stderr
@@ -180,20 +199,20 @@ class UV:
         Raises:
           AnsibleModuleFailJson:
               If the uninstall command exits with a non-zero return code.
-      """
-      installed_versions, install_paths = self._get_installed_versions("--managed-python")
-      if not installed_versions:
-        return False, "", "", 0, [], []
-      if self.module.check_mode:
-        return True, "", "", 0, installed_versions, install_paths
-      rc, out, err = self._exec(self.python_version_str, "uninstall", check_rc=True)
-      return True, out, err, rc, installed_versions, install_paths
+        """
+        installed_versions, install_paths = self._get_installed_versions("--managed-python")
+        if not installed_versions:
+            return False, "", "", 0, [], []
+        if self.module.check_mode:
+            return True, "", "", 0, installed_versions, install_paths
+        rc, out, err = self._exec(self.python_version_str, "uninstall", check_rc=True)
+        return True, out, err, rc, installed_versions, install_paths
 
     def upgrade_python(self):
-      """
+        """
         Runs command 'uv python install X.Y.Z' with latest patch version available.
-        Returns: 
-          tuple [bool, str, str, int, list, list] 
+        Returns:
+          tuple [bool, str, str, int, list, list]
           - boolean to indicate if method changed state
           - command's stdout
           - command's stderr
@@ -204,25 +223,25 @@ class UV:
           AnsibleModuleFailJson:
               If the install command exits with a non-zero return code.
               If resolved patch version is not available for download.
-      """
-      rc, installed_version_str, _ = self._find_python("--show-version")
-      installed_version = self._parse_version(installed_version_str)
-      latest_version_str, _ = self._get_latest_patch_release("--managed-python")
-      if not latest_version_str:
-         self.module.fail_json(msg=f"Version {self.python_version_str} is not available.")
-      if rc == 0 and installed_version >= Version(latest_version_str):
-          _, install_path, _ = self._find_python()
-          return False, "", "", rc, [installed_version.__str__()], [install_path]
-      if self.module.check_mode:
-          return True, "", "", 0, [latest_version_str], []
-      # it's possible to have latest version already installed but not used as default 
-      # so in this case 'uv python install' will set latest version as default
-      rc, out, err = self._exec(latest_version_str, "install", check_rc=True)
-      latest_version_str, latest_path = self._get_latest_patch_release("--only-installed", "--managed-python")
-      return True, out, err, rc, [latest_version_str], [latest_path]
+        """
+        rc, installed_version_str, ignored_err = self._find_python("--show-version")
+        installed_version = self._parse_version(installed_version_str)
+        latest_version_str, ignored_path = self._get_latest_patch_release("--managed-python")
+        if not latest_version_str:
+            self.module.fail_json(msg=f"Version {self.python_version_str} is not available.")
+        if rc == 0 and installed_version >= Version(latest_version_str):
+            ignored_rc, install_path, ignored_err = self._find_python()
+            return False, "", "", rc, [installed_version_str], [install_path]
+        if self.module.check_mode:
+            return True, "", "", 0, [latest_version_str], []
+        # it's possible to have latest version already installed but not used as default
+        # so in this case 'uv python install' will set latest version as default
+        rc, out, err = self._exec(latest_version_str, "install", check_rc=True)
+        latest_version_str, latest_path = self._get_latest_patch_release("--only-installed", "--managed-python")
+        return True, out, err, rc, [latest_version_str], [latest_path]
 
     def _exec(self, python_version, command, *args, check_rc=False):
-      """
+        """
         Execute a uv python subcommand.
         Args:
           python_version (str): Python version specifier (e.g. "3.12", "3.12.3").
@@ -235,15 +254,15 @@ class UV:
         Raises:
           AnsibleModuleFailJson:
               If check_rc is True and the command exits with a non-zero return code.
-      """
-      cmd = [self.module.get_bin_path("uv", required=True), "python", command, python_version, "--color", "never", *args]
-      rc, out, err = self.module.run_command(cmd, check_rc=check_rc)
-      return rc, out, err
+        """
+        cmd = [self.module.get_bin_path("uv", required=True), "python", command, python_version, "--color", "never", *args]
+        rc, out, err = self.module.run_command(cmd, check_rc=check_rc)
+        return rc, out, err
 
     def _find_python(self, *args, check_rc=False):
-      """
+        """
         Runs command 'uv python find' which returns path of installed patch releases for a given python version.
-        If multiple patch versions are installed, "uv python find" returns the one used by default 
+        If multiple patch versions are installed, "uv python find" returns the one used by default
         if inside a virtualenv otherwise it returns latest installed patch version.
         Args:
           *args: Additional positional arguments passed to _exec.
@@ -254,14 +273,14 @@ class UV:
         Raises:
           AnsibleModuleFailJson:
             If check_rc is True and the command exits with a non-zero return code.
-      """
-      rc, out, err = self._exec(self.python_version_str, "find", *args, check_rc=check_rc)
-      if rc == 0:
-        out = out.strip()
-      return rc, out, err
+        """
+        rc, out, err = self._exec(self.python_version_str, "find", *args, check_rc=check_rc)
+        if rc == 0:
+            out = out.strip()
+        return rc, out, err
 
     def _list_python(self, *args, check_rc=False):
-      """
+        """
         Runs command 'uv python list' (which returns list of installed patch releases for a given python version).
         Official documentation https://docs.astral.sh/uv/reference/cli/#uv-python-list
         Args:
@@ -273,17 +292,17 @@ class UV:
         Raises:
           AnsibleModuleFailJson:
             If check_rc is True and the command exits with a non-zero return code.
-      """
-      rc, out, err = self._exec(self.python_version_str, "list", "--output-format", "json", *args, check_rc=check_rc)
-      try:
-        out = json.loads(out)
-      except json.decoder.JSONDecodeError:
-        # This happens when no version is found
-        pass
-      return rc, out, err
+        """
+        rc, out, err = self._exec(self.python_version_str, "list", "--output-format", "json", *args, check_rc=check_rc)
+        try:
+            out = json.loads(out)
+        except json.decoder.JSONDecodeError:
+            # This happens when no version is found
+            pass
+        return rc, out, err
 
     def _get_latest_patch_release(self, *args):
-      """
+        """
         Returns latest available patch release for a given python version.
         Args:
           *args: Additional positional arguments passed to _list_python.
@@ -291,18 +310,19 @@ class UV:
           tuple[str, str]:
             - latest found patch version in format X.Y.Z
             - installation path of latest patch version if version exists
-      """
-      latest_version = path = ""
-      _, results, _ = self._list_python(*args) # uv returns versions in descending order but we sort them just in case future uv behavior changes
-      valid_results = self._parse_versions(results)
-      if valid_results:
-        version = max(valid_results, key=lambda result: result["parsed_version"])
-        latest_version = version.get("version", "")
-        path = version.get("path", "")
-      return latest_version, path
+        """
+        latest_version = path = ""
+        # 'uv python list' returns versions in descending order but we sort them just in case future uv behavior changes
+        ignored_rc, results, ignored_err = self._list_python(*args)
+        valid_results = self._parse_versions(results)
+        if valid_results:
+            version = max(valid_results, key=lambda result: result["parsed_version"])
+            latest_version = version.get("version", "")
+            path = version.get("path", "")
+        return latest_version, path
 
     def _get_installed_versions(self, *args):
-      """
+        """
         Returns installed patch releases for a given python version.
         Args:
           *args: Additional positional arguments passed to _list_python.
@@ -310,62 +330,53 @@ class UV:
           tuple[list, list]:
             - list of latest found patch versions
             - list of installation paths of installed versions
-      """
-      _, results, _ = self._list_python("--only-installed", *args)
-      if results:
-        return [result["version"] for result in results], [result["path"] for result in results]
-      return [], []
+        """
+        ignored_rc, results, ignored_err = self._list_python("--only-installed", *args)
+        if results:
+            return [result["version"] for result in results], [result["path"] for result in results]
+        return [], []
 
     @staticmethod
     def _parse_versions(results):
-      valid_results =[]
-      for result in results:
-        try:
-          result["parsed_version"] = Version(result.get("version", ""))
-          valid_results.append(result)
-        except InvalidVersion:
-            continue
-      return valid_results
+        valid_results = []
+        for result in results:
+            try:
+                result["parsed_version"] = Version(result.get("version", ""))
+                valid_results.append(result)
+            except InvalidVersion:
+                continue
+        return valid_results
 
     @staticmethod
     def _parse_version(version_str):
-      try:
-          return Version(version_str)
-      except InvalidVersion:
-          return Version("0")
+        try:
+            return Version(version_str)
+        except InvalidVersion:
+            return Version("0")
 
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            version=dict(type='str', required=True),
-            state=dict(type='str', default='present', choices=['present', 'absent', 'latest']),
+            version=dict(type="str", required=True),
+            state=dict(type="str", default="present", choices=["present", "absent", "latest"]),
         ),
-        supports_check_mode=True
+        supports_check_mode=True,
     )
 
     if not HAS_LIB:
-      module.fail_json(msg=missing_required_lib("packaging"),
-                     exception=LIB_IMP_ERR)
-    
-    result = dict(
-        changed=False,
-        stdout="",
-        stderr="",
-        rc=0,
-        python_versions=[],
-        python_paths=[],
-        failed=False
-    )
+        module.fail_json(msg=missing_required_lib("packaging"), exception=LIB_IMP_ERR)
+
+    result = dict(changed=False, stdout="", stderr="", rc=0, python_versions=[], python_paths=[], failed=False)
     state = module.params["state"]
 
     uv = UV(module)
     if state == "present":
-      result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_versions"], result["python_paths"] = uv.install_python()
+        result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_versions"], result["python_paths"] = uv.install_python()
     elif state == "absent":
-      result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_versions"], result["python_paths"] = uv.uninstall_python()
+        result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_versions"], result["python_paths"] = uv.uninstall_python()
     elif state == "latest":
-      result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_versions"], result["python_paths"] = uv.upgrade_python()
+        result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_versions"], result["python_paths"] = uv.upgrade_python()
 
     module.exit_json(**result)
 

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -51,17 +51,18 @@ python:
   type: dict
 '''
 
-import re
 import json
-from enum import Enum
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.compat.version import StrictVersion
 
 
 class UV:
     """
-      Documentation for uv python https://docs.astral.sh/uv/concepts/python-versions/#installing-a-python-version
+      Module for "uv python" command
+      Official documentation for uv python https://docs.astral.sh/uv/concepts/python-versions/#installing-a-python-version
     """
+    subcommand = "python"
+
     def __init__(self, module, **kwargs):
         self.module = module
         python_version = module.params["version"]
@@ -77,56 +78,58 @@ class UV:
           )
 
     def install_python(self):
-        rc, out, _ = self._find_python() 
+        rc, out, _ = self._find_python("--show-version") 
         if rc == 0:
-          return False, out
+          return False, out.split()[0]
         if self.module.check_mode:
-          return True, ""
+          return True, self.python_version_str
 
-        cmd = [self.module.get_bin_path("uv", required=True), "python", "install", self.python_version_str]
-        _, out, _ = self.module.run_command(cmd, check_rc=True)
-        return True, out
+        cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "install", self.python_version_str]
+        self.module.run_command(cmd, check_rc=True)
+        return True, self.python_version_str
     
     def uninstall_python(self):
       rc, out, _ = self._find_python()
       if rc != 0:
           return False, out
       if self.module.check_mode:
-          return True, out
+          return True, ""
       
-      cmd = [self.module.get_bin_path("uv", required=True), "python", "uninstall", self.python_version_str]
-      _, out, _ = self.module.run_command(cmd, check_rc=True)
-      return True, out
+      cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "uninstall", self.python_version_str]
+      self.module.run_command(cmd, check_rc=True)
+      return True, ""
     
     def upgrade_python(self):
       rc, out, _ = self._find_python("--show-version")
-      detected_version = out.split()[0]
       latest_version = self._get_latest_patch_release()
-      if rc == 0 and detected_version == latest_version:
-          return False, out
+      if rc == 0:
+        detected_version = out.split()[0]
+        if detected_version == latest_version:
+          return False, latest_version
       if self.module.check_mode:
           return True, latest_version
       
-      cmd = [self.module.get_bin_path("uv", required=True), "python", "install", latest_version]
-      _, out, _ = self.module.run_command(cmd, check_rc=True)
-      return True, out
+      cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "install", latest_version]
+      self.module.run_command(cmd, check_rc=True)
+      return True, latest_version
 
     def _find_python(self, *args):
-      # if multiple similar minor versions exist, find returns the one used by default if inside a virtualenv otherwise it returns latest installed patch version
-      cmd = [self.module.get_bin_path("uv", required=True), "python", "find", self.python_version_str, *args]
+      # if multiple similar minor versions exist, "uv python find" returns the one used by default if inside a virtualenv otherwise it returns latest installed patch version
+      cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "find", self.python_version_str, *args]
       rc, out, err = self.module.run_command(cmd)
       return rc, out, err
     
     def _list_python(self):
       # https://docs.astral.sh/uv/reference/cli/#uv-python-list
-      cmd = [self.module.get_bin_path("uv", required=True), "python", "list", self.python_version_str, "--output-format", "json"]
+      cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "list", self.python_version_str, "--output-format", "json"]
       rc, out, err = self.module.run_command(cmd)
       return rc, out, err
 
     def _get_latest_patch_release(self):
-      _, out, _ = self._list_python()
-      result = json.loads(out)
-      return result[0]["version"] # uv orders versions in descending order
+      _, out, _ = self._list_python() # uv returns versions in descending order but we sort them just in case future uv behavior changes
+      results = json.loads(out)
+      versions = [StrictVersion(result["version"]) for result in results]
+      return max(versions).__str__()
     
 
 def main():

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -101,9 +101,9 @@ rc:
 """
 
 import json
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.compat.version import LooseVersion, StrictVersion
-
 
 MINIMUM_UV_VERSION = "0.8.0"
 
@@ -118,10 +118,9 @@ class UV:
         self.bin_path = self.module.get_bin_path("uv", required=True)
         self._ensure_min_uv_version()
         try:
-            python_version = module.params["version"]
-            self.python_version = StrictVersion(python_version)
+            self.python_version = StrictVersion(module.params["version"])
             self.python_version_str = str(self.python_version)
-        except ValueError:
+        except (ValueError, AttributeError):
             self.module.fail_json(
                 msg="Unsupported version format. Valid version numbers consist of two or three dot-separated numeric components, \
                   with an optional 'pre-release' tag on the end (e.g. 3.12, 3.12.3, 3.15.0a5) are supported in this release."

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -51,28 +51,44 @@ python:
   type: dict
 '''
 
+import re
 from ansible.module_utils.basic import AnsibleModule
 
 
 class UV:
+    """
+      Documentation for uv python https://docs.astral.sh/uv/concepts/python-versions/#installing-a-python-version
+    """
     def __init__(self, module, **kwargs):
         self.module = module
+        self.python_version = module.params["version"]
 
     def install_python(self):
-        rc, out = self._find_python()
+        rc, out, _ = self._find_python()
         if rc == 0:
           return False, out
         if self.module.check_mode:
           return True, ""
         
-        cmd = [self.module.get_bin_path("uv", required=True), "python", "install", self.module.params["version"]]
+        cmd = [self.module.get_bin_path("uv", required=True), "python", "install", self.python_version]
         _, out, _ = self.module.run_command(cmd, check_rc=True)
         return True, out
     
+    def uninstall_python(self):
+      rc, out, _ = self._find_python()
+      if rc != 0:
+          return False, out
+      if self.module.check_mode:
+          return True, ""
+      
+      cmd = [self.module.get_bin_path("uv", required=True), "python", "uninstall", self.python_version]
+      _, out, _ = self.module.run_command(cmd, check_rc=True)
+      return True, out
+
     def _find_python(self):
-      cmd = [self.module.get_bin_path("uv", required=True), "python", "find", self.module.params["version"]]
-      rc, out, _ = self.module.run_command(cmd)
-      return rc, out
+      cmd = [self.module.get_bin_path("uv", required=True), "python", "find", self.python_version]
+      rc, out, err = self.module.run_command(cmd)
+      return rc, out, err
 
 
 def main():
@@ -92,7 +108,9 @@ def main():
     uv = UV(module)
 
     if state == "present":
-        result["changed"], result["msg"] = uv.install_python()
+      result["changed"], result["msg"] = uv.install_python()
+    elif state == "absent":
+      result["changed"], result["msg"] = uv.uninstall_python()
 
     module.exit_json(**result)
 

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -87,7 +87,7 @@ class UV:
       """
       rc, out, _ = self._find_python("--show-version") 
       if rc == 0:
-        return False, out.split()[0]
+        return False, out.strip(), "", rc
       if self.module.check_mode:
         _, versions_available, _ = self._list_python()
         # when uv does not find any available patch version the install command will fail
@@ -96,11 +96,11 @@ class UV:
             self.module.fail_json(msg=(f"Version {self.python_version_str} is not available."))
         except json.decoder.JSONDecodeError as e:
           self.module.fail_json(msg=f"Failed to parse 'uv python list' output with error {str(e)}")
-        return True, self.python_version_str
+        return True, self.python_version_str, "", 0
 
       cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "install", self.python_version_str]
-      self.module.run_command(cmd, check_rc=True)
-      return True, self.python_version_str
+      rc, _, err = self.module.run_command(cmd, check_rc=True)
+      return True, self.python_version_str, err, rc
     
     def uninstall_python(self):
       """
@@ -110,16 +110,18 @@ class UV:
           - boolean to indicate if method changed state
           - removed version
       """
-      rc, _, _ = self._find_python("--show-version")
-      # if "uv python find" fails, it means specified version does not exist
-      if rc != 0:
-          return False, ""
+      rc, _, err = self._find_python("--show-version")
+      # if "uv python find" fails with return code 2, it means specified version is not installed or is not available
+      if rc == 2:
+        return False, "", "", 0
+      elif rc != 0:
+        self.module.fail_json(msg=err)
       if self.module.check_mode:
-        return True, self.python_version_str
+        return True, self.python_version_str, "", 0
       
       cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "uninstall", self.python_version_str]
-      self.module.run_command(cmd, check_rc=True)
-      return True, self.python_version_str
+      rc, _, err = self.module.run_command(cmd, check_rc=True)
+      return True, self.python_version_str, err, rc
     
     def upgrade_python(self):
       """
@@ -131,15 +133,15 @@ class UV:
       rc, out, _ = self._find_python("--show-version")
       latest_version = self._get_latest_patch_release()
       if not latest_version:
-         self.module.fail_json(msg=(f"Version {self.python_version_str} is not available."))
-      if rc == 0 and out.split()[0] == latest_version:
-          return False, latest_version
+         self.module.fail_json(msg=f"Version {self.python_version_str} is not available.")
+      if rc == 0 and out.strip() == latest_version:
+          return False, latest_version, "", rc
       if self.module.check_mode:
-          return True, latest_version
+          return True, latest_version, "", 0
       
       cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "install", latest_version]
-      self.module.run_command(cmd, check_rc=True)
-      return True, latest_version
+      rc, _, err = self.module.run_command(cmd, check_rc=True)
+      return True, latest_version, err, rc
 
     def _find_python(self, *args):
       """
@@ -194,18 +196,20 @@ def main():
 
     result = dict(
         changed=False,
-        msg="",
+        stdout="",
+        stderr="",
+        rc=0,
         failed=False
     )
     state = module.params["state"]
 
     uv = UV(module)
     if state == "present":
-      result["changed"], result["msg"] = uv.install_python()
+      result["changed"], result["stdout"], result["stderr"], result["rc"] = uv.install_python()
     elif state == "absent":
-      result["changed"], result["msg"] = uv.uninstall_python()
+      result["changed"], result["stdout"], result["stderr"], result["rc"] = uv.uninstall_python()
     elif state == "latest":
-      result["changed"], result["msg"] = uv.upgrade_python()
+      result["changed"], result["stdout"], result["stderr"], result["rc"] = uv.upgrade_python()
 
     module.exit_json(**result)
 

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -6,37 +6,47 @@
 DOCUMENTATION = r'''
 ---
 module: uv_python
-short_description: Manage Python versions and installations using uv.
+short_description: Manage Python versions and installations using uv Python package manager.
 description:
-  - Install, uninstall or upgrade Python versions managed by uv. 
-version_added: "1.0.0"
+  - Install, uninstall or upgrade Python versions managed by C(uv).
+version_added: "0.1.8"
 requirements:
-  - uv must be installed and available on PATH
-  - uv version should be at least 0.8.0
-deprecated:
-author: Mariam Ahhttouche (@mriamah)
+  - uv must be installed and available in PATH.
+  - uv version must be at least 0.8.0.
 options:
   version:
-    description: 
-      - Python version to manage. 
-      - Expected formats are "X", "X.Y" or "X.Y.Z".
+    description:
+      - Python version to manage.
+      - Only L(canonical Python versions, https://peps.python.org/pep-0440/) are supported in this release such as C(3), C(3.12), C(3.12.3), C(3.15.0a5).
+      - Advanced uv selectors such as C(>=3.12,<3.13) or C(cpython@3.12) are not supported in this release.
+      - When specifying only a major or major.minor version, behavior depends on the O(state) parameter.
     type: str
     required: true
   state:
-    description: Desired state of the specified Python version.
+    description:
+      - Desired state of the specified Python version.
+      - C(present) ensures the specified version is installed. If a full patch version is specified (for example C(3.12.3)), that exact version will be installed if not already present. If only a minor version is specified (for example 3.12), the latest available patch version for that minor release is installed only if no patch version for that minor release is currently installed (including patch versions not managed by C(uv)). RV(python_versions) and RV(python_paths) lengths are always equal to one for this state. Uses C(uv python install) command.
+      - C(absent) ensures the specified version is removed. If a full patch version is specified, only that exact patch version is removed. If only a minor version is specified (for example C(3.12)), all installed patch versions for that minor release are removed. If the specified version is not installed, no changes are made. RV(python_versions) and RV(python_paths) lengths can be higher or equal to one for this state. Uses C(uv python uninstall) command.
+      - C(latest) ensures the latest available patch version for the specified version is installed. If only a minor version is specified (for example C(3.12)), the latest available patch version for that minor release is always installed. If another patch version is already installed but is not the latest, the latest patch version is installed. The latest patch version installed depends on the C(uv) version, since available Python versions are frozen per C(uv) release. RV(python_versions) and RV(python_paths) lengths are always equal to one for this state. This state does not use C(uv python upgrade).
     type: str
     choices: [present, absent, latest]
     default: present
-seealso: 
-  - https://docs.astral.sh/uv/concepts/python-versions/
-  - https://docs.astral.sh/uv/reference/cli/#uv-python
 attributes:
-  - check_mode:
+  check_mode:
       description: Can run in check_mode and return changed status prediction without modifying target.
       support: full
-  - diff_mode:
+  diff_mode:
       description: Returns details on what has changed (or possibly needs changing in check_mode), when in diff mode.
       support: none
+notes:
+seealso:
+- name: uv documentation
+  description: Python versions management with uv.
+  link: https://docs.astral.sh/uv/concepts/python-versions/
+- name: uv CLI documentation
+  description: uv CLI reference guide.
+  link: https://docs.astral.sh/uv/reference/cli/#uv-python
+author: Mariam Ahhttouche (@mriamah)
 
 '''
 
@@ -47,7 +57,7 @@ EXAMPLES = r'''
 
 - name: Remove Python 3.13.5
   mriamah.uv_python:
-    version: "3.13.5"
+    version: 3.13.5
     state: absent
 
 - name: Upgrade python 3
@@ -66,29 +76,39 @@ python_paths:
   returned: success
   type: list
 stdout:
-  description: Stdout of command run.
+  description: Stdout of the executed command.
   returned: success
   type: str
 stderr:
-  description: Stderr of command run.
+  description: Stderr of the executed command.
   returned: success
   type: str
 rc:
-  description: Return code of command run.
+  description: Return code of the executed command.
   returned: success
   type: int
 '''
 
 import json
+import traceback
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.compat.version import LooseVersion
+from ansible.module_utils.basic import missing_required_lib
+
+LIB_IMP_ERR = None
+HAS_LIB = False
+try:
+    from packaging.version import Version, InvalidVersion
+    HAS_LIB = True
+except:
+    LIB_IMP_ERR = traceback.format_exc()
 
 
 MINIMUM_UV_VERSION = "0.8.0"
 
 class UV:
     """
-      Module for "uv python" command
+      Module for managing Python versions and installations using "uv python" command
     """
 
     def __init__(self, module):
@@ -96,13 +116,12 @@ class UV:
         self._ensure_min_uv_version()
         python_version = module.params["version"]
         try:
-          self.python_version = LooseVersion(python_version)
+          self.python_version = Version(python_version)
           self.python_version_str = self.python_version.__str__()
-        except ValueError as err:
+        except InvalidVersion:
           self.module.fail_json(
-            msg=err
+            msg="Unsupported version format. Only canonical Python versions (e.g. 3, 3.12, 3.12.3, 3.15.0a5) are supported in this release."
           )
-
 
     def _ensure_min_uv_version(self):
       cmd = [self.module.get_bin_path("uv", required=True), "--version", "--color", "never"]
@@ -114,7 +133,6 @@ class UV:
               detected_version=detected,
               required_version=MINIMUM_UV_VERSION,
           )
-
 
     def install_python(self):
       """
@@ -133,9 +151,9 @@ class UV:
               If the install command exits with a non-zero return code.
               If specified version is not available for download.
       """
-      find_rc, existing_version, _ = self._find_python(self.python_version_str, "--show-version")
+      find_rc, existing_version, _ = self._find_python("--show-version")
       if find_rc == 0:
-        _, version_path, _ = self._find_python(self.python_version_str)
+        _, version_path, _ = self._find_python()
         return False, "", "", 0, [existing_version], [version_path]
       if self.module.check_mode:
         latest_version, _ = self._get_latest_patch_release("--managed-python")
@@ -143,11 +161,9 @@ class UV:
         if not latest_version:
           self.module.fail_json(msg=(f"Version {self.python_version_str} is not available."))
         return True, "", "", 0, [latest_version], [""]
-
       rc, out, err = self._exec(self.python_version_str, "install", check_rc=True)
       latest_version, path = self._get_latest_patch_release("--only-installed", "--managed-python")
       return True, out, err, rc, [latest_version], [path]
-
 
     def uninstall_python(self):
       """
@@ -170,10 +186,8 @@ class UV:
         return False, "", "", 0, [], []
       if self.module.check_mode:
         return True, "", "", 0, installed_versions, install_paths
-      
       rc, out, err = self._exec(self.python_version_str, "uninstall", check_rc=True)
       return True, out, err, rc, installed_versions, install_paths
-    
 
     def upgrade_python(self):
       """
@@ -191,21 +205,21 @@ class UV:
               If the install command exits with a non-zero return code.
               If resolved patch version is not available for download.
       """
-      rc, installed_version, _ = self._find_python(self.python_version_str, "--show-version")
-      latest_version, _ = self._get_latest_patch_release("--managed-python")
-      if not latest_version:
+      rc, installed_version_str, _ = self._find_python("--show-version")
+      installed_version = self._parse_version(installed_version_str)
+      latest_version_str, _ = self._get_latest_patch_release("--managed-python")
+      if not latest_version_str:
          self.module.fail_json(msg=f"Version {self.python_version_str} is not available.")
-      if rc == 0 and LooseVersion(installed_version) >= LooseVersion(latest_version):
-          _, install_path, _ = self._find_python(self.python_version_str)
-          return False, "", "", rc, [installed_version], [install_path]
+      if rc == 0 and installed_version >= Version(latest_version_str):
+          _, install_path, _ = self._find_python()
+          return False, "", "", rc, [installed_version.__str__()], [install_path]
       if self.module.check_mode:
-          return True, "", "", 0, [latest_version], []
+          return True, "", "", 0, [latest_version_str], []
       # it's possible to have latest version already installed but not used as default 
       # so in this case 'uv python install' will set latest version as default
-      rc, out, err = self._exec(latest_version, "install", check_rc=True)
-      latest_version, latest_path = self._get_latest_patch_release("--only-installed", "--managed-python")
-      return True, out, err, rc, [latest_version], [latest_path]
-
+      rc, out, err = self._exec(latest_version_str, "install", check_rc=True)
+      latest_version_str, latest_path = self._get_latest_patch_release("--only-installed", "--managed-python")
+      return True, out, err, rc, [latest_version_str], [latest_path]
 
     def _exec(self, python_version, command, *args, check_rc=False):
       """
@@ -226,14 +240,12 @@ class UV:
       rc, out, err = self.module.run_command(cmd, check_rc=check_rc)
       return rc, out, err
 
-
-    def _find_python(self, python_version, *args, check_rc=False):
+    def _find_python(self, *args, check_rc=False):
       """
         Runs command 'uv python find' which returns path of installed patch releases for a given python version.
         If multiple patch versions are installed, "uv python find" returns the one used by default 
         if inside a virtualenv otherwise it returns latest installed patch version.
         Args:
-          python_version (str): Python version specifier (e.g. "3.12", "3.12.3").
           *args: Additional positional arguments passed to _exec.
           check_rc (bool): Whether to fail if the command exits with non-zero return code.
         Returns:
@@ -243,18 +255,16 @@ class UV:
           AnsibleModuleFailJson:
             If check_rc is True and the command exits with a non-zero return code.
       """
-      rc, out, err = self._exec(python_version, "find", *args, check_rc=check_rc)
+      rc, out, err = self._exec(self.python_version_str, "find", *args, check_rc=check_rc)
       if rc == 0:
         out = out.strip()
       return rc, out, err
 
-
-    def _list_python(self, python_version, *args, check_rc=False):
+    def _list_python(self, *args, check_rc=False):
       """
         Runs command 'uv python list' (which returns list of installed patch releases for a given python version).
         Official documentation https://docs.astral.sh/uv/reference/cli/#uv-python-list
         Args:
-          python_version (str): Python version specifier (e.g. "3.12", "3.12.3").
           *args: Additional positional arguments passed to _exec.
           check_rc (bool): Whether to fail if the command exits with non-zero return code.
         Returns:
@@ -264,14 +274,13 @@ class UV:
           AnsibleModuleFailJson:
             If check_rc is True and the command exits with a non-zero return code.
       """
-      rc, out, err = self._exec(python_version, "list", "--output-format", "json", *args, check_rc=check_rc)
+      rc, out, err = self._exec(self.python_version_str, "list", "--output-format", "json", *args, check_rc=check_rc)
       try:
         out = json.loads(out)
       except json.decoder.JSONDecodeError:
         # This happens when no version is found
         pass
       return rc, out, err
-
 
     def _get_latest_patch_release(self, *args):
       """
@@ -284,13 +293,13 @@ class UV:
             - installation path of latest patch version if version exists
       """
       latest_version = path = ""
-      _, results, _ = self._list_python(self.python_version_str, *args) # uv returns versions in descending order but we sort them just in case future uv behavior changes
-      if results:
-        version = max(results, key=lambda item: (item["version_parts"]["major"], item["version_parts"]["minor"], item["version_parts"]["patch"]))
-        latest_version = version["version"]
-        path = version["path"] if version["path"] else ""
+      _, results, _ = self._list_python(*args) # uv returns versions in descending order but we sort them just in case future uv behavior changes
+      valid_results = self._parse_versions(results)
+      if valid_results:
+        version = max(valid_results, key=lambda result: result["parsed_version"])
+        latest_version = version.get("version", "")
+        path = version.get("path", "")
       return latest_version, path
-
 
     def _get_installed_versions(self, *args):
       """
@@ -302,11 +311,28 @@ class UV:
             - list of latest found patch versions
             - list of installation paths of installed versions
       """
-      _, results, _ = self._list_python(self.python_version_str, "--only-installed", *args)
+      _, results, _ = self._list_python("--only-installed", *args)
       if results:
         return [result["version"] for result in results], [result["path"] for result in results]
       return [], []
 
+    @staticmethod
+    def _parse_versions(results):
+      valid_results =[]
+      for result in results:
+        try:
+          result["parsed_version"] = Version(result.get("version", ""))
+          valid_results.append(result)
+        except InvalidVersion:
+            continue
+      return valid_results
+
+    @staticmethod
+    def _parse_version(version_str):
+      try:
+          return Version(version_str)
+      except InvalidVersion:
+          return Version("0")
 
 
 def main():
@@ -318,6 +344,10 @@ def main():
         supports_check_mode=True
     )
 
+    if not HAS_LIB:
+      module.fail_json(msg=missing_required_lib("packaging"),
+                     exception=LIB_IMP_ERR)
+    
     result = dict(
         changed=False,
         stdout="",

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -111,6 +111,7 @@ rc:
 
 import json
 import re
+from pathlib import Path
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.compat.version import LooseVersion, StrictVersion
@@ -226,7 +227,7 @@ class UV:
         latest_version_str, latest_path = self._get_latest_patch_release("--only-installed", "--managed-python")
         return True, out, err, rc, [latest_version_str], [latest_path]
 
-    def _exec(self, python_version: str, command, *args, check_rc=False) -> tuple[int, str, str]:
+    def _exec(self, python_version: str, command: str, *args, check_rc: bool = False) -> tuple[int, str, str]:
         """
         Execute a uv python subcommand.
         Args:
@@ -235,11 +236,19 @@ class UV:
           *args: Additional positional arguments passed to the command.
           check_rc (bool): Whether to fail if the command exits with non-zero return code.
         """
-        cmd = [self.bin_path, "python", command, python_version, "--color", "never", *args]
+        cmd = [
+            self.bin_path,
+            "python",
+            command,
+            python_version,
+            "--color",
+            "never",
+            *args,
+        ]
         rc, out, err = self.module.run_command(cmd, check_rc=check_rc)
         return rc, out, err
 
-    def _find_python(self, *args, check_rc=False) -> tuple[int, str, str]:
+    def _find_python(self, *args, check_rc: bool = False) -> tuple[int, str, str]:
         """
         Runs command 'uv python find' which returns path of installed patch releases for a given python version.
         If multiple patch versions are installed, "uv python find" returns the one used by default
@@ -253,7 +262,7 @@ class UV:
             out = out.strip()
         return rc, out, err
 
-    def _list_python(self, *args, check_rc=False) -> tuple[int, list, str]:
+    def _list_python(self, *args, check_rc: bool = False) -> tuple[int, list, str]:
         """
         Runs command 'uv python list' (which returns list of installed patch releases for a given python version).
         Official documentation https://docs.astral.sh/uv/reference/cli/#uv-python-list
@@ -261,13 +270,24 @@ class UV:
           *args: Additional positional arguments passed to _exec.
           check_rc (bool): Whether to fail if the command exits with non-zero return code.
         """
-        rc, out, err = self._exec(self.python_version_str, "list", "--output-format", "json", *args, check_rc=check_rc)
+        rc, out, err = self._exec(
+            self.python_version_str,
+            "list",
+            "--output-format",
+            "json",
+            *args,
+            check_rc=check_rc,
+        )
         pythons_installed = []
         try:
             pythons_installed = json.loads(out)
+            # convert path to absolute path since in some recent uv releases "uv python list" returns relative install paths instead of absolute paths
+            for result in pythons_installed:
+                path = result.get("path", "")
+                if path and not Path(path).is_absolute():
+                    result["path"] = str(Path(path).resolve())
         except json.decoder.JSONDecodeError:
-            # This happens when no version is found
-            pass
+            self.module.debug("No Python installation found.")
         return rc, pythons_installed, err
 
     def _get_latest_patch_release(self, *args) -> tuple[str, str]:
@@ -303,7 +323,7 @@ class UV:
             return [result.get("version") for result in results], [result.get("path") for result in results]
         return [], []
 
-    def _filter_valid_versions(self, results):
+    def _filter_valid_versions(self, results: list):
         valid_results = []
         for result in results:
             version = result.get("version", "")
@@ -315,7 +335,7 @@ class UV:
         return valid_results
 
     @staticmethod
-    def _parse_version(version_str):
+    def _parse_version(version_str: str):
         try:
             return StrictVersion(version_str)
         except ValueError:
@@ -331,17 +351,61 @@ def main():
         supports_check_mode=True,
     )
 
-    result = dict(changed=False, stdout="", stderr="", rc=0, python_versions=[], python_paths=[], failed=False)
+    result = dict(
+        changed=False,
+        stdout="",
+        stderr="",
+        rc=0,
+        python_versions=[],
+        python_paths=[],
+        failed=False,
+    )
     state = module.params["state"]
     exec_result = {}
     uv = UV(module)
 
     if state == "present":
-        exec_result = dict(zip(["changed", "stdout", "stderr", "rc", "python_versions", "python_paths"], uv.install_python()))
+        exec_result = dict(
+            zip(
+                [
+                    "changed",
+                    "stdout",
+                    "stderr",
+                    "rc",
+                    "python_versions",
+                    "python_paths",
+                ],
+                uv.install_python(),
+            )
+        )
     elif state == "absent":
-        exec_result = dict(zip(["changed", "stdout", "stderr", "rc", "python_versions", "python_paths"], uv.uninstall_python()))
+        exec_result = dict(
+            zip(
+                [
+                    "changed",
+                    "stdout",
+                    "stderr",
+                    "rc",
+                    "python_versions",
+                    "python_paths",
+                ],
+                uv.uninstall_python(),
+            )
+        )
     elif state == "latest":
-        exec_result = dict(zip(["changed", "stdout", "stderr", "rc", "python_versions", "python_paths"], uv.upgrade_python()))
+        exec_result = dict(
+            zip(
+                [
+                    "changed",
+                    "stdout",
+                    "stderr",
+                    "rc",
+                    "python_versions",
+                    "python_paths",
+                ],
+                uv.upgrade_python(),
+            )
+        )
 
     result.update(exec_result)
 

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -6,31 +6,28 @@
 DOCUMENTATION = r'''
 ---
 module: uv_python
-short_description: Manage Python installations using uv
+short_description: Manage Python installations using uv.
 description:
-  - Install or remove Python versions managed by uv.
-# requirements:
-#   - uv must be installed and available on PATH
+  - Install, remove or upgrade Python versions managed by uv.
+version_added: "X.Y"
+requirements:
+  - uv must be installed and available on PATH
+  - uv >= 0.8.0
 options:
   version:
-    description: Python version to manage
+    description: 
+      - Python version to manage. 
+      - Expected formats are "X.Y" or "X.Y.Z".
     type: str
     required: true
   state:
-    description: Desired state
+    description: Desired state of the specified Python version.
     type: str
-    choices: [present, absent]
+    choices: [present, absent, latest]
     default: present
-  force:
-    description: Force reinstall
-    type: bool
-    default: false
-  uv_path:
-    description: Path to uv binary
-    type: str
-    default: uv
 author:
-  - Your Name
+  - Mariam Ahhttouche (@mriamah)
+deprecated:
 '''
 
 EXAMPLES = r'''
@@ -61,9 +58,8 @@ class UV:
       Module for "uv python" command
       Official documentation for uv python https://docs.astral.sh/uv/concepts/python-versions/#installing-a-python-version
     """
-    subcommand = "python"
 
-    def __init__(self, module, **kwargs):
+    def __init__(self, module):
         self.module = module
         python_version = module.params["version"]
         try:
@@ -77,121 +73,197 @@ class UV:
             )
           )
 
+
     def install_python(self):
       """
         Runs command 'uv python install X.Y.Z' which installs specified python version.
         If patch version is not specified uv installs latest available patch version.
-        Returns: tuple with following elements 
+        Returns: 
+          tuple [bool, str, str, int, list, list] 
           - boolean to indicate if method changed state
-          - installed version
+          - command's stdout
+          - command's stderr
+          - command's return code
+          - list of installed versions
+          - list of installation paths for each installed version
+        Raises:
+          AnsibleModuleFailJson:
+              If the install command exits with a non-zero return code.
+              If specified version is not available for download.
       """
-      find_rc, find_version, _ = self._find_python("--show-version")
+      find_rc, existing_version, _ = self._find_python(self.python_version_str, "--show-version")
       if find_rc == 0:
-        _, find_out, _ = self._find_python()
-        return False, "", "", 0, [find_version.split()[0]], [find_out.split()[0]]
+        _, version_path, _ = self._find_python(self.python_version_str)
+        return False, "", "", 0, [existing_version], [version_path]
       if self.module.check_mode:
-        latest_version, _ = self._get_latest_patch_release()
+        latest_version, _ = self._get_latest_patch_release("--managed-python")
         # when uv does not find any available patch version the install command will fail
         if not latest_version:
           self.module.fail_json(msg=(f"Version {self.python_version_str} is not available."))
         return True, "", "", 0, [latest_version], [""]
 
-      cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "install", self.python_version_str]
-      rc, out, err = self.module.run_command(cmd, check_rc=True, expand_user_and_vars=False)
-      latest_version, path = self._get_latest_patch_release("--only-installed")
+      rc, out, err = self._exec(self.python_version_str, "install", check_rc=True)
+      latest_version, path = self._get_latest_patch_release("--only-installed", "--managed-python")
       return True, out, err, rc, [latest_version], [path]
-    
+
+
     def uninstall_python(self):
       """
         Runs command 'uv python uninstall X.Y.Z' which removes specified python version from environment.
         If patch version is not specified all correspending installed patch versions are removed.
-        Returns: tuple with following elements 
+        Returns: 
+          tuple [bool, str, str, int, list, list] 
           - boolean to indicate if method changed state
-          - removed version
+          - command's stdout
+          - command's stderr
+          - command's return code
+          - list of uninstalled versions
+          - list of previous installation paths for each uninstalled version
+        Raises:
+          AnsibleModuleFailJson:
+              If the uninstall command exits with a non-zero return code.
       """
-      installed_versions, install_paths = self._get_installed_versions()
+      installed_versions, install_paths = self._get_installed_versions("--managed-python")
       if not installed_versions:
         return False, "", "", 0, [], []
       if self.module.check_mode:
         return True, "", "", 0, installed_versions, install_paths
       
-      cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "uninstall", self.python_version_str]
-      rc, out, err = self.module.run_command(cmd, check_rc=True)
+      rc, out, err = self._exec(self.python_version_str, "uninstall", check_rc=True)
       return True, out, err, rc, installed_versions, install_paths
     
+
     def upgrade_python(self):
       """
-        Runs command 'uv python install X.Y.Z' which installs specified python version.
-        Returns: tuple with following elements 
+        Runs command 'uv python install X.Y.Z' with latest patch version available.
+        Returns: 
+          tuple [bool, str, str, int, list, list] 
           - boolean to indicate if method changed state
-          - installed version
+          - command's stdout
+          - command's stderr
+          - command's return code
+          - list of installed versions
+          - list of installation paths for each installed version
+        Raises:
+          AnsibleModuleFailJson:
+              If the install command exits with a non-zero return code.
+              If resolved patch version is not available for download.
       """
-      rc, out, _ = self._find_python("--show-version")
-      latest_version, latest_path = self._get_latest_patch_release()
+      rc, installed_version, _ = self._find_python(self.python_version_str, "--show-version")
+      latest_version, _ = self._get_latest_patch_release("--managed-python")
       if not latest_version:
          self.module.fail_json(msg=f"Version {self.python_version_str} is not available.")
-      if rc == 0 and out.strip() == latest_version:
-          return False, "", "", rc, [latest_version], [latest_path]
+      if rc == 0 and StrictVersion(installed_version) >= StrictVersion(latest_version):
+          _, install_path, _ = self._find_python(self.python_version_str)
+          return False, "", "", rc, [installed_version], [install_path]
       if self.module.check_mode:
           return True, "", "", 0, [latest_version], []
       # it's possible to have latest version already installed but not used as default so in this case 'uv python install' will set latest version as default
-      cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "install", latest_version]
-      rc, out, err = self.module.run_command(cmd, check_rc=True)
-      latest_version, latest_path = self._get_latest_patch_release("--only-installed")
+      rc, out, err = self._exec(latest_version, "install", check_rc=True)
+      latest_version, latest_path = self._get_latest_patch_release("--only-installed", "--managed-python")
       return True, out, err, rc, [latest_version], [latest_path]
 
-    def _find_python(self, *args):
+
+    def _exec(self, python_version, command, *args, check_rc=False):
+      """
+        Execute a uv python subcommand.
+        Args:
+          python_version (str): Python version specifier (e.g. "3.12", "3.12.3").
+          command (str): uv python subcommand (e.g. "install", "uninstall", "find").
+          *args: Additional positional arguments passed to the command.
+          check_rc (bool): Whether to fail if the command exits with non-zero return code.
+        Returns:
+          tuple[int, str, str]:
+            A tuple containing (rc, stdout, stderr).
+        Raises:
+          AnsibleModuleFailJson:
+              If check_rc is True and the command exits with a non-zero return code.
+      """
+      cmd = [self.module.get_bin_path("uv", required=True), "python", command, python_version, *args]
+      rc, out, err = self.module.run_command(cmd, check_rc=check_rc)
+      return rc, out, err
+
+
+    def _find_python(self, python_version, *args, check_rc=False):
       """
         Runs command 'uv python find' which returns path of installed patch releases for a given python version.
         If multiple patch versions are installed, "uv python find" returns the one used by default if inside a virtualenv otherwise it returns latest installed patch version.
-        Returns: tuple with following elements 
-          - return code of executed command
-          - stdout of command
-          - stderr of command
+        Args:
+          python_version (str): Python version specifier (e.g. "3.12", "3.12.3").
+          *args: Additional positional arguments passed to _exec.
+          check_rc (bool): Whether to fail if the command exits with non-zero return code.
+        Returns:
+          tuple[int, str, str]:
+            A tuple containing (rc, stdout, stderr).
+        Raises:
+          AnsibleModuleFailJson:
+            If check_rc is True and the command exits with a non-zero return code.
       """
-      cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "find", self.python_version_str, *args]
-      rc, out, err = self.module.run_command(cmd, expand_user_and_vars=False)
+      rc, out, err = self._exec(python_version, "find", *args, check_rc=check_rc)
+      if rc == 0:
+        out = out.strip()
       return rc, out, err
-    
-    def _list_python(self, *args):
+
+
+    def _list_python(self, python_version, *args, check_rc=False):
       """
-        Runs command 'uv python list' which returns list of installed patch releases for a given python version.
-        Returns: tuple with following elements 
-          - return code of executed command
-          - stdout of command
-          - stderr of command
+        Runs command 'uv python list' (which returns list of installed patch releases for a given python version).
+        Official documentation https://docs.astral.sh/uv/reference/cli/#uv-python-list
+        Args:
+          python_version (str): Python version specifier (e.g. "3.12", "3.12.3").
+          *args: Additional positional arguments passed to _exec.
+          check_rc (bool): Whether to fail if the command exits with non-zero return code.
+        Returns:
+          tuple[int, str, str]:
+            A tuple containing (rc, stdout, stderr).
+        Raises:
+          AnsibleModuleFailJson:
+            If check_rc is True and the command exits with a non-zero return code.
       """
-      # https://docs.astral.sh/uv/reference/cli/#uv-python-list
-      cmd = [self.module.get_bin_path("uv", required=True), self.subcommand, "list", self.python_version_str, "--output-format", "json", *args]
-      rc, out, err = self.module.run_command(cmd)
+      rc, out, err = self._exec(python_version, "list", "--output-format", "json", *args, check_rc=check_rc)
+      try:
+        out = json.loads(out)
+      except json.decoder.JSONDecodeError:
+        # This happens when no version is found
+        pass
       return rc, out, err
+
 
     def _get_latest_patch_release(self, *args):
       """
         Returns latest available patch release for a given python version.
-        Fails when no available release exists for the specified version.
+        Args:
+          *args: Additional positional arguments passed to _list_python.
+        Returns:
+          tuple[str, str]:
+            - latest found patch version in format X.Y.Z
+            - installation path of latest patch version if version exists
       """
       latest_version = path = ""
-      try:
-        _, out, _ = self._list_python(*args) # uv returns versions in descending order but we sort them just in case future uv behavior changes
-        results = json.loads(out)
-        if results:
-          version = max(results, key=lambda item: (item["version_parts"]["major"], item["version_parts"]["minor"], item["version_parts"]["patch"]))
-          latest_version = version["version"]
-          path = version["path"]
-      except json.decoder.JSONDecodeError as e:
-         self.module.fail_json(msg=f"Failed to parse 'uv python list' output with error {str(e)}")
+      _, results, _ = self._list_python(self.python_version_str, *args) # uv returns versions in descending order but we sort them just in case future uv behavior changes
+      if results:
+        version = max(results, key=lambda item: (item["version_parts"]["major"], item["version_parts"]["minor"], item["version_parts"]["patch"]))
+        latest_version = version["version"]
+        path = version["path"] if version["path"] else ""
       return latest_version, path
-    
+
+
     def _get_installed_versions(self, *args):
-      _, out_list, _ = self._list_python("--only-installed", *args)
-      try:
-        if out_list:
-          results = json.loads(out_list)
-          return [result["version"] for result in results], [result["path"] for result in results]
-      except json.decoder.JSONDecodeError:
-         self.module.fail_json(msg=f"Failed to parse 'uv python list' output")
+      """
+        Returns installed patch releases for a given python version.
+        Args:
+          *args: Additional positional arguments passed to _list_python.
+        Returns:
+          tuple[list, list]:
+            - list of latest found patch versions
+            - list of installation paths of installed versions
+      """
+      _, results, _ = self._list_python(self.python_version_str, "--only-installed", *args)
+      if results:
+        return [result["version"] for result in results], [result["path"] for result in results]
       return [], []
+
+
 
 def main():
     module = AnsibleModule(
@@ -217,11 +289,12 @@ def main():
     if state == "present":
       result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_versions"], result["python_paths"] = uv.install_python()
     elif state == "absent":
-      result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_versions"], result["python_paths"]  = uv.uninstall_python()
+      result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_versions"], result["python_paths"] = uv.uninstall_python()
     elif state == "latest":
       result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_versions"], result["python_paths"] = uv.upgrade_python()
 
     module.exit_json(**result)
+
 
 if __name__ == "__main__":
     main()

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
 
 DOCUMENTATION = r"""
 module: uv_python
@@ -11,7 +12,7 @@ description:
   - Install, uninstall or upgrade Python versions managed by C(uv).
 version_added: "12.5.0"
 requirements:
-  - uv must be installed and available in PATH and uv version must be at least 0.8.0.
+  - C(uv) must be installed and available in E(PATH) and must be at least 0.8.0.
   - Python version must be at least 3.9.
 extends_documentation_fragment:
   - community.general.attributes
@@ -82,22 +83,31 @@ python_versions:
   description: List of Python versions changed.
   returned: success
   type: list
+  elements: str
+  sample:
+    - "3.13.5"
 python_paths:
   description: List of installation paths of Python versions changed.
   returned: success
   type: list
+  elements: str
+  sample:
+    - "/root/.local/share/uv/python/cpython-3.13.5-linux-x86_64-gnu/bin/python3.13"
 stdout:
   description: Stdout of the executed command.
   returned: success
   type: str
+  sample: ""
 stderr:
   description: Stderr of the executed command.
   returned: success
   type: str
+  sample: ""
 rc:
   description: Return code of the executed command.
   returned: success
   type: int
+  sample: 0
 """
 
 import json
@@ -113,7 +123,7 @@ class UV:
     Module for managing Python versions and installations using "uv python" command
     """
 
-    def __init__(self, module):
+    def __init__(self, module: AnsibleModule) -> None:
         self.module = module
         self.bin_path = self.module.get_bin_path("uv", required=True)
         self._ensure_min_uv_version()
@@ -128,7 +138,7 @@ class UV:
                 )
             )
 
-    def _ensure_min_uv_version(self):
+    def _ensure_min_uv_version(self) -> None:
         cmd = [self.bin_path, "--version", "--color", "never"]
         dummy_rc, out, dummy_err = self.module.run_command(cmd, check_rc=True)
         detected = out.strip().split()[-1]
@@ -139,12 +149,11 @@ class UV:
                 required_version=MINIMUM_UV_VERSION,
             )
 
-    def install_python(self) -> tuple[bool, str, str, int, list, list]:
+    def install_python(self) -> tuple[bool, str, str, int, list[str], list[str]]:
         """
         Runs command 'uv python install X.Y.Z' which installs specified python version.
         If patch version is not specified uv installs latest available patch version.
         Returns:
-          tuple [bool, str, str, int, list, list]
           - boolean to indicate if method changed state
           - command's stdout
           - command's stderr
@@ -281,7 +290,7 @@ class UV:
         latest_version = path = ""
         # 'uv python list' returns versions in descending order but we sort them just in case future uv behavior changes
         dummy_rc, results, dummy_err = self._list_python(*args)
-        valid_results = self._parse_versions(results)
+        valid_results = self._filter_valid_versions(results)
         if valid_results:
             version = max(valid_results, key=lambda result: result["parsed_version"])
             latest_version = version.get("version", "")
@@ -303,15 +312,15 @@ class UV:
             return [result.get("version") for result in results], [result.get("path") for result in results]
         return [], []
 
-    @staticmethod
-    def _parse_versions(results):
+    def _filter_valid_versions(self, results):
         valid_results = []
         for result in results:
+            version = result.get("version", "")
             try:
-                result["parsed_version"] = StrictVersion(result.get("version", ""))
+                result["parsed_version"] = StrictVersion(version)
                 valid_results.append(result)
             except ValueError:
-                continue
+                self.module.debug(f"Found {version} available, but it's not yet supported by uv_python module.")
         return valid_results
 
     @staticmethod
@@ -333,14 +342,17 @@ def main():
 
     result = dict(changed=False, stdout="", stderr="", rc=0, python_versions=[], python_paths=[], failed=False)
     state = module.params["state"]
-
+    exec_result = {}
     uv = UV(module)
+
     if state == "present":
-        result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_versions"], result["python_paths"] = uv.install_python()
+        exec_result = dict(zip(["changed", "stdout", "stderr", "rc", "python_versions", "python_paths"], uv.install_python()))
     elif state == "absent":
-        result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_versions"], result["python_paths"] = uv.uninstall_python()
+        exec_result = dict(zip(["changed", "stdout", "stderr", "rc", "python_versions", "python_paths"], uv.uninstall_python()))
     elif state == "latest":
-        result["changed"], result["stdout"], result["stderr"], result["rc"], result["python_versions"], result["python_paths"] = uv.upgrade_python()
+        exec_result = dict(zip(["changed", "stdout", "stderr", "rc", "python_versions", "python_paths"], uv.upgrade_python()))
+
+    result.update(exec_result)
 
     module.exit_json(**result)
 

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -11,7 +11,8 @@ description:
   - Install, uninstall or upgrade Python versions managed by C(uv).
 version_added: "12.5.0"
 requirements:
-  - uv must be installed and available in PATH and uv version must be >= 0.8.0.
+  - uv must be installed and available in PATH and uv version must be at least 0.8.0.
+  - Python version must be at least 3.9
 extends_documentation_fragment:
   - community.general.attributes
 attributes:
@@ -24,7 +25,7 @@ options:
     description:
       - Python version to manage.
       - "Not all canonical Python versions are supported in this release. Valid version numbers consist of two or three dot-separated
-        numeric components,\nwith an optional 'pre-release' tag at the end such as V(3.12), V(3.12.3), V(3.15.0a5)."
+        numeric components, with an optional 'pre-release' tag at the end such as V(3.12), V(3.12.3), V(3.15.0a5)."
       - Advanced uv selectors such as V(>=3.12,<3.13) or V(cpython@3.12) are not supported in this release.
       - "When you specify only a major.minor version, make sure the number is enclosed in quotes so that it gets parsed correctly.\n\
         Note that in case only a major.minor version are specified behavior depends on the O(state) parameter."
@@ -33,20 +34,20 @@ options:
   state:
     description:
       - Desired state of the specified Python version.
-      - "V(present) ensures the specified version is installed.\nIf you specify a full patch version (for example O(version=3.12.3)),
-        that exact version is be installed if not already present.\nIf you only specify a minor version (for example V(3.12)),
-        the latest available patch version for that minor release is installed only\nif no patch version for that minor release
-        is currently installed (including patch versions not managed by C(uv)).\nRV(python_versions) and RV(python_paths)
+      - "V(present) ensures the specified version is installed. If you specify a full patch version (for example O(version=3.12.3)),
+        that exact version is be installed if not already present. If you only specify a minor version (for example V(3.12)),
+        the latest available patch version for that minor release is installed only if no patch version for that minor release
+        is currently installed (including patch versions not managed by C(uv)). RV(python_versions) and RV(python_paths)
         lengths are always equal to one for this state."
-      - "V(absent) ensures the specified version is removed.\nIf you specify a full patch version, only that exact patch version
-        is removed.\nIf you only specify a minor version (for example V(3.12)), all installed patch versions for that minor
-        release are removed.\nIf you specify a version that is not installed, no changes are made.\nRV(python_versions) and
+      - "V(absent) ensures the specified version is removed. If you specify a full patch version, only that exact patch version
+        is removed. If you only specify a minor version (for example V(3.12)), all installed patch versions for that minor
+        release are removed. If you specify a version that is not installed, no changes are made. RV(python_versions) and
         RV(python_paths) lengths can be higher or equal to one in this state."
-      - "V(latest) ensures the latest available patch version for the specified version is installed.\nIf you only specify
-        a minor version (for example V(3.12)), the latest available patch version for that minor release is always installed.\n\
-        If another patch version is already installed but is not the latest, the latest patch version is installed.\nThe latest
-        patch version installed depends on the C(uv) version, since available Python versions are frozen per C(uv) release.\n\
-        RV(python_versions) and RV(python_paths) lengths are always equal to one in this state.\nThis state does not use C(uv
+      - "V(latest) ensures the latest available patch version for the specified version is installed. If you only specify
+        a minor version (for example V(3.12)), the latest available patch version for that minor release is always installed. \
+        If another patch version is already installed but is not the latest, the latest patch version is installed. The latest
+        patch version installed depends on the C(uv) version, since available Python versions are frozen per C(uv) release. \
+        RV(python_versions) and RV(python_paths) lengths are always equal to one in this state. This state does not use C(uv
         python upgrade)."
     type: str
     choices: [present, absent, latest]
@@ -123,12 +124,12 @@ class UV:
         except (ValueError, AttributeError):
             self.module.fail_json(
                 msg="Unsupported version format. Valid version numbers consist of two or three dot-separated numeric components, \
-                  with an optional 'pre-release' tag on the end (e.g. 3.12, 3.12.3, 3.15.0a5) are supported in this release."
+                  with an optional 'pre-release' tag on the end (for example 3.12, 3.12.3, 3.15.0a5) are supported in this release."
             )
 
     def _ensure_min_uv_version(self):
         cmd = [self.bin_path, "--version", "--color", "never"]
-        ignored_rc, out, ignored_err = self.module.run_command(cmd, check_rc=True)
+        dummy_rc, out, dummy_err = self.module.run_command(cmd, check_rc=True)
         detected = out.strip().split()[-1]
         if LooseVersion(detected) < LooseVersion(MINIMUM_UV_VERSION):
             self.module.fail_json(
@@ -150,12 +151,12 @@ class UV:
           - list of installed versions
           - list of installation paths for each installed version
         """
-        find_rc, existing_version, ignored_err = self._find_python("--show-version")
+        find_rc, existing_version, dummy_err = self._find_python("--show-version")
         if find_rc == 0:
-            ignored_rc, version_path, ignored_err = self._find_python()
+            dummy_rc, version_path, dummy_err = self._find_python()
             return False, "", "", 0, [existing_version], [version_path]
         if self.module.check_mode:
-            latest_version, ignored_path = self._get_latest_patch_release("--managed-python")
+            latest_version, dummy_path = self._get_latest_patch_release("--managed-python")
             # when uv does not find any available patch version the install command will fail
             if not latest_version:
                 self.module.fail_json(msg=(f"Version {self.python_version_str} is not available."))
@@ -197,13 +198,13 @@ class UV:
           - list of installed versions
           - list of installation paths for each installed version
         """
-        rc, installed_version_str, ignored_err = self._find_python("--show-version")
+        rc, installed_version_str, dummy_err = self._find_python("--show-version")
         installed_version = self._parse_version(installed_version_str)
-        latest_version_str, ignored_path = self._get_latest_patch_release("--managed-python")
+        latest_version_str, dummy_path = self._get_latest_patch_release("--managed-python")
         if not latest_version_str:
             self.module.fail_json(msg=f"Version {self.python_version_str} is not available.")
         if rc == 0 and installed_version >= StrictVersion(latest_version_str):
-            ignored_rc, install_path, ignored_err = self._find_python()
+            dummy_rc, install_path, dummy_err = self._find_python()
             return False, "", "", rc, [installed_version_str], [install_path]
         if self.module.check_mode:
             return True, "", "", 0, [latest_version_str], []
@@ -278,7 +279,7 @@ class UV:
         """
         latest_version = path = ""
         # 'uv python list' returns versions in descending order but we sort them just in case future uv behavior changes
-        ignored_rc, results, ignored_err = self._list_python(*args)
+        dummy_rc, results, dummy_err = self._list_python(*args)
         valid_results = self._parse_versions(results)
         if valid_results:
             version = max(valid_results, key=lambda result: result["parsed_version"])
@@ -296,7 +297,7 @@ class UV:
             - list of latest found patch versions
             - list of installation paths of installed versions
         """
-        ignored_rc, results, ignored_err = self._list_python("--only-installed", *args)
+        dummy_rc, results, dummy_err = self._list_python("--only-installed", *args)
         if results:
             return [result.get("version") for result in results], [result.get("path") for result in results]
         return [], []

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -6,13 +6,15 @@
 DOCUMENTATION = r'''
 ---
 module: uv_python
-short_description: Manage Python installations using uv.
+short_description: Manage Python versions and installations using uv.
 description:
-  - Install, remove or upgrade Python versions managed by uv.
+  - Install, remove or upgrade Python versions managed by uv. 
 version_added: "X.Y"
 requirements:
   - uv must be installed and available on PATH
-  - uv >= 0.8.0
+  - uv version should be at least 0.8.0
+deprecated:
+author: Mariam Ahhttouche (@mriamah)
 options:
   version:
     description: 
@@ -25,27 +27,56 @@ options:
     type: str
     choices: [present, absent, latest]
     default: present
-author:
-  - Mariam Ahhttouche (@mriamah)
-deprecated:
+seealso: 
+  - https://docs.astral.sh/uv/concepts/python-versions/
+  - https://docs.astral.sh/uv/reference/cli/#uv-python
+attributes:
+  - check_mode:
+      description: Can run in check_mode and return changed status prediction without modifying target.
+      support: full
+  - diff_mode:
+      description: Returns details on what has changed (or possibly needs changing in check_mode), when in diff mode.
+      support: none
+
 '''
 
 EXAMPLES = r'''
-- name: Install Python 3.12
-  uv_python:
-    version: "3.12"
+- name: Install Python 3.14
+  mriamah.uv_python:
+    version: "3.14"
 
-- name: Remove Python 3.11
-  uv_python:
-    version: "3.11"
+- name: Remove Python 3.13.5
+  mriamah.uv_python:
+    version: "3.13.5"
     state: absent
+
+- name: Upgrade python 3
+  mriamah.uv_python:
+    version: 3
+    state: latest
 '''
 
 RETURN = r'''
-python:
-  description: Installed Python info
-  returned: when state=present
-  type: dict
+python_versions:
+  description: List of Python versions changed.
+  returned: success
+  type: list
+python_paths:
+  description: List of installation paths of Python versions changed.
+  returned: success
+  type: list
+stdout:
+  description: Stdout of command run.
+  returned: success
+  type: str
+stderr:
+  description: Stderr of command run.
+  returned: success
+  type: str
+rc:
+  description: Return code of command run.
+  returned: success
+  type: int
 '''
 
 import json
@@ -58,11 +89,11 @@ MINIMUM_UV_VERSION = "0.8.0"
 class UV:
     """
       Module for "uv python" command
-      Official documentation for uv python https://docs.astral.sh/uv/concepts/python-versions/#installing-a-python-version
     """
 
     def __init__(self, module):
         self.module = module
+        self._ensure_min_uv_version()
         python_version = module.params["version"]
         try:
           self.python_version = LooseVersion(python_version)
@@ -70,6 +101,18 @@ class UV:
         except ValueError as err:
           self.module.fail_json(
             msg=err
+          )
+
+
+    def _ensure_min_uv_version(self):
+      cmd = [self.module.get_bin_path("uv", required=True), "--version"]
+      _, out, _ = self.module.run_command(cmd, check_rc=True)
+      detected = out.strip().split()[-1]
+      if LooseVersion(detected) < LooseVersion(MINIMUM_UV_VERSION):
+          self.module.fail_json(
+              msg=f"uv_python module requires uv >= {MINIMUM_UV_VERSION}",
+              detected_version=detected,
+              required_version=MINIMUM_UV_VERSION,
           )
 
 

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -10,12 +10,11 @@ module: uv_python
 short_description: Manage Python versions and installations using the C(uv) Python package manager
 description:
   - Install, uninstall or upgrade Python versions managed by C(uv).
-version_added: "12.5.0"
+version_added: "13.0.0"
 requirements:
   - C(uv) must be installed and available in E(PATH) and must be at least 0.8.0.
-  - Python version must be at least 3.9.
 extends_documentation_fragment:
-  - community.general.attributes
+  - community.general._attributes
 attributes:
   check_mode:
     support: full
@@ -312,7 +311,7 @@ class UV:
                 result["parsed_version"] = StrictVersion(version)
                 valid_results.append(result)
             except ValueError:
-                self.module.debug(f"Found {version} available, but it's not yet supported by uv_python module.")
+                self.module.debug(f"Found {version!r} available, but it's not yet supported by uv_python module.")
         return valid_results
 
     @staticmethod

--- a/plugins/modules/uv_python.py
+++ b/plugins/modules/uv_python.py
@@ -331,7 +331,7 @@ class UV:
                 result["parsed_version"] = StrictVersion(version)
                 valid_results.append(result)
             except ValueError:
-                self.module.debug(f"Found {version!r} available, but it's not yet supported by uv_python module.")
+                self.module.debug(f"Filtering out version {version!r} since it's not supported by uv_python module.")
         return valid_results
 
     @staticmethod

--- a/tests/integration/targets/uv_python/aliases
+++ b/tests/integration/targets/uv_python/aliases
@@ -1,0 +1,9 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+uv_python
+uv
+python
+skip/python2
+skip/windows

--- a/tests/integration/targets/uv_python/aliases
+++ b/tests/integration/targets/uv_python/aliases
@@ -5,3 +5,4 @@
 azp/posix/2
 destructive
 skip/macos  # TODO executables are installed in /Library/Frameworks/Python.framework/Versions/3.x/bin, which isn't part of $PATH
+skip/freebsd

--- a/tests/integration/targets/uv_python/aliases
+++ b/tests/integration/targets/uv_python/aliases
@@ -7,3 +7,5 @@ destructive
 skip/python2
 skip/python3.8
 skip/windows
+skip/freebsd
+skip/rhel

--- a/tests/integration/targets/uv_python/aliases
+++ b/tests/integration/targets/uv_python/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-uv_python
-uv
-python
+azp/posix/2
+destructive
 skip/python2
+skip/python3.8
 skip/windows

--- a/tests/integration/targets/uv_python/aliases
+++ b/tests/integration/targets/uv_python/aliases
@@ -4,8 +4,4 @@
 
 azp/posix/2
 destructive
-skip/python2
-skip/python3.8
-skip/windows
-skip/freebsd
-skip/rhel
+skip/macos  # TODO executables are installed in /Library/Frameworks/Python.framework/Versions/3.x/bin, which isn't part of $PATH

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -39,7 +39,7 @@
     that:
       - install_check_mode.changed is true
       - install_check_mode.failed is false
-      - '"3.14" in install_check_mode.msg'
+      - '"3.14" in install_check_mode.stdout'
 
 - name: Install python 3.14
   uv_python:
@@ -52,7 +52,7 @@
     that:
       - install_python.changed is true
       - install_python.failed is false
-      - '"3.14" in install_python.msg'
+      - '"3.14" in install_python.stdout'
 
 - name: Re-install python 3.14
   uv_python:
@@ -65,7 +65,7 @@
     that:
       - reinstall_python.changed is false
       - reinstall_python.failed is false
-      - '"3.14" in reinstall_python.msg'
+      - '"3.14" in reinstall_python.stdout'
 
 - name: Install latest python 3.15 # installs latest patch version for 3.15
   uv_python:
@@ -78,7 +78,7 @@
     that:
       - install_latest_python.changed is true
       - install_latest_python.failed is false
-      - '"3.15" in install_latest_python.msg'
+      - '"3.15" in install_latest_python.stdout'
 
 - name: Install python 3.13.5
   uv_python:
@@ -91,7 +91,7 @@
     that:
       - install_python.changed is true
       - install_python.failed is false
-      - '"3.13.5" in install_python.msg'
+      - '"3.13.5" in install_python.stdout'
 
 - name: Re-install python 3.13.5
   uv_python:
@@ -104,7 +104,7 @@
     that:
       - reinstall_python.changed is false
       - reinstall_python.failed is false
-      - '"3.13.5" in reinstall_python.msg'
+      - '"3.13.5" in reinstall_python.stdout'
 
 - name: Remove unexisting python 3.10 # removes latest patch version for 3.10 if exists
   uv_python:
@@ -117,7 +117,7 @@
     that:
       - remove_python.changed is false
       - remove_python.failed is false
-      - 'remove_python.msg == ""'
+      - 'remove_python.stdout == ""'
 
 - name: Remove python 3.13.5 in check mode
   uv_python:
@@ -131,7 +131,7 @@
     that:
       - remove_python_in_check_mode.changed is true
       - remove_python_in_check_mode.failed is false
-      - '"3.13.5" in remove_python_in_check_mode.msg'
+      - '"3.13.5" in remove_python_in_check_mode.stdout'
 
 - name: Remove python 3.13.5
   uv_python:
@@ -144,7 +144,7 @@
     that:
       - remove_python.changed is true
       - remove_python.failed is false
-      - '"3.13.5" in remove_python_in_check_mode.msg'
+      - '"3.13.5" in remove_python_in_check_mode.stdout'
 
 - name: Remove python 3.13.5 again
   uv_python:
@@ -157,7 +157,7 @@
     that:
       - remove_python.changed is false
       - remove_python.failed is false
-      - 'remove_python.msg == ""'
+      - 'remove_python.stdout == ""'
 
 - name: Install python 3
   uv_python:
@@ -183,7 +183,7 @@
     that:
       - upgrade_python.changed is true
       - upgrade_python.failed is false
-      - '"3.13" in upgrade_python.msg'
+      - '"3.13" in upgrade_python.stdout'
 
 - name: Upgrade python 3.13 in check mode
   uv_python:
@@ -197,7 +197,7 @@
     that:
       - upgrade_python.changed is false
       - upgrade_python.failed is false
-      - '"3.13" in upgrade_python.msg'
+      - '"3.13" in upgrade_python.stdout'
 
 - name: Install unexisting python version in check mode
   uv_python:

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -13,54 +13,78 @@
     curl -LsSf https://astral.sh/uv/install.sh | sh
   environment:
     UV_INSTALL_DIR: /usr/local/bin
+
+- name: Install python 3.14 in check mode
+  uv_python:
+    version: 3.14
+    state: present
+  check_mode: yes
+
 - name: Install python 3.14
   uv_python:
     version: 3.14
     state: present
+
 - name: Re-install python 3.14 # installs latest patch version for 3.14
   uv_python:
     version: 3.14
     state: present
+
 - name: Install latest python 3.14 # installs latest patch version for 3.14
   uv_python:
     version: 3.14
     state: latest
+
 - name: Install python 3.13.5
   uv_python:
     version: 3.13.5
     state: present
+
 - name: Re-install python 3.13.5
   uv_python:
     version: 3.13.5
     state: present
+
 - name: Remove unexisting python 3.15 # removes latest patch version for 3.15 if exists
   uv_python:
     version: 3.15
     state: absent
+
 - name: Remove globally existing python 3.8
   uv_python:
     version: 3.8
     state: absent
+
 - name: Remove python 3.13.5
   uv_python:
     version: 3.13.5
     state: absent
+
 - name: Remove python 3.13.5 again
   uv_python:
     version: 3.13.5
     state: absent
+
 - name: Install python 3
   uv_python:
     version: 3
     state: present
   register: result
   ignore_errors: true
+
 - name: Assert invalid version failed
   ansible.builtin.assert:
     that:
       - result is failed
       - "'Expected formats are X.Y or X.Y.Z' in result.msg"
+
 - name: Upgrade python 3.13
   uv_python:
     version: 3.13
     state: latest
+
+- name: Upgrade python 3.13 in check mode
+  uv_python:
+    version: 3.13
+    state: latest
+  check_mode: yes

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -27,41 +27,6 @@
   environment:
     UV_INSTALL_DIR: /usr/local/bin
 
-- name: Install python 3
-  uv_python:
-    version: 3
-    state: present
-  register: python_install
-
-- name: Assert python 3 is installed
-  ansible.builtin.assert:
-    that:
-      - python_install.failed is false
-      - python_install.python_versions | length >= 1
-
-- name: Upgrade python 3
-  uv_python:
-    version: 3
-    state: latest
-  register: python_install
-
-- name: Assert python 3 upgraded
-  ansible.builtin.assert:
-    that:
-      - python_install.failed is false
-      - python_install.python_versions | length >= 1
-
-- name: Remove python 3
-  uv_python:
-    version: 3
-    state: absent
-  register: python_delete
-
-- name: Assert python 3 deleted
-  ansible.builtin.assert:
-    that:
-      - python_delete.failed is false
-
 - name: Install python 3.14 in check mode
   uv_python:
     version: 3.14

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -29,3 +29,19 @@
   uv_python:
     version: 3.13.5
     state: present
+- name: Remove unexisting python 3.15
+  uv_python:
+    version: 3.15
+    state: absent
+- name: Remove globally existing python 3.8
+  uv_python:
+    version: 3.8
+    state: absent
+- name: Remove python 3.13.5
+  uv_python:
+    version: 3.13.5
+    state: absent
+- name: Remove python 3.13.5 again
+  uv_python:
+    version: 3.13.5
+    state: absent

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -50,6 +50,12 @@
     version: 3.15
     state: absent
 
+- name: Remove globally existing python 3.8 in check mode
+  uv_python:
+    version: 3.8
+    state: absent
+  check_mode: true
+
 - name: Remove globally existing python 3.8
   uv_python:
     version: 3.8

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -21,6 +21,10 @@
   uv_python:
     version: 3.14
     state: present
+- name: Install latest python 3.14 # installs latest patch version for 3.14
+  uv_python:
+    version: 3.14
+    state: latest
 - name: Install python 3.13.5
   uv_python:
     version: 3.13.5
@@ -55,4 +59,8 @@
   ansible.builtin.assert:
     that:
       - result is failed
-      - "'Expected X.Y or X.Y.Z' in result.msg"
+      - "'Expected formats are X.Y or X.Y.Z' in result.msg"
+- name: Upgrade python 3.13
+  uv_python:
+    version: 3.13
+    state: latest

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -133,7 +133,7 @@
     that:
       - remove_python_in_check_mode.changed is true
       - remove_python_in_check_mode.failed is false
-      - 'remove_python_in_check_mode.msg == ""'
+      - '"3.13.5" in remove_python_in_check_mode.msg'
 
 - name: Remove python 3.13.5
   uv_python:
@@ -146,7 +146,7 @@
     that:
       - remove_python.changed is true
       - remove_python.failed is false
-      - 'remove_python.msg == ""'
+      - '"3.13.5" in remove_python_in_check_mode.msg'
 
 - name: Remove python 3.13.5 again
   uv_python:
@@ -154,7 +154,7 @@
     state: absent
   register: remove_python
 
-- name: Verify python 3.13.5 deletion
+- name: Verify python 3.13.5 deletion again
   assert:
     that:
       - remove_python.changed is false
@@ -194,7 +194,7 @@
   check_mode: yes
   register: upgrade_python
 
-- name: Verify python 3.13.5 deletion in check mode
+- name: Verify python 3.13 deletion in check mode
   assert:
     that:
       - upgrade_python.changed is false
@@ -208,7 +208,7 @@
   register: unexisting_python
   ignore_errors: true
 
-- name: Verify python 3.13.5 deletion in check mode
+- name: Verify python 3.12.13 deletion
   assert:
     that:
       - unexisting_python.changed is false
@@ -222,9 +222,9 @@
   register: unexisting_python
   ignore_errors: true
 
-- name: Verify python 3.13.5 deletion in check mode
+- name: Verify python 3.12.13 deletion
   assert:
     that:
       - unexisting_python.changed is false
       - unexisting_python.failed is true
-      - '"Version 3.12.13 does not exist" in unexisting_python.msg'
+      - '"Version 3.12.13 is not available" in unexisting_python.msg'

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -39,7 +39,7 @@
     that:
       - install_check_mode.changed is true
       - install_check_mode.failed is false
-      - '"3.14" in install_check_mode.python_version'
+      - 'install_check_mode.python_versions != []'
 
 - name: Install python 3.14
   uv_python:
@@ -47,12 +47,12 @@
     state: present
   register: install_python
 
-- name: Verify python 3.14 installation in check mode
+- name: Verify python 3.14 installation
   assert:
     that:
       - install_python.changed is true
       - install_python.failed is false
-      - '"3.14" in install_python.python_version'
+      - 'install_python.python_versions != []'
 
 - name: Re-install python 3.14
   uv_python:
@@ -65,7 +65,7 @@
     that:
       - reinstall_python.changed is false
       - reinstall_python.failed is false
-      - '"3.14" in reinstall_python.python_version'
+      - 'reinstall_python.python_versions != []'
 
 - name: Install latest python 3.15 # installs latest patch version for 3.15
   uv_python:
@@ -78,7 +78,7 @@
     that:
       - install_latest_python.changed is true
       - install_latest_python.failed is false
-      - '"3.15" in install_latest_python.stdout'
+      - 'install_latest_python.stdout != []'
 
 - name: Install python 3.13.5
   uv_python:
@@ -91,7 +91,7 @@
     that:
       - install_python.changed is true
       - install_python.failed is false
-      - '"3.13.5" in install_python.python_version'
+      - 'install_python.python_versions != []'
 
 - name: Re-install python 3.13.5
   uv_python:
@@ -104,7 +104,7 @@
     that:
       - reinstall_python.changed is false
       - reinstall_python.failed is false
-      - '"3.13.5" in reinstall_python.python_version'
+      - 'reinstall_python.python_versions != []'
 
 - name: Remove unexisting python 3.10 # removes latest patch version for 3.10 if exists
   uv_python:
@@ -117,7 +117,7 @@
     that:
       - remove_python.changed is false
       - remove_python.failed is false
-      - 'remove_python.stdout == ""'
+      - 'remove_python.python_versions == []'
 
 - name: Remove python 3.13.5 in check mode
   uv_python:
@@ -131,7 +131,7 @@
     that:
       - remove_python_in_check_mode.changed is true
       - remove_python_in_check_mode.failed is false
-      - '"3.13.5" in remove_python_in_check_mode.stdout'
+      - 'remove_python_in_check_mode.python_versions != []'
 
 - name: Remove python 3.13.5
   uv_python:
@@ -144,7 +144,7 @@
     that:
       - remove_python.changed is true
       - remove_python.failed is false
-      - '"3.13.5" in remove_python_in_check_mode.stdout'
+      - 'remove_python_in_check_mode.python_versions != []'
 
 - name: Remove python 3.13.5 again
   uv_python:
@@ -157,7 +157,7 @@
     that:
       - remove_python.changed is false
       - remove_python.failed is false
-      - 'remove_python.stdout == ""'
+      - 'remove_python.python_versions == []'
 
 - name: Install python 3
   uv_python:
@@ -183,7 +183,7 @@
     that:
       - upgrade_python.changed is true
       - upgrade_python.failed is false
-      - '"3.13" in upgrade_python.stdout'
+      - 'upgrade_python.python_versions != []'
 
 - name: Upgrade python 3.13 in check mode
   uv_python:
@@ -197,7 +197,7 @@
     that:
       - upgrade_python.changed is false
       - upgrade_python.failed is false
-      - '"3.13" in upgrade_python.stdout'
+      - 'upgrade_python.python_versions != []'
 
 - name: Upgrade python 3.13 again
   uv_python:
@@ -211,7 +211,7 @@
     that:
       - upgrade_python.changed is false
       - upgrade_python.failed is false
-      - '"3.13" in upgrade_python.stdout'
+      - 'upgrade_python.python_versions != []'
 
 - name: Install unexisting python version in check mode
   uv_python:

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -39,46 +39,52 @@
     that:
       - install_check_mode.changed is true
       - install_check_mode.failed is false
-      - 'install_check_mode.python_versions != []'
+      - install_check_mode.python_versions | length >= 1
 
 - name: Install python 3.14
   uv_python:
     version: 3.14
     state: present
   register: install_python
-
+- debug:
+    var: install_python
 - name: Verify python 3.14 installation
   assert:
     that:
       - install_python.changed is true
       - install_python.failed is false
-      - 'install_python.python_versions != []'
+      - install_python.python_versions | length >= 1
+      - install_python.python_paths | length >= 1
 
 - name: Re-install python 3.14
   uv_python:
     version: 3.14
     state: present
   register: reinstall_python
-
+- debug:
+    var: install_python
 - name: Verify python 3.14 re-installation
   assert:
     that:
       - reinstall_python.changed is false
       - reinstall_python.failed is false
-      - 'reinstall_python.python_versions != []'
+      - reinstall_python.python_versions | length >= 1
+      - reinstall_python.python_paths | length >= 1
 
 - name: Install latest python 3.15 # installs latest patch version for 3.15
   uv_python:
     version: 3.15
     state: latest
   register: install_latest_python
-
+- debug:
+    var: install_latest_python
 - name: Verify python 3.15 installation
   assert:
     that:
       - install_latest_python.changed is true
       - install_latest_python.failed is false
-      - 'install_latest_python.stdout != []'
+      - install_latest_python.python_versions | length >= 1
+      - install_latest_python.python_paths | length >= 1
 
 - name: Install python 3.13.5
   uv_python:
@@ -91,33 +97,37 @@
     that:
       - install_python.changed is true
       - install_python.failed is false
-      - 'install_python.python_versions != []'
+      # - install_python.python_versions | length >= 1
+      - '"3.13.5" in install_python.python_versions'
+      - install_python.python_paths | length >= 1
 
 - name: Re-install python 3.13.5
   uv_python:
     version: 3.13.5
     state: present
   register: reinstall_python
-
+- debug:
+    var: reinstall_python
 - name: Verify python 3.13.5 installation
   assert:
     that:
       - reinstall_python.changed is false
       - reinstall_python.failed is false
-      - 'reinstall_python.python_versions != []'
+      - '"3.13.5" in reinstall_python.python_versions'
 
-- name: Remove unexisting python 3.10 # removes latest patch version for 3.10 if exists
+- name: Remove uninstalled python 3.10 # removes latest patch version for 3.10 if exists
   uv_python:
     version: 3.10
     state: absent
   register: remove_python
-
+- debug:
+    var: remove_python
 - name: Verify python 3.10 deletion
   assert:
     that:
       - remove_python.changed is false
       - remove_python.failed is false
-      - 'remove_python.python_versions == []'
+      - remove_python.python_versions | length == 0
 
 - name: Remove python 3.13.5 in check mode
   uv_python:
@@ -125,39 +135,45 @@
     state: absent
   check_mode: true
   register: remove_python_in_check_mode
-
+- debug:
+    var: remove_python_in_check_mode
 - name: Verify python 3.13.5 deletion in check mode
   assert:
     that:
       - remove_python_in_check_mode.changed is true
       - remove_python_in_check_mode.failed is false
-      - 'remove_python_in_check_mode.python_versions != []'
+      - '"3.13.5" in remove_python_in_check_mode.python_versions'
+      - remove_python_in_check_mode.python_paths | length >= 1
 
 - name: Remove python 3.13.5
   uv_python:
     version: 3.13.5
     state: absent
   register: remove_python
-
+- debug:
+    var: remove_python
 - name: Verify python 3.13.5 deletion
   assert:
     that:
       - remove_python.changed is true
       - remove_python.failed is false
-      - 'remove_python_in_check_mode.python_versions != []'
+      - remove_python.python_paths | length >= 1
+      - '"3.13.5" in remove_python.python_versions'
 
 - name: Remove python 3.13.5 again
   uv_python:
     version: 3.13.5
     state: absent
   register: remove_python
-
+- debug:
+    var: remove_python
 - name: Verify python 3.13.5 deletion again
   assert:
     that:
       - remove_python.changed is false
       - remove_python.failed is false
-      - 'remove_python.python_versions == []'
+      - remove_python.python_versions | length == 0
+      - remove_python.python_paths | length == 0
 
 - name: Install python 3
   uv_python:
@@ -177,13 +193,15 @@
     version: 3.13
     state: latest
   register: upgrade_python
-
+- debug:
+    var: upgrade_python
 - name: Verify python 3.13 upgrade
   assert:
     that:
       - upgrade_python.changed is true
       - upgrade_python.failed is false
-      - 'upgrade_python.python_versions != []'
+      - upgrade_python.python_versions | length >= 1
+      - upgrade_python.python_paths | length >= 1
 
 - name: Upgrade python 3.13 in check mode
   uv_python:
@@ -191,13 +209,14 @@
     state: latest
   check_mode: yes
   register: upgrade_python
-
+- debug:
+    var: upgrade_python
 - name: Verify python 3.13 upgrade in check mode
   assert:
     that:
       - upgrade_python.changed is false
       - upgrade_python.failed is false
-      - 'upgrade_python.python_versions != []'
+      - upgrade_python.python_versions | length >= 1
 
 - name: Upgrade python 3.13 again
   uv_python:
@@ -205,13 +224,14 @@
     state: latest
   check_mode: yes
   register: upgrade_python
-
+- debug:
+    var: upgrade_python
 - name: Verify python 3.13 upgrade again
   assert:
     that:
       - upgrade_python.changed is false
       - upgrade_python.failed is false
-      - 'upgrade_python.python_versions != []'
+      - upgrade_python.python_versions | length >= 1
 
 - name: Install unexisting python version in check mode
   uv_python:
@@ -220,7 +240,8 @@
   register: unexisting_python_check_mode
   ignore_errors: true
   check_mode: true
-
+- debug:
+    var: unexisting_python_check_mode
 - name: Verify unexisting python 3.12.13 install in check mode
   assert:
     that:
@@ -234,7 +255,8 @@
     state: present
   register: unexisting_python
   ignore_errors: true
-
+- debug:
+    var: unexisting_python
 - name: Verify unexisting python 3.12.13 install
   assert:
     that:
@@ -247,9 +269,32 @@
     state: latest
   register: unexisting_python
   ignore_errors: true
-
-- name: Verify python 3.12.13 deletion with latest state
+- debug:
+    var: unexisting_python
+- name: Verify python 3.12.13 install with latest state
   assert:
     that:
       - unexisting_python.changed is false
       - unexisting_python.failed is true
+
+- name: Install python 3.13.11 version
+  uv_python:
+    version: 3.13.11
+    state: present
+
+- name: Delete python 3.13 version
+  uv_python:
+    version: 3.13
+    state: absent
+  register: uninstall_result
+
+- debug:
+    var: uninstall_result
+
+- name: Verify python 3.13 deletion
+  assert:
+    that:
+      - uninstall_result.changed is true
+      - uninstall_result.failed is false
+      - '"3.13.11" in uninstall_result.python_versions'
+      - uninstall_result.python_versions | length >= 2

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -1,0 +1,31 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Install uv
+  shell: |
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+  environment:
+    UV_INSTALL_DIR: /usr/local/bin
+- name: Install python 3.14
+  uv_python:
+    version: 3.14
+    state: present
+- name: Re-install python 3.14
+  uv_python:
+    version: 3.14
+    state: present
+- name: Install python 3.13.5
+  uv_python:
+    version: 3.13.5
+    state: present
+- name: Re-install python 3.13.5
+  uv_python:
+    version: 3.13.5
+    state: present

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -19,78 +19,170 @@
     version: 3.14
     state: present
   check_mode: yes
+  register: install_check_mode
+
+- name: Verify python 3.14 installation in check mode
+  assert:
+    that:
+      - install_check_mode["changed"] is true
+      - install_check_mode["failed"] is false
+      - '"3.14" in install_check_mode["msg"]'
 
 - name: Install python 3.14
   uv_python:
     version: 3.14
     state: present
+  register: install_python
 
-- name: Re-install python 3.14 # installs latest patch version for 3.14
+- name: Verify python 3.14 installation in check mode
+  assert:
+    that:
+      - install_python["changed"] is true
+      - install_python["failed"] is false
+      - '"3.14" in install_python["msg"]'
+
+- name: Re-install python 3.14
   uv_python:
     version: 3.14
     state: present
+  register: reinstall_python
 
-- name: Install latest python 3.14 # installs latest patch version for 3.14
+- name: Verify python 3.14 re-installation
+  assert:
+    that:
+      - reinstall_python["changed"] is false
+      - reinstall_python["failed"] is false
+      - '"3.14" in reinstall_python["msg"]'
+
+- name: Install latest python 3.15 # installs latest patch version for 3.15
   uv_python:
-    version: 3.14
+    version: 3.15
     state: latest
+  register: install_latest_python
+- debug:
+    var: install_latest_python
+- name: Verify python 3.15 installation
+  assert:
+    that:
+      - install_latest_python["changed"] is true
+      - install_latest_python["failed"] is false
+      - '"3.15" in install_latest_python["msg"]'
 
 - name: Install python 3.13.5
   uv_python:
     version: 3.13.5
     state: present
+  register: install_python
+
+- name: Verify python 3.13.5 installation
+  assert:
+    that:
+      - install_python["changed"] is true
+      - install_python["failed"] is false
+      - '"3.13.5" in install_python["msg"]'
 
 - name: Re-install python 3.13.5
   uv_python:
     version: 3.13.5
     state: present
+  register: reinstall_python
 
-- name: Remove unexisting python 3.15 # removes latest patch version for 3.15 if exists
+- name: Verify python 3.13.5 installation
+  assert:
+    that:
+      - reinstall_python["changed"] is false
+      - reinstall_python["failed"] is false
+      - '"3.13.5" in reinstall_python["msg"]'
+
+- name: Remove unexisting python 3.10 # removes latest patch version for 3.10 if exists
   uv_python:
-    version: 3.15
+    version: 3.10
     state: absent
+  register: remove_python
 
-- name: Remove globally existing python 3.8 in check mode
+- name: Verify python 3.10 deletion
+  assert:
+    that:
+      - remove_python["changed"] is false
+      - remove_python["failed"] is false
+      - 'remove_python["msg"] == ""'
+
+- name: Remove python 3.13.5 in check mode
   uv_python:
-    version: 3.8
+    version: 3.13.5
     state: absent
   check_mode: true
+  register: remove_python_in_check_mode
 
-- name: Remove globally existing python 3.8
-  uv_python:
-    version: 3.8
-    state: absent
+- name: Verify python 3.13.5 deletion in check mode
+  assert:
+    that:
+      - remove_python_in_check_mode["changed"] is true
+      - remove_python_in_check_mode["failed"] is false
+      - 'remove_python_in_check_mode["msg"] == ""'
 
 - name: Remove python 3.13.5
   uv_python:
     version: 3.13.5
     state: absent
+  register: remove_python
+
+- name: Verify python 3.13.5 deletion
+  assert:
+    that:
+      - remove_python["changed"] is true
+      - remove_python["failed"] is false
+      - 'remove_python["msg"] == ""'
 
 - name: Remove python 3.13.5 again
   uv_python:
     version: 3.13.5
     state: absent
+  register: remove_python
+
+- name: Verify python 3.13.5 deletion
+  assert:
+    that:
+      - remove_python["changed"] is false
+      - remove_python["failed"] is false
+      - 'remove_python["msg"] == ""'
 
 - name: Install python 3
   uv_python:
     version: 3
     state: present
-  register: result
+  register: invalid_version
   ignore_errors: true
 
 - name: Assert invalid version failed
   ansible.builtin.assert:
     that:
-      - result is failed
-      - "'Expected formats are X.Y or X.Y.Z' in result.msg"
+      - invalid_version is failed
+      - "'Expected formats are X.Y or X.Y.Z' in invalid_version.msg"
 
 - name: Upgrade python 3.13
   uv_python:
     version: 3.13
     state: latest
+  register: upgrade_python
+
+- name: Verify python 3.13 upgrade
+  assert:
+    that:
+      - upgrade_python["changed"] is true
+      - upgrade_python["failed"] is false
+      - '"3.13" in upgrade_python["msg"]'
 
 - name: Upgrade python 3.13 in check mode
   uv_python:
     version: 3.13
     state: latest
   check_mode: yes
+  register: upgrade_python
+
+- name: Verify python 3.13.5 deletion in check mode
+  assert:
+    that:
+      - upgrade_python["changed"] is false
+      - upgrade_python["failed"] is false
+      - '"3.13" in upgrade_python["msg"]'

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -39,7 +39,7 @@
     that:
       - install_check_mode.changed is true
       - install_check_mode.failed is false
-      - '"3.14" in install_check_mode.stdout'
+      - '"3.14" in install_check_mode.python_version'
 
 - name: Install python 3.14
   uv_python:
@@ -52,7 +52,7 @@
     that:
       - install_python.changed is true
       - install_python.failed is false
-      - '"3.14" in install_python.stdout'
+      - '"3.14" in install_python.python_version'
 
 - name: Re-install python 3.14
   uv_python:
@@ -65,7 +65,7 @@
     that:
       - reinstall_python.changed is false
       - reinstall_python.failed is false
-      - '"3.14" in reinstall_python.stdout'
+      - '"3.14" in reinstall_python.python_version'
 
 - name: Install latest python 3.15 # installs latest patch version for 3.15
   uv_python:
@@ -91,7 +91,7 @@
     that:
       - install_python.changed is true
       - install_python.failed is false
-      - '"3.13.5" in install_python.stdout'
+      - '"3.13.5" in install_python.python_version'
 
 - name: Re-install python 3.13.5
   uv_python:
@@ -104,7 +104,7 @@
     that:
       - reinstall_python.changed is false
       - reinstall_python.failed is false
-      - '"3.13.5" in reinstall_python.stdout'
+      - '"3.13.5" in reinstall_python.python_version'
 
 - name: Remove unexisting python 3.10 # removes latest patch version for 3.10 if exists
   uv_python:
@@ -192,7 +192,21 @@
   check_mode: yes
   register: upgrade_python
 
-- name: Verify python 3.13 deletion in check mode
+- name: Verify python 3.13 upgrade in check mode
+  assert:
+    that:
+      - upgrade_python.changed is false
+      - upgrade_python.failed is false
+      - '"3.13" in upgrade_python.stdout'
+
+- name: Upgrade python 3.13 again
+  uv_python:
+    version: 3.13
+    state: latest
+  check_mode: yes
+  register: upgrade_python
+
+- name: Verify python 3.13 upgrade again
   assert:
     that:
       - upgrade_python.changed is false

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -8,6 +8,20 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+- name: Install python 3.14 when no uv executable exists
+  uv_python:
+    version: 3.14
+    state: present
+  check_mode: yes
+  register: failed_install
+  ignore_errors: true
+
+- name: Verify python 3.14 installation failed
+  assert:
+    that:
+      - failed_install["failed"] is true
+      - '"Failed to find required executable" in failed_install["msg"]'
+
 - name: Install uv
   shell: |
     curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -17,7 +17,7 @@
   uv_python:
     version: 3.14
     state: present
-- name: Re-install python 3.14
+- name: Re-install python 3.14 # installs latest patch version for 3.14
   uv_python:
     version: 3.14
     state: present
@@ -29,7 +29,7 @@
   uv_python:
     version: 3.13.5
     state: present
-- name: Remove unexisting python 3.15
+- name: Remove unexisting python 3.15 # removes latest patch version for 3.15 if exists
   uv_python:
     version: 3.15
     state: absent
@@ -45,3 +45,14 @@
   uv_python:
     version: 3.13.5
     state: absent
+- name: Install python 3
+  uv_python:
+    version: 3
+    state: present
+  register: result
+  ignore_errors: true
+- name: Assert invalid version failed
+  ansible.builtin.assert:
+    that:
+      - result is failed
+      - "'Expected X.Y or X.Y.Z' in result.msg"

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -12,10 +12,15 @@
   ansible.builtin.pip:
     name: uv
 
+- name: Add uv installation directory to PATH in macOS
+  shell: export PATH="$(python3 -m site --user-base)/bin:$PATH"
+  when: ansible_facts['os_family'] == "Darwin"
+  
 - name: Check if Python 3.14 exists already
   command: uv python find 3.14
   ignore_errors: true
   register: check_python_314_exists
+  changed_when: false
 
 - name: Install Python 3.14 in check mode
   uv_python:
@@ -63,6 +68,7 @@
   command: uv python find 3.13.5
   ignore_errors: true
   register: check_python_3135_exists
+  changed_when: false
 
 - name: Install Python 3.13.5
   uv_python:

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -8,11 +8,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: Install uv
-  shell: |
-    curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.10.5/uv-installer.sh | sh
-  environment:
-    UV_INSTALL_DIR: /usr/local/bin
+- name: Install uv python package
+  ansible.builtin.pip:
+    name: uv
 
 - name: Check if Python 3.14 exists already
   command: uv python find 3.14
@@ -200,46 +198,46 @@
       - upgrade_python.failed is false
       - upgrade_python.python_versions | length >= 1
 
-- name: Install unexisting Python version in check mode
+- name: Install unsupported Python version in check mode
   uv_python:
-    version: 3.12.13
+    version: 2.0
     state: present
-  register: unexisting_python_check_mode
+  register: unsupported_python_check_mode
   ignore_errors: true
   check_mode: true
 
-- name: Verify unexisting Python 3.12.13 install in check mode
+- name: Verify unsupported Python 2.0 install in check mode
   assert:
     that:
-      - unexisting_python_check_mode.changed is false
-      - unexisting_python_check_mode.failed is true
-      - '"Version 3.12.13 is not available." in unexisting_python_check_mode.msg'
+      - unsupported_python_check_mode.changed is false
+      - unsupported_python_check_mode.failed is true
+      - '"Version 2.0 is not available." in unsupported_python_check_mode.msg'
 
-- name: Install unexisting Python version
+- name: Install unsupported Python version
   uv_python:
     state: present
-    version: 3.12.13
-  register: unexisting_python
+    version: 2.0
+  register: unsupported_python
   ignore_errors: true
 
-- name: Verify unexisting Python 3.12.13 install
+- name: Verify unsupported Python 2.0 install
   assert:
     that:
-      - unexisting_python.changed is false
-      - unexisting_python.failed is true
+      - unsupported_python.changed is false
+      - unsupported_python.failed is true
 
-- name: Install unexisting Python version with latest state
+- name: Install unsupported Python version with latest state
   uv_python:
-    version: 3.12.13
+    version: 2.0
     state: latest
-  register: unexisting_python
+  register: unsupported_python
   ignore_errors: true
 
-- name: Verify Python 3.12.13 install with latest state
+- name: Verify Python 2.0 install with latest state
   assert:
     that:
-      - unexisting_python.changed is false
-      - unexisting_python.failed is true
+      - unsupported_python.changed is false
+      - unsupported_python.failed is true
 
 - name: Delete Python 3.13 version
   uv_python:

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -66,22 +66,18 @@
   ignore_errors: true
   register: check_python_3135_exists
 
-- name: Check if Python
-  command: uv python list
-  ignore_errors: true
-
 - name: Install Python 3.13.5
   uv_python:
     version: 3.13.5
-  register: install_python
+  register: install_python_3135
 
 - name: Verify Python 3.13.5 installation
   assert:
     that:
-      - install_python.changed == check_python_3135_exists.failed
-      - install_python.failed is false
-      - '"3.13.5" in install_python.python_versions'
-      - install_python.python_paths | length >= 1
+      - install_python_3135.changed == check_python_3135_exists.failed
+      - install_python_3135.failed is false
+      - '"3.13.5" in install_python_3135.python_versions'
+      - install_python_3135.python_paths | length >= 1
 
 - name: Re-install Python 3.13.5
   uv_python:
@@ -119,8 +115,13 @@
 - name: Verify Python 3.13.5 deletion in check mode
   assert:
     that:
-      - remove_python_in_check_mode.changed is true
+      - remove_python_in_check_mode.changed == install_python_3135.changed
       - remove_python_in_check_mode.failed is false
+
+- name: Additional check for Python 3.13.5 deletion in check mode
+  when: install_python_3135.changed is true
+  assert:
+    that:
       - '"3.13.5" in remove_python_in_check_mode.python_versions'
       - remove_python_in_check_mode.python_paths | length >= 1
 
@@ -133,8 +134,13 @@
 - name: Verify Python 3.13.5 deletion
   assert:
     that:
-      - remove_python.changed is true
+      - remove_python.changed == install_python_3135.changed
       - remove_python.failed is false
+
+- name: Additional check for Python 3.13.5 deletion
+  when: install_python_3135.changed is true
+  assert:
+    that:
       - remove_python.python_paths | length >= 1
       - '"3.13.5" in remove_python.python_versions'
 

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -257,6 +257,7 @@
 - name: No specified version
   uv_python:
     state: latest
+    version: ""
   ignore_errors: true
   register: no_version
 
@@ -264,3 +265,17 @@
   assert:
     that:
       - no_version.failed is true
+      - '"Unsupported version format" in no_version.msg'
+
+- name: Unsupported version format given
+  uv_python:
+    state: latest
+    version: "3.8.post2"
+  ignore_errors: true
+  register: wrong_version
+
+- name: Verify failure when unsupported version format is specified
+  assert:
+    that:
+      - wrong_version.failed is true
+      - '"Unsupported version format" in wrong_version.msg'

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -12,10 +12,6 @@
   ansible.builtin.pip:
     name: uv
 
-- name: Add uv installation directory to PATH in macOS
-  shell: export PATH="$(python3 -m site --user-base)/bin:$PATH"
-  when: ansible_facts['os_family'] == "Darwin"
-  
 - name: Check if Python 3.14 exists already
   command: uv python find 3.14
   ignore_errors: true

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -20,7 +20,7 @@
 
 - name: Install Python 3.14 in check mode
   uv_python:
-    version: 3.14
+    version: "3.14"
     state: present
   check_mode: true
   register: install_check_mode
@@ -34,7 +34,7 @@
 
 - name: Install Python 3.14
   uv_python:
-    version: 3.14
+    version: "3.14"
     state: present
   register: install_python
 
@@ -48,15 +48,15 @@
 
 - name: Re-install Python 3.14
   uv_python:
-    version: 3.14
+    version: "3.14"
     state: present
   register: reinstall_python
 
 - name: Verify Python 3.14 re-installation
   assert:
     that:
-      - reinstall_python.changed is false
-      - reinstall_python.failed is false
+      - reinstall_python is not changed
+      - reinstall_python is not failed
       - reinstall_python.python_versions | length >= 1
       - reinstall_python.python_paths | length >= 1
 
@@ -230,7 +230,7 @@
 
 - name: Install unsupported Python version with latest state
   uv_python:
-    version: 2.0
+    version: "2.0"
     state: latest
   register: unsupported_python
   ignore_errors: true
@@ -243,7 +243,7 @@
 
 - name: Delete Python 3.13 version
   uv_python:
-    version: 3.13
+    version: "3.13"
     state: absent
   register: uninstall_result
 
@@ -252,7 +252,8 @@
     that:
       - uninstall_result.changed is true
       - uninstall_result.failed is false
-      - '"3.13.12" in uninstall_result.python_versions'
+      - uninstall_result.python_versions | length >= 1
+      - '"3.13" in uninstall_result.python_versions[0]'
 
 - name: No specified version
   uv_python:

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -27,6 +27,41 @@
   environment:
     UV_INSTALL_DIR: /usr/local/bin
 
+- name: Install python 3
+  uv_python:
+    version: 3
+    state: present
+  register: python_install
+
+- name: Assert python 3 is installed
+  ansible.builtin.assert:
+    that:
+      - python_install.failed is false
+      - python_install.python_versions | length >= 1
+
+- name: Upgrade python 3
+  uv_python:
+    version: 3
+    state: latest
+  register: python_install
+
+- name: Assert python 3 upgraded
+  ansible.builtin.assert:
+    that:
+      - python_install.failed is false
+      - python_install.python_versions | length >= 1
+
+- name: Remove python 3
+  uv_python:
+    version: 3
+    state: absent
+  register: python_delete
+
+- name: Assert python 3 deleted
+  ansible.builtin.assert:
+    that:
+      - python_delete.failed is false
+
 - name: Install python 3.14 in check mode
   uv_python:
     version: 3.14
@@ -46,8 +81,7 @@
     version: 3.14
     state: present
   register: install_python
-- debug:
-    var: install_python
+
 - name: Verify python 3.14 installation
   assert:
     that:
@@ -61,8 +95,7 @@
     version: 3.14
     state: present
   register: reinstall_python
-- debug:
-    var: install_python
+
 - name: Verify python 3.14 re-installation
   assert:
     that:
@@ -71,25 +104,9 @@
       - reinstall_python.python_versions | length >= 1
       - reinstall_python.python_paths | length >= 1
 
-- name: Install latest python 3.15 # installs latest patch version for 3.15
-  uv_python:
-    version: 3.15
-    state: latest
-  register: install_latest_python
-- debug:
-    var: install_latest_python
-- name: Verify python 3.15 installation
-  assert:
-    that:
-      - install_latest_python.changed is true
-      - install_latest_python.failed is false
-      - install_latest_python.python_versions | length >= 1
-      - install_latest_python.python_paths | length >= 1
-
 - name: Install python 3.13.5
   uv_python:
     version: 3.13.5
-    state: present
   register: install_python
 
 - name: Verify python 3.13.5 installation
@@ -97,7 +114,6 @@
     that:
       - install_python.changed is true
       - install_python.failed is false
-      # - install_python.python_versions | length >= 1
       - '"3.13.5" in install_python.python_versions'
       - install_python.python_paths | length >= 1
 
@@ -106,8 +122,7 @@
     version: 3.13.5
     state: present
   register: reinstall_python
-- debug:
-    var: reinstall_python
+
 - name: Verify python 3.13.5 installation
   assert:
     that:
@@ -117,11 +132,10 @@
 
 - name: Remove uninstalled python 3.10 # removes latest patch version for 3.10 if exists
   uv_python:
-    version: 3.10
+    version: "3.10"
     state: absent
   register: remove_python
-- debug:
-    var: remove_python
+
 - name: Verify python 3.10 deletion
   assert:
     that:
@@ -135,8 +149,7 @@
     state: absent
   check_mode: true
   register: remove_python_in_check_mode
-- debug:
-    var: remove_python_in_check_mode
+
 - name: Verify python 3.13.5 deletion in check mode
   assert:
     that:
@@ -150,8 +163,7 @@
     version: 3.13.5
     state: absent
   register: remove_python
-- debug:
-    var: remove_python
+
 - name: Verify python 3.13.5 deletion
   assert:
     that:
@@ -165,8 +177,7 @@
     version: 3.13.5
     state: absent
   register: remove_python
-- debug:
-    var: remove_python
+
 - name: Verify python 3.13.5 deletion again
   assert:
     that:
@@ -175,26 +186,12 @@
       - remove_python.python_versions | length == 0
       - remove_python.python_paths | length == 0
 
-- name: Install python 3
-  uv_python:
-    version: 3
-    state: present
-  register: invalid_version
-  ignore_errors: true
-
-- name: Assert invalid version failed
-  ansible.builtin.assert:
-    that:
-      - invalid_version is failed
-      - '"Expected formats are X.Y or X.Y.Z" in invalid_version.msg'
-
 - name: Upgrade python 3.13
   uv_python:
     version: 3.13
     state: latest
   register: upgrade_python
-- debug:
-    var: upgrade_python
+
 - name: Verify python 3.13 upgrade
   assert:
     that:
@@ -209,8 +206,7 @@
     state: latest
   check_mode: yes
   register: upgrade_python
-- debug:
-    var: upgrade_python
+
 - name: Verify python 3.13 upgrade in check mode
   assert:
     that:
@@ -224,8 +220,7 @@
     state: latest
   check_mode: yes
   register: upgrade_python
-- debug:
-    var: upgrade_python
+
 - name: Verify python 3.13 upgrade again
   assert:
     that:
@@ -240,8 +235,7 @@
   register: unexisting_python_check_mode
   ignore_errors: true
   check_mode: true
-- debug:
-    var: unexisting_python_check_mode
+
 - name: Verify unexisting python 3.12.13 install in check mode
   assert:
     that:
@@ -251,12 +245,11 @@
 
 - name: Install unexisting python version
   uv_python:
-    version: 3.12.13
     state: present
+    version: 3.12.13
   register: unexisting_python
   ignore_errors: true
-- debug:
-    var: unexisting_python
+
 - name: Verify unexisting python 3.12.13 install
   assert:
     that:
@@ -269,18 +262,12 @@
     state: latest
   register: unexisting_python
   ignore_errors: true
-- debug:
-    var: unexisting_python
+
 - name: Verify python 3.12.13 install with latest state
   assert:
     that:
       - unexisting_python.changed is false
       - unexisting_python.failed is true
-
-- name: Install python 3.13.11 version
-  uv_python:
-    version: 3.13.11
-    state: present
 
 - name: Delete python 3.13 version
   uv_python:
@@ -288,13 +275,20 @@
     state: absent
   register: uninstall_result
 
-- debug:
-    var: uninstall_result
-
 - name: Verify python 3.13 deletion
   assert:
     that:
       - uninstall_result.changed is true
       - uninstall_result.failed is false
-      - '"3.13.11" in uninstall_result.python_versions'
-      - uninstall_result.python_versions | length >= 2
+      - '"3.13.12" in uninstall_result.python_versions'
+
+- name: No specified version
+  uv_python:
+    state: latest
+  ignore_errors: true
+  register: no_version
+
+- name: Verify failure when no version is specified
+  assert:
+    that:
+      - no_version.failed is true

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -8,60 +8,52 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: Install Python 3.14 when no uv executable exists
-  uv_python:
-    version: 3.14
-    state: present
-  check_mode: true
-  register: failed_install
-  ignore_errors: true
-
-- name: Verify python 3.14 installation failed
-  assert:
-    that:
-      - failed_install.failed is true
-
 - name: Install uv
   shell: |
     curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.10.5/uv-installer.sh | sh
   environment:
     UV_INSTALL_DIR: /usr/local/bin
 
-- name: Install python 3.14 in check mode
+- name: Check if Python 3.14 exists already
+  command: uv python find 3.14
+  ignore_errors: true
+  register: check_python_314_exists
+
+- name: Install Python 3.14 in check mode
   uv_python:
     version: 3.14
     state: present
   check_mode: true
   register: install_check_mode
 
-- name: Verify python 3.14 installation in check mode
+- name: Verify Python 3.14 installation in check mode
   assert:
     that:
-      - install_check_mode.changed is true
+      - install_check_mode.changed == check_python_314_exists.failed
       - install_check_mode.failed is false
       - install_check_mode.python_versions | length >= 1
 
-- name: Install python 3.14
+- name: Install Python 3.14
   uv_python:
     version: 3.14
     state: present
   register: install_python
 
-- name: Verify python 3.14 installation
+- name: Verify Python 3.14 installation
   assert:
     that:
-      - install_python.changed is true
+      - install_python.changed == check_python_314_exists.failed
       - install_python.failed is false
       - install_python.python_versions | length >= 1
       - install_python.python_paths | length >= 1
 
-- name: Re-install python 3.14
+- name: Re-install Python 3.14
   uv_python:
     version: 3.14
     state: present
   register: reinstall_python
 
-- name: Verify python 3.14 re-installation
+- name: Verify Python 3.14 re-installation
   assert:
     that:
       - reinstall_python.changed is false
@@ -69,53 +61,62 @@
       - reinstall_python.python_versions | length >= 1
       - reinstall_python.python_paths | length >= 1
 
-- name: Install python 3.13.5
+- name: Check if Python 3.13.5 exists already
+  command: uv python find 3.13.5
+  ignore_errors: true
+  register: check_python_3135_exists
+
+- name: Check if Python
+  command: uv python list
+  ignore_errors: true
+
+- name: Install Python 3.13.5
   uv_python:
     version: 3.13.5
   register: install_python
 
-- name: Verify python 3.13.5 installation
+- name: Verify Python 3.13.5 installation
   assert:
     that:
-      - install_python.changed is true
+      - install_python.changed == check_python_3135_exists.failed
       - install_python.failed is false
       - '"3.13.5" in install_python.python_versions'
       - install_python.python_paths | length >= 1
 
-- name: Re-install python 3.13.5
+- name: Re-install Python 3.13.5
   uv_python:
     version: 3.13.5
     state: present
   register: reinstall_python
 
-- name: Verify python 3.13.5 installation
+- name: Verify Python 3.13.5 installation
   assert:
     that:
       - reinstall_python.changed is false
       - reinstall_python.failed is false
       - '"3.13.5" in reinstall_python.python_versions'
 
-- name: Remove uninstalled python 3.10 # removes latest patch version for 3.10 if exists
+- name: Remove uninstalled Python 3.10 # removes latest patch version for 3.10 if exists
   uv_python:
     version: "3.10"
     state: absent
   register: remove_python
 
-- name: Verify python 3.10 deletion
+- name: Verify Python 3.10 deletion
   assert:
     that:
       - remove_python.changed is false
       - remove_python.failed is false
       - remove_python.python_versions | length == 0
 
-- name: Remove python 3.13.5 in check mode
+- name: Remove Python 3.13.5 in check mode
   uv_python:
     version: 3.13.5
     state: absent
   check_mode: true
   register: remove_python_in_check_mode
 
-- name: Verify python 3.13.5 deletion in check mode
+- name: Verify Python 3.13.5 deletion in check mode
   assert:
     that:
       - remove_python_in_check_mode.changed is true
@@ -123,13 +124,13 @@
       - '"3.13.5" in remove_python_in_check_mode.python_versions'
       - remove_python_in_check_mode.python_paths | length >= 1
 
-- name: Remove python 3.13.5
+- name: Remove Python 3.13.5
   uv_python:
     version: 3.13.5
     state: absent
   register: remove_python
 
-- name: Verify python 3.13.5 deletion
+- name: Verify Python 3.13.5 deletion
   assert:
     that:
       - remove_python.changed is true
@@ -137,13 +138,13 @@
       - remove_python.python_paths | length >= 1
       - '"3.13.5" in remove_python.python_versions'
 
-- name: Remove python 3.13.5 again
+- name: Remove Python 3.13.5 again
   uv_python:
     version: 3.13.5
     state: absent
   register: remove_python
 
-- name: Verify python 3.13.5 deletion again
+- name: Verify Python 3.13.5 deletion again
   assert:
     that:
       - remove_python.changed is false
@@ -151,13 +152,13 @@
       - remove_python.python_versions | length == 0
       - remove_python.python_paths | length == 0
 
-- name: Upgrade python 3.13
+- name: Upgrade Python 3.13
   uv_python:
     version: 3.13
     state: latest
   register: upgrade_python
 
-- name: Verify python 3.13 upgrade
+- name: Verify Python 3.13 upgrade
   assert:
     that:
       - upgrade_python.changed is true
@@ -165,35 +166,35 @@
       - upgrade_python.python_versions | length >= 1
       - upgrade_python.python_paths | length >= 1
 
-- name: Upgrade python 3.13 in check mode
+- name: Upgrade Python 3.13 in check mode
   uv_python:
     version: 3.13
     state: latest
   check_mode: true
   register: upgrade_python
 
-- name: Verify python 3.13 upgrade in check mode
+- name: Verify Python 3.13 upgrade in check mode
   assert:
     that:
       - upgrade_python.changed is false
       - upgrade_python.failed is false
       - upgrade_python.python_versions | length >= 1
 
-- name: Upgrade python 3.13 again
+- name: Upgrade Python 3.13 again
   uv_python:
     version: 3.13
     state: latest
   check_mode: true
   register: upgrade_python
 
-- name: Verify python 3.13 upgrade again
+- name: Verify Python 3.13 upgrade again
   assert:
     that:
       - upgrade_python.changed is false
       - upgrade_python.failed is false
       - upgrade_python.python_versions | length >= 1
 
-- name: Install unexisting python version in check mode
+- name: Install unexisting Python version in check mode
   uv_python:
     version: 3.12.13
     state: present
@@ -201,46 +202,46 @@
   ignore_errors: true
   check_mode: true
 
-- name: Verify unexisting python 3.12.13 install in check mode
+- name: Verify unexisting Python 3.12.13 install in check mode
   assert:
     that:
       - unexisting_python_check_mode.changed is false
       - unexisting_python_check_mode.failed is true
       - '"Version 3.12.13 is not available." in unexisting_python_check_mode.msg'
 
-- name: Install unexisting python version
+- name: Install unexisting Python version
   uv_python:
     state: present
     version: 3.12.13
   register: unexisting_python
   ignore_errors: true
 
-- name: Verify unexisting python 3.12.13 install
+- name: Verify unexisting Python 3.12.13 install
   assert:
     that:
       - unexisting_python.changed is false
       - unexisting_python.failed is true
 
-- name: Install unexisting python version with latest state
+- name: Install unexisting Python version with latest state
   uv_python:
     version: 3.12.13
     state: latest
   register: unexisting_python
   ignore_errors: true
 
-- name: Verify python 3.12.13 install with latest state
+- name: Verify Python 3.12.13 install with latest state
   assert:
     that:
       - unexisting_python.changed is false
       - unexisting_python.failed is true
 
-- name: Delete python 3.13 version
+- name: Delete Python 3.13 version
   uv_python:
     version: 3.13
     state: absent
   register: uninstall_result
 
-- name: Verify python 3.13 deletion
+- name: Verify Python 3.13 deletion
   assert:
     that:
       - uninstall_result.changed is true

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -19,8 +19,8 @@
 - name: Verify python 3.14 installation failed
   assert:
     that:
-      - failed_install["failed"] is true
-      - '"Failed to find required executable" in failed_install["msg"]'
+      - failed_install.failed is true
+      - '"Failed to find required executable" in failed_install.msg'
 
 - name: Install uv
   shell: |
@@ -38,9 +38,9 @@
 - name: Verify python 3.14 installation in check mode
   assert:
     that:
-      - install_check_mode["changed"] is true
-      - install_check_mode["failed"] is false
-      - '"3.14" in install_check_mode["msg"]'
+      - install_check_mode.changed is true
+      - install_check_mode.failed is false
+      - '"3.14" in install_check_mode.msg'
 
 - name: Install python 3.14
   uv_python:
@@ -51,9 +51,9 @@
 - name: Verify python 3.14 installation in check mode
   assert:
     that:
-      - install_python["changed"] is true
-      - install_python["failed"] is false
-      - '"3.14" in install_python["msg"]'
+      - install_python.changed is true
+      - install_python.failed is false
+      - '"3.14" in install_python.msg'
 
 - name: Re-install python 3.14
   uv_python:
@@ -64,9 +64,9 @@
 - name: Verify python 3.14 re-installation
   assert:
     that:
-      - reinstall_python["changed"] is false
-      - reinstall_python["failed"] is false
-      - '"3.14" in reinstall_python["msg"]'
+      - reinstall_python.changed is false
+      - reinstall_python.failed is false
+      - '"3.14" in reinstall_python.msg'
 
 - name: Install latest python 3.15 # installs latest patch version for 3.15
   uv_python:
@@ -78,9 +78,9 @@
 - name: Verify python 3.15 installation
   assert:
     that:
-      - install_latest_python["changed"] is true
-      - install_latest_python["failed"] is false
-      - '"3.15" in install_latest_python["msg"]'
+      - install_latest_python.changed is true
+      - install_latest_python.failed is false
+      - '"3.15" in install_latest_python.msg'
 
 - name: Install python 3.13.5
   uv_python:
@@ -91,9 +91,9 @@
 - name: Verify python 3.13.5 installation
   assert:
     that:
-      - install_python["changed"] is true
-      - install_python["failed"] is false
-      - '"3.13.5" in install_python["msg"]'
+      - install_python.changed is true
+      - install_python.failed is false
+      - '"3.13.5" in install_python.msg'
 
 - name: Re-install python 3.13.5
   uv_python:
@@ -104,9 +104,9 @@
 - name: Verify python 3.13.5 installation
   assert:
     that:
-      - reinstall_python["changed"] is false
-      - reinstall_python["failed"] is false
-      - '"3.13.5" in reinstall_python["msg"]'
+      - reinstall_python.changed is false
+      - reinstall_python.failed is false
+      - '"3.13.5" in reinstall_python.msg'
 
 - name: Remove unexisting python 3.10 # removes latest patch version for 3.10 if exists
   uv_python:
@@ -117,9 +117,9 @@
 - name: Verify python 3.10 deletion
   assert:
     that:
-      - remove_python["changed"] is false
-      - remove_python["failed"] is false
-      - 'remove_python["msg"] == ""'
+      - remove_python.changed is false
+      - remove_python.failed is false
+      - 'remove_python.msg == ""'
 
 - name: Remove python 3.13.5 in check mode
   uv_python:
@@ -131,9 +131,9 @@
 - name: Verify python 3.13.5 deletion in check mode
   assert:
     that:
-      - remove_python_in_check_mode["changed"] is true
-      - remove_python_in_check_mode["failed"] is false
-      - 'remove_python_in_check_mode["msg"] == ""'
+      - remove_python_in_check_mode.changed is true
+      - remove_python_in_check_mode.failed is false
+      - 'remove_python_in_check_mode.msg == ""'
 
 - name: Remove python 3.13.5
   uv_python:
@@ -144,9 +144,9 @@
 - name: Verify python 3.13.5 deletion
   assert:
     that:
-      - remove_python["changed"] is true
-      - remove_python["failed"] is false
-      - 'remove_python["msg"] == ""'
+      - remove_python.changed is true
+      - remove_python.failed is false
+      - 'remove_python.msg == ""'
 
 - name: Remove python 3.13.5 again
   uv_python:
@@ -157,9 +157,9 @@
 - name: Verify python 3.13.5 deletion
   assert:
     that:
-      - remove_python["changed"] is false
-      - remove_python["failed"] is false
-      - 'remove_python["msg"] == ""'
+      - remove_python.changed is false
+      - remove_python.failed is false
+      - 'remove_python.msg == ""'
 
 - name: Install python 3
   uv_python:
@@ -172,7 +172,7 @@
   ansible.builtin.assert:
     that:
       - invalid_version is failed
-      - "'Expected formats are X.Y or X.Y.Z' in invalid_version.msg"
+      - '"Expected formats are X.Y or X.Y.Z" in invalid_version.msg'
 
 - name: Upgrade python 3.13
   uv_python:
@@ -183,9 +183,9 @@
 - name: Verify python 3.13 upgrade
   assert:
     that:
-      - upgrade_python["changed"] is true
-      - upgrade_python["failed"] is false
-      - '"3.13" in upgrade_python["msg"]'
+      - upgrade_python.changed is true
+      - upgrade_python.failed is false
+      - '"3.13" in upgrade_python.msg'
 
 - name: Upgrade python 3.13 in check mode
   uv_python:
@@ -197,6 +197,34 @@
 - name: Verify python 3.13.5 deletion in check mode
   assert:
     that:
-      - upgrade_python["changed"] is false
-      - upgrade_python["failed"] is false
-      - '"3.13" in upgrade_python["msg"]'
+      - upgrade_python.changed is false
+      - upgrade_python.failed is false
+      - '"3.13" in upgrade_python.msg'
+
+- name: Install unexisting python version
+  uv_python:
+    version: 3.12.13
+    state: present
+  register: unexisting_python
+  ignore_errors: true
+
+- name: Verify python 3.13.5 deletion in check mode
+  assert:
+    that:
+      - unexisting_python.changed is false
+      - unexisting_python.failed is true
+      - '"No download found for request" in unexisting_python.msg'
+
+- name: Install unexisting python version
+  uv_python:
+    version: 3.12.13
+    state: latest
+  register: unexisting_python
+  ignore_errors: true
+
+- name: Verify python 3.13.5 deletion in check mode
+  assert:
+    that:
+      - unexisting_python.changed is false
+      - unexisting_python.failed is true
+      - '"Version 3.12.13 does not exist" in unexisting_python.msg'

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -20,7 +20,6 @@
   assert:
     that:
       - failed_install.failed is true
-      - '"Failed to find required executable" in failed_install.msg'
 
 - name: Install uv
   shell: |
@@ -73,8 +72,7 @@
     version: 3.15
     state: latest
   register: install_latest_python
-- debug:
-    var: install_latest_python
+
 - name: Verify python 3.15 installation
   assert:
     that:
@@ -201,6 +199,21 @@
       - upgrade_python.failed is false
       - '"3.13" in upgrade_python.msg'
 
+- name: Install unexisting python version in check mode
+  uv_python:
+    version: 3.12.13
+    state: present
+  register: unexisting_python_check_mode
+  ignore_errors: true
+  check_mode: true
+
+- name: Verify unexisting python 3.12.13 install in check mode
+  assert:
+    that:
+      - unexisting_python_check_mode.changed is false
+      - unexisting_python_check_mode.failed is true
+      - '"Version 3.12.13 is not available." in unexisting_python_check_mode.msg'
+
 - name: Install unexisting python version
   uv_python:
     version: 3.12.13
@@ -208,23 +221,21 @@
   register: unexisting_python
   ignore_errors: true
 
-- name: Verify python 3.12.13 deletion
+- name: Verify unexisting python 3.12.13 install
   assert:
     that:
       - unexisting_python.changed is false
       - unexisting_python.failed is true
-      - '"No download found for request" in unexisting_python.msg'
 
-- name: Install unexisting python version
+- name: Install unexisting python version with latest state
   uv_python:
     version: 3.12.13
     state: latest
   register: unexisting_python
   ignore_errors: true
 
-- name: Verify python 3.12.13 deletion
+- name: Verify python 3.12.13 deletion with latest state
   assert:
     that:
       - unexisting_python.changed is false
       - unexisting_python.failed is true
-      - '"Version 3.12.13 is not available" in unexisting_python.msg'

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -8,11 +8,11 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: Install python 3.14 when no uv executable exists
+- name: Install Python 3.14 when no uv executable exists
   uv_python:
     version: 3.14
     state: present
-  check_mode: yes
+  check_mode: true
   register: failed_install
   ignore_errors: true
 
@@ -23,7 +23,7 @@
 
 - name: Install uv
   shell: |
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.10.5/uv-installer.sh | sh
   environment:
     UV_INSTALL_DIR: /usr/local/bin
 
@@ -66,7 +66,7 @@
   uv_python:
     version: 3.14
     state: present
-  check_mode: yes
+  check_mode: true
   register: install_check_mode
 
 - name: Verify python 3.14 installation in check mode
@@ -204,7 +204,7 @@
   uv_python:
     version: 3.13
     state: latest
-  check_mode: yes
+  check_mode: true
   register: upgrade_python
 
 - name: Verify python 3.13 upgrade in check mode
@@ -218,7 +218,7 @@
   uv_python:
     version: 3.13
     state: latest
-  check_mode: yes
+  check_mode: true
   register: upgrade_python
 
 - name: Verify python 3.13 upgrade again

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -12,6 +12,15 @@
   ansible.builtin.pip:
     name: uv
 
+- name: Install uv in RHEL
+  when: ansible_facts['os_family'] == "RedHat"
+  shell: |
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+  environment:
+    UV_INSTALL_DIR: "{{ ansible_env.HOME }}/ansible/bin"
+  args:
+    creates: "{{ ansible_env.HOME }}/ansible/bin/uv"
+
 - name: Check if Python 3.14 exists already
   command: uv python find 3.14
   ignore_errors: true
@@ -28,8 +37,8 @@
 - name: Verify Python 3.14 installation in check mode
   assert:
     that:
-      - install_check_mode.changed == check_python_314_exists.failed
-      - install_check_mode.failed is false
+      - (install_check_mode is changed) == (check_python_314_exists is failed)
+      - install_check_mode is not failed
       - install_check_mode.python_versions | length >= 1
 
 - name: Install Python 3.14

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -55,6 +55,17 @@
       - install_python.python_versions | length >= 1
       - install_python.python_paths | length >= 1
 
+- name: Get Python install path stats
+  ansible.builtin.stat:
+    path: "{{ install_python.python_paths[0] }}"
+    follow: true
+  register: python_path_stats
+
+- name: Verify that Python 3.14 install path exists on host
+  ansible.builtin.fail:
+    msg: "Python install path {{ install_python.python_paths[0] }} is not correct"
+  when: not python_path_stats.stat.exists
+
 - name: Re-install Python 3.14
   uv_python:
     version: "3.14"


### PR DESCRIPTION
### SUMMARY

Introduces a new module `uv_python` to manage Python versions using the `uv python` subcommand from the Astral [uv](https://github.com/astral-sh/uv) package manager. The module allows users to install, remove, and upgrade patch version of Python interpreters managed by `uv`.

#### Design Decisions

- Valid version numbers consist of two or three dot-separated numeric components, with an optional 'pre-release' tag on the end such as `3.12`, `3.12.3`, `3.15.0a5`.
- Does not support advanced uv selector formats in the initial release (e.g. `>=3.12,<3.13`, `cpython@3.12`).
- Implements full `check_mode` support.
- Does not implement `diff_mode`.

---

### ISSUE TYPE

- New Module/Plugin Pull Request

---

### COMPONENT NAME

`uv_python`

---

### ADDITIONAL INFORMATION

#### Example Usage

```yaml
- name: Ensure Python 3.12 latest patch is installed
  community.general.uv_python:
    version: "3.12"
    state: latest

- name: Install exact Python version
  community.general.uv_python:
    version: 3.12.3
    state: present

- name: Remove all 3.11 patch versions
  community.general.uv_python:
    version: 3.11
    state: absent
```

This was recently published as a collection [mriamah.uv.python](https://galaxy.ansible.com/ui/repo/published/mriamah/uv/docs/?version=0.1.10)  in Ansible galaxy.
