### PR TITLE
remove skip/aix from aliases files

### DIFF
--- a/tests/integration/targets/alternatives/aliases
+++ b/tests/integration/targets/alternatives/aliases
@@ -5,7 +5,6 @@
 azp/posix/3
 destructive
 needs/root
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/apache2_mod_proxy/aliases
+++ b/tests/integration/targets/apache2_mod_proxy/aliases
@@ -4,4 +4,3 @@
 
 azp/posix/3
 destructive
-skip/aix

--- a/tests/integration/targets/apache2_module/aliases
+++ b/tests/integration/targets/apache2_module/aliases
@@ -4,4 +4,3 @@
 
 azp/posix/3
 destructive
-skip/aix

--- a/tests/integration/targets/apk/aliases
+++ b/tests/integration/targets/apk/aliases
@@ -5,7 +5,6 @@
 azp/posix/2
 needs/root
 destructive
-skip/aix
 skip/osx
 skip/macos
 skip/freebsd

--- a/tests/integration/targets/archive/aliases
+++ b/tests/integration/targets/archive/aliases
@@ -5,5 +5,4 @@
 azp/posix/2
 needs/root
 destructive
-skip/aix
 skip/osx  # FIXME

--- a/tests/integration/targets/btrfs_subvolume/aliases
+++ b/tests/integration/targets/btrfs_subvolume/aliases
@@ -6,7 +6,6 @@ azp/posix/3
 azp/posix/vm
 destructive
 needs/privileged
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/cargo/aliases
+++ b/tests/integration/targets/cargo/aliases
@@ -4,4 +4,3 @@
 
 azp/posix/2
 destructive
-skip/aix

--- a/tests/integration/targets/cloud_init_data_facts/aliases
+++ b/tests/integration/targets/cloud_init_data_facts/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/1
 destructive
-skip/aix
 skip/osx
 skip/macos
 skip/freebsd

--- a/tests/integration/targets/consul/aliases
+++ b/tests/integration/targets/consul/aliases
@@ -4,5 +4,4 @@
 
 azp/posix/2
 destructive
-skip/aix
 skip/macos  # cannot simply create binaries in system locations on newer macOS versions

--- a/tests/integration/targets/cpanm/aliases
+++ b/tests/integration/targets/cpanm/aliases
@@ -7,4 +7,3 @@ destructive
 skip/macos
 skip/osx
 skip/freebsd
-skip/aix

--- a/tests/integration/targets/cronvar/aliases
+++ b/tests/integration/targets/cronvar/aliases
@@ -4,6 +4,5 @@
 
 azp/posix/3
 destructive
-skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/dnf_versionlock/aliases
+++ b/tests/integration/targets/dnf_versionlock/aliases
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/dpkg_divert/aliases
+++ b/tests/integration/targets/dpkg_divert/aliases
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/aix
 skip/osx
 skip/macos
 skip/rhel

--- a/tests/integration/targets/etcd3/aliases
+++ b/tests/integration/targets/etcd3/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/1
 destructive
-skip/aix
 skip/osx
 skip/macos
 skip/freebsd

--- a/tests/integration/targets/filesystem/aliases
+++ b/tests/integration/targets/filesystem/aliases
@@ -5,6 +5,5 @@
 azp/posix/1
 azp/posix/vm
 destructive
-skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/filter_json_query/aliases
+++ b/tests/integration/targets/filter_json_query/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/aix

--- a/tests/integration/targets/filter_random_mac/aliases
+++ b/tests/integration/targets/filter_random_mac/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/aix

--- a/tests/integration/targets/flatpak/aliases
+++ b/tests/integration/targets/flatpak/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/3
 destructive
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/flatpak_remote/aliases
+++ b/tests/integration/targets/flatpak_remote/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/3
 destructive
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/gem/aliases
+++ b/tests/integration/targets/gem/aliases
@@ -4,6 +4,5 @@
 
 azp/posix/1
 destructive
-skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/git_config/aliases
+++ b/tests/integration/targets/git_config/aliases
@@ -3,5 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/3
-skip/aix
 destructive

--- a/tests/integration/targets/git_config_info/aliases
+++ b/tests/integration/targets/git_config_info/aliases
@@ -3,5 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/3
-skip/aix
 destructive

