### PR TITLE
logrotate: improve `config_dir` param description

### DIFF
--- a/plugins/modules/logrotate.py
+++ b/plugins/modules/logrotate.py
@@ -36,7 +36,7 @@ options:
   config_dir:
     description:
       - Directory where logrotate configurations are stored.
-      - Default is V(/etc/logrotate.d) for system-wide configurations.
+      - Typically V(/etc/logrotate.d) for system-wide configurations.
       - Use V(~/.logrotate.d) for user-specific configurations.
       - This directory must exist before using the module.
     type: path


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Improves phrasing of the `logrotate` module's `config_dir` parameter description.

The phrasing "Default is ..." is potentially misleading and could cause users to believe this parameter is optional if they don't look further.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
logrotate

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
