### PR TITLE
sssd_info: fix attributes

### DIFF
--- a/plugins/modules/sssd_info.py
+++ b/plugins/modules/sssd_info.py
@@ -15,11 +15,6 @@ author: "Aleksandr Gabidullin (@a-gabidullin)"
 requirements:
   - dbus
   - SSSD needs to be running
-attributes:
-  check_mode:
-    support: full
-  diff_mode:
-    support: none
 options:
   action:
     description:
@@ -46,6 +41,7 @@ options:
     choices: ['IPA', 'AD']
 extends_documentation_fragment:
   - community.general.attributes
+  - community.general.attributes.info_module
 """
 
 EXAMPLES = r"""


### PR DESCRIPTION
##### SUMMARY
There's a special doc fragment for _info attributes.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
sssd_info