--- a/tests/integration/targets/hg/aliases
+++ b/tests/integration/targets/hg/aliases
@@ -3,6 +3,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/aix
 skip/macos
 disabled  # TODO osdn.net is out of business, so cloning a repo from there does not work

--- a/tests/integration/targets/homebrew/aliases
+++ b/tests/integration/targets/homebrew/aliases
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/aix
 skip/freebsd
 skip/rhel
 skip/docker

--- a/tests/integration/targets/homebrew_cask/aliases
+++ b/tests/integration/targets/homebrew_cask/aliases
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/aix
 skip/freebsd
 skip/rhel
 skip/docker

--- a/tests/integration/targets/homebrew_services/aliases
+++ b/tests/integration/targets/homebrew_services/aliases
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/aix
 skip/freebsd
 skip/rhel
 skip/docker

--- a/tests/integration/targets/homectl/aliases
+++ b/tests/integration/targets/homectl/aliases
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/iptables_state/aliases
+++ b/tests/integration/targets/iptables_state/aliases
@@ -9,7 +9,6 @@ skip/docker             # kernel modules not loadable
 skip/freebsd            # no iptables/netfilter (Linux specific)
 skip/osx                # no iptables/netfilter (Linux specific)
 skip/macos              # no iptables/netfilter (Linux specific)
-skip/aix                # no iptables/netfilter (Linux specific)
 
 skip/ubuntu22.04  # TODO there's a problem here!
 skip/rhel10.0     # TODO there's a problem here!

--- a/tests/integration/targets/iso_create/aliases
+++ b/tests/integration/targets/iso_create/aliases
@@ -4,4 +4,3 @@
 
 azp/posix/1
 destructive
-skip/aix

--- a/tests/integration/targets/iso_customize/aliases
+++ b/tests/integration/targets/iso_customize/aliases
@@ -5,7 +5,6 @@
 
 azp/posix/1
 destructive
-skip/aix
 skip/freebsd
 skip/alpine
 skip/docker

--- a/tests/integration/targets/iso_extract/aliases
+++ b/tests/integration/targets/iso_extract/aliases
@@ -5,7 +5,6 @@
 azp/posix/1
 needs/target/setup_epel
 destructive
-skip/aix
 skip/osx  # FIXME
 skip/rhel9.0  # FIXME
 skip/rhel9.1  # FIXME

--- a/tests/integration/targets/java_cert/aliases
+++ b/tests/integration/targets/java_cert/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/3
 destructive
-skip/aix
 skip/osx
 skip/macos
 skip/freebsd

--- a/tests/integration/targets/java_keystore/aliases
+++ b/tests/integration/targets/java_keystore/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/3
 destructive
-skip/aix
 skip/osx
 skip/macos
 skip/freebsd

--- a/tests/integration/targets/jboss/aliases
+++ b/tests/integration/targets/jboss/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/1
 destructive
-skip/aix
 skip/osx
 skip/macos
 skip/freebsd

--- a/tests/integration/targets/kea_command/aliases
+++ b/tests/integration/targets/kea_command/aliases
@@ -10,7 +10,6 @@ destructive
 
 azp/posix/2
 azp/posix/vm
-skip/aix
 skip/alpine  # TODO: make this work
 skip/docker
 skip/fedora  # TODO: make this work (not running in CI right now)

--- a/tests/integration/targets/kernel_blacklist/aliases
+++ b/tests/integration/targets/kernel_blacklist/aliases
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/ldap_inc/aliases
+++ b/tests/integration/targets/ldap_inc/aliases
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/ldap_search/aliases
+++ b/tests/integration/targets/ldap_search/aliases
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/listen_ports_facts/aliases
+++ b/tests/integration/targets/listen_ports_facts/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/3
 destructive
-skip/aix
 skip/osx
 skip/macos
 skip/freebsd

--- a/tests/integration/targets/locale_gen/aliases
+++ b/tests/integration/targets/locale_gen/aliases
@@ -5,7 +5,6 @@
 azp/posix/3
 destructive
 needs/root
-skip/aix
 skip/fedora
 skip/freebsd
 skip/macos

--- a/tests/integration/targets/lookup_cartesian/aliases
+++ b/tests/integration/targets/lookup_cartesian/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/aix

