### PR TITLE
btrfs_subvolume: Fix for symlinked btrfs devices

### DIFF
--- a/changelogs/fragments/11687-btrfs_subvolume-fix-symlinked-devices.yml
+++ b/changelogs/fragments/11687-btrfs_subvolume-fix-symlinked-devices.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - btrfs_subvolume - devices that are symlinked (i.e. when using LUKS) were not found and lead to an error (https://github.com/ansible-collections/community.general/pull/11687)
+  

--- a/changelogs/fragments/11687-btrfs_subvolume-fix-symlinked-devices.yml
+++ b/changelogs/fragments/11687-btrfs_subvolume-fix-symlinked-devices.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - btrfs_subvolume - devices that are symlinked (i.e. when using LUKS) were not found and lead to an error (https://github.com/ansible-collections/community.general/pull/11687)
+  - btrfs_subvolume - devices that are symlinked (for example when using LUKS) were not found and lead to an error (https://github.com/ansible-collections/community.general/pull/11687).
   

--- a/plugins/module_utils/btrfs.py
+++ b/plugins/module_utils/btrfs.py
@@ -146,7 +146,7 @@ class BtrfsInfoProvider:
     def __filter_mountpoints_for_devices(
         self, mountpoints: list[dict[str, t.Any]], devices: list[str]
     ) -> list[dict[str, t.Any]]:
-        return [m for m in mountpoints if bool(set(m["devices"]).intersection(devices))]
+        return [m for m in mountpoints if set(m["devices"]).intersection(devices)]
 
     def __find_mountpoints(self) -> list[dict[str, t.Any]]:
         command = [self.__findmnt_path, "-t", "btrfs", "-nvP", "--output", "TARGET,SOURCES,OPTIONS"]

--- a/plugins/module_utils/btrfs.py
+++ b/plugins/module_utils/btrfs.py
@@ -146,10 +146,10 @@ class BtrfsInfoProvider:
     def __filter_mountpoints_for_devices(
         self, mountpoints: list[dict[str, t.Any]], devices: list[str]
     ) -> list[dict[str, t.Any]]:
-        return [m for m in mountpoints if (m["device"] in devices)]
+        return [m for m in mountpoints if bool(set(m["devices"]).intersection(devices))]
 
     def __find_mountpoints(self) -> list[dict[str, t.Any]]:
-        command = [self.__findmnt_path, "-t", "btrfs", "-nvP"]
+        command = [self.__findmnt_path, "-t", "btrfs", "-nvP", "--output", "TARGET,SOURCES,OPTIONS"]
         result = self.__module.run_command(command)
         mountpoints = []
         if result[0] == 0:
@@ -161,15 +161,16 @@ class BtrfsInfoProvider:
 
     def __parse_mountpoint_pairs(self, line) -> dict[str, t.Any]:
         pattern = re.compile(
-            r'^TARGET="(?P<target>.*)"\s+SOURCE="(?P<source>.*)"\s+FSTYPE="(?P<fstype>.*)"\s+OPTIONS="(?P<options>.*)"\s*$'
+            r'^TARGET="(?P<target>.*)"\s+SOURCES="(?P<sources>.*)"\s+OPTIONS="(?P<options>.*)"\s*$'
         )
         match = pattern.search(line)
         if match is not None:
             groups = match.groupdict()
 
+            # when devices are symlinked (e.g. LUKS), the devices are separated by encoded newlines (\x0a)
             return {
                 "mountpoint": groups["target"],
-                "device": groups["source"],
+                "devices": groups["sources"].split("\\x0a"),
                 "subvolid": self.__extract_mount_subvolid(groups["options"]),
             }
         else:


### PR DESCRIPTION
##### SUMMARY
Fixes #11331 (and maybe also #10161)

When using btrfs_submodule the device filter did not take into account that there may be source devices that were symlinked. When calling `findmnt` the only result for the source device was the "root" device, not the symlink that was used to mount the device.
This patch lists all source devices (including symlinks) and filters for an intersection.
(Thanks to @zhengliw for leading me to the right point in #11331) 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
btrfs_subvolume

##### ADDITIONAL INFORMATION
When using LUKS encrypted disks you use `/dev/mapped/<devicename>` instead of `/dev/dm-X` to mount a disk. LUKS automatically creates the labeled symlink to be able to easier identify the correct disk. Without this patch the module only listed `/dev/dm-X` as the source device. When using the labeled symlink in the playbook, the btrfs mount wasn't found, because the source device didn't match. Now all source devices are listed and compared for an intersecting device.
