### PR TITLE
pfexec become plugin: fix broken defaults for illumos/SmartOS

### DIFF
--- a/changelogs/fragments/pfexec-fix-defaults.yml
+++ b/changelogs/fragments/pfexec-fix-defaults.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - "pfexec become plugin - fix default ``become_flags`` from ``-H -S -n`` (sudo flags) to empty string, as ``pfexec`` does not accept these options (https://github.com/ansible-collections/community.general/pull/XXXXX)."
-  - "pfexec become plugin - change default ``wrap_exe`` from ``false`` to ``true``, as ``pfexec`` does not interpret shell constructs internally and requires commands to be wrapped in a shell invocation (https://github.com/ansible-collections/community.general/pull/XXXXX)."
+  - "pfexec become plugin - fix default ``become_flags`` from ``-H -S -n`` (sudo flags) to empty string, as ``pfexec`` does not accept these options (https://github.com/ansible-collections/community.general/pull/11623)."
+  - "pfexec become plugin - change default ``wrap_exe`` from ``false`` to ``true``, as ``pfexec`` does not interpret shell constructs internally and requires commands to be wrapped in a shell invocation (https://github.com/ansible-collections/community.general/pull/11623)."

--- a/changelogs/fragments/pfexec-fix-defaults.yml
+++ b/changelogs/fragments/pfexec-fix-defaults.yml
@@ -1,4 +1,4 @@
 bugfixes:
   - "pfexec become plugin - fix default ``become_flags`` from ``-H -S -n`` (sudo flags) to empty string, as ``pfexec`` does not accept these options (https://github.com/ansible-collections/community.general/pull/11623)."
 deprecated_features:
-  - "pfexec become plugin - the default value of the ``wrap_exe`` option will change from ``false`` to ``true`` in community.general 15.0.0. The current default only works in very limited cases because ``pfexec`` does not interpret shell constructs internally. Set ``wrap_exe`` explicitly to silence the deprecation warning (https://github.com/ansible-collections/community.general/pull/11623)."
+  - "pfexec become plugin - the default value of the ``wrap_exe`` option will change from ``false`` to ``true`` in community.general 14.0.0. The current default only works in very limited cases because ``pfexec`` does not interpret shell constructs internally. Set ``wrap_exe`` explicitly to silence the deprecation warning (https://github.com/ansible-collections/community.general/pull/11623)."

--- a/changelogs/fragments/pfexec-fix-defaults.yml
+++ b/changelogs/fragments/pfexec-fix-defaults.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "pfexec become plugin - fix default ``become_flags`` from ``-H -S -n`` (sudo flags) to empty string, as ``pfexec`` does not accept these options (https://github.com/ansible-collections/community.general/pull/XXXXX)."
+  - "pfexec become plugin - change default ``wrap_exe`` from ``false`` to ``true``, as ``pfexec`` does not interpret shell constructs internally and requires commands to be wrapped in a shell invocation (https://github.com/ansible-collections/community.general/pull/XXXXX)."

--- a/changelogs/fragments/pfexec-fix-defaults.yml
+++ b/changelogs/fragments/pfexec-fix-defaults.yml
@@ -1,3 +1,4 @@
 bugfixes:
   - "pfexec become plugin - fix default ``become_flags`` from ``-H -S -n`` (sudo flags) to empty string, as ``pfexec`` does not accept these options (https://github.com/ansible-collections/community.general/pull/11623)."
-  - "pfexec become plugin - change default ``wrap_exe`` from ``false`` to ``true``, as ``pfexec`` does not interpret shell constructs internally and requires commands to be wrapped in a shell invocation (https://github.com/ansible-collections/community.general/pull/11623)."
+deprecated_features:
+  - "pfexec become plugin - the default value of the ``wrap_exe`` option will change from ``false`` to ``true`` in community.general 15.0.0. The current default only works in very limited cases because ``pfexec`` does not interpret shell constructs internally. Set ``wrap_exe`` explicitly to silence the deprecation warning (https://github.com/ansible-collections/community.general/pull/11623)."

--- a/plugins/become/pfexec.py
+++ b/plugins/become/pfexec.py
@@ -78,8 +78,9 @@ options:
       - Unlike C(sudo), C(pfexec) does not interpret shell constructs internally,
         so commands containing shell operators must be wrapped in a shell invocation.
       - The current default of V(false) only works in very limited cases (for example
-        with M(ansible.builtin.raw)). The default will change to V(true) in a future
-        release.
+        with M(ansible.builtin.raw)).
+      - The current default is B(deprecated) and will change to V(true) in community.general 14.0.0.
+        To avoid the deprecation message, you can explicitly set this option to a value.
     type: bool
     ini:
       - section: pfexec_become_plugin