--- a/tests/integration/targets/lookup_etcd3/aliases
+++ b/tests/integration/targets/lookup_etcd3/aliases
@@ -6,7 +6,6 @@ azp/posix/1
 destructive
 needs/file/tests/utils/constraints.txt
 needs/target/setup_etcd3
-skip/aix
 skip/osx
 skip/macos
 skip/freebsd

--- a/tests/integration/targets/lookup_flattened/aliases
+++ b/tests/integration/targets/lookup_flattened/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/aix

--- a/tests/integration/targets/lookup_lmdb_kv/aliases
+++ b/tests/integration/targets/lookup_lmdb_kv/aliases
@@ -4,5 +4,4 @@
 
 azp/posix/2
 destructive
-skip/aix
 disabled  # TODO: currently broken

--- a/tests/integration/targets/lookup_passwordstore/aliases
+++ b/tests/integration/targets/lookup_passwordstore/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/1
 destructive
-skip/aix
 skip/rhel
 skip/osx  # FIXME https://github.com/ansible-collections/community.general/issues/2978
 skip/macos  # FIXME https://github.com/ansible-collections/community.general/issues/2978

--- a/tests/integration/targets/lookup_random_pet/aliases
+++ b/tests/integration/targets/lookup_random_pet/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/aix

--- a/tests/integration/targets/lookup_random_string/aliases
+++ b/tests/integration/targets/lookup_random_string/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/aix

--- a/tests/integration/targets/lookup_random_words/aliases
+++ b/tests/integration/targets/lookup_random_words/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/aix

--- a/tests/integration/targets/lvg/aliases
+++ b/tests/integration/targets/lvg/aliases
@@ -6,7 +6,6 @@ azp/posix/1
 azp/posix/vm
 destructive
 needs/privileged
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/lvg_rename/aliases
+++ b/tests/integration/targets/lvg_rename/aliases
@@ -7,7 +7,6 @@ azp/posix/1
 azp/posix/vm
 destructive
 needs/privileged
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/lvm_pv/aliases
+++ b/tests/integration/targets/lvm_pv/aliases
@@ -7,7 +7,6 @@ azp/posix/1
 azp/posix/vm
 destructive
 needs/privileged
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/lvm_pv_move_data/aliases
+++ b/tests/integration/targets/lvm_pv_move_data/aliases
@@ -7,7 +7,6 @@ azp/posix/1
 azp/posix/vm
 destructive
 needs/privileged
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/lvol/aliases
+++ b/tests/integration/targets/lvol/aliases
@@ -6,7 +6,6 @@ azp/posix/1
 azp/posix/vm
 destructive
 needs/privileged
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/monit/aliases
+++ b/tests/integration/targets/monit/aliases
@@ -8,5 +8,4 @@ needs/target/setup_epel
 skip/osx
 skip/macos
 skip/freebsd
-skip/aix
 skip/rhel  # FIXME

--- a/tests/integration/targets/mqtt/aliases
+++ b/tests/integration/targets/mqtt/aliases
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/aix
 skip/osx
 skip/macos
 skip/freebsd

--- a/tests/integration/targets/nomad/aliases
+++ b/tests/integration/targets/nomad/aliases
@@ -5,7 +5,6 @@
 azp/posix/2
 nomad_job_info
 destructive
-skip/aix
 skip/centos6
 skip/freebsd
 disabled  # TODO

--- a/tests/integration/targets/npm/aliases
+++ b/tests/integration/targets/npm/aliases
@@ -4,5 +4,4 @@
 
 azp/posix/2
 destructive
-skip/aix
 skip/freebsd

--- a/tests/integration/targets/osx_defaults/aliases
+++ b/tests/integration/targets/osx_defaults/aliases
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/aix
 skip/freebsd
 skip/rhel
 skip/docker

--- a/tests/integration/targets/pacman/aliases
+++ b/tests/integration/targets/pacman/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/1
 destructive
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/pam_limits/aliases
+++ b/tests/integration/targets/pam_limits/aliases
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/pamd/aliases
+++ b/tests/integration/targets/pamd/aliases
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/parted/aliases
+++ b/tests/integration/targets/parted/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/2
 azp/posix/vm
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/redis_info/aliases
+++ b/tests/integration/targets/redis_info/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/1
 destructive
