### PR TITLE
[FIX-11365] Fix nmap cache misses when using pickle cache plugin

### DIFF
--- a/changelogs/fragments/11365-pickle-cache-miss.yml
+++ b/changelogs/fragments/11365-pickle-cache-miss.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nmap with pickle as cache plugin - Fixed the cache misses due to the absence of the Plugin Interposer (Issue https://github.com/ansible-collections/community.general/issues/11365) 

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -178,7 +178,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _is_plugin_interposer(self):
         return self._cache._plugin._persistent
 
-
     def _get_value_from_cache(self, cache_key):
         if not self._is_plugin_interposer():
             self._cache[cache_key] = self._cache._plugin.get(cache_key)

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -174,15 +174,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 valid = True
 
         return valid
-    
+
     def _is_plugin_interposer(self):
         return self._cache._plugin._persistent
-    
+
+
     def _get_value_from_cache(self, cache_key):
         if not self._is_plugin_interposer():
             self._cache[cache_key] = self._cache._plugin.get(cache_key)
-            self._cache._retrieved = self._cache 
-        
+            self._cache._retrieved = self._cache
+
         return self._cache[cache_key]
 
     def parse(self, inventory, loader, path, cache=True):

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -174,6 +174,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 valid = True
 
         return valid
+    
+    def _is_plugin_interposer(self):
+        return self._cache._plugin._persistent
+    
+    def _get_value_from_cache(self, cache_key):
+        if not self._is_plugin_interposer():
+            self._cache[cache_key] = self._cache._plugin.get(cache_key)
+            self._cache._retrieved = self._cache 
+        
+        return self._cache[cache_key]
 
     def parse(self, inventory, loader, path, cache=True):
         try:
@@ -198,7 +208,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         if attempt_to_read_cache:
             try:
-                results = self._cache[cache_key]
+                results = self._get_value_from_cache(cache_key)
             except KeyError:
                 # This occurs if the cache_key is not in the cache or if the cache_key expired, so the cache needs to be updated
                 cache_needs_update = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The pickle cache plugin is not lazy loaded because it is not considered as persistent to prevent unnecessary JSON serialization and key munging, Therefore any other plugin using the pickle cache plugin will always re-execute the command without checking the cache.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #11365 
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
nmap.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Other plugins could be affected with this issue:
- linode.py
- iocage.py
<!--- Paste verbatim command output below, e.g. before and after your change -->

