### PR TITLE
redfish_utils: Add optional boot_override_mode param to DisableBootOverride command

### DIFF
--- a/changelogs/fragments/11543-add-optional-param-to-disablebootoverride.yml
+++ b/changelogs/fragments/11543-add-optional-param-to-disablebootoverride.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - redfish_utils module utils - adds support for including ``boot_override_mode`` attribute in the payload of the ``set_boot_override`` method when disabling BootOverride (https://github.com/ansible-collections/community.general/issues/11542, https://github.com/ansible-collections/community.general/pull/11543).
+  - redfish_command - adds support for including ``boot_override_mode`` attribute in the payload of the ``DisableBootOverride`` command when disabling BootOverride (https://github.com/ansible-collections/community.general/issues/11542, https://github.com/ansible-collections/community.general/pull/11543).

--- a/changelogs/fragments/11543-add-optional-param-to-disablebootoverride.yml
+++ b/changelogs/fragments/11543-add-optional-param-to-disablebootoverride.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - redfish_utils module utils - adds support for including ``boot_override_mode`` attribute in the payload of the ``set_boot_override`` method when disabling BootOverride (https://github.com/ansible-collections/community.general/issues/11542, https://github.com/ansible-collections/community.general/pull/11543).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -2401,10 +2401,10 @@ class RedfishUtils:
                 if annotation in boot:
                     allowable_values = boot[annotation]
                     if isinstance(allowable_values, list) and boot_override_mode not in allowable_values:
-                    return {
-                        "ret": False,
-                        "msg": f"BootSourceOverrideMode: {boot_override_mode} not in list of allowable values ({allowable_values})",
-                    }
+                        return {
+                            "ret": False,
+                            "msg": f"BootSourceOverrideMode: {boot_override_mode} not in list of allowable values ({allowable_values})",
+                        }
                 payload["Boot"]["BootSourceOverrideMode"] = boot_override_mode
         elif bootdevice == "UefiTarget":
             if not uefi_target:

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -2396,6 +2396,16 @@ class RedfishUtils:
         # Build the request payload based on the desired boot override options
         if override_enabled == "Disabled":
             payload = {"Boot": {"BootSourceOverrideEnabled": override_enabled, "BootSourceOverrideTarget": "None"}}
+            if boot_override_mode:
+                annotation = "BootSourceOverrideMode@Redfish.AllowableValues"
+                if annotation in boot:
+                    allowable_values = boot[annotation]
+                    if isinstance(allowable_values, list) and boot_override_mode not in allowable_values:
+                    return {
+                        "ret": False,
+                        "msg": f"BootSourceOverrideMode: {boot_override_mode} not in list of allowable values ({allowable_values})",
+                    }
+                payload["Boot"]["BootSourceOverrideMode"] = boot_override_mode
         elif bootdevice == "UefiTarget":
             if not uefi_target:
                 return {"ret": False, "msg": "uefi_target option required to SetOneTimeBoot for UefiTarget"}

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -394,6 +394,13 @@ EXAMPLES = r"""
     category: Systems
     command: DisableBootOverride
 
+- name: Disable persistent boot device override with additional params
+  community.general.redfish_command:
+    category: Systems
+    command: DisableBootOverride
+    boot_override_mode: UEFI
+    resource_id: 437XR1138R2
+
 - name: Set system indicator LED to blink using security token for auth
   community.general.redfish_command:
     category: Systems


### PR DESCRIPTION
##### SUMMARY
Add support for including an optional boot_override_mode when using the `DisableBootOverride` command to accommodate BMC's that require it.

Fixes #11542

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
redfish_utils

##### ADDITIONAL INFORMATION
Using the changes provided:
Beginning state (Pxe continuous override enabled):
```
    "BootSourceOverrideEnabled": "Continuous", <-- enabled
    "BootSourceOverrideEnabled@Redfish.AllowableValues": [
      "Disabled",
      "Once",
      "Continuous"
    ],
    "BootSourceOverrideMode": "UEFI",
    "BootSourceOverrideMode@Redfish.AllowableValues": [
      "Legacy",
      "UEFI"
    ],
    "BootSourceOverrideTarget": "Pxe", <-- override set
```

Running the changed redfish_command:
```
TASK [Disable Pxe Override] ******************************************************************************************************************************************************************************************************************************************************************************************
Thursday 26 February 2026  23:02:11 +0000 (0:00:00.028)       0:00:00.028 *****
changed: [localhost] => {"changed": true, "msg": "Action was successful", "return_values": {}, "session": {}}
```

and verifying the Boot data post change:
```
  "BootOrderPropertySelection": "BootOrder",
  "BootSourceOverrideEnabled": "Disabled", <-- now disabled
  "BootSourceOverrideEnabled@Redfish.AllowableValues": [
    "Disabled",
    "Once",
    "Continuous"
  ],
  "BootSourceOverrideMode": "UEFI",
  "BootSourceOverrideMode@Redfish.AllowableValues": [
    "Legacy",
    "UEFI"
  ],
  "BootSourceOverrideTarget": "None",
```

The boot override is now disabled as expected.