-skip/aix
 skip/osx
 skip/macos
 skip/rhel

--- a/tests/integration/targets/rundeck/aliases
+++ b/tests/integration/targets/rundeck/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/1
 destructive
-skip/aix
 skip/osx
 skip/macos
 skip/windows

--- a/tests/integration/targets/sefcontext/aliases
+++ b/tests/integration/targets/sefcontext/aliases
@@ -4,4 +4,3 @@
 
 azp/posix/2
 needs/root
-skip/aix

--- a/tests/integration/targets/snap/aliases
+++ b/tests/integration/targets/snap/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/1
 azp/posix/vm
-skip/aix
 skip/alpine
 skip/fedora
 skip/freebsd

--- a/tests/integration/targets/snap_alias/aliases
+++ b/tests/integration/targets/snap_alias/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/1
 azp/posix/vm
-skip/aix
 skip/alpine
 skip/fedora
 skip/freebsd

--- a/tests/integration/targets/supervisorctl/aliases
+++ b/tests/integration/targets/supervisorctl/aliases
@@ -4,6 +4,5 @@
 
 azp/posix/2
 destructive
-skip/aix
 skip/rhel  # TODO executables are installed in /usr/local/bin, which isn't part of $PATH
 skip/macos  # TODO executables are installed in /Library/Frameworks/Python.framework/Versions/3.11/bin, which isn't part of $PATH

--- a/tests/integration/targets/systemd_creds_decrypt/aliases
+++ b/tests/integration/targets/systemd_creds_decrypt/aliases
@@ -5,7 +5,6 @@
 needs/root
 
 azp/posix/1
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/systemd_creds_encrypt/aliases
+++ b/tests/integration/targets/systemd_creds_encrypt/aliases
@@ -5,7 +5,6 @@
 needs/root
 
 azp/posix/1
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/systemd_info/aliases
+++ b/tests/integration/targets/systemd_info/aliases
@@ -4,7 +4,6 @@
 
 needs/root
 azp/posix/1
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/terraform/aliases
+++ b/tests/integration/targets/terraform/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/1
 skip/windows
-skip/aix
 skip/osx
 skip/macos
 skip/freebsd

--- a/tests/integration/targets/timezone/aliases
+++ b/tests/integration/targets/timezone/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/1
 destructive
-skip/aix
 skip/osx
 skip/macos
 skip/rhel7.9  # TODO: '/bin/timedatectl set-local-rtc no' fails with 'Failed to set local RTC: Failed to set RTC to local/UTC: Input/output error'

--- a/tests/integration/targets/ufw/aliases
+++ b/tests/integration/targets/ufw/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/2
 azp/posix/vm
-skip/aix
 skip/osx
 skip/macos
 skip/freebsd

--- a/tests/integration/targets/wakeonlan/aliases
+++ b/tests/integration/targets/wakeonlan/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/aix

--- a/tests/integration/targets/xattr/aliases
+++ b/tests/integration/targets/xattr/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/2
 azp/posix/vm
-skip/aix
 skip/docker
 skip/freebsd
 skip/osx

--- a/tests/integration/targets/xfs_quota/aliases
+++ b/tests/integration/targets/xfs_quota/aliases
@@ -6,7 +6,6 @@ azp/posix/1
 azp/posix/vm
 needs/privileged
 needs/root
-skip/aix
 skip/osx
 skip/macos
 skip/freebsd

--- a/tests/integration/targets/xml/aliases
+++ b/tests/integration/targets/xml/aliases
@@ -4,4 +4,3 @@
 
 azp/posix/3
 destructive
-skip/aix

--- a/tests/integration/targets/yarn/aliases
+++ b/tests/integration/targets/yarn/aliases
@@ -4,5 +4,4 @@
 
 azp/posix/1
 destructive
-skip/aix
 skip/freebsd

--- a/tests/integration/targets/yum_versionlock/aliases
+++ b/tests/integration/targets/yum_versionlock/aliases
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/zpool/aliases
+++ b/tests/integration/targets/zpool/aliases
@@ -6,7 +6,6 @@ azp/posix/3
 azp/posix/vm
 destructive
 needs/privileged
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/zypper/aliases
+++ b/tests/integration/targets/zypper/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/1
 destructive
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos

