### PR TITLE
github_repo - add parameters for managing repository settings

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -630,6 +630,8 @@ files:
     maintainers: guenhter
   $modules/github_:
     maintainers: stpierre
+  $modules/github_branch_protection.py:
+    maintainers: john-westcott-iv
   $modules/github_deploy_key.py:
     maintainers: bincyber
   $modules/github_issue.py:
@@ -638,14 +640,22 @@ files:
     ignore: erydo
     labels: github_key
     maintainers: erydo
+  $modules/github_label.py:
+    maintainers: john-westcott-iv
   $modules/github_release.py:
     maintainers: adrianmoisey
   $modules/github_repo.py:
-    maintainers: atorrescogollo
+    maintainers: atorrescogollo john-westcott-iv
+  $modules/github_repo_ruleset.py:
+    maintainers: john-westcott-iv
   $modules/github_secrets.py:
     maintainers: konstruktoid
   $modules/github_secrets_info.py:
     maintainers: konstruktoid
+  $modules/github_team.py:
+    maintainers: john-westcott-iv
+  $modules/github_team_members.py:
+    maintainers: john-westcott-iv
   $modules/gitlab_:
     keywords: gitlab source_control
     maintainers: $team_gitlab

--- a/changelogs/fragments/github-repo-settings.yml
+++ b/changelogs/fragments/github-repo-settings.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - github_repo - add parameters for managing wiki, projects, discussions, issues, merge strategies, auto-merge, branch deletion, commit title/message defaults, homepage, and topics (https://github.com/ansible-collections/community.general/pull/XXXX).

--- a/plugins/modules/github_repo.py
+++ b/plugins/modules/github_repo.py
@@ -55,6 +55,87 @@ options:
       - Defaults to V(false) if O(force_defaults=false) when creating a new repository.
       - This is only used when O(state=present).
     type: bool
+  has_issues:
+    description:
+      - Whether to enable issues on the repository.
+    type: bool
+    version_added: NEXT_PATCH
+  has_wiki:
+    description:
+      - Whether to enable the wiki on the repository.
+    type: bool
+    version_added: NEXT_PATCH
+  has_projects:
+    description:
+      - Whether to enable projects on the repository.
+    type: bool
+    version_added: NEXT_PATCH
+  has_discussions:
+    description:
+      - Whether to enable discussions on the repository.
+    type: bool
+    version_added: NEXT_PATCH
+  allow_squash_merge:
+    description:
+      - Whether to allow squash merges for pull requests.
+    type: bool
+    version_added: NEXT_PATCH
+  allow_merge_commit:
+    description:
+      - Whether to allow merge commits for pull requests.
+    type: bool
+    version_added: NEXT_PATCH
+  allow_rebase_merge:
+    description:
+      - Whether to allow rebase merges for pull requests.
+    type: bool
+    version_added: NEXT_PATCH
+  delete_branch_on_merge:
+    description:
+      - Whether to automatically delete head branches after pull requests are merged.
+    type: bool
+    version_added: NEXT_PATCH
+  allow_auto_merge:
+    description:
+      - Whether to allow auto-merge on pull requests.
+    type: bool
+    version_added: NEXT_PATCH
+  squash_merge_commit_title:
+    description:
+      - The default value for a squash merge commit title.
+    type: str
+    choices: [PR_TITLE, COMMIT_OR_PR_TITLE]
+    version_added: NEXT_PATCH
+  squash_merge_commit_message:
+    description:
+      - The default value for a squash merge commit message.
+    type: str
+    choices: [PR_BODY, COMMIT_MESSAGES, BLANK]
+    version_added: NEXT_PATCH
+  merge_commit_title:
+    description:
+      - The default value for a merge commit title.
+    type: str
+    choices: [PR_TITLE, MERGE_MESSAGE]
+    version_added: NEXT_PATCH
+  merge_commit_message:
+    description:
+      - The default value for a merge commit message.
+    type: str
+    choices: [PR_BODY, PR_TITLE, BLANK]
+    version_added: NEXT_PATCH
+  homepage:
+    description:
+      - A URL with more information about the repository.
+    type: str
+    version_added: NEXT_PATCH
+  topics:
+    description:
+      - A list of topics to set on the repository.
+      - This replaces all existing topics.
+    type: list
+    elements: str
+    version_added: NEXT_PATCH
   state:
     description:
       - Whether the repository should exist or not.
@@ -98,6 +179,30 @@ EXAMPLES = r"""
     force_defaults: false
   register: result
 
+- name: Update repository settings
+  community.general.github_repo:
+    access_token: mytoken
+    organization: MyOrganization
+    name: myrepo
+    has_wiki: false
+    has_issues: true
+    has_projects: false
+    has_discussions: true
+    allow_squash_merge: true
+    allow_merge_commit: false
+    allow_rebase_merge: false
+    delete_branch_on_merge: true
+    allow_auto_merge: true
+    squash_merge_commit_title: PR_TITLE
+    squash_merge_commit_message: PR_BODY
+    homepage: "https://example.com"
+    topics:
+      - ansible
+      - automation
+    state: present
+    force_defaults: false
+  register: result
+
 - name: Delete the repository
   community.general.github_repo:
     username: octocat
@@ -129,6 +234,24 @@ except Exception:
     GITHUB_IMP_ERR = traceback.format_exc()
     HAS_GITHUB_PACKAGE = False
 
+# Parameters that map directly to Repository.edit() kwargs
+REPO_EDIT_PARAMS = [
+    "has_issues",
+    "has_wiki",
+    "has_projects",
+    "has_discussions",
+    "allow_squash_merge",
+    "allow_merge_commit",
+    "allow_rebase_merge",
+    "delete_branch_on_merge",
+    "allow_auto_merge",
+    "squash_merge_commit_title",
+    "squash_merge_commit_message",
+    "merge_commit_title",
+    "merge_commit_message",
+    "homepage",
+]
+
 
 def authenticate(username=None, password=None, access_token=None, api_url=None):
     if not api_url:
@@ -140,7 +263,7 @@ def authenticate(username=None, password=None, access_token=None, api_url=None):
         return Github(base_url=api_url, login_or_token=username, password=password)
 
 
-def create_repo(gh, name, organization=None, private=None, description=None, check_mode=False):
+def create_repo(gh, name, organization=None, private=None, description=None, check_mode=False, **extra_params):
     result = dict(changed=False, repo=dict())
     if organization:
         target = gh.get_organization(organization)
@@ -170,17 +293,31 @@ def create_repo(gh, name, organization=None, private=None, description=None, che
         if repo is None or repo.raw_data["description"] not in (description, description or None):
             changes["description"] = description
 
+    for param in REPO_EDIT_PARAMS:
+        value = extra_params.get(param)
+        if value is not None:
+            raw_key = param
+            if repo is None or repo.raw_data.get(raw_key) != value:
+                changes[param] = value
+
     if changes:
         if not check_mode:
             repo.edit(**changes)
 
-        result["repo"].update(
-            {
-                "private": repo._private.value if not check_mode else private,
-                "description": repo._description.value if not check_mode else description,
-            }
-        )
+        result["repo"].update(changes)
         result["changed"] = True
+
+    # Handle topics separately (different API endpoint)
+    topics = extra_params.get("topics")
+    if topics is not None:
+        current_topics = sorted(repo.get_topics()) if repo is not None and not check_mode else []
+        if sorted(topics) != current_topics:
+            if not check_mode:
+                repo.replace_topics(topics)
+                result["repo"]["topics"] = topics
+            else:
+                result["repo"]["topics"] = topics
+            result["changed"] = True
 
     return result
 
@@ -216,6 +353,9 @@ def run_module(params, check_mode=False):
     if params["state"] == "absent":
         return delete_repo(gh=gh, name=params["name"], organization=params["organization"], check_mode=check_mode)
     else:
+        extra_params = {param: params[param] for param in REPO_EDIT_PARAMS if params.get(param) is not None}
+        if params.get("topics") is not None:
+            extra_params["topics"] = params["topics"]
         return create_repo(
             gh=gh,
             name=params["name"],
@@ -223,6 +363,7 @@ def run_module(params, check_mode=False):
             private=params["private"],
             description=params["description"],
             check_mode=check_mode,
+            **extra_params,
         )
 
 
@@ -233,11 +374,24 @@ def main():
         access_token=dict(type="str", no_log=True),
         name=dict(type="str", required=True),
         state=dict(type="str", default="present", choices=["present", "absent"]),
-        organization=dict(
-            type="str",
-        ),
+        organization=dict(type="str"),
         private=dict(type="bool"),
         description=dict(type="str"),
+        has_issues=dict(type="bool"),
+        has_wiki=dict(type="bool"),
+        has_projects=dict(type="bool"),
+        has_discussions=dict(type="bool"),
+        allow_squash_merge=dict(type="bool"),
+        allow_merge_commit=dict(type="bool"),
+        allow_rebase_merge=dict(type="bool"),
+        delete_branch_on_merge=dict(type="bool"),
+        allow_auto_merge=dict(type="bool"),
+        squash_merge_commit_title=dict(type="str", choices=["PR_TITLE", "COMMIT_OR_PR_TITLE"]),
+        squash_merge_commit_message=dict(type="str", choices=["PR_BODY", "COMMIT_MESSAGES", "BLANK"]),
+        merge_commit_title=dict(type="str", choices=["PR_TITLE", "MERGE_MESSAGE"]),
+        merge_commit_message=dict(type="str", choices=["PR_BODY", "PR_TITLE", "BLANK"]),
+        homepage=dict(type="str"),
+        topics=dict(type="list", elements="str"),
         api_url=dict(type="str", default="https://api.github.com"),
         force_defaults=dict(type="bool"),
     )

--- a/tests/unit/plugins/modules/test_github_repo.py
+++ b/tests/unit/plugins/modules/test_github_repo.py
@@ -16,6 +16,61 @@ from ansible_collections.community.general.plugins.modules import github_repo
 pytest.importorskip("github")
 
 
+BASE_PARAMS = {
+    "username": None,
+    "password": None,
+    "access_token": "mytoken",
+    "api_url": "https://api.github.com",
+    "force_defaults": False,
+    "has_issues": None,
+    "has_wiki": None,
+    "has_projects": None,
+    "has_discussions": None,
+    "allow_squash_merge": None,
+    "allow_merge_commit": None,
+    "allow_rebase_merge": None,
+    "delete_branch_on_merge": None,
+    "allow_auto_merge": None,
+    "squash_merge_commit_title": None,
+    "squash_merge_commit_message": None,
+    "merge_commit_title": None,
+    "merge_commit_message": None,
+    "homepage": None,
+    "topics": None,
+}
+
+
+FULL_REPO_DATA = {
+    "name": "myrepo",
+    "full_name": "MyOrganization/myrepo",
+    "url": "https://api.github.com/repos/MyOrganization/myrepo",
+    "private": False,
+    "description": "This your first repo!",
+    "default_branch": "master",
+    "allow_rebase_merge": True,
+    "allow_squash_merge": True,
+    "allow_merge_commit": True,
+    "allow_auto_merge": False,
+    "delete_branch_on_merge": False,
+    "has_issues": True,
+    "has_wiki": True,
+    "has_projects": True,
+    "has_discussions": False,
+    "squash_merge_commit_title": "COMMIT_OR_PR_TITLE",
+    "squash_merge_commit_message": "COMMIT_MESSAGES",
+    "merge_commit_title": "MERGE_MESSAGE",
+    "merge_commit_message": "PR_TITLE",
+    "homepage": "",
+    "topics": ["existing-topic"],
+}
+
+
+def make_params(**overrides):
+    params = dict(BASE_PARAMS)
+    params.update(overrides)
+    return params
+
+
 @urlmatch(netloc=r".*")
 def debug_mock(url, request):
     print(request.original.__dict__)
@@ -47,44 +102,33 @@ def get_repo_notfound_mock(url, request):
     return response(404, '{"message": "Not Found"}', "", "Not Found", 5, request)
 
 
-@urlmatch(netloc=r"api\.github\.com(:[0-9]+)?$", path=r"/repos/.*/.*", method="get")
+@urlmatch(netloc=r"api\.github\.com(:[0-9]+)?$", path=r"/repos/[^/]+/[^/]+$", method="get")
 def get_repo_mock(url, request):
     match = re.search(r"api\.github\.com(:[0-9]+)?/repos/(?P<org>[^/]+)/(?P<repo>[^/]+)", request.url)
     org = match.group("org")
     repo = match.group("repo")
 
-    # https://docs.github.com/en/rest/reference/repos#get-a-repository
     headers = {"content-type": "application/json"}
-    content = {
-        "name": repo,
-        "full_name": f"{org}/{repo}",
-        "url": f"https://api.github.com/repos/{org}/{repo}",
-        "private": False,
-        "description": "This your first repo!",
-        "default_branch": "master",
-        "allow_rebase_merge": True,
-    }
+    content = dict(FULL_REPO_DATA)
+    content["full_name"] = f"{org}/{repo}"
+    content["url"] = f"https://api.github.com/repos/{org}/{repo}"
+    content["name"] = repo
     content = json.dumps(content).encode("utf-8")
     return response(200, content, headers, None, 5, request)
 
 
-@urlmatch(netloc=r"api\.github\.com(:[0-9]+)?$", path=r"/repos/.*/.*", method="get")
+@urlmatch(netloc=r"api\.github\.com(:[0-9]+)?$", path=r"/repos/[^/]+/[^/]+$", method="get")
 def get_private_repo_mock(url, request):
     match = re.search(r"api\.github\.com(:[0-9]+)?/repos/(?P<org>[^/]+)/(?P<repo>[^/]+)", request.url)
     org = match.group("org")
     repo = match.group("repo")
 
-    # https://docs.github.com/en/rest/reference/repos#get-a-repository
     headers = {"content-type": "application/json"}
-    content = {
-        "name": repo,
-        "full_name": f"{org}/{repo}",
-        "url": f"https://api.github.com/repos/{org}/{repo}",
-        "private": True,
-        "description": "This your first repo!",
-        "default_branch": "master",
-        "allow_rebase_merge": True,
-    }
+    content = dict(FULL_REPO_DATA)
+    content["full_name"] = f"{org}/{repo}"
+    content["url"] = f"https://api.github.com/repos/{org}/{repo}"
+    content["name"] = repo
+    content["private"] = True
     content = json.dumps(content).encode("utf-8")
     return response(200, content, headers, None, 5, request)
 
@@ -123,7 +167,7 @@ def create_new_user_repo_mock(url, request):
     return response(201, content, headers, None, 5, request)
 
 
-@urlmatch(netloc=r"api\.github\.com(:[0-9]+)?$", path=r"/repos/.*/.*", method="patch")
+@urlmatch(netloc=r"api\.github\.com(:[0-9]+)?$", path=r"/repos/[^/]+/[^/]+$", method="patch")
 def patch_repo_mock(url, request):
     match = re.search(r"api\.github\.com(:[0-9]+)?/repos/(?P<org>[^/]+)/(?P<repo>[^/]+)", request.url)
     org = match.group("org")
@@ -131,16 +175,11 @@ def patch_repo_mock(url, request):
 
     body = json.loads(request.body)
     headers = {"content-type": "application/json"}
-    # https://docs.github.com/en/rest/reference/repos#update-a-repository
-    content = {
-        "name": repo,
-        "full_name": f"{org}/{repo}",
-        "url": f"https://api.github.com/repos/{org}/{repo}",
-        "private": body.get("private", False),
-        "description": body.get("description"),
-        "default_branch": "master",
-        "allow_rebase_merge": True,
-    }
+    content = dict(FULL_REPO_DATA)
+    content["name"] = repo
+    content["full_name"] = f"{org}/{repo}"
+    content["url"] = f"https://api.github.com/repos/{org}/{repo}"
+    content.update(body)
     content = json.dumps(content).encode("utf-8")
     return response(200, content, headers, None, 5, request)
 
@@ -157,24 +196,34 @@ def delete_repo_notfound_mock(url, request):
     return response(404, '{"message": "Not Found"}', "", "Not Found", 5, request)
 
 
+@urlmatch(netloc=r"api\.github\.com(:[0-9]+)?$", path=r"/repos/[^/]+/[^/]+/topics$", method="get")
+def get_topics_mock(url, request):
+    headers = {"content-type": "application/json"}
+    content = json.dumps({"names": ["existing-topic"]}).encode("utf-8")
+    return response(200, content, headers, None, 5, request)
+
+
+@urlmatch(netloc=r"api\.github\.com(:[0-9]+)?$", path=r"/repos/[^/]+/[^/]+/topics$", method="put")
+def put_topics_mock(url, request):
+    body = json.loads(request.body)
+    headers = {"content-type": "application/json"}
+    content = json.dumps({"names": body["names"]}).encode("utf-8")
+    return response(200, content, headers, None, 5, request)
+
+
 class TestGithubRepo(unittest.TestCase):
     @with_httmock(get_orgs_mock)
     @with_httmock(get_repo_notfound_mock)
     @with_httmock(create_new_org_repo_mock)
     def test_create_new_org_repo(self):
         result = github_repo.run_module(
-            {
-                "username": None,
-                "password": None,
-                "access_token": "mytoken",
-                "organization": "MyOrganization",
-                "name": "myrepo",
-                "description": "Just for fun",
-                "private": False,
-                "state": "present",
-                "api_url": "https://api.github.com",
-                "force_defaults": False,
-            }
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description="Just for fun",
+                private=False,
+                state="present",
+            )
         )
 
         self.assertEqual(result["changed"], True)
@@ -186,18 +235,13 @@ class TestGithubRepo(unittest.TestCase):
     @with_httmock(create_new_org_repo_mock)
     def test_create_new_org_repo_incomplete(self):
         result = github_repo.run_module(
-            {
-                "username": None,
-                "password": None,
-                "access_token": "mytoken",
-                "organization": "MyOrganization",
-                "name": "myrepo",
-                "description": None,
-                "private": None,
-                "state": "present",
-                "api_url": "https://api.github.com",
-                "force_defaults": False,
-            }
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description=None,
+                private=None,
+                state="present",
+            )
         )
 
         self.assertEqual(result["changed"], True)
@@ -209,18 +253,13 @@ class TestGithubRepo(unittest.TestCase):
     @with_httmock(create_new_user_repo_mock)
     def test_create_new_user_repo(self):
         result = github_repo.run_module(
-            {
-                "username": None,
-                "password": None,
-                "access_token": "mytoken",
-                "organization": None,
-                "name": "myrepo",
-                "description": "Just for fun",
-                "private": True,
-                "state": "present",
-                "api_url": "https://api.github.com",
-                "force_defaults": False,
-            }
+            make_params(
+                organization=None,
+                name="myrepo",
+                description="Just for fun",
+                private=True,
+                state="present",
+            )
         )
         self.assertEqual(result["changed"], True)
         self.assertEqual(result["repo"]["private"], True)
@@ -230,18 +269,13 @@ class TestGithubRepo(unittest.TestCase):
     @with_httmock(patch_repo_mock)
     def test_patch_existing_org_repo(self):
         result = github_repo.run_module(
-            {
-                "username": None,
-                "password": None,
-                "access_token": "mytoken",
-                "organization": "MyOrganization",
-                "name": "myrepo",
-                "description": "Just for fun",
-                "private": True,
-                "state": "present",
-                "api_url": "https://api.github.com",
-                "force_defaults": False,
-            }
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description="Just for fun",
+                private=True,
+                state="present",
+            )
         )
         self.assertEqual(result["changed"], True)
         self.assertEqual(result["repo"]["private"], True)
@@ -250,18 +284,13 @@ class TestGithubRepo(unittest.TestCase):
     @with_httmock(get_private_repo_mock)
     def test_idempotency_existing_org_private_repo(self):
         result = github_repo.run_module(
-            {
-                "username": None,
-                "password": None,
-                "access_token": "mytoken",
-                "organization": "MyOrganization",
-                "name": "myrepo",
-                "description": None,
-                "private": None,
-                "state": "present",
-                "api_url": "https://api.github.com",
-                "force_defaults": False,
-            }
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description=None,
+                private=None,
+                state="present",
+            )
         )
         self.assertEqual(result["changed"], False)
         self.assertEqual(result["repo"]["private"], True)
@@ -272,18 +301,13 @@ class TestGithubRepo(unittest.TestCase):
     @with_httmock(delete_repo_mock)
     def test_delete_org_repo(self):
         result = github_repo.run_module(
-            {
-                "username": None,
-                "password": None,
-                "access_token": "mytoken",
-                "organization": "MyOrganization",
-                "name": "myrepo",
-                "description": "Just for fun",
-                "private": False,
-                "state": "absent",
-                "api_url": "https://api.github.com",
-                "force_defaults": False,
-            }
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description="Just for fun",
+                private=False,
+                state="absent",
+            )
         )
         self.assertEqual(result["changed"], True)
 
@@ -292,18 +316,13 @@ class TestGithubRepo(unittest.TestCase):
     @with_httmock(delete_repo_mock)
     def test_delete_user_repo(self):
         result = github_repo.run_module(
-            {
-                "username": None,
-                "password": None,
-                "access_token": "mytoken",
-                "organization": None,
-                "name": "myrepo",
-                "description": "Just for fun",
-                "private": False,
-                "state": "absent",
-                "api_url": "https://api.github.com",
-                "force_defaults": False,
-            }
+            make_params(
+                organization=None,
+                name="myrepo",
+                description="Just for fun",
+                private=False,
+                state="absent",
+            )
         )
         self.assertEqual(result["changed"], True)
 
@@ -312,17 +331,256 @@ class TestGithubRepo(unittest.TestCase):
     @with_httmock(delete_repo_notfound_mock)
     def test_delete_org_repo_notfound(self):
         result = github_repo.run_module(
-            {
-                "username": None,
-                "password": None,
-                "access_token": "mytoken",
-                "organization": "MyOrganization",
-                "name": "myrepo",
-                "description": "Just for fun",
-                "private": True,
-                "state": "absent",
-                "api_url": "https://api.github.com",
-                "force_defaults": False,
-            }
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description="Just for fun",
+                private=True,
+                state="absent",
+            )
         )
         self.assertEqual(result["changed"], False)
+
+    # --- Tests for new settings parameters ---
+
+    @with_httmock(get_orgs_mock)
+    @with_httmock(get_repo_mock)
+    @with_httmock(patch_repo_mock)
+    def test_update_wiki_setting(self):
+        result = github_repo.run_module(
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description=None,
+                private=None,
+                state="present",
+                has_wiki=False,
+            )
+        )
+        self.assertEqual(result["changed"], True)
+        self.assertEqual(result["repo"]["has_wiki"], False)
+
+    @with_httmock(get_orgs_mock)
+    @with_httmock(get_repo_mock)
+    def test_idempotency_wiki_already_enabled(self):
+        result = github_repo.run_module(
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description=None,
+                private=None,
+                state="present",
+                has_wiki=True,
+            )
+        )
+        self.assertEqual(result["changed"], False)
+
+    @with_httmock(get_orgs_mock)
+    @with_httmock(get_repo_mock)
+    @with_httmock(patch_repo_mock)
+    def test_update_merge_settings(self):
+        result = github_repo.run_module(
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description=None,
+                private=None,
+                state="present",
+                allow_squash_merge=False,
+                allow_merge_commit=False,
+                allow_rebase_merge=False,
+            )
+        )
+        self.assertEqual(result["changed"], True)
+        self.assertEqual(result["repo"]["allow_squash_merge"], False)
+        self.assertEqual(result["repo"]["allow_merge_commit"], False)
+        self.assertEqual(result["repo"]["allow_rebase_merge"], False)
+
+    @with_httmock(get_orgs_mock)
+    @with_httmock(get_repo_mock)
+    @with_httmock(patch_repo_mock)
+    def test_update_delete_branch_on_merge(self):
+        result = github_repo.run_module(
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description=None,
+                private=None,
+                state="present",
+                delete_branch_on_merge=True,
+            )
+        )
+        self.assertEqual(result["changed"], True)
+        self.assertEqual(result["repo"]["delete_branch_on_merge"], True)
+
+    @with_httmock(get_orgs_mock)
+    @with_httmock(get_repo_mock)
+    @with_httmock(patch_repo_mock)
+    def test_update_auto_merge(self):
+        result = github_repo.run_module(
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description=None,
+                private=None,
+                state="present",
+                allow_auto_merge=True,
+            )
+        )
+        self.assertEqual(result["changed"], True)
+        self.assertEqual(result["repo"]["allow_auto_merge"], True)
+
+    @with_httmock(get_orgs_mock)
+    @with_httmock(get_repo_mock)
+    @with_httmock(patch_repo_mock)
+    def test_update_squash_merge_commit_options(self):
+        result = github_repo.run_module(
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description=None,
+                private=None,
+                state="present",
+                squash_merge_commit_title="PR_TITLE",
+                squash_merge_commit_message="PR_BODY",
+            )
+        )
+        self.assertEqual(result["changed"], True)
+        self.assertEqual(result["repo"]["squash_merge_commit_title"], "PR_TITLE")
+        self.assertEqual(result["repo"]["squash_merge_commit_message"], "PR_BODY")
+
+    @with_httmock(get_orgs_mock)
+    @with_httmock(get_repo_mock)
+    @with_httmock(patch_repo_mock)
+    def test_update_merge_commit_options(self):
+        result = github_repo.run_module(
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description=None,
+                private=None,
+                state="present",
+                merge_commit_title="PR_TITLE",
+                merge_commit_message="PR_BODY",
+            )
+        )
+        self.assertEqual(result["changed"], True)
+        self.assertEqual(result["repo"]["merge_commit_title"], "PR_TITLE")
+        self.assertEqual(result["repo"]["merge_commit_message"], "PR_BODY")
+
+    @with_httmock(get_orgs_mock)
+    @with_httmock(get_repo_mock)
+    @with_httmock(patch_repo_mock)
+    def test_update_discussions(self):
+        result = github_repo.run_module(
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description=None,
+                private=None,
+                state="present",
+                has_discussions=True,
+            )
+        )
+        self.assertEqual(result["changed"], True)
+        self.assertEqual(result["repo"]["has_discussions"], True)
+
+    @with_httmock(get_orgs_mock)
+    @with_httmock(get_repo_mock)
+    @with_httmock(patch_repo_mock)
+    def test_update_homepage(self):
+        result = github_repo.run_module(
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description=None,
+                private=None,
+                state="present",
+                homepage="https://example.com",
+            )
+        )
+        self.assertEqual(result["changed"], True)
+        self.assertEqual(result["repo"]["homepage"], "https://example.com")
+
+    @with_httmock(get_orgs_mock)
+    @with_httmock(get_repo_mock)
+    @with_httmock(get_topics_mock)
+    @with_httmock(put_topics_mock)
+    def test_update_topics(self):
+        result = github_repo.run_module(
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description=None,
+                private=None,
+                state="present",
+                topics=["ansible", "automation"],
+            )
+        )
+        self.assertEqual(result["changed"], True)
+        self.assertIn("ansible", result["repo"]["topics"])
+        self.assertIn("automation", result["repo"]["topics"])
+
+    @with_httmock(get_orgs_mock)
+    @with_httmock(get_repo_mock)
+    @with_httmock(get_topics_mock)
+    def test_idempotency_topics_unchanged(self):
+        result = github_repo.run_module(
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description=None,
+                private=None,
+                state="present",
+                topics=["existing-topic"],
+            )
+        )
+        self.assertEqual(result["changed"], False)
+
+    @with_httmock(get_orgs_mock)
+    @with_httmock(get_repo_mock)
+    def test_idempotency_all_settings_match(self):
+        result = github_repo.run_module(
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description=None,
+                private=None,
+                state="present",
+                has_issues=True,
+                has_wiki=True,
+                has_projects=True,
+                has_discussions=False,
+                allow_squash_merge=True,
+                allow_merge_commit=True,
+                allow_rebase_merge=True,
+                allow_auto_merge=False,
+                delete_branch_on_merge=False,
+            )
+        )
+        self.assertEqual(result["changed"], False)
+
+    @with_httmock(get_orgs_mock)
+    @with_httmock(get_repo_mock)
+    @with_httmock(patch_repo_mock)
+    def test_update_multiple_settings(self):
+        result = github_repo.run_module(
+            make_params(
+                organization="MyOrganization",
+                name="myrepo",
+                description=None,
+                private=None,
+                state="present",
+                has_wiki=False,
+                has_issues=False,
+                allow_squash_merge=False,
+                delete_branch_on_merge=True,
+                homepage="https://example.com",
+            )
+        )
+        self.assertEqual(result["changed"], True)
+        self.assertEqual(result["repo"]["has_wiki"], False)
+        self.assertEqual(result["repo"]["has_issues"], False)
+        self.assertEqual(result["repo"]["allow_squash_merge"], False)
+        self.assertEqual(result["repo"]["delete_branch_on_merge"], True)
+        self.assertEqual(result["repo"]["homepage"], "https://example.com")


### PR DESCRIPTION
##### SUMMARY

Add parameters to the existing `github_repo` module for managing additional repository settings via PyGithub's `Repository.edit()`:

- `has_wiki`, `has_projects`, `has_discussions`, `has_issues` - feature toggles
- `allow_squash_merge`, `allow_merge_commit`, `allow_rebase_merge` - merge strategies
- `delete_branch_on_merge`, `allow_auto_merge` - merge behavior
- `squash_merge_commit_title`, `squash_merge_commit_message` - squash merge defaults
- `merge_commit_title`, `merge_commit_message` - merge commit defaults
- `homepage` - repository homepage URL
- `topics` - repository topics (uses separate `replace_topics()` API)

All new parameters are optional and only sent to the API when explicitly provided, preserving existing settings.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

github_repo

##### ADDITIONAL INFORMATION

- All existing tests continue to pass
- New unit tests added for each parameter including idempotency checks
- Changelog fragment included

🤖 Generated with [Claude Code](https://claude.ai/code)