### PR TITLE
CI: Replace apt_repository and apt_key with deb822_repository

### DIFF
--- a/tests/integration/targets/flatpak/tasks/setup.yml
+++ b/tests/integration/targets/flatpak/tasks/setup.yml
@@ -10,19 +10,10 @@
   become: true
   when: ansible_facts.distribution == 'Fedora'
 
-- block:
-    - name: Activate flatpak ppa on Ubuntu
-      apt_repository:
-        repo: ppa:alexlarsson/flatpak
-        state: present
-        mode: '0644'
-      when: ansible_facts.lsb.major_release | int < 18
-
-    - name: Install flatpak package on Ubuntu
-      apt:
-        name: flatpak
-        state: present
-
+- name: Install flatpak package on Ubuntu
+  apt:
+    name: flatpak
+    state: present
   when: ansible_facts.distribution == 'Ubuntu'
 
 - name: Install dummy remote for user

--- a/tests/integration/targets/flatpak_remote/tasks/setup.yml
+++ b/tests/integration/targets/flatpak_remote/tasks/setup.yml
@@ -8,17 +8,10 @@
     name: flatpak
     state: present
   when: ansible_facts.distribution == 'Fedora'
-- block:
-    - name: Activate flatpak ppa on Ubuntu versions older than 18.04/bionic
-      apt_repository:
-        repo: ppa:alexlarsson/flatpak
-        state: present
-        mode: '0644'
-      when: ansible_facts.lsb.major_release | int < 18
-    - name: Install flatpak package on Ubuntu
-      apt:
-        name: flatpak
-        state: present
+- name: Install flatpak package on Ubuntu
+  apt:
+    name: flatpak
+    state: present
   when: ansible_facts.distribution == 'Ubuntu'
 - name: Install flatpak remote for testing check mode
   flatpak_remote:

--- a/tests/integration/targets/lookup_passwordstore/tasks/package.yml
+++ b/tests/integration/targets/lookup_passwordstore/tasks/package.yml
@@ -45,16 +45,37 @@
       ansible.builtin.get_url:
         url: https://packages.gopass.pw/repos/gopass/gopass-archive-keyring.gpg
         dest: /usr/share/keyrings/gopass-archive-keyring.gpg
-    - name: Add gopass repo
-      ansible.builtin.apt_repository:
-        repo: "deb [arch=amd64,arm64,armhf \
-          signed-by=/usr/share/keyrings/gopass-archive-keyring.gpg] \
-          https://packages.gopass.pw/repos/gopass stable main"
+    - name: Make sure python3-debian is installed
+      ansible.builtin.apt:
+        name: python3-debian
         state: present
-    - name: Update apt-cache and install gopass package
+    - name: Add gopass repo
+      ansible.builtin.deb822_repository:
+        name: gopass
+        types: deb
+        architectures:
+          - amd64
+          - arm64
+          - armhf
+        signed_by: /usr/share/keyrings/gopass-archive-keyring.gpg
+        uris:
+          - https://packages.gopass.pw/repos/gopass
+        suites:
+          - stable
+        components:
+          - main
+        state: present
+      register: apt_repo
+
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+      when: apt_repo is changed
+
+    - name: Install gopass package
       ansible.builtin.apt:
         name: gopass
-        update_cache: true
+        state: present
 
 - name: Install on macOS
   when: ansible_facts.distribution == 'MacOSX'

--- a/tests/integration/targets/setup_influxdb/tasks/setup.yml
+++ b/tests/integration/targets/setup_influxdb/tasks/setup.yml
@@ -16,14 +16,37 @@
     - ndg-httpsclient
     - pyasn1
 
-- name: Add InfluxDB public GPG key
-  apt_key: url=https://repos.influxdata.com/influxdb.key state=present
+- name: Make sure python3-debian is installed
+  ansible.builtin.apt:
+    name: python3-debian
+    state: present
 
 - name: Add InfluxDB repository
-  apt_repository: repo='deb https://repos.influxdata.com/ubuntu trusty stable' filename='influxdb' state=present update_cache=yes
+  ansible.builtin.deb822_repository:
+    update_cache: true
+    name: influxdb
+    types: deb
+    signed_by: https://repos.influxdata.com/influxdb.key
+    uris:
+      - https://repos.influxdata.com/ubuntu
+    suites:
+      - trusty
+    components:
+      - stable
+    state: present
+  register: apt_repo
+
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: true
+  when: apt_repo is changed
 
 - name: Install InfluxDB
-  apt: name=influxdb state=latest
+  ansible.builtin.apt:
+    name: influxdb
+    state: latest
 
 - name: Start InfluxDB service
-  service: name=influxdb state=started
+  ansible.builtin.service:
+    name: influxdb
+    state: started


### PR DESCRIPTION
##### SUMMARY
The apt_repository module is deprecated in devel, and the deprecation PR also accidentally made it impossible to use it right now. I guess that's a good point to stop using it :)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
integration tests