--- a/tests/integration/targets/zypper_repository/aliases
+++ b/tests/integration/targets/zypper_repository/aliases
@@ -4,7 +4,6 @@
 
 azp/posix/1
 destructive
-skip/aix
 skip/freebsd
 skip/osx
 skip/macos


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This collection has not run CI tests against AIX for a long time.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
tests/integration/targets/alternatives/aliases
tests/integration/targets/apache2_mod_proxy/aliases
tests/integration/targets/apache2_module/aliases
tests/integration/targets/apk/aliases
tests/integration/targets/archive/aliases
tests/integration/targets/btrfs_subvolume/aliases
tests/integration/targets/cargo/aliases
tests/integration/targets/cloud_init_data_facts/aliases
tests/integration/targets/consul/aliases
tests/integration/targets/cpanm/aliases
tests/integration/targets/cronvar/aliases
tests/integration/targets/dnf_versionlock/aliases
tests/integration/targets/dpkg_divert/aliases
tests/integration/targets/etcd3/aliases
tests/integration/targets/filesystem/aliases
tests/integration/targets/filter_json_query/aliases
tests/integration/targets/filter_random_mac/aliases
tests/integration/targets/flatpak/aliases
tests/integration/targets/flatpak_remote/aliases
tests/integration/targets/gem/aliases
tests/integration/targets/git_config/aliases
tests/integration/targets/git_config_info/aliases
tests/integration/targets/hg/aliases
tests/integration/targets/homebrew/aliases
tests/integration/targets/homebrew_cask/aliases
tests/integration/targets/homebrew_services/aliases
tests/integration/targets/homectl/aliases
tests/integration/targets/iptables_state/aliases
tests/integration/targets/iso_create/aliases
tests/integration/targets/iso_customize/aliases
tests/integration/targets/iso_extract/aliases
tests/integration/targets/java_cert/aliases
tests/integration/targets/java_keystore/aliases
tests/integration/targets/jboss/aliases
tests/integration/targets/kea_command/aliases
tests/integration/targets/kernel_blacklist/aliases
tests/integration/targets/ldap_inc/aliases
tests/integration/targets/ldap_search/aliases
tests/integration/targets/listen_ports_facts/aliases
tests/integration/targets/locale_gen/aliases
tests/integration/targets/lookup_cartesian/aliases
tests/integration/targets/lookup_etcd3/aliases
tests/integration/targets/lookup_flattened/aliases
tests/integration/targets/lookup_lmdb_kv/aliases
tests/integration/targets/lookup_passwordstore/aliases
tests/integration/targets/lookup_random_pet/aliases
tests/integration/targets/lookup_random_string/aliases
tests/integration/targets/lookup_random_words/aliases
tests/integration/targets/lvg/aliases
tests/integration/targets/lvg_rename/aliases
tests/integration/targets/lvm_pv/aliases
tests/integration/targets/lvm_pv_move_data/aliases
tests/integration/targets/lvol/aliases
tests/integration/targets/monit/aliases
tests/integration/targets/mqtt/aliases
tests/integration/targets/nomad/aliases
tests/integration/targets/npm/aliases
tests/integration/targets/osx_defaults/aliases
tests/integration/targets/pacman/aliases
tests/integration/targets/pam_limits/aliases
tests/integration/targets/pamd/aliases
tests/integration/targets/parted/aliases
tests/integration/targets/redis_info/aliases
tests/integration/targets/rundeck/aliases
tests/integration/targets/sefcontext/aliases
tests/integration/targets/snap/aliases
tests/integration/targets/snap_alias/aliases
tests/integration/targets/supervisorctl/aliases
tests/integration/targets/systemd_creds_decrypt/aliases
tests/integration/targets/systemd_creds_encrypt/aliases
tests/integration/targets/systemd_info/aliases
tests/integration/targets/terraform/aliases
tests/integration/targets/timezone/aliases
tests/integration/targets/ufw/aliases
tests/integration/targets/wakeonlan/aliases
tests/integration/targets/xattr/aliases
tests/integration/targets/xfs_quota/aliases
tests/integration/targets/xml/aliases
tests/integration/targets/yarn/aliases
tests/integration/targets/yum_versionlock/aliases
tests/integration/targets/zpool/aliases
tests/integration/targets/zypper/aliases
tests/integration/targets/zypper_repository/aliases