@@ -114,9 +115,9 @@ class BecomeModule(BecomeBase):
         if wrap_exe is None:
             display.deprecated(
                 "The default value of the wrap_exe option for the community.general.pfexec "
-                "become plugin will change from false to true in community.general 15.0.0. "
+                "become plugin will change from false to true in community.general 14.0.0. "
                 "Set wrap_exe explicitly to silence this warning.",
-                version="15.0.0",
+                version="14.0.0",
                 collection_name="community.general",
             )
             wrap_exe = False

--- a/plugins/become/pfexec.py
+++ b/plugins/become/pfexec.py
@@ -46,7 +46,7 @@ options:
   become_flags:
     description: Options to pass to C(pfexec).
     type: string
-    default: -H -S -n
+    default: ""
     ini:
       - section: privilege_escalation
         key: become_flags
@@ -73,8 +73,12 @@ options:
       - section: pfexec_become_plugin
         key: password
   wrap_exe:
-    description: Toggle to wrap the command C(pfexec) calls in C(shell -c) or not.
-    default: false
+    description:
+      - Toggle to wrap the command C(pfexec) calls in C(shell -c) or not.
+      - Unlike C(sudo), C(pfexec) does not interpret shell constructs internally,
+        so commands containing shell operators must be wrapped in a shell invocation.
+      - This should generally be left enabled.
+    default: true
     type: bool
     ini:
       - section: pfexec_become_plugin
@@ -103,4 +107,7 @@ class BecomeModule(BecomeBase):
 
         flags = self.get_option("become_flags")
         noexe = not self.get_option("wrap_exe")
-        return f"{exe} {flags} {self._build_success_command(cmd, shell, noexe=noexe)}"
+        become_cmd = self._build_success_command(cmd, shell, noexe=noexe)
+        if flags:
+            return f"{exe} {flags} {become_cmd}"
+        return f"{exe} {become_cmd}"

--- a/plugins/become/pfexec.py
+++ b/plugins/become/pfexec.py
@@ -77,7 +77,9 @@ options:
       - Toggle to wrap the command C(pfexec) calls in C(shell -c) or not.
       - Unlike C(sudo), C(pfexec) does not interpret shell constructs internally,
         so commands containing shell operators must be wrapped in a shell invocation.
-    default: true
+      - The current default of V(false) only works in very limited cases (for example
+        with M(ansible.builtin.raw)). The default will change to V(true) in a future
+        release.
     type: bool
     ini:
       - section: pfexec_become_plugin
