### PR TITLE
cmd_runner_fmt tests: assert that `unpack_*` functions can handle `_ArgFormat` objects

### DIFF
--- a/tests/unit/plugins/module_utils/test_cmd_runner.py
+++ b/tests/unit/plugins/module_utils/test_cmd_runner.py
@@ -93,6 +93,42 @@ TC_FORMATS = dict(
         ["--answer=42", "--answer=17"],
         None,
     ),
+    unpack_args_plain=(
+        lambda: cmd_runner_fmt.unpack_args(lambda a, b: [f"--{a}={b}"]),
+        ("food", "potatoes"),
+        ["--food=potatoes"],
+        None,
+    ),
+    unpack_args_argformat=(
+        lambda: cmd_runner_fmt.unpack_args(cmd_runner_fmt.as_optval("-t")),
+        ("potatoes",),
+        ["-tpotatoes"],
+        None,
+    ),
+    unpack_args_argformat_inner_none=(
+        lambda: cmd_runner_fmt.unpack_args(cmd_runner_fmt.as_optval("-t")),
+        (None,),
+        [],
+        None,
+    ),
+    unpack_kwargs_plain=(
+        lambda: cmd_runner_fmt.unpack_kwargs(lambda a, b: [f"--{a}={b}"]),
+        {"a": "food", "b": "potatoes"},
+        ["--food=potatoes"],
+        None,
+    ),
+    unpack_kwargs_argformat=(
+        lambda: cmd_runner_fmt.unpack_kwargs(cmd_runner_fmt.as_opt_val("--food")),
+        {"value": "potatoes"},
+        ["--food", "potatoes"],
+        None,
+    ),
+    unpack_kwargs_argformat_inner_none=(
+        lambda: cmd_runner_fmt.unpack_kwargs(cmd_runner_fmt.as_opt_val("--food")),
+        {"value": None},
+        [],
+        None,
+    ),
 )
 TC_FORMATS_IDS = sorted(TC_FORMATS.keys())
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Those functions were written primarily to wrap other functions and it wasn't entirely clear whether they could handle a class object (with a `__call__()` method) in the same way. These tests respond that question.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
tests/unit/plugins/module_utils/test_cmd_runner.py