### PR TITLE
github_label - new module for managing repository labels

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -638,6 +638,8 @@ files:
     ignore: erydo
     labels: github_key
     maintainers: erydo
+  $modules/github_label.py:
+    maintainers: john-westcott-iv
   $modules/github_release.py:
     maintainers: adrianmoisey
   $modules/github_repo.py:

--- a/plugins/modules/github_label.py
+++ b/plugins/modules/github_label.py
@@ -1,0 +1,294 @@
+#!/usr/bin/python
+
+# Copyright (c) 2025, John Westcott IV (@john-westcott-iv)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+DOCUMENTATION = r"""
+module: github_label
+short_description: Manage labels on Github repositories
+version_added: NEXT_PATCH
+description:
+  - Create, update, rename, and delete labels on Github repositories using the PyGithub library.
+  - Authentication can be done with O(access_token) or with O(username) and O(password).
+extends_documentation_fragment:
+  - community.general.attributes
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
+options:
+  username:
+    description:
+      - Username used for authentication.
+      - This is only needed when not using O(access_token).
+    type: str
+  password:
+    description:
+      - Password used for authentication.
+      - This is only needed when not using O(access_token).
+    type: str
+  access_token:
+    description:
+      - Token parameter for authentication.
+      - This is only needed when not using O(username) and O(password).
+    type: str
+  api_url:
+    description:
+      - URL to the GitHub API if not using github.com but your own instance.
+    type: str
+    default: 'https://api.github.com'
+  organization:
+    description:
+      - Repository owner (user or organization).
+    type: str
+    required: true
+  repo:
+    description:
+      - Repository name.
+    type: str
+    required: true
+  name:
+    description:
+      - Label name.
+    type: str
+    required: true
+  color:
+    description:
+      - Hex color code for the label, without the leading C(#).
+      - For example V(0e8a16) or V(ff0000).
+      - Required when O(state=present) and the label does not already exist.
+    type: str
+  description:
+    description:
+      - A short description for the label.
+    type: str
+    default: ''
+  new_name:
+    description:
+      - Rename the label to this value.
+      - Only used when O(state=present) and the label already exists.
+    type: str
+  state:
+    description:
+      - Whether the label should exist or not.
+    type: str
+    default: present
+    choices: [absent, present]
+requirements:
+  - PyGithub>=1.54
+notes:
+  - For Python 3, PyGithub>=1.54 should be used.
+author:
+  - John Westcott IV (@john-westcott-iv)
+"""
+
+EXAMPLES = r"""
+- name: Create a label
+  community.general.github_label:
+    access_token: mytoken
+    organization: MyOrganization
+    repo: myrepo
+    name: bug
+    color: "d73a4a"
+    description: "Something isn't working"
+    state: present
+
+- name: Update a label color
+  community.general.github_label:
+    access_token: mytoken
+    organization: MyOrganization
+    repo: myrepo
+    name: bug
+    color: "ff0000"
+    state: present
+
+- name: Rename a label
+  community.general.github_label:
+    access_token: mytoken
+    organization: MyOrganization
+    repo: myrepo
+    name: bug
+    new_name: defect
+    color: "d73a4a"
+    state: present
+
+- name: Delete a label
+  community.general.github_label:
+    access_token: mytoken
+    organization: MyOrganization
+    repo: myrepo
+    name: bug
+    state: absent
+"""
+
+RETURN = r"""
+label:
+  description: Label information as a dictionary.
+  returned: success and O(state=present)
+  type: dict
+  contains:
+    name:
+      description: The label name.
+      type: str
+      returned: success
+    color:
+      description: The label color (hex without C(#)).
+      type: str
+      returned: success
+    description:
+      description: The label description.
+      type: str
+      returned: success
+    url:
+      description: The API URL of the label.
+      type: str
+      returned: success
+"""
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+
+GITHUB_IMP_ERR = None
+try:
+    from github import Github, GithubException
+    from github.GithubException import UnknownObjectException
+
+    HAS_GITHUB_PACKAGE = True
+except Exception:
+    GITHUB_IMP_ERR = traceback.format_exc()
+    HAS_GITHUB_PACKAGE = False
+
+
+def authenticate(username=None, password=None, access_token=None, api_url=None):
+    if access_token:
+        return Github(base_url=api_url, login_or_token=access_token)
+    else:
+        return Github(base_url=api_url, login_or_token=username, password=password)
+
+
+def label_to_dict(label):
+    return {
+        "name": label.name,
+        "color": label.color,
+        "description": label.description or "",
+        "url": label.url,
+    }
+
+
+def run_module(params, check_mode=False):
+    gh = authenticate(
+        username=params["username"],
+        password=params["password"],
+        access_token=params["access_token"],
+        api_url=params["api_url"],
+    )
+
+    repo = gh.get_repo(f"{params['organization']}/{params['repo']}")
+
+    name = params["name"]
+    state = params["state"]
+    color = params["color"]
+    description = params["description"]
+    new_name = params["new_name"]
+
+    result = dict(changed=False)
+
+    try:
+        label = repo.get_label(name)
+    except UnknownObjectException:
+        label = None
+
+    if state == "absent":
+        if label is not None:
+            if not check_mode:
+                label.delete()
+            result["changed"] = True
+        return result
+
+    # state == present
+    if label is None:
+        if color is None:
+            raise ValueError("Parameter 'color' is required when creating a new label")
+        if not check_mode:
+            label = repo.create_label(name=name, color=color, description=description)
+            result["label"] = label_to_dict(label)
+        else:
+            result["label"] = {"name": name, "color": color, "description": description, "url": ""}
+        result["changed"] = True
+        return result
+
+    # Label exists, check for changes
+    changes = {}
+    target_name = new_name if new_name else name
+    target_color = color if color else label.color
+    target_description = description if description is not None else (label.description or "")
+
+    if target_name != label.name:
+        changes["name"] = target_name
+    if target_color != label.color:
+        changes["color"] = target_color
+    if target_description != (label.description or ""):
+        changes["description"] = target_description
+
+    if changes:
+        if not check_mode:
+            label.edit(
+                name=target_name,
+                color=target_color,
+                description=target_description,
+            )
+
+        result["label"] = {
+            "name": target_name,
+            "color": target_color,
+            "description": target_description,
+            "url": label.url,
+        }
+        result["changed"] = True
+    else:
+        result["label"] = label_to_dict(label)
+
+    return result
+
+
+def main():
+    module_args = dict(
+        username=dict(type="str"),
+        password=dict(type="str", no_log=True),
+        access_token=dict(type="str", no_log=True),
+        api_url=dict(type="str", default="https://api.github.com"),
+        organization=dict(type="str", required=True),
+        repo=dict(type="str", required=True),
+        name=dict(type="str", required=True),
+        color=dict(type="str"),
+        description=dict(type="str", default=""),
+        new_name=dict(type="str"),
+        state=dict(type="str", default="present", choices=["present", "absent"]),
+    )
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        required_together=[("username", "password")],
+        required_one_of=[("username", "access_token")],
+        mutually_exclusive=[("username", "access_token")],
+    )
+
+    if not HAS_GITHUB_PACKAGE:
+        module.fail_json(msg=missing_required_lib("PyGithub"), exception=GITHUB_IMP_ERR)
+
+    try:
+        result = run_module(module.params, module.check_mode)
+        module.exit_json(**result)
+    except GithubException as e:
+        module.fail_json(msg=f"Github error. {e}")
+    except Exception as e:
+        module.fail_json(msg=f"Unexpected error. {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/plugins/modules/test_github_label.py
+++ b/tests/unit/plugins/modules/test_github_label.py
@@ -1,0 +1,181 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import json
+import re
+import unittest
+
+import pytest
+from httmock import response, urlmatch, with_httmock
+
+from ansible_collections.community.general.plugins.modules import github_label
+
+pytest.importorskip("github")
+
+
+BASE_PARAMS = {
+    "username": None,
+    "password": None,
+    "access_token": "mytoken",
+    "api_url": "https://api.github.com",
+    "organization": "MyOrganization",
+    "repo": "myrepo",
+    "name": "bug",
+    "color": "d73a4a",
+    "description": "",
+    "new_name": None,
+    "state": "present",
+}
+
+
+def make_params(**overrides):
+    params = dict(BASE_PARAMS)
+    params.update(overrides)
+    return params
+
+
+@urlmatch(netloc=r"api\.github\.com(:[0-9]+)?$", path=r"/repos/[^/]+/[^/]+$", method="get")
+def get_repo_mock(url, request):
+    match = re.search(r"/repos/(?P<owner>[^/]+)/(?P<repo>[^/]+)$", request.url)
+    owner = match.group("owner")
+    repo = match.group("repo")
+    headers = {"content-type": "application/json"}
+    content = json.dumps(
+        {
+            "full_name": f"{owner}/{repo}",
+            "url": f"https://api.github.com/repos/{owner}/{repo}",
+        }
+    ).encode("utf-8")
+    return response(200, content, headers, None, 5, request)
+
+
+@urlmatch(netloc=r"api\.github\.com(:[0-9]+)?$", path=r"/repos/[^/]+/[^/]+/labels/[^/]+$", method="get")
+def get_label_mock(url, request):
+    match = re.search(r"/repos/[^/]+/[^/]+/labels/(?P<name>[^/]+)$", request.url)
+    name = match.group("name")
+    headers = {"content-type": "application/json"}
+    content = json.dumps(
+        {
+            "name": name,
+            "color": "d73a4a",
+            "description": "Something isn't working",
+            "url": f"https://api.github.com/repos/MyOrganization/myrepo/labels/{name}",
+        }
+    ).encode("utf-8")
+    return response(200, content, headers, None, 5, request)
+
+
+@urlmatch(netloc=r"api\.github\.com(:[0-9]+)?$", path=r"/repos/[^/]+/[^/]+/labels/[^/]+$", method="get")
+def get_label_notfound_mock(url, request):
+    return response(404, '{"message": "Not Found"}', "", "Not Found", 5, request)
+
+
+@urlmatch(netloc=r"api\.github\.com(:[0-9]+)?$", path=r"/repos/[^/]+/[^/]+/labels$", method="post")
+def create_label_mock(url, request):
+    body = json.loads(request.body)
+    headers = {"content-type": "application/json"}
+    content = json.dumps(
+        {
+            "name": body["name"],
+            "color": body["color"],
+            "description": body.get("description", ""),
+            "url": f"https://api.github.com/repos/MyOrganization/myrepo/labels/{body['name']}",
+        }
+    ).encode("utf-8")
+    return response(201, content, headers, None, 5, request)
+
+
+@urlmatch(netloc=r"api\.github\.com(:[0-9]+)?$", path=r"/repos/[^/]+/[^/]+/labels/[^/]+$", method="patch")
+def patch_label_mock(url, request):
+    body = json.loads(request.body)
+    headers = {"content-type": "application/json"}
+    name = body.get("new_name", body.get("name", "bug"))
+    content = json.dumps(
+        {
+            "name": name,
+            "color": body.get("color", "d73a4a"),
+            "description": body.get("description", ""),
+            "url": f"https://api.github.com/repos/MyOrganization/myrepo/labels/{name}",
+        }
+    ).encode("utf-8")
+    return response(200, content, headers, None, 5, request)
+
+
+@urlmatch(netloc=r"api\.github\.com(:[0-9]+)?$", path=r"/repos/[^/]+/[^/]+/labels/[^/]+$", method="delete")
+def delete_label_mock(url, request):
+    return response(204, None, None, None, 5, request)
+
+
+class TestGithubLabel(unittest.TestCase):
+    @with_httmock(get_repo_mock)
+    @with_httmock(get_label_notfound_mock)
+    @with_httmock(create_label_mock)
+    def test_create_label(self):
+        result = github_label.run_module(make_params(description="Something isn't working"))
+        self.assertEqual(result["changed"], True)
+        self.assertEqual(result["label"]["name"], "bug")
+        self.assertEqual(result["label"]["color"], "d73a4a")
+        self.assertEqual(result["label"]["description"], "Something isn't working")
+
+    @with_httmock(get_repo_mock)
+    @with_httmock(get_label_notfound_mock)
+    @with_httmock(create_label_mock)
+    def test_create_label_no_description(self):
+        result = github_label.run_module(make_params())
+        self.assertEqual(result["changed"], True)
+        self.assertEqual(result["label"]["name"], "bug")
+        self.assertEqual(result["label"]["description"], "")
+
+    @with_httmock(get_repo_mock)
+    @with_httmock(get_label_mock)
+    def test_idempotency_label_exists(self):
+        result = github_label.run_module(make_params(description="Something isn't working"))
+        self.assertEqual(result["changed"], False)
+        self.assertEqual(result["label"]["name"], "bug")
+
+    @with_httmock(get_repo_mock)
+    @with_httmock(get_label_mock)
+    @with_httmock(patch_label_mock)
+    def test_update_label_color(self):
+        result = github_label.run_module(make_params(color="ff0000", description="Something isn't working"))
+        self.assertEqual(result["changed"], True)
+        self.assertEqual(result["label"]["color"], "ff0000")
+
+    @with_httmock(get_repo_mock)
+    @with_httmock(get_label_mock)
+    @with_httmock(patch_label_mock)
+    def test_update_label_description(self):
+        result = github_label.run_module(make_params(description="New description"))
+        self.assertEqual(result["changed"], True)
+        self.assertEqual(result["label"]["description"], "New description")
+
+    @with_httmock(get_repo_mock)
+    @with_httmock(get_label_mock)
+    @with_httmock(patch_label_mock)
+    def test_rename_label(self):
+        result = github_label.run_module(make_params(new_name="defect", description="Something isn't working"))
+        self.assertEqual(result["changed"], True)
+        self.assertEqual(result["label"]["name"], "defect")
+
+    @with_httmock(get_repo_mock)
+    @with_httmock(get_label_mock)
+    @with_httmock(delete_label_mock)
+    def test_delete_label(self):
+        result = github_label.run_module(make_params(state="absent"))
+        self.assertEqual(result["changed"], True)
+        self.assertNotIn("label", result)
+
+    @with_httmock(get_repo_mock)
+    @with_httmock(get_label_notfound_mock)
+    def test_delete_label_not_found(self):
+        result = github_label.run_module(make_params(state="absent"))
+        self.assertEqual(result["changed"], False)
+
+    @with_httmock(get_repo_mock)
+    @with_httmock(get_label_notfound_mock)
+    def test_create_label_no_color_fails(self):
+        with self.assertRaises(ValueError):
+            github_label.run_module(make_params(color=None))


### PR DESCRIPTION
##### SUMMARY

New module `github_label` for managing labels on GitHub repositories.

Features:
- Create, update, rename, and delete labels
- Supports `color`, `description`, and `new_name` parameters
- Full check mode support
- Uses PyGithub (consistent with existing github_repo module)

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

github_label

##### ADDITIONAL INFORMATION

- Unit tests included covering create, update, rename, delete, idempotency, and error cases
- BOTMETA entry added

🤖 Generated with [Claude Code](https://claude.ai/code)