@@ -91,6 +93,9 @@ notes:
 """
 
 from ansible.plugins.become import BecomeBase
+from ansible.utils.display import Display
+
+display = Display()
 
 
 class BecomeModule(BecomeBase):
@@ -103,8 +108,18 @@ class BecomeModule(BecomeBase):
             return cmd
 
         exe = self.get_option("become_exe")
-
         flags = self.get_option("become_flags")
-        noexe = not self.get_option("wrap_exe")
-        become_cmd = self._build_success_command(cmd, shell, noexe=noexe)
-        return f"{exe} {flags} {become_cmd}"
+
+        wrap_exe = self.get_option("wrap_exe")
+        if wrap_exe is None:
+            display.deprecated(
+                "The default value of the wrap_exe option for the community.general.pfexec "
+                "become plugin will change from false to true in community.general 15.0.0. "
+                "Set wrap_exe explicitly to silence this warning.",
+                version="15.0.0",
+                collection_name="community.general",
+            )
+            wrap_exe = False
+
+        become_cmd = self._build_success_command(cmd, shell, noexe=not wrap_exe)
+        return " ".join(part for part in (exe, flags, become_cmd) if part)

--- a/plugins/become/pfexec.py
+++ b/plugins/become/pfexec.py
@@ -77,7 +77,6 @@ options:
       - Toggle to wrap the command C(pfexec) calls in C(shell -c) or not.
       - Unlike C(sudo), C(pfexec) does not interpret shell constructs internally,
         so commands containing shell operators must be wrapped in a shell invocation.
-      - This should generally be left enabled.
     default: true
     type: bool
     ini:
@@ -108,6 +107,4 @@ class BecomeModule(BecomeBase):
         flags = self.get_option("become_flags")
         noexe = not self.get_option("wrap_exe")
         become_cmd = self._build_success_command(cmd, shell, noexe=noexe)
-        if flags:
-            return f"{exe} {flags} {become_cmd}"
-        return f"{exe} {become_cmd}"
+        return f"{exe} {flags} {become_cmd}"

--- a/tests/unit/plugins/become/test_pfexec.py
+++ b/tests/unit/plugins/become/test_pfexec.py
@@ -15,13 +15,13 @@ from .helper import call_become_plugin
 
 
 def test_pfexec_basic(mocker, parser, reset_cli_args):
+    """Test pfexec with default settings (no flags, wrap_exe enabled)."""
     options = parser.parse_args([])
     context._init_global_context(options)
 
     default_cmd = "/bin/foo"
     default_exe = "/bin/bash"
     pfexec_exe = "pfexec"
-    pfexec_flags = "-H -S -n"
 
     success = "BECOME-SUCCESS-.+?"
 
@@ -31,39 +31,63 @@ def test_pfexec_basic(mocker, parser, reset_cli_args):
     var_options = {}
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match(f"""{pfexec_exe} {pfexec_flags} 'echo {success}; {default_cmd}'""", cmd) is not None
+    # With wrap_exe=true (default), command is wrapped in shell -c
+    assert re.match(f"""{pfexec_exe} {default_exe} -c 'echo {success}; {default_cmd}'""", cmd) is not None
 
 
-def test_pfexec(mocker, parser, reset_cli_args):
+def test_pfexec_no_wrap(mocker, parser, reset_cli_args):
+    """Test pfexec with wrap_exe disabled (legacy behaviour)."""
     options = parser.parse_args([])
     context._init_global_context(options)
 
     default_cmd = "/bin/foo"
     default_exe = "/bin/bash"
     pfexec_exe = "pfexec"
-    pfexec_flags = ""
 
     success = "BECOME-SUCCESS-.+?"
 
     task = {
-        "become_user": "foo",
+        "become_method": "community.general.pfexec",
+        "become_flags": "",
+    }
+    var_options = {
+        "ansible_pfexec_wrap_execution": "false",
+    }
+    cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
+    print(cmd)
+    assert re.match(f"""{pfexec_exe} 'echo {success}; {default_cmd}'""", cmd) is not None
+
+
+def test_pfexec_custom_flags(mocker, parser, reset_cli_args):
+    """Test pfexec with custom flags."""
+    options = parser.parse_args([])
+    context._init_global_context(options)
+
+    default_cmd = "/bin/foo"
+    default_exe = "/bin/bash"
+    pfexec_exe = "pfexec"
+    pfexec_flags = "-P basic"
+
+    success = "BECOME-SUCCESS-.+?"
+
+    task = {
         "become_method": "community.general.pfexec",
         "become_flags": pfexec_flags,
     }
     var_options = {}
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match(f"""{pfexec_exe} {pfexec_flags} 'echo {success}; {default_cmd}'""", cmd) is not None
+    assert re.match(f"""{pfexec_exe} {pfexec_flags} {default_exe} -c 'echo {success}; {default_cmd}'""", cmd) is not None
 
 
 def test_pfexec_varoptions(mocker, parser, reset_cli_args):
+    """Test that var_options override task options."""
     options = parser.parse_args([])
     context._init_global_context(options)
 
     default_cmd = "/bin/foo"
     default_exe = "/bin/bash"
     pfexec_exe = "pfexec"
-    pfexec_flags = ""
 
     success = "BECOME-SUCCESS-.+?"
 
@@ -74,8 +98,9 @@ def test_pfexec_varoptions(mocker, parser, reset_cli_args):
     }
     var_options = {
         "ansible_become_user": "bar",
-        "ansible_become_flags": pfexec_flags,
+        "ansible_become_flags": "",
     }
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match(f"""{pfexec_exe} {pfexec_flags} 'echo {success}; {default_cmd}'""", cmd) is not None
+    # var_options override task flags, so flags should be empty
+    assert re.match(f"""{pfexec_exe} {default_exe} -c 'echo {success}; {default_cmd}'""", cmd) is not None

--- a/tests/unit/plugins/become/test_pfexec.py
+++ b/tests/unit/plugins/become/test_pfexec.py
@@ -32,7 +32,7 @@ def test_pfexec_basic(mocker, parser, reset_cli_args):
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
     # With wrap_exe=true (default), command is wrapped in shell -c
-    assert re.match(f"""{pfexec_exe} {default_exe} -c 'echo {success}; {default_cmd}'""", cmd) is not None
+    assert re.match(f"""{pfexec_exe}  {default_exe} -c 'echo {success}; {default_cmd}'""", cmd) is not None
 
 
 def test_pfexec_no_wrap(mocker, parser, reset_cli_args):
@@ -55,7 +55,7 @@ def test_pfexec_no_wrap(mocker, parser, reset_cli_args):
     }
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match(f"""{pfexec_exe} 'echo {success}; {default_cmd}'""", cmd) is not None
+    assert re.match(f"""{pfexec_exe}  'echo {success}; {default_cmd}'""", cmd) is not None
 
 
 def test_pfexec_custom_flags(mocker, parser, reset_cli_args):
@@ -105,4 +105,4 @@ def test_pfexec_varoptions(mocker, parser, reset_cli_args):
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
     # var_options override task flags, so flags should be empty
-    assert re.match(f"""{pfexec_exe} {default_exe} -c 'echo {success}; {default_cmd}'""", cmd) is not None
+    assert re.match(f"""{pfexec_exe}  {default_exe} -c 'echo {success}; {default_cmd}'""", cmd) is not None

--- a/tests/unit/plugins/become/test_pfexec.py
+++ b/tests/unit/plugins/become/test_pfexec.py
@@ -14,8 +14,8 @@ from ansible import context
 from .helper import call_become_plugin
 
 
-def test_pfexec_basic(mocker, parser, reset_cli_args):
-    """Test pfexec with default settings (no flags, wrap_exe enabled)."""
+def test_pfexec_wrap(mocker, parser, reset_cli_args):
+    """Test pfexec with wrap_exe explicitly enabled."""
     options = parser.parse_args([])
     context._init_global_context(options)
 
@@ -28,15 +28,16 @@ def test_pfexec_basic(mocker, parser, reset_cli_args):
     task = {
         "become_method": "community.general.pfexec",
     }
-    var_options = {}
+    var_options = {
+        "ansible_pfexec_wrap_execution": "true",
+    }
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    # With wrap_exe=true (default), command is wrapped in shell -c
-    assert re.match(f"""{pfexec_exe}  {default_exe} -c 'echo {success}; {default_cmd}'""", cmd) is not None
+    assert re.match(f"""{pfexec_exe} {default_exe} -c 'echo {success}; {default_cmd}'""", cmd) is not None
 
 
 def test_pfexec_no_wrap(mocker, parser, reset_cli_args):
-    """Test pfexec with wrap_exe disabled (legacy behaviour)."""
+    """Test pfexec with wrap_exe explicitly disabled."""
     options = parser.parse_args([])
     context._init_global_context(options)
 
@@ -55,11 +56,11 @@ def test_pfexec_no_wrap(mocker, parser, reset_cli_args):
     }
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match(f"""{pfexec_exe}  'echo {success}; {default_cmd}'""", cmd) is not None
+    assert re.match(f"""{pfexec_exe} 'echo {success}; {default_cmd}'""", cmd) is not None
 
 
 def test_pfexec_custom_flags(mocker, parser, reset_cli_args):
-    """Test pfexec with custom flags."""
+    """Test pfexec with custom flags and wrap_exe enabled."""
     options = parser.parse_args([])
     context._init_global_context(options)
 
@@ -74,7 +75,9 @@ def test_pfexec_custom_flags(mocker, parser, reset_cli_args):
         "become_method": "community.general.pfexec",
         "become_flags": pfexec_flags,
     }
-    var_options = {}
+    var_options = {
+        "ansible_pfexec_wrap_execution": "true",
+    }
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
     assert (
@@ -101,8 +104,9 @@ def test_pfexec_varoptions(mocker, parser, reset_cli_args):
     var_options = {
         "ansible_become_user": "bar",
         "ansible_become_flags": "",
+        "ansible_pfexec_wrap_execution": "true",
     }
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
     # var_options override task flags, so flags should be empty
-    assert re.match(f"""{pfexec_exe}  {default_exe} -c 'echo {success}; {default_cmd}'""", cmd) is not None
+    assert re.match(f"""{pfexec_exe} {default_exe} -c 'echo {success}; {default_cmd}'""", cmd) is not None

--- a/tests/unit/plugins/become/test_pfexec.py
+++ b/tests/unit/plugins/become/test_pfexec.py
@@ -77,7 +77,9 @@ def test_pfexec_custom_flags(mocker, parser, reset_cli_args):
     var_options = {}
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match(f"""{pfexec_exe} {pfexec_flags} {default_exe} -c 'echo {success}; {default_cmd}'""", cmd) is not None
+    assert (
+        re.match(f"""{pfexec_exe} {pfexec_flags} {default_exe} -c 'echo {success}; {default_cmd}'""", cmd) is not None
+    )
 
 
 def test_pfexec_varoptions(mocker, parser, reset_cli_args):


### PR DESCRIPTION
##### SUMMARY

The `pfexec` become plugin has had incorrect defaults since it was migrated from Ansible core, making it unusable on illumos/SmartOS/OmniOS/OpenIndiana without manual workarounds in the user's inventory or playbook configuration.

**Two default values are wrong:**

1. **`become_flags`** defaults to `"-H -S -n"` — these are `sudo` flags, not `pfexec` flags. The illumos `pfexec` command does not accept any of these options (`-H` sets HOME in sudo, `-S` reads password from stdin, `-n` is non-interactive mode). This causes `exec: illegal option -- H` on every invocation.

2. **`wrap_exe`** defaults to `false`. Unlike `sudo`, `pfexec` does not interpret shell constructs internally — it calls `exec()` directly on its argument. Since Ansible generates compound commands containing shell operators (e.g. `echo BECOME-SUCCESS-xxx ; /opt/local/bin/python3`), these must be wrapped in `/bin/sh -c '...'` for `pfexec` to execute them. Without wrapping, pfexec tries to exec the compound string as a single binary name and fails silently.

**History:**

- Originally reported in 2016: ansible/ansible#15642
- Migrated to community.general: #3671
- Partially fixed by #3889 in 2022 (corrected quoting, but not the defaults)
- The issue was closed with a documented workaround (`become_flags: ""` + `ansible_pfexec_wrap_execution: yes`), but the defaults were never corrected
- The broken defaults have persisted for the entire lifetime of the plugin

**Changes in this PR:**

- `become_flags` default: `"-H -S -n"` → `""` (pfexec accepts no flags by default)
- `wrap_exe` default: `false` → `true` (required for Ansible's compound commands)
- `build_become_command`: handle empty flags without injecting extra whitespace
- Improved `wrap_exe` description explaining why it should be enabled
- Updated unit tests to match corrected defaults
- Added test case for custom flags

**Tested on:** SmartOS (illumos) native zones with Ansible 13.4.0 / community.general 12.4.0, managing infrastructure via `pfexec` with RBAC profiles. Confirmed working with `ansible.builtin.user`, `ansible.builtin.command`, `ansible.builtin.file`, `ansible.builtin.template`, `ansible.builtin.uri`, and `ansible.builtin.lineinfile` modules.

Fixes #3671

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/become/pfexec.py

##### ADDITIONAL INFORMATION

**Before (broken):**
```
$ ansible-playbook site.yml --become --become-method=community.general.pfexec
fatal: [illumos-host]: FAILED! => {"msg": "exec: illegal option -- H"}
```

Users had to add workarounds to every inventory or playbook:
```yaml
ansible_become_flags: ""
ansible_pfexec_wrap_execution: yes
```

**After (works with no user configuration):**
```yaml
- hosts: illumos_zones
  become: true
  become_method: community.general.pfexec
  tasks:
    - ansible.builtin.user:
        name: admin
        profile: "Primary Administrator"
```

No `become_flags` or `wrap_exe` overrides needed.

**Why these defaults are correct for pfexec:**

- **Empty flags:** `pfexec` is RBAC-based. Privileges are granted by profiles in `/etc/security/user_attr` and `/etc/security/exec_attr`. There is no password prompting (`-S`/`-n` are meaningless), and `pfexec` preserves the caller's environment (`-H` is meaningless). The `pfexec` binary accepts only `pfexec [-P privset] cmd [arg ..]`.

- **wrap_exe=true:** `sudo` has an internal shell parser that handles compound commands. `pfexec` does not — it calls `exec()` directly. Since Ansible always generates compound commands (the `BECOME-SUCCESS` echo followed by the Python interpreter), the command must be wrapped in `/bin/sh -c '...'` for pfexec to execute it.