### PR TITLE
CI: Remove FreeBSD 14.3 for devel, and replace macOS 15.3 with 26.3

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -198,8 +198,9 @@ stages:
             # TODO: enable this ASAP!
             # - name: FreeBSD 15.0
             #   test: freebsd/15.0
-            - name: FreeBSD 14.4
-              test: freebsd/14.4
+            # TODO: enable this ASAP!
+            # - name: FreeBSD 14.4
+            #   test: freebsd/14.4
           groups:
             - 1
             - 2

--- a/tests/integration/targets/iso_extract/aliases
+++ b/tests/integration/targets/iso_extract/aliases
@@ -26,4 +26,5 @@ skip/freebsd14.0  # FIXME
 skip/freebsd14.1  # FIXME
 skip/freebsd14.2  # FIXME
 skip/freebsd14.3  # FIXME
+skip/freebsd14.4  # FIXME
 skip/freebsd15.0  # FIXME


### PR DESCRIPTION
##### SUMMARY
For ansible-test devel, replace FreeBSD 14.3 with 14.4 (https://github.com/ansible/ansible/pull/86698), and macOS 15.3 with 26.3 (https://github.com/ansible/ansible/pull/86699).

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
