### PR TITLE
monit: remove unstable tag from integration tests

### DIFF
--- a/tests/integration/targets/monit/aliases
+++ b/tests/integration/targets/monit/aliases
@@ -10,4 +10,3 @@ skip/macos
 skip/freebsd
 skip/aix
 skip/rhel  # FIXME
-unstable  # TODO: the tests fail a lot; 'unstable' only requires them to pass when the module itself has been modified


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As a followup to #11255 this PR removes the `unstable` tag in `aliases` for the integration test of `monit`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
monit