### PR TITLE
Remove changelog fragments of deprecations that are already removed in 13.0.0

### DIFF
--- a/changelogs/fragments/11069-deprecate-spotinst.yml
+++ b/changelogs/fragments/11069-deprecate-spotinst.yml
@@ -1,2 +1,0 @@
-deprecated_features:
-  - spotinst_aws_elastigroup - module relies on Python package supporting Python 2.7 only; the module will be removed from community.general 13.0.0 (https://github.com/ansible-collections/community.general/pull/11069).

--- a/changelogs/fragments/11205-module_utils.yml
+++ b/changelogs/fragments/11205-module_utils.yml
@@ -1,9 +1,0 @@
-deprecated_features:
-  - "cloud module utils - this module utils is not used by community.general and will thus be removed from community.general 13.0.0.
-     If you are using it from another collection, please copy it over (https://github.com/ansible-collections/community.general/pull/11205)."
-  - "database module utils - this module utils is not used by community.general and will thus be removed from community.general 13.0.0.
-     If you are using it from another collection, please copy it over (https://github.com/ansible-collections/community.general/pull/11205)."
-  - "known_hosts module utils - this module utils is not used by community.general and will thus be removed from community.general 13.0.0.
-     If you are using it from another collection, please copy it over (https://github.com/ansible-collections/community.general/pull/11205)."
-  - "saslprep module utils - this module utils is not used by community.general and will thus be removed from community.general 13.0.0.
-     If you are using it from another collection, please copy it over (https://github.com/ansible-collections/community.general/pull/11205)."

--- a/changelogs/fragments/11224-deprecate-pushbullet.yml
+++ b/changelogs/fragments/11224-deprecate-pushbullet.yml
@@ -1,2 +1,0 @@
-deprecated_features:
-  - pushbullet - module relies on Python package supporting Python 3.2 only; the module will be removed from community.general 13.0.0 (https://github.com/ansible-collections/community.general/pull/11224).

--- a/changelogs/fragments/private.yml
+++ b/changelogs/fragments/private.yml
@@ -1,8 +1,0 @@
-deprecated_features:
-  - "All module utils, plugin utils, and doc fragments will be made **private** in community.general 13.0.0.
-     This means that they will no longer be part of the public API of the collection, and can have breaking
-     changes even in bugfix releases. If you depend on importing code from the module or plugin utils,
-     or use one of the doc fragments, please
-     `comment in the issue to discuss this <https://github.com/ansible-collections/community.general/issues/11312>`__.
-     Note that this does not affect any use of community.general in task files, roles, or playbooks
-     (https://github.com/ansible-collections/community.general/issues/11312, https://github.com/ansible-collections/community.general/pull/11320)."


### PR DESCRIPTION
##### SUMMARY
These changelog fragments would otherwise show up in the 13.0.0 changelog together with fragments that announce the actual removal.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelog
