### PR TITLE
jira - resolve Cloud assignee email to account ID via user search

### DIFF
--- a/changelogs/fragments/11734-jira-cloud-assignee-email-resolution.yml
+++ b/changelogs/fragments/11734-jira-cloud-assignee-email-resolution.yml
@@ -1,6 +1,5 @@
 minor_changes:
   - jira - when ``cloud=true`` and ``assignee`` is an
     email address, the module now automatically resolves
-    the email to a Jira Cloud account ID using the
-    ``/rest/api/2/user/search`` endpoint
+    the email to a Jira Cloud account ID
     (https://github.com/ansible-collections/community.general/issues/11734, https://github.com/ansible-collections/community.general/pull/11735).

--- a/changelogs/fragments/11734-jira-cloud-assignee-email-resolution.yml
+++ b/changelogs/fragments/11734-jira-cloud-assignee-email-resolution.yml
@@ -1,5 +1,7 @@
 minor_changes:
-  - jira - when ``cloud=true`` and ``assignee`` is an
-    email address, the module now automatically resolves
-    the email to a Jira Cloud account ID
+  - jira - when ``cloud=true``, user-type fields
+    (``assignee``, ``reporter``, and any listed in the new
+    ``custom_user_fields`` parameter) containing an email
+    address are automatically resolved to Jira Cloud
+    account IDs
     (https://github.com/ansible-collections/community.general/issues/11734, https://github.com/ansible-collections/community.general/pull/11735).

--- a/changelogs/fragments/11734-jira-cloud-assignee-email-resolution.yml
+++ b/changelogs/fragments/11734-jira-cloud-assignee-email-resolution.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - jira - when ``cloud=true`` and ``assignee`` is an
+    email address, the module now automatically resolves
+    the email to a Jira Cloud account ID using the
+    ``/rest/api/2/user/search`` endpoint
+    (https://github.com/ansible-collections/community.general/issues/11734, https://github.com/ansible-collections/community.general/pull/11735).

--- a/plugins/modules/jira.py
+++ b/plugins/modules/jira.py
@@ -700,8 +700,8 @@ class JIRA(StateModuleHelper):
             self.module.fail_json(
                 msg=(
                     f'Failed to resolve field "{field_name}" email "{email}" to a unique '
-                    f"Jira Cloud account ID: found {count} result(s). "
-                    f"Specify the account ID directly."
+                    f'Jira Cloud account ID: found "{count}" result(s). '
+                    "Specify the account ID directly."
                 )
             )
         user = result[0]
@@ -711,7 +711,7 @@ class JIRA(StateModuleHelper):
                 msg=(
                     f'Failed to resolve field "{field_name}" email "{email}": '
                     f'the email address on the matched account "{user_email}" does not match. '
-                    f"Specify the account ID directly."
+                    "Specify the account ID directly."
                 )
             )
         return user["accountId"]

--- a/plugins/modules/jira.py
+++ b/plugins/modules/jira.py
@@ -138,6 +138,7 @@ options:
         C(@), the module resolves an email to an account ID via the Jira Cloud user search API (C(/rest/api/2/user/search)); resolution
         succeeds only when exactly one user matches and the returned email address matches the value provided. Jira Server and Jira Data
         Center may still accept O(assignee) as a username.
+      - Email-based assignee auto-resolution was added in community.general 12.6.0.
       - Note that JIRA may not allow changing field values on specific transitions or states.
   account_id:
     type: str
@@ -512,6 +513,7 @@ import os
 import random
 import string
 import traceback
+from urllib.parse import quote
 from urllib.request import pathname2url
 
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
@@ -643,7 +645,7 @@ class JIRA(StateModuleHelper):
             self.vars.fields["assignee"] = {"accountId": self.vars.account_id}
 
     def _resolve_account_id(self, email):
-        url = f"{self.vars.restbase}/user/search?query={pathname2url(email)}"
+        url = f"{self.vars.restbase}/user/search?query={quote(email, safe='')}"
         result = self.get(url)
         if not isinstance(result, list) or len(result) != 1:
             count = len(result) if isinstance(result, list) else 0

--- a/plugins/modules/jira.py
+++ b/plugins/modules/jira.py
@@ -134,7 +134,10 @@ options:
     type: str
     description:
       - Sets the assignee when O(operation) is V(create), V(transition), or V(edit).
-      - Recent versions of JIRA no longer accept a user name as a user identifier. In that case, use O(account_id) instead.
+      - Jira Cloud requires the assignee as an account ID (use O(account_id)). Alternatively, when O(cloud=true) and O(assignee) contains
+        C(@), the module resolves an email to an account ID via the Jira Cloud user search API (C(/rest/api/2/user/search)); resolution
+        succeeds only when exactly one user matches and the returned email address matches the value provided. Jira Server and Jira Data
+        Center may still accept O(assignee) as a username.
       - Note that JIRA may not allow changing field values on specific transitions or states.
   account_id:
     type: str
@@ -195,6 +198,8 @@ options:
       - Enable when using Jira Cloud.
       - When set to V(true), O(operation=search) uses the C(/rest/api/2/search/jql) endpoint required by Jira Cloud,
         since the legacy C(/rest/api/2/search) endpoint has been removed.
+      - When set to V(true) and O(assignee) contains C(@), the module resolves the assignee as an email address
+        to an account ID using the C(/rest/api/2/user/search) endpoint.
       - When set to V(false) (the default), the legacy endpoint is used, which is still required for Jira Data Center / Server.
       - See U(https://developer.atlassian.com/changelog/#CHANGE-2046) for details about the endpoint deprecation.
       - In the future, if this option is set to V(true), other endpoints might also be replaced to address
@@ -351,6 +356,18 @@ EXAMPLES = r"""
     description: Created and assigned using Ansible
     issuetype: Task
     assignee: ssmith
+
+# Assign an issue on Jira Cloud using an email address
+# (the module resolves the email to an account ID automatically)
+- name: Assign an issue on Jira Cloud using email
+  community.general.jira:
+    uri: '{{ server }}'
+    username: '{{ user }}'
+    password: '{{ pass }}'
+    issue: '{{ issue.meta.key }}'
+    operation: edit
+    cloud: true
+    assignee: user@example.com
 
 # Edit an issue
 - name: Set the labels on an issue using free-form fields
@@ -612,14 +629,45 @@ class JIRA(StateModuleHelper):
     state_param = "operation"
 
     def __init_module__(self):
+        self.vars.uri = self.vars.uri.strip("/")
+        self.vars.set("restbase", f"{self.vars.uri}/rest/api/2")
         if self.vars.fields is None:
             self.vars.fields = {}
         if self.vars.assignee:
-            self.vars.fields["assignee"] = {"name": self.vars.assignee}
+            if self.vars.cloud and "@" in self.vars.assignee:
+                account_id = self._resolve_account_id(self.vars.assignee)
+                self.vars.fields["assignee"] = {"accountId": account_id}
+            else:
+                self.vars.fields["assignee"] = {"name": self.vars.assignee}
         if self.vars.account_id:
             self.vars.fields["assignee"] = {"accountId": self.vars.account_id}
-        self.vars.uri = self.vars.uri.strip("/")
-        self.vars.set("restbase", f"{self.vars.uri}/rest/api/2")
+
+    def _resolve_account_id(self, email):
+        url = f"{self.vars.restbase}/user/search?query={pathname2url(email)}"
+        result = self.get(url)
+        if not isinstance(result, list) or len(result) != 1:
+            count = len(result) if isinstance(result, list) else 0
+            self.module.fail_json(
+                msg=(
+                    f"Failed to resolve assignee '{email}' to "
+                    f"a unique Jira Cloud account ID: found "
+                    f"{count} result(s). Use the 'account_id' "
+                    f"parameter to specify the account ID "
+                    f"directly."
+                )
+            )
+        user = result[0]
+        if user.get("emailAddress", "").lower() != email.lower():
+            self.module.fail_json(
+                msg=(
+                    f"Failed to resolve assignee '{email}': "
+                    f"the returned user's email address "
+                    f"'{user.get('emailAddress')}' does not "
+                    f"match. Use the 'account_id' parameter "
+                    f"to specify the account ID directly."
+                )
+            )
+        return user["accountId"]
 
     @cause_changes(when="success")
     def operation_create(self):

--- a/plugins/modules/jira.py
+++ b/plugins/modules/jira.py
@@ -134,10 +134,11 @@ options:
     type: str
     description:
       - Sets the assignee when O(operation) is V(create), V(transition), or V(edit).
-      - Jira Cloud generally requires account IDs for user fields (including assignee), so use O(account_id) where possible.
-      - When O(cloud=true) and O(assignee) contains C(@), the module can automatically resolve the email to an account ID.
+      - Jira Cloud requires account IDs for all user-type fields. When O(cloud=true), a string value containing C(@) is
+        resolved as an email to an account ID automatically. A string without C(@) is assumed to be an account ID.
+        See also O(account_id) for a dedicated assignee account ID parameter.
+        Added in community.general 12.6.0.
       - Jira Server and Jira Data Center may still accept O(assignee) as a username.
-      - Email-based assignee auto-resolution was added in community.general 12.6.0.
       - Note that JIRA may not allow changing field values on specific transitions or states.
   account_id:
     type: str
@@ -164,6 +165,9 @@ options:
       - This is a free-form data structure that can contain arbitrary data. This is passed directly to the JIRA REST API (possibly
         after merging with other required data, as when passed to create). See examples for more information, and the JIRA
         REST API for the structure required for various fields.
+      - When O(cloud=true), user-type fields (V(assignee), V(reporter), and any fields listed in O(custom_user_fields)) that
+        contain a string value with C(@) are automatically resolved from email to account ID. String values without C(@) are
+        assumed to be account IDs. Added in community.general 12.6.0.
       - When passed to comment, the data structure is merged at the first level since community.general 4.6.0. Useful to add
         JIRA properties for example.
       - Note that JIRA may not allow changing field values on specific transitions or states.
@@ -201,6 +205,18 @@ options:
       - In the future, this option might affect additional operations for Jira Cloud compatibility.
     type: bool
     default: false
+    version_added: '12.6.0'
+
+  custom_user_fields:
+    description:
+      - A list of field names (including custom fields such as V(customfield_10050)) that hold user values.
+      - When O(cloud=true) and a listed field is present in O(fields) as a string containing C(@), the module resolves the
+        email to a Jira Cloud account ID automatically.
+      - The built-in user fields V(assignee) and V(reporter) are always resolved; this option is only needed for additional
+        custom fields.
+    type: list
+    elements: str
+    default: []
     version_added: '12.6.0'
 
   attachment:
@@ -364,6 +380,27 @@ EXAMPLES = r"""
     cloud: true
     assignee: user@example.com
 
+# Create an issue on Jira Cloud with reporter and a custom user field
+# resolved from email addresses to account IDs
+- name: Create an issue on Jira Cloud with user field resolution
+  community.general.jira:
+    uri: '{{ server }}'
+    username: '{{ user }}'
+    password: '{{ pass }}'
+    project: ANS
+    operation: create
+    summary: Example Issue
+    description: Created using Ansible
+    issuetype: Task
+    cloud: true
+    assignee: assignee@example.com
+    custom_user_fields:
+      - customfield_10050
+  args:
+    fields:
+      reporter: reporter@example.com
+      customfield_10050: approver@example.com
+
 # Edit an issue
 - name: Set the labels on an issue using free-form fields
   community.general.jira:
@@ -517,6 +554,8 @@ from ansible_collections.community.general.plugins.module_utils.module_helper im
 
 
 class JIRA(StateModuleHelper):
+    _USER_FIELDS = ["assignee", "reporter"]
+
     module = dict(
         argument_spec=dict(
             attachment=dict(
@@ -594,6 +633,7 @@ class JIRA(StateModuleHelper):
                 type="str",
             ),
             cloud=dict(type="bool", default=False),
+            custom_user_fields=dict(type="list", elements="str", default=[]),
             maxresults=dict(type="int"),
             timeout=dict(type="float", default=10),
             validate_certs=dict(default=True, type="bool"),
@@ -631,25 +671,40 @@ class JIRA(StateModuleHelper):
             self.vars.fields = {}
         if self.vars.assignee:
             if self.vars.cloud and "@" in self.vars.assignee:
-                account_id = self._resolve_account_id(self.vars.assignee)
+                account_id = self._resolve_account_id(self.vars.assignee, "assignee")
                 self.vars.fields["assignee"] = {"accountId": account_id}
+            elif self.vars.cloud:
+                self.vars.fields["assignee"] = {"accountId": self.vars.assignee}
             else:
                 self.vars.fields["assignee"] = {"name": self.vars.assignee}
         if self.vars.account_id:
             self.vars.fields["assignee"] = {"accountId": self.vars.account_id}
+        self._resolve_user_fields()
 
-    def _resolve_account_id(self, email):
+    def _resolve_user_fields(self):
+        if not self.vars.cloud or not self.vars.fields:
+            return
+        user_fields = self._USER_FIELDS + (self.vars.custom_user_fields or [])
+        for field_name in user_fields:
+            value = self.vars.fields.get(field_name)
+            if not isinstance(value, str):
+                continue
+            if "@" in value:
+                account_id = self._resolve_account_id(value, field_name)
+                self.vars.fields[field_name] = {"accountId": account_id}
+            else:
+                self.vars.fields[field_name] = {"accountId": value}
+
+    def _resolve_account_id(self, email, field_name="assignee"):
         url = f"{self.vars.restbase}/user/search?query={quote(email, safe='')}"
         result = self.get(url)
         if not isinstance(result, list) or len(result) != 1:
             count = len(result) if isinstance(result, list) else 0
             self.module.fail_json(
                 msg=(
-                    f"Failed to resolve assignee {email!r} to "
-                    f"a unique Jira Cloud account ID: found "
-                    f"{count} results. Use the 'account_id' "
-                    f"parameter to specify the account ID "
-                    f"directly."
+                    f"Failed to resolve field {field_name!r} email {email!r} to a unique "
+                    f"Jira Cloud account ID: found {count} result(s). "
+                    f"Specify the account ID directly."
                 )
             )
         user = result[0]
@@ -657,11 +712,9 @@ class JIRA(StateModuleHelper):
         if (user_email or "").lower() != email.lower():
             self.module.fail_json(
                 msg=(
-                    f"Failed to resolve assignee {email!r}: "
-                    f"the returned user's email address "
-                    f"{user_email!r} does not "
-                    f"match. Use the 'account_id' parameter "
-                    f"to specify the account ID directly."
+                    f"Failed to resolve field {field_name!r} email {email!r}: "
+                    f"the returned user's email address {user_email!r} does not match. "
+                    f"Specify the account ID directly."
                 )
             )
         return user["accountId"]

--- a/plugins/modules/jira.py
+++ b/plugins/modules/jira.py
@@ -709,8 +709,8 @@ class JIRA(StateModuleHelper):
         if (user_email or "").lower() != email.lower():
             self.module.fail_json(
                 msg=(
-                    f"Failed to resolve field \"{field_name}\" email \"{email}\": "
-                    f"the returned user's email address \"{user_email}\" does not match. "
+                    f'Failed to resolve field "{field_name}" email "{email}": '
+                    f'the email address on the matched account "{user_email}" does not match. '
                     f"Specify the account ID directly."
                 )
             )

--- a/plugins/modules/jira.py
+++ b/plugins/modules/jira.py
@@ -212,7 +212,7 @@ options:
       - A list of field names (for example V(customfield_10050)) that hold user values.
       - When O(cloud=true) and a listed field is present in O(fields) as a string containing C(@), the module resolves the
         email to a Jira Cloud account ID automatically.
-      - The built-in user fields V(assignee) and V(reporter) are always resolved when present; list here any further
+      - The built-in user fields O(assignee) and V(reporter) are always resolved when present; list here any further
         user-typed fields (from other Jira products or extensions) that should receive the same resolution.
     type: list
     elements: str

--- a/plugins/modules/jira.py
+++ b/plugins/modules/jira.py
@@ -209,11 +209,11 @@ options:
 
   custom_user_fields:
     description:
-      - A list of field names (including custom fields such as V(customfield_10050)) that hold user values.
+      - A list of field names (for example V(customfield_10050)) that hold user values.
       - When O(cloud=true) and a listed field is present in O(fields) as a string containing C(@), the module resolves the
         email to a Jira Cloud account ID automatically.
-      - The built-in user fields V(assignee) and V(reporter) are always resolved; this option is only needed for additional
-        custom fields.
+      - The built-in user fields V(assignee) and V(reporter) are always resolved when present; list here any further
+        user-typed fields (from other Jira products or extensions) that should receive the same resolution.
     type: list
     elements: str
     default: []
@@ -554,7 +554,7 @@ from ansible_collections.community.general.plugins.module_utils.module_helper im
 
 
 class JIRA(StateModuleHelper):
-    _USER_FIELDS = ["assignee", "reporter"]
+    USER_FIELDS = ["assignee", "reporter"]
 
     module = dict(
         argument_spec=dict(
@@ -670,39 +670,36 @@ class JIRA(StateModuleHelper):
         if self.vars.fields is None:
             self.vars.fields = {}
         if self.vars.assignee:
-            if self.vars.cloud and "@" in self.vars.assignee:
-                account_id = self._resolve_account_id(self.vars.assignee, "assignee")
-                self.vars.fields["assignee"] = {"accountId": account_id}
-            elif self.vars.cloud:
-                self.vars.fields["assignee"] = {"accountId": self.vars.assignee}
+            if self.vars.cloud:
+                self.vars.fields["assignee"] = self.vars.assignee
             else:
                 self.vars.fields["assignee"] = {"name": self.vars.assignee}
         if self.vars.account_id:
             self.vars.fields["assignee"] = {"accountId": self.vars.account_id}
-        self._resolve_user_fields()
+        self.resolve_user_fields()
 
-    def _resolve_user_fields(self):
+    def resolve_user_fields(self):
         if not self.vars.cloud or not self.vars.fields:
             return
-        user_fields = self._USER_FIELDS + (self.vars.custom_user_fields or [])
+        user_fields = self.USER_FIELDS + self.vars.custom_user_fields
         for field_name in user_fields:
             value = self.vars.fields.get(field_name)
             if not isinstance(value, str):
                 continue
             if "@" in value:
-                account_id = self._resolve_account_id(value, field_name)
+                account_id = self.resolve_account_id(value, field_name)
                 self.vars.fields[field_name] = {"accountId": account_id}
             else:
                 self.vars.fields[field_name] = {"accountId": value}
 
-    def _resolve_account_id(self, email, field_name="assignee"):
+    def resolve_account_id(self, email, field_name="assignee"):
         url = f"{self.vars.restbase}/user/search?query={quote(email, safe='')}"
         result = self.get(url)
         if not isinstance(result, list) or len(result) != 1:
             count = len(result) if isinstance(result, list) else 0
             self.module.fail_json(
                 msg=(
-                    f"Failed to resolve field {field_name!r} email {email!r} to a unique "
+                    f'Failed to resolve field "{field_name}" email "{email}" to a unique '
                     f"Jira Cloud account ID: found {count} result(s). "
                     f"Specify the account ID directly."
                 )
@@ -712,8 +709,8 @@ class JIRA(StateModuleHelper):
         if (user_email or "").lower() != email.lower():
             self.module.fail_json(
                 msg=(
-                    f"Failed to resolve field {field_name!r} email {email!r}: "
-                    f"the returned user's email address {user_email!r} does not match. "
+                    f"Failed to resolve field \"{field_name}\" email \"{email}\": "
+                    f"the returned user's email address \"{user_email}\" does not match. "
                     f"Specify the account ID directly."
                 )
             )

--- a/plugins/modules/jira.py
+++ b/plugins/modules/jira.py
@@ -651,20 +651,21 @@ class JIRA(StateModuleHelper):
             count = len(result) if isinstance(result, list) else 0
             self.module.fail_json(
                 msg=(
-                    f"Failed to resolve assignee '{email}' to "
+                    f"Failed to resolve assignee {email!r} to "
                     f"a unique Jira Cloud account ID: found "
-                    f"{count} result(s). Use the 'account_id' "
+                    f"{count} results. Use the 'account_id' "
                     f"parameter to specify the account ID "
                     f"directly."
                 )
             )
         user = result[0]
-        if user.get("emailAddress", "").lower() != email.lower():
+        user_email = user.get("emailAddress")
+        if (user_email or "").lower() != email.lower():
             self.module.fail_json(
                 msg=(
-                    f"Failed to resolve assignee '{email}': "
+                    f"Failed to resolve assignee {email!r}: "
                     f"the returned user's email address "
-                    f"'{user.get('emailAddress')}' does not "
+                    f"{user_email!r} does not "
                     f"match. Use the 'account_id' parameter "
                     f"to specify the account ID directly."
                 )

--- a/plugins/modules/jira.py
+++ b/plugins/modules/jira.py
@@ -134,10 +134,9 @@ options:
     type: str
     description:
       - Sets the assignee when O(operation) is V(create), V(transition), or V(edit).
-      - Jira Cloud requires the assignee as an account ID (use O(account_id)). Alternatively, when O(cloud=true) and O(assignee) contains
-        C(@), the module resolves an email to an account ID via the Jira Cloud user search API (C(/rest/api/2/user/search)); resolution
-        succeeds only when exactly one user matches and the returned email address matches the value provided. Jira Server and Jira Data
-        Center may still accept O(assignee) as a username.
+      - Jira Cloud generally requires account IDs for user fields (including assignee), so use O(account_id) where possible.
+      - When O(cloud=true) and O(assignee) contains C(@), the module can automatically resolve the email to an account ID.
+      - Jira Server and Jira Data Center may still accept O(assignee) as a username.
       - Email-based assignee auto-resolution was added in community.general 12.6.0.
       - Note that JIRA may not allow changing field values on specific transitions or states.
   account_id:
@@ -197,14 +196,9 @@ options:
   cloud:
     description:
       - Enable when using Jira Cloud.
-      - When set to V(true), O(operation=search) uses the C(/rest/api/2/search/jql) endpoint required by Jira Cloud,
-        since the legacy C(/rest/api/2/search) endpoint has been removed.
-      - When set to V(true) and O(assignee) contains C(@), the module resolves the assignee as an email address
-        to an account ID using the C(/rest/api/2/user/search) endpoint.
-      - When set to V(false) (the default), the legacy endpoint is used, which is still required for Jira Data Center / Server.
-      - See U(https://developer.atlassian.com/changelog/#CHANGE-2046) for details about the endpoint deprecation.
-      - In the future, if this option is set to V(true), other endpoints might also be replaced to address
-        Jira Cloud deprecations.
+      - When set to V(true), the module uses Jira Cloud compatible behavior.
+      - When set to V(false) (the default), the module uses Jira Server / Data Center compatible behavior.
+      - In the future, this option might affect additional operations for Jira Cloud compatibility.
     type: bool
     default: false
     version_added: '12.6.0'


### PR DESCRIPTION
When cloud=true and assignee contains '@', look up a unique user with GET /rest/api/2/user/search and use accountId for create, transition, and edit. Document Jira Cloud vs Server/Data Center assignee behavior.

Fixes https://github.com/ansible-collections/community.general/issues/11734

Assisted-by AI: Claude 4.6 Opus (Anthropic) via Cursor IDE

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
jira

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
