### PR TITLE
keycloak_user: fix email_verified is not idempotent

### DIFF
--- a/plugins/module_utils/_keycloak.py
+++ b/plugins/module_utils/_keycloak.py
@@ -3095,11 +3095,13 @@ class KeycloakAPI:
                 realm_group = self.find_group_by_path(group_to_add, realm=realm)
                 if realm_group:
                     self.add_user_to_group(user_id=userrep["id"], group_id=realm_group["id"], realm=realm)
+                # TODO: raise if user not found
 
             for group_to_remove in groups_to_remove:
                 realm_group = self.find_group_by_path(group_to_remove, realm=realm)
                 if realm_group:
                     self.remove_user_from_group(user_id=userrep["id"], group_id=realm_group["id"], realm=realm)
+                # TODO: raise if user not found
 
             return True
         except Exception as e:

--- a/plugins/module_utils/_keycloak.py
+++ b/plugins/module_utils/_keycloak.py
@@ -322,7 +322,9 @@ def get_token(module_params: dict[str, t.Any]) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
 
-def is_struct_included(struct1: object, struct2: object, exclude: Sequence[str] | None = None, empty_list_result: bool = True) -> bool:
+def is_struct_included(
+    struct1: object, struct2: object, exclude: Sequence[str] | None = None, empty_list_result: bool = True
+) -> bool:
     """
     This function compare if the first parameter structure is included in the second.
     The function use every elements of struct1 and validates they are present in the struct2 structure.
@@ -359,7 +361,7 @@ def is_struct_included(struct1: object, struct2: object, exclude: Sequence[str] 
     if isinstance(struct1, list) and isinstance(struct2, list):
         if not struct1 and not struct2:
             return True
-        
+
         if not struct1:
             return empty_list_result
 

--- a/plugins/module_utils/_keycloak.py
+++ b/plugins/module_utils/_keycloak.py
@@ -2999,7 +2999,7 @@ class KeycloakAPI:
             updated_user = self.get_user_by_id(user_id=userrep["id"], realm=realm, user_profile_metadata=True)
             return updated_user
         except Exception as e:
-            self.fail_request(e, msg="Could not update user %s in realm %s: %s" % (userrep["username"], realm, str(e)))
+            self.fail_request(e, msg=f"Could not update user {userrep['username']} in realm {realm}: {str(e)}")
 
     def delete_user(self, user_id, realm: str = "master"):
         """

--- a/plugins/module_utils/_keycloak.py
+++ b/plugins/module_utils/_keycloak.py
@@ -322,7 +322,7 @@ def get_token(module_params: dict[str, t.Any]) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
 
-def is_struct_included(struct1: object, struct2: object, exclude: Sequence[str] | None = None) -> bool:
+def is_struct_included(struct1: object, struct2: object, exclude: Sequence[str] | None = None, empty_list_result: bool = True) -> bool:
     """
     This function compare if the first parameter structure is included in the second.
     The function use every elements of struct1 and validates they are present in the struct2 structure.
@@ -344,6 +344,12 @@ def is_struct_included(struct1: object, struct2: object, exclude: Sequence[str] 
         description:
             Key to exclude from the comparison.
         default: None
+    :param empty_list_result:
+        type:
+            bool
+        description:
+            Return this value, when struct1 is an empty list.
+        default: True
     :return:
         type:
             bool
@@ -353,10 +359,14 @@ def is_struct_included(struct1: object, struct2: object, exclude: Sequence[str] 
     if isinstance(struct1, list) and isinstance(struct2, list):
         if not struct1 and not struct2:
             return True
+        
+        if not struct1:
+            return empty_list_result
+
         for item1 in struct1:
             if isinstance(item1, (list, dict)):
                 for item2 in struct2:
-                    if is_struct_included(item1, item2, exclude):
+                    if is_struct_included(item1, item2, exclude, empty_list_result):
                         break
                 else:
                     return False
@@ -370,7 +380,7 @@ def is_struct_included(struct1: object, struct2: object, exclude: Sequence[str] 
         try:
             for key in struct1:
                 if not (exclude and key in exclude):
-                    if not is_struct_included(struct1[key], struct2[key], exclude):
+                    if not is_struct_included(struct1[key], struct2[key], exclude, empty_list_result):
                         return False
         except KeyError:
             return False

--- a/plugins/module_utils/_keycloak.py
+++ b/plugins/module_utils/_keycloak.py
@@ -2932,15 +2932,18 @@ class KeycloakAPI:
         except Exception as e:
             self.fail_request(e, msg=f"Could not delete scope {id} for client {client_id} in realm {realm}: {e}")
 
-    def get_user_by_id(self, user_id, realm: str = "master"):
+    def get_user_by_id(self, user_id, realm: str = "master", user_profile_metadata: bool = False):
         """
         Get a User by its ID.
         :param user_id: ID of the user.
         :param realm: Realm
+        :param user_profile_metadata: (optional) include user profile metadata in the response
         :return: Representation of the user.
         """
         try:
             user_url = URL_USER.format(url=self.baseurl, realm=realm, id=user_id)
+            if user_profile_metadata:
+                user_url += "?userProfileMetadata=True"
             userrep = json.load(self._request(user_url, method="GET"))
             return userrep
         except Exception as e:
@@ -2993,10 +2996,10 @@ class KeycloakAPI:
                 userrep["attributes"] = self.convert_user_attributes_to_keycloak_dict(attributes=attributes)
             user_url = URL_USER.format(url=self.baseurl, realm=realm, id=userrep["id"])
             self._request(user_url, method="PUT", data=json.dumps(userrep))
-            updated_user = self.get_user_by_id(user_id=userrep["id"], realm=realm)
+            updated_user = self.get_user_by_id(user_id=userrep["id"], realm=realm, user_profile_metadata=True)
             return updated_user
         except Exception as e:
-            self.fail_request(e, msg=f"Could not update user {userrep['username']} in realm {realm}: {e}")
+            self.fail_request(e, msg="Could not update user %s in realm %s: %s" % (userrep["username"], realm, str(e)))
 
     def delete_user(self, user_id, realm: str = "master"):
         """

--- a/plugins/module_utils/_keycloak.py
+++ b/plugins/module_utils/_keycloak.py
@@ -323,7 +323,10 @@ def get_token(module_params: dict[str, t.Any]) -> dict[str, str]:
 
 
 def is_struct_included(
-    struct1: object, struct2: object, exclude: Sequence[str] | None = None, empty_list_result: bool = True
+    struct1: dict | list | bool | int | str,
+    struct2: dict | list | bool | int | str,
+    exclude: Sequence[str] | None = None,
+    empty_list_result: bool = True,
 ) -> bool:
     """
     This function compare if the first parameter structure is included in the second.
@@ -331,30 +334,18 @@ def is_struct_included(
     The two structure does not need to be equals for that function to return true.
     Each elements are compared recursively.
     :param struct1:
-        type:
-            dict for the initial call, can be dict, list, bool, int or str for recursive calls
         description:
             reference structure
     :param struct2:
-        type:
-            dict for the initial call, can be dict, list, bool, int or str for recursive calls
         description:
             structure to compare with first parameter.
     :param exclude:
-        type:
-            list
         description:
             Key to exclude from the comparison.
-        default: None
     :param empty_list_result:
-        type:
-            bool
         description:
             Return this value, when struct1 is an empty list.
-        default: True
     :return:
-        type:
-            bool
         description:
             Return True if all element of dict 1 are present in dict 2, return false otherwise.
     """

--- a/plugins/module_utils/_keycloak.py
+++ b/plugins/module_utils/_keycloak.py
@@ -3087,13 +3087,19 @@ class KeycloakAPI:
                 realm_group = self.find_group_by_path(group_to_add, realm=realm)
                 if realm_group:
                     self.add_user_to_group(user_id=userrep["id"], group_id=realm_group["id"], realm=realm)
-                # TODO: raise if user not found
+                else:
+                    self.module.fail_json(
+                        msg=f"Could not update group membership for user {userrep['username']} in realm {realm}: group not found {group_to_add}"
+                    )
 
             for group_to_remove in groups_to_remove:
                 realm_group = self.find_group_by_path(group_to_remove, realm=realm)
                 if realm_group:
                     self.remove_user_from_group(user_id=userrep["id"], group_id=realm_group["id"], realm=realm)
-                # TODO: raise if user not found
+                else:
+                    self.module.fail_json(
+                        msg=f"Could not update group membership for user {userrep['username']} in realm {realm}: group not found {group_to_remove}"
+                    )
 
             return True
         except Exception as e:

--- a/plugins/module_utils/_keycloak.py
+++ b/plugins/module_utils/_keycloak.py
@@ -2928,7 +2928,6 @@ class KeycloakAPI:
         Get a User by its ID.
         :param user_id: ID of the user.
         :param realm: Realm
-        :param user_profile_metadata: (optional) include user profile metadata in the response
         :return: Representation of the user.
         """
         try:

--- a/plugins/module_utils/_keycloak.py
+++ b/plugins/module_utils/_keycloak.py
@@ -2923,7 +2923,7 @@ class KeycloakAPI:
         except Exception as e:
             self.fail_request(e, msg=f"Could not delete scope {id} for client {client_id} in realm {realm}: {e}")
 
-    def get_user_by_id(self, user_id, realm: str = "master", user_profile_metadata: bool = False):
+    def get_user_by_id(self, user_id, realm: str = "master"):
         """
         Get a User by its ID.
         :param user_id: ID of the user.
@@ -2932,9 +2932,7 @@ class KeycloakAPI:
         :return: Representation of the user.
         """
         try:
-            user_url = URL_USER.format(url=self.baseurl, realm=realm, id=user_id)
-            if user_profile_metadata:
-                user_url += "?userProfileMetadata=True"
+            user_url = URL_USER.format(url=self.baseurl, realm=realm, id=user_id) + "?userProfileMetadata=True"
             userrep = json.load(self._request(user_url, method="GET"))
             return userrep
         except Exception as e:
@@ -2987,7 +2985,7 @@ class KeycloakAPI:
                 userrep["attributes"] = self.convert_user_attributes_to_keycloak_dict(attributes=attributes)
             user_url = URL_USER.format(url=self.baseurl, realm=realm, id=userrep["id"])
             self._request(user_url, method="PUT", data=json.dumps(userrep))
-            updated_user = self.get_user_by_id(user_id=userrep["id"], realm=realm, user_profile_metadata=True)
+            updated_user = self.get_user_by_id(user_id=userrep["id"], realm=realm)
             return updated_user
         except Exception as e:
             self.fail_request(e, msg=f"Could not update user {userrep['username']} in realm {realm}: {str(e)}")

--- a/plugins/module_utils/_keycloak.py
+++ b/plugins/module_utils/_keycloak.py
@@ -2988,7 +2988,7 @@ class KeycloakAPI:
             updated_user = self.get_user_by_id(user_id=userrep["id"], realm=realm)
             return updated_user
         except Exception as e:
-            self.fail_request(e, msg=f"Could not update user {userrep['username']} in realm {realm}: {str(e)}")
+            self.fail_request(e, msg=f"Could not update user {userrep['username']} in realm {realm}: {e}")
 
     def delete_user(self, user_id, realm: str = "master"):
         """

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -135,8 +135,7 @@ options:
         default: false
   required_actions:
     description:
-      - RequiredActions user Auth.
-    default: []
+        - Set or reset a user's required actions.
     type: list
     elements: str
     aliases:

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -565,7 +565,7 @@ def main():
             # Compare users
             if not (
                 is_struct_included(desired_user, before_user, excludes, empty_list_result=False)
-            ):  # If the new user does not introduce a change to the existing user
+            ):  # If the new user introduces a change to the existing user
                 # Update the user
                 if not module.check_mode:
                     after_user = kc.update_user(userrep=desired_user, realm=realm)

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -404,7 +404,7 @@ def main():
         disableable_credential_types=dict(
             type="list", default=[], aliases=["disableableCredentialTypes"], elements="str"
         ),
-        required_actions=dict(type="list", default=[], aliases=["requiredActions"], elements="str"),
+        required_actions=dict(type="list", aliases=["requiredActions"], elements="str"),
         credentials=dict(type="list", default=[], elements="dict", options=credential_spec),
         federated_identities=dict(type="list", default=[], aliases=["federatedIdentities"], elements="str"),
         client_consents=dict(
@@ -557,7 +557,7 @@ def main():
                 "groups",
                 "clientConsents",
                 "federatedIdentities",
-                "requiredActions",
+                
             ]
             # Add user ID to new representation
             desired_user["id"] = before_user["id"]

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -35,9 +35,10 @@ options:
     type: bool
   email_verified:
     description:
-      - Check the validity of user email.
-    default: false
-    type: bool
+      - Set or reset the emailVerified flag of the user.
+    choices: ["ignore", "verified", "unverified"]
+    default: ignore
+    type: str
     aliases:
       - emailVerified
   first_name:
@@ -380,7 +381,7 @@ def main():
         last_name=dict(type="str", aliases=["lastName"]),
         email=dict(type="str"),
         enabled=dict(type="bool"),
-        email_verified=dict(type="bool", default=False, aliases=["emailVerified"]),
+        email_verified=dict(type="str", choices=["ignore", "verified", "unverified"], default="ignore", aliases=["emailVerified"]),
         federation_link=dict(type="str", aliases=["federationLink"]),
         service_account_client_id=dict(type="str", aliases=["serviceAccountClientId"]),
         attributes=dict(type="list", elements="dict", options=attributes_spec),
@@ -420,12 +421,21 @@ def main():
         module.fail_json(msg=str(e))
 
     kc = KeycloakAPI(module, connection_header)
+    
 
     realm = module.params.get("realm")
     state = module.params.get("state")
     force = module.params.get("force")
     username = module.params.get("username")
     groups = module.params.get("groups")
+    email_verified = module.params.get("email_verified")
+    
+    if email_verified == "verified":
+        module.params["email_verified"] = True
+    elif email_verified == "unverified":
+        module.params["email_verified"] = False
+
+        
 
     # Filter and map the parameters names that apply to the user
     user_params = [
@@ -508,14 +518,16 @@ def main():
                 # create_user could have failed, but we don't know for sure until we try to create the user.'
                 result["user_created"] = True
                 module.exit_json(**result)
-
-            # Create the user
-            after_user = kc.create_user(userrep=desired_user, realm=realm)
-            result["msg"] = f"User {desired_user['username']} created"
-            # Add user ID to new representation
-            desired_user["id"] = after_user["id"]
-            # Set user_created flag
-            result["user_created"] = True
+            else:
+              # Create the user
+              if desired_user.get("emailVerified") == "ignore":
+                  desired_user["emailVerified"] = False
+              after_user = kc.create_user(userrep=desired_user, realm=realm)
+              result["msg"] = f"User {desired_user['username']} created"
+              # Add user ID to new representation
+              desired_user["id"] = after_user["id"]
+              # Set user_created flag
+              result["user_created"] = True
         else:
             excludes = [
                 "access",
@@ -529,6 +541,8 @@ def main():
                 "federatedIdentities",
                 "requiredActions",
             ]
+            if desired_user.get("emailVerified") == "ignore":
+                excludes.append("emailVerified")
             # Add user ID to new representation
             desired_user["id"] = before_user["id"]
 
@@ -537,12 +551,14 @@ def main():
                 is_struct_included(desired_user, before_user, excludes)
             ):  # If the new user does not introduce a change to the existing user
                 # Update the user
-                after_user = kc.update_user(userrep=desired_user, realm=realm)
+                if not module.check_mode:
+                  after_user = kc.update_user(userrep=desired_user, realm=realm)
                 changed = True
 
-        # set user groups
-        if kc.update_user_groups_membership(userrep=desired_user, groups=groups, realm=realm):
-            changed = True
+        if not module.check_mode:
+          # set user groups
+          if kc.update_user_groups_membership(userrep=desired_user, groups=groups, realm=realm):
+              changed = True
         # Get the user groups
         after_user["groups"] = kc.get_user_groups(user_id=desired_user["id"], realm=realm)
         result["end_state"] = after_user

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -586,16 +586,15 @@ def main():
             if kc.update_user_groups_membership(userrep=desired_user, groups=groups, realm=realm):
                 changed = True
 
-        
         if module._diff:
             present_groups = [g["name"] for g in groups if g["state"] == "present"]
             absent_groups = [g["name"] for g in groups if g["state"] == "absent"]
-            
+
             desired_user["groups"] = (set(before_groups) | set(present_groups)) - set(absent_groups)
             after_groups = kc.get_user_groups(user_id=desired_user["id"], realm=realm) if "id" in desired_user else []
             if after_user:
                 after_user["groups"] = after_groups
-            
+
             if module.check_mode:
                 # after_user will not have changed, so use the desired user
                 result["diff"] = dict(before=before_user, after=desired_user)
@@ -606,7 +605,9 @@ def main():
                 if after_user:
                     result["diff"] = dict(before=before_user, after=after_user)
                 else:
-                    result["diff"] = dict(before={"groups": sorted(before_groups)}, after={"groups": sorted(after_groups)})
+                    result["diff"] = dict(
+                        before={"groups": sorted(before_groups)}, after={"groups": sorted(after_groups)}
+                    )
 
         result["end_state"] = after_user
         if changed:

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -531,21 +531,20 @@ def main():
                 module.fail_json(msg="username must be specified when creating a new user")
 
             if module._diff:
-                result["diff"] = dict(before="", after=desired_user)
+                result["diff"] = dict(before=before_user, after=desired_user)
 
             if module.check_mode:
                 # Set user_created flag explicit for check_mode
                 # create_user could have failed, but we don't know for sure until we try to create the user.'
                 result["user_created"] = True
-                module.exit_json(**result)
-
-            # Create the user
-            after_user = kc.create_user(userrep=desired_user, realm=realm)
-            result["msg"] = f"User {desired_user['username']} created"
-            # Add user ID to new representation
-            desired_user["id"] = after_user["id"]
-            # Set user_created flag
-            result["user_created"] = True
+            else:
+                # Create the user
+                after_user = kc.create_user(userrep=desired_user, realm=realm)
+                result["msg"] = f"User {desired_user['username']} created"
+                # Add user ID to new representation
+                desired_user["id"] = after_user["id"]
+                # Set user_created flag
+                result["user_created"] = True
         else:
             # Update an existing user
             excludes = [
@@ -576,28 +575,38 @@ def main():
 
                 changed = True
 
+        if before_user:
+            before_groups = kc.get_user_groups(user_id=before_user["id"], realm=realm)
+            before_user["groups"] = before_groups
+        else:
+            before_groups = []
+
         if not module.check_mode:
             # set user groups
             if kc.update_user_groups_membership(userrep=desired_user, groups=groups, realm=realm):
                 changed = True
 
-        after_user["groups"] = kc.get_user_groups(user_id=desired_user["id"], realm=realm)
-
+        
         if module._diff:
-            try:
-                # try to get the user groups
-                before_user["groups"] = kc.get_user_groups(user_id=before_user["id"], realm=realm)
-            except:
-                before_user["groups"] = []
-
+            present_groups = [g["name"] for g in groups if g["state"] == "present"]
+            absent_groups = [g["name"] for g in groups if g["state"] == "absent"]
+            
+            desired_user["groups"] = (set(before_groups) | set(present_groups)) - set(absent_groups)
+            after_groups = kc.get_user_groups(user_id=desired_user["id"], realm=realm) if "id" in desired_user else []
+            if after_user:
+                after_user["groups"] = after_groups
+            
             if module.check_mode:
                 # after_user will not have changed, so use the desired user
                 result["diff"] = dict(before=before_user, after=desired_user)
-                changed = not is_struct_included(
-                    desired_user["groups"], before_user["groups"], excludes, empty_list_result=False
+                changed = changed or not is_struct_included(
+                    groups, before_user["groups"], excludes, empty_list_result=False
                 )
             else:
-                result["diff"] = dict(before=before_user, after=after_user)
+                if after_user:
+                    result["diff"] = dict(before=before_user, after=after_user)
+                else:
+                    result["diff"] = dict(before={"groups": sorted(before_groups)}, after={"groups": sorted(after_groups)})
 
         result["end_state"] = after_user
         if changed:

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -445,7 +445,7 @@ def main():
 
     if module.params["keycloak_default_behavior"] == "compatibility":
         old_default_values = dict(
-            emailVerified=False,
+            email_verified=False,
         )
         for param, value in old_default_values.items():
             if module.params[param] is None:

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -578,8 +578,22 @@ def main():
             # set user groups
             if kc.update_user_groups_membership(userrep=desired_user, groups=groups, realm=realm):
                 changed = True
-        # Get the user groups
+        
         after_user["groups"] = kc.get_user_groups(user_id=desired_user["id"], realm=realm)
+        
+        if module._diff:
+            try:
+                # try to get the user groups
+                before_user["groups"] = kc.get_user_groups(user_id=before_user["id"], realm=realm)    
+            except:
+                before_user["groups"] = []
+            
+            if module.check_mode:
+                # after_user will not have changed, so use the desired user
+                result["diff"] = dict(before=before_user, after=desired_user)
+            else:
+                result["diff"] = dict(before=before_user, after=after_user)
+
         result["end_state"] = after_user
         if changed:
             result["msg"] = f"User {desired_user['username']} updated"

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -36,8 +36,8 @@ options:
   email_verified:
     description:
       - Set or reset the I(emailVerified) flag of the user.
-      - If I(keycloak_default_behavior) is set to C(compatiblity) (the default value), this
-        option has a default of C(false).
+      - If O(keycloak_default_behavior) is set to V(compatiblity) (the default value), this
+        option has a default of V(false).
     type: bool
     aliases:
       - emailVerified
@@ -208,7 +208,7 @@ options:
         problems when they have been set.
       - The default value is C(compatibility), which will ensure that the default values
         are used when the values are not explicitly specified by the user.
-      - This affects the I(emailVerified) option.
+      - This affects the O(email_verified) option.
     type: str
     choices:
       - compatibility

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -490,6 +490,12 @@ def main():
     desired_user = copy.deepcopy(before_user)
     desired_user.update(changeset)
 
+    if before_user:
+        before_groups = kc.get_user_groups(user_id=before_user["id"], realm=realm)
+        before_user["groups"] = before_groups
+    else:
+        before_groups = []
+    
     result["proposed"] = changeset
     result["existing"] = before_user
     # Default values for user_created
@@ -571,11 +577,7 @@ def main():
 
                 changed = True
 
-        if before_user:
-            before_groups = kc.get_user_groups(user_id=before_user["id"], realm=realm)
-            before_user["groups"] = before_groups
-        else:
-            before_groups = []
+
 
         if not module.check_mode:
             # set user groups

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -495,7 +495,7 @@ def main():
         before_user["groups"] = before_groups
     else:
         before_groups = []
-    
+
     result["proposed"] = changeset
     result["existing"] = before_user
     # Default values for user_created
@@ -562,7 +562,6 @@ def main():
                 "groups",
                 "clientConsents",
                 "federatedIdentities",
-                
             ]
             # Add user ID to new representation
             desired_user["id"] = before_user["id"]
@@ -576,8 +575,6 @@ def main():
                     after_user = kc.update_user(userrep=desired_user, realm=realm)
 
                 changed = True
-
-
 
         if not module.check_mode:
             # set user groups

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -484,10 +484,10 @@ def main():
             # Delete user
             if module._diff:
                 result["diff"] = dict(before=before_user, after="")
-            
+
             if not module.check_mode:
-              kc.delete_user(user_id=before_user["id"], realm=realm)
-              result["msg"] = f"User {before_user['username']} deleted"
+                kc.delete_user(user_id=before_user["id"], realm=realm)
+                result["msg"] = f"User {before_user['username']} deleted"
             changed = True
 
     else:
@@ -542,10 +542,10 @@ def main():
                 # Update the user
                 if not module.check_mode:
                     after_user = kc.update_user(userrep=desired_user, realm=realm)
-          
+
                 if module._diff:
-                  result["diff"] = dict(before=before_user, after=desired_user)
-          
+                    result["diff"] = dict(before=before_user, after=desired_user)
+
                 changed = True
 
         if not module.check_mode:

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -570,9 +570,6 @@ def main():
                 if not module.check_mode:
                     after_user = kc.update_user(userrep=desired_user, realm=realm)
 
-                if module._diff:
-                    result["diff"] = dict(before=before_user, after=desired_user)
-
                 changed = True
 
         if before_user:
@@ -591,9 +588,6 @@ def main():
             absent_groups = [g["name"] for g in groups if g["state"] == "absent"]
 
             desired_user["groups"] = (set(before_groups) | set(present_groups)) - set(absent_groups)
-            after_groups = kc.get_user_groups(user_id=desired_user["id"], realm=realm) if "id" in desired_user else []
-            if after_user:
-                after_user["groups"] = after_groups
 
             if module.check_mode:
                 # after_user will not have changed, so use the desired user
@@ -602,7 +596,11 @@ def main():
                     groups, before_user["groups"], excludes, empty_list_result=False
                 )
             else:
+                after_groups = (
+                    kc.get_user_groups(user_id=desired_user["id"], realm=realm) if "id" in desired_user else []
+                )
                 if after_user:
+                    after_user["groups"] = after_groups
                     result["diff"] = dict(before=before_user, after=after_user)
                 else:
                     result["diff"] = dict(

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -455,7 +455,9 @@ def main():
     user_params = [
         x
         for x in module.params
-        if x not in list(keycloak_argument_spec().keys()) + ["state", "realm", "force", "groups", "keycloak_default_behavior"]
+        if x
+        not in list(keycloak_argument_spec().keys())
+        + ["state", "realm", "force", "groups", "keycloak_default_behavior"]
         and module.params.get(x) is not None
     ]
 
@@ -578,20 +580,22 @@ def main():
             # set user groups
             if kc.update_user_groups_membership(userrep=desired_user, groups=groups, realm=realm):
                 changed = True
-        
+
         after_user["groups"] = kc.get_user_groups(user_id=desired_user["id"], realm=realm)
-        
+
         if module._diff:
             try:
                 # try to get the user groups
-                before_user["groups"] = kc.get_user_groups(user_id=before_user["id"], realm=realm)    
+                before_user["groups"] = kc.get_user_groups(user_id=before_user["id"], realm=realm)
             except:
                 before_user["groups"] = []
-            
+
             if module.check_mode:
                 # after_user will not have changed, so use the desired user
                 result["diff"] = dict(before=before_user, after=desired_user)
-                changed = not is_struct_included(desired_user["groups"], before_user["groups"], excludes, empty_list_result=False)
+                changed = not is_struct_included(
+                    desired_user["groups"], before_user["groups"], excludes, empty_list_result=False
+                )
             else:
                 result["diff"] = dict(before=before_user, after=after_user)
 

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -135,7 +135,7 @@ options:
         default: false
   required_actions:
     description:
-        - Set or reset a user's required actions.
+      - Set or reset a user's required actions.
     type: list
     elements: str
     aliases:

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -591,6 +591,7 @@ def main():
             if module.check_mode:
                 # after_user will not have changed, so use the desired user
                 result["diff"] = dict(before=before_user, after=desired_user)
+                changed = not is_struct_included(desired_user["groups"], before_user["groups"], excludes, empty_list_result=False)
             else:
                 result["diff"] = dict(before=before_user, after=after_user)
 

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -509,8 +509,6 @@ def main():
                 module.exit_json(**result)
 
             # Create the user
-            if desired_user.get("emailVerified") == "ignore":
-                desired_user["emailVerified"] = False
             after_user = kc.create_user(userrep=desired_user, realm=realm)
             result["msg"] = f"User {desired_user['username']} created"
             # Add user ID to new representation
@@ -530,8 +528,6 @@ def main():
                 "federatedIdentities",
                 "requiredActions",
             ]
-            # if desired_user.get("emailVerified") == "ignore":
-            #     excludes.append("emailVerified")
             # Add user ID to new representation
             desired_user["id"] = before_user["id"]
 

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -5,6 +5,16 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
+from ansible_collections.community.general.plugins.module_utils.identity.keycloak.keycloak import (
+    KeycloakAPI,
+    KeycloakError,
+    camel,
+    get_token,
+    is_struct_included,
+    keycloak_argument_spec,
+)
+from ansible.module_utils.basic import AnsibleModule
+import copy
 
 DOCUMENTATION = r"""
 module: keycloak_user
@@ -369,9 +379,11 @@ def main():
     attributes_spec = dict(
         name=dict(type="str"),
         values=dict(type="list", elements="str"),
-        state=dict(type="str", choices=["present", "absent"], default="present"),
+        state=dict(type="str", choices=[
+                   "present", "absent"], default="present"),
     )
-    groups_spec = dict(name=dict(type="str"), state=dict(type="str", choices=["present", "absent"], default="present"))
+    groups_spec = dict(name=dict(type="str"), state=dict(
+        type="str", choices=["present", "absent"], default="present"))
     meta_args = dict(
         realm=dict(type="str", default="master"),
         self=dict(type="str"),
@@ -381,18 +393,24 @@ def main():
         last_name=dict(type="str", aliases=["lastName"]),
         email=dict(type="str"),
         enabled=dict(type="bool"),
-        email_verified=dict(type="str", choices=["ignore", "verified", "unverified"], default="ignore", aliases=["emailVerified"]),
+        email_verified=dict(type="str", choices=[
+                            "ignore", "verified", "unverified"], default="ignore", aliases=["emailVerified"]),
         federation_link=dict(type="str", aliases=["federationLink"]),
-        service_account_client_id=dict(type="str", aliases=["serviceAccountClientId"]),
+        service_account_client_id=dict(
+            type="str", aliases=["serviceAccountClientId"]),
         attributes=dict(type="list", elements="dict", options=attributes_spec),
         access=dict(type="dict"),
-        groups=dict(type="list", default=[], elements="dict", options=groups_spec),
+        groups=dict(type="list", default=[],
+                    elements="dict", options=groups_spec),
         disableable_credential_types=dict(
             type="list", default=[], aliases=["disableableCredentialTypes"], elements="str"
         ),
-        required_actions=dict(type="list", default=[], aliases=["requiredActions"], elements="str"),
-        credentials=dict(type="list", default=[], elements="dict", options=credential_spec),
-        federated_identities=dict(type="list", default=[], aliases=["federatedIdentities"], elements="str"),
+        required_actions=dict(type="list", default=[], aliases=[
+                              "requiredActions"], elements="str"),
+        credentials=dict(type="list", default=[],
+                         elements="dict", options=credential_spec),
+        federated_identities=dict(type="list", default=[], aliases=[
+                                  "federatedIdentities"], elements="str"),
         client_consents=dict(
             type="list", default=[], aliases=["clientConsents"], elements="dict", options=client_consents_spec
         ),
@@ -406,13 +424,15 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_one_of=(
-            [["token", "auth_realm", "auth_username", "auth_password", "auth_client_id", "auth_client_secret"]]
+            [["token", "auth_realm", "auth_username", "auth_password",
+                "auth_client_id", "auth_client_secret"]]
         ),
         required_together=([["auth_username", "auth_password"]]),
         required_by={"refresh_token": "auth_realm"},
     )
 
-    result = dict(changed=False, msg="", diff={}, proposed={}, existing={}, end_state={})
+    result = dict(changed=False, msg="", diff={},
+                  proposed={}, existing={}, end_state={})
 
     # Obtain access token, initialize API
     try:
@@ -421,7 +441,6 @@ def main():
         module.fail_json(msg=str(e))
 
     kc = KeycloakAPI(module, connection_header)
-    
 
     realm = module.params.get("realm")
     state = module.params.get("state")
@@ -429,13 +448,11 @@ def main():
     username = module.params.get("username")
     groups = module.params.get("groups")
     email_verified = module.params.get("email_verified")
-    
+
     if email_verified == "verified":
         module.params["email_verified"] = True
     elif email_verified == "unverified":
         module.params["email_verified"] = False
-
-        
 
     # Filter and map the parameters names that apply to the user
     user_params = [
@@ -455,7 +472,8 @@ def main():
     for param in user_params:
         new_param_value = module.params.get(param)
         if param == "attributes" and param in before_user:
-            old_value = kc.convert_keycloak_user_attributes_dict_to_module_list(attributes=before_user["attributes"])
+            old_value = kc.convert_keycloak_user_attributes_dict_to_module_list(
+                attributes=before_user["attributes"])
         else:
             old_value = before_user[param] if param in before_user else None
         if new_param_value != old_value:
@@ -508,7 +526,8 @@ def main():
             changed = True
 
             if username is None:
-                module.fail_json(msg="username must be specified when creating a new user")
+                module.fail_json(
+                    msg="username must be specified when creating a new user")
 
             if module._diff:
                 result["diff"] = dict(before="", after=desired_user)
@@ -519,15 +538,15 @@ def main():
                 result["user_created"] = True
                 module.exit_json(**result)
             else:
-              # Create the user
-              if desired_user.get("emailVerified") == "ignore":
-                  desired_user["emailVerified"] = False
-              after_user = kc.create_user(userrep=desired_user, realm=realm)
-              result["msg"] = f"User {desired_user['username']} created"
-              # Add user ID to new representation
-              desired_user["id"] = after_user["id"]
-              # Set user_created flag
-              result["user_created"] = True
+                # Create the user
+                if desired_user.get("emailVerified") == "ignore":
+                    desired_user["emailVerified"] = False
+                after_user = kc.create_user(userrep=desired_user, realm=realm)
+                result["msg"] = f"User {desired_user['username']} created"
+                # Add user ID to new representation
+                desired_user["id"] = after_user["id"]
+                # Set user_created flag
+                result["user_created"] = True
         else:
             excludes = [
                 "access",
@@ -552,15 +571,17 @@ def main():
             ):  # If the new user does not introduce a change to the existing user
                 # Update the user
                 if not module.check_mode:
-                  after_user = kc.update_user(userrep=desired_user, realm=realm)
+                    after_user = kc.update_user(
+                        userrep=desired_user, realm=realm)
                 changed = True
 
         if not module.check_mode:
-          # set user groups
-          if kc.update_user_groups_membership(userrep=desired_user, groups=groups, realm=realm):
-              changed = True
+            # set user groups
+            if kc.update_user_groups_membership(userrep=desired_user, groups=groups, realm=realm):
+                changed = True
         # Get the user groups
-        after_user["groups"] = kc.get_user_groups(user_id=desired_user["id"], realm=realm)
+        after_user["groups"] = kc.get_user_groups(
+            user_id=desired_user["id"], realm=realm)
         result["end_state"] = after_user
         if changed:
             result["msg"] = f"User {desired_user['username']} updated"

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -482,13 +482,17 @@ def main():
             module.exit_json(**result)
         else:
             # Delete user
-            kc.delete_user(user_id=before_user["id"], realm=realm)
-            result["msg"] = f"User {before_user['username']} deleted"
+            if module._diff:
+                result["diff"] = dict(before=before_user, after="")
+            
+            if not module.check_mode:
+              kc.delete_user(user_id=before_user["id"], realm=realm)
+              result["msg"] = f"User {before_user['username']} deleted"
             changed = True
 
     else:
         after_user = {}
-        if force and before_user:  # If the force option is set to true
+        if force and before_user and not module.check_mode:  # If the force option is set to true
             # Delete the existing user
             kc.delete_user(user_id=before_user["id"], realm=realm)
 
@@ -538,6 +542,10 @@ def main():
                 # Update the user
                 if not module.check_mode:
                     after_user = kc.update_user(userrep=desired_user, realm=realm)
+          
+                if module._diff:
+                  result["diff"] = dict(before=before_user, after=desired_user)
+          
                 changed = True
 
         if not module.check_mode:

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -35,10 +35,9 @@ options:
     type: bool
   email_verified:
     description:
-      - Set or reset the C(emailVerified) flag of the user.
-      - >
-        The default value for this param is C(false) but that is being deprecated
-        and it will be removed in community.general 15.0.0.
+      - Set or reset the I(emailVerified) flag of the user.
+      - If I(keycloak_default_behavior) is set to C(compatiblity) (the default value), this
+        option has a default of C(false).
     type: bool
     aliases:
       - emailVerified
@@ -202,6 +201,20 @@ options:
       - If V(true), allows to remove user and recreate it.
     type: bool
     default: false
+  keycloak_default_behavior:
+    description:
+      - Various module options used to have default values. This caused problems when the
+        user expects different behavior from keycloak by default or fill options which cause
+        problems when they have been set.
+      - The default value is C(compatibility), which will ensure that the default values
+        are used when the values are not explicitly specified by the user.
+      - This affects the I(emailVerified) option.
+    type: str
+    choices:
+      - compatibility
+      - no_defaults
+    default: compatibility
+    version_added: "13.0.0"
 extends_documentation_fragment:
   - community.general._keycloak
   - community.general._keycloak.actiongroup_keycloak
@@ -400,6 +413,7 @@ def main():
         origin=dict(type="str"),
         state=dict(choices=["absent", "present"], default="present"),
         force=dict(type="bool", default=False),
+        keycloak_default_behavior=dict(type="str", choices=["compatibility", "no_defaults"], default="compatibility"),
     )
     argument_spec.update(meta_args)
 
@@ -429,13 +443,13 @@ def main():
     username = module.params.get("username")
     groups = module.params.get("groups")
 
-    if module.params.get("emailVerified") is None:
-        module.params["emailVerified"] = False
-        module.deprecate(
-            "The default value False for parameter emailVerified is being deprecated and it will be removed",
-            version="15.0.0",
-            collection_name="community.general"
+    if module.params["keycloak_default_behavior"] == "compatibility":
+        old_default_values = dict(
+            emailVerified=False,
         )
+        for param, value in old_default_values.items():
+            if module.params[param] is None:
+                module.params[param] = value
 
     # Filter and map the parameters names that apply to the user
     user_params = [

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
 
 DOCUMENTATION = r"""
 module: keycloak_user
@@ -506,16 +507,16 @@ def main():
                 # create_user could have failed, but we don't know for sure until we try to create the user.'
                 result["user_created"] = True
                 module.exit_json(**result)
-            else:
-                # Create the user
-                if desired_user.get("emailVerified") == "ignore":
-                    desired_user["emailVerified"] = False
-                after_user = kc.create_user(userrep=desired_user, realm=realm)
-                result["msg"] = f"User {desired_user['username']} created"
-                # Add user ID to new representation
-                desired_user["id"] = after_user["id"]
-                # Set user_created flag
-                result["user_created"] = True
+            
+            # Create the user
+            if desired_user.get("emailVerified") == "ignore":
+                desired_user["emailVerified"] = False
+            after_user = kc.create_user(userrep=desired_user, realm=realm)
+            result["msg"] = f"User {desired_user['username']} created"
+            # Add user ID to new representation
+            desired_user["id"] = after_user["id"]
+            # Set user_created flag
+            result["user_created"] = True
         else:
             excludes = [
                 "access",

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -507,7 +507,7 @@ def main():
                 # create_user could have failed, but we don't know for sure until we try to create the user.'
                 result["user_created"] = True
                 module.exit_json(**result)
-            
+
             # Create the user
             if desired_user.get("emailVerified") == "ignore":
                 desired_user["emailVerified"] = False

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -35,7 +35,7 @@ options:
     type: bool
   email_verified:
     description:
-      - Set or reset the emailVerified flag of the user.
+      - Set or reset the C(emailVerified) flag of the user.
     type: bool
     aliases:
       - emailVerified

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -36,6 +36,9 @@ options:
   email_verified:
     description:
       - Set or reset the C(emailVerified) flag of the user.
+      - >
+        The default value for this param is C(false) but that is being deprecated
+        and it will be removed in community.general 15.0.0.
     type: bool
     aliases:
       - emailVerified
@@ -425,6 +428,14 @@ def main():
     force = module.params.get("force")
     username = module.params.get("username")
     groups = module.params.get("groups")
+
+    if module.params.get("emailVerified") is None:
+        module.params["emailVerified"] = False
+        module.deprecate(
+            "The default value False for parameter emailVerified is being deprecated and it will be removed",
+            version="15.0.0",
+            collection_name="community.general"
+        )
 
     # Filter and map the parameters names that apply to the user
     user_params = [

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -455,7 +455,7 @@ def main():
     user_params = [
         x
         for x in module.params
-        if x not in list(keycloak_argument_spec().keys()) + ["state", "realm", "force", "groups"]
+        if x not in list(keycloak_argument_spec().keys()) + ["state", "realm", "force", "groups", "keycloak_default_behavior"]
         and module.params.get(x) is not None
     ]
 
@@ -522,7 +522,7 @@ def main():
             kc.delete_user(user_id=before_user["id"], realm=realm)
 
         if not before_user or force:
-            # Process a creation
+            # Create a new user
             changed = True
 
             if username is None:
@@ -545,6 +545,7 @@ def main():
             # Set user_created flag
             result["user_created"] = True
         else:
+            # Update an existing user
             excludes = [
                 "access",
                 "notBefore",
@@ -562,7 +563,7 @@ def main():
 
             # Compare users
             if not (
-                is_struct_included(desired_user, before_user, excludes)
+                is_struct_included(desired_user, before_user, excludes, empty_list_result=False)
             ):  # If the new user does not introduce a change to the existing user
                 # Update the user
                 if not module.check_mode:

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -35,9 +35,7 @@ options:
   email_verified:
     description:
       - Set or reset the emailVerified flag of the user.
-    choices: ["ignore", "verified", "unverified"]
-    default: ignore
-    type: str
+    type: bool
     aliases:
       - emailVerified
   first_name:
@@ -351,8 +349,7 @@ from ansible_collections.community.general.plugins.module_utils._keycloak import
     is_struct_included,
     keycloak_argument_spec,
 )
-from ansible.module_utils.basic import AnsibleModule
-import copy
+
 
 def main():
     argument_spec = keycloak_argument_spec()
@@ -369,11 +366,9 @@ def main():
     attributes_spec = dict(
         name=dict(type="str"),
         values=dict(type="list", elements="str"),
-        state=dict(type="str", choices=[
-                   "present", "absent"], default="present"),
+        state=dict(type="str", choices=["present", "absent"], default="present"),
     )
-    groups_spec = dict(name=dict(type="str"), state=dict(
-        type="str", choices=["present", "absent"], default="present"))
+    groups_spec = dict(name=dict(type="str"), state=dict(type="str", choices=["present", "absent"], default="present"))
     meta_args = dict(
         realm=dict(type="str", default="master"),
         self=dict(type="str"),
@@ -385,21 +380,16 @@ def main():
         enabled=dict(type="bool"),
         email_verified=dict(type="bool", aliases=["emailVerified"]),
         federation_link=dict(type="str", aliases=["federationLink"]),
-        service_account_client_id=dict(
-            type="str", aliases=["serviceAccountClientId"]),
+        service_account_client_id=dict(type="str", aliases=["serviceAccountClientId"]),
         attributes=dict(type="list", elements="dict", options=attributes_spec),
         access=dict(type="dict"),
-        groups=dict(type="list", default=[],
-                    elements="dict", options=groups_spec),
+        groups=dict(type="list", default=[], elements="dict", options=groups_spec),
         disableable_credential_types=dict(
             type="list", default=[], aliases=["disableableCredentialTypes"], elements="str"
         ),
-        required_actions=dict(type="list", default=[], aliases=[
-                              "requiredActions"], elements="str"),
-        credentials=dict(type="list", default=[],
-                         elements="dict", options=credential_spec),
-        federated_identities=dict(type="list", default=[], aliases=[
-                                  "federatedIdentities"], elements="str"),
+        required_actions=dict(type="list", default=[], aliases=["requiredActions"], elements="str"),
+        credentials=dict(type="list", default=[], elements="dict", options=credential_spec),
+        federated_identities=dict(type="list", default=[], aliases=["federatedIdentities"], elements="str"),
         client_consents=dict(
             type="list", default=[], aliases=["clientConsents"], elements="dict", options=client_consents_spec
         ),
@@ -413,15 +403,13 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_one_of=(
-            [["token", "auth_realm", "auth_username", "auth_password",
-                "auth_client_id", "auth_client_secret"]]
+            [["token", "auth_realm", "auth_username", "auth_password", "auth_client_id", "auth_client_secret"]]
         ),
         required_together=([["auth_username", "auth_password"]]),
         required_by={"refresh_token": "auth_realm"},
     )
 
-    result = dict(changed=False, msg="", diff={},
-                  proposed={}, existing={}, end_state={})
+    result = dict(changed=False, msg="", diff={}, proposed={}, existing={}, end_state={})
 
     # Obtain access token, initialize API
     try:
@@ -455,8 +443,7 @@ def main():
     for param in user_params:
         new_param_value = module.params.get(param)
         if param == "attributes" and param in before_user:
-            old_value = kc.convert_keycloak_user_attributes_dict_to_module_list(
-                attributes=before_user["attributes"])
+            old_value = kc.convert_keycloak_user_attributes_dict_to_module_list(attributes=before_user["attributes"])
         else:
             old_value = before_user[param] if param in before_user else None
         if new_param_value != old_value:
@@ -509,8 +496,7 @@ def main():
             changed = True
 
             if username is None:
-                module.fail_json(
-                    msg="username must be specified when creating a new user")
+                module.fail_json(msg="username must be specified when creating a new user")
 
             if module._diff:
                 result["diff"] = dict(before="", after=desired_user)
@@ -562,8 +548,7 @@ def main():
             if kc.update_user_groups_membership(userrep=desired_user, groups=groups, realm=realm):
                 changed = True
         # Get the user groups
-        after_user["groups"] = kc.get_user_groups(
-            user_id=desired_user["id"], realm=realm)
+        after_user["groups"] = kc.get_user_groups(user_id=desired_user["id"], realm=realm)
         result["end_state"] = after_user
         if changed:
             result["msg"] = f"User {desired_user['username']} updated"

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -383,8 +383,7 @@ def main():
         last_name=dict(type="str", aliases=["lastName"]),
         email=dict(type="str"),
         enabled=dict(type="bool"),
-        email_verified=dict(type="str", choices=[
-                            "ignore", "verified", "unverified"], default="ignore", aliases=["emailVerified"]),
+        email_verified=dict(type="bool", aliases=["emailVerified"]),
         federation_link=dict(type="str", aliases=["federationLink"]),
         service_account_client_id=dict(
             type="str", aliases=["serviceAccountClientId"]),
@@ -437,12 +436,6 @@ def main():
     force = module.params.get("force")
     username = module.params.get("username")
     groups = module.params.get("groups")
-    email_verified = module.params.get("email_verified")
-
-    if email_verified == "verified":
-        module.params["email_verified"] = True
-    elif email_verified == "unverified":
-        module.params["email_verified"] = False
 
     # Filter and map the parameters names that apply to the user
     user_params = [
@@ -550,8 +543,8 @@ def main():
                 "federatedIdentities",
                 "requiredActions",
             ]
-            if desired_user.get("emailVerified") == "ignore":
-                excludes.append("emailVerified")
+            # if desired_user.get("emailVerified") == "ignore":
+            #     excludes.append("emailVerified")
             # Add user ID to new representation
             desired_user["id"] = before_user["id"]
 
@@ -561,8 +554,7 @@ def main():
             ):  # If the new user does not introduce a change to the existing user
                 # Update the user
                 if not module.check_mode:
-                    after_user = kc.update_user(
-                        userrep=desired_user, realm=realm)
+                    after_user = kc.update_user(userrep=desired_user, realm=realm)
                 changed = True
 
         if not module.check_mode:

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -36,7 +36,7 @@ options:
   email_verified:
     description:
       - Set or reset the I(emailVerified) flag of the user.
-      - If O(keycloak_default_behavior) is set to V(compatiblity) (the default value), this
+      - If O(email_verified_behavior) is set to V(compatiblity) (the default value), this
         option has a default of V(false).
     type: bool
     aliases:
@@ -200,14 +200,12 @@ options:
       - If V(true), allows to remove user and recreate it.
     type: bool
     default: false
-  keycloak_default_behavior:
+  email_verified_behavior:
     description:
-      - Various module options used to have default values. This caused problems when the
-        user expects different behavior from keycloak by default or fill options which cause
-        problems when they have been set.
-      - The default value is C(compatibility), which will ensure that the default values
-        are used when the values are not explicitly specified by the user.
-      - This affects the O(email_verified) option.
+      - The O(email_verified) option used to have a default value. This caused problems when the
+        user expects different behavior from keycloak by default.
+      - The default value of this option is C(compatibility), which will ensure that the old default value
+        for O(email_verified) is used.
     type: str
     choices:
       - compatibility
@@ -412,7 +410,7 @@ def main():
         origin=dict(type="str"),
         state=dict(choices=["absent", "present"], default="present"),
         force=dict(type="bool", default=False),
-        keycloak_default_behavior=dict(type="str", choices=["compatibility", "no_defaults"], default="compatibility"),
+        email_verified_behavior=dict(type="str", choices=["compatibility", "no_defaults"], default="compatibility"),
     )
     argument_spec.update(meta_args)
 
@@ -442,13 +440,9 @@ def main():
     username = module.params.get("username")
     groups = module.params.get("groups")
 
-    if module.params["keycloak_default_behavior"] == "compatibility":
-        old_default_values = dict(
-            email_verified=False,
-        )
-        for param, value in old_default_values.items():
-            if module.params[param] is None:
-                module.params[param] = value
+    # If there is no value for email_verified, check if we should to set the old default
+    if module.params["email_verified"] is None and module.params["email_verified_behavior"] == "compatibility":
+        module.params["param"] = False
 
     # Filter and map the parameters names that apply to the user
     user_params = [
@@ -456,7 +450,7 @@ def main():
         for x in module.params
         if x
         not in list(keycloak_argument_spec().keys())
-        + ["state", "realm", "force", "groups", "keycloak_default_behavior"]
+        + ["state", "realm", "force", "groups", "email_verified_behavior"]
         and module.params.get(x) is not None
     ]
 

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -442,7 +442,7 @@ def main():
 
     # If there is no value for email_verified, check if we should to set the old default
     if module.params["email_verified"] is None and module.params["email_verified_behavior"] == "compatibility":
-        module.params["param"] = False
+        module.params["email_verified"] = False
 
     # Filter and map the parameters names that apply to the user
     user_params = [

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -449,8 +449,7 @@ def main():
         x
         for x in module.params
         if x
-        not in list(keycloak_argument_spec().keys())
-        + ["state", "realm", "force", "groups", "email_verified_behavior"]
+        not in list(keycloak_argument_spec().keys()) + ["state", "realm", "force", "groups", "email_verified_behavior"]
         and module.params.get(x) is not None
     ]
 

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -4,17 +4,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import annotations
-from ansible_collections.community.general.plugins.module_utils.identity.keycloak.keycloak import (
-    KeycloakAPI,
-    KeycloakError,
-    camel,
-    get_token,
-    is_struct_included,
-    keycloak_argument_spec,
-)
-from ansible.module_utils.basic import AnsibleModule
-import copy
 
 DOCUMENTATION = r"""
 module: keycloak_user
@@ -362,7 +351,8 @@ from ansible_collections.community.general.plugins.module_utils._keycloak import
     is_struct_included,
     keycloak_argument_spec,
 )
-
+from ansible.module_utils.basic import AnsibleModule
+import copy
 
 def main():
     argument_spec = keycloak_argument_spec()

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -445,13 +445,15 @@ def main():
     # If there is no value for email_verified, check if we should to set the old default
     if module.params["email_verified"] is None and module.params["email_verified_behavior"] == "compatibility":
         module.params["email_verified"] = False
+    
+    ignored_arguments = list(keycloak_argument_spec().keys()) + ["state", "realm", "force", "groups", "email_verified_behavior"]
 
     # Filter and map the parameters names that apply to the user
     user_params = [
         x
         for x in module.params
         if x
-        not in list(keycloak_argument_spec().keys()) + ["state", "realm", "force", "groups", "email_verified_behavior"]
+        not in ignored_arguments
         and module.params.get(x) is not None
     ]
 

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -532,7 +532,7 @@ def main():
                 desired_user["id"] = after_user["id"]
             else:
                 after_user = desired_user
-            
+
             result["msg"] = f"User {desired_user['username']} created"
             # Set user_created flag
             result["user_created"] = True
@@ -560,7 +560,7 @@ def main():
                     after_user = desired_user
 
                 changed = True
-        
+
         # set user groups
         if not module.check_mode:
             changed |= kc.update_user_groups_membership(userrep=desired_user, groups=groups, realm=realm)
@@ -572,13 +572,12 @@ def main():
 
         if module.check_mode:
             # after_user will not have changed, so use the desired user
-            changed |= not is_struct_included(
-                groups, before_user["groups"], excludes, empty_list_result=False
-            )
+            changed |= not is_struct_included(groups, before_user["groups"], excludes, empty_list_result=False)
         else:
-            after_user["groups"] = kc.get_user_groups(user_id=desired_user["id"], realm=realm) if "id" in desired_user else []
+            after_user["groups"] = (
+                kc.get_user_groups(user_id=desired_user["id"], realm=realm) if "id" in desired_user else []
+            )
 
-    
     if not result["msg"]:
         if changed:
             result["msg"] = f"User {desired_user['username']} updated"

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -212,7 +212,7 @@ options:
       - compatibility
       - no_defaults
     default: compatibility
-    version_added: "13.0.0"
+    version_added: "13.1.0"
 extends_documentation_fragment:
   - community.general._keycloak
   - community.general._keycloak.actiongroup_keycloak
@@ -454,7 +454,7 @@ def main():
     ]
 
     # Filter and map the parameters names that apply to the user
-    user_params = [x for x in module.params if x not in ignored_arguments and module.params.get(x) is not None]
+    user_params = [x for x in module.params if x not in ignored_arguments and module.params[x] is not None]
 
     before_user = kc.get_user_by_username(username=username, realm=realm)
 

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -556,10 +556,11 @@ def main():
                 # Update the user
                 if not module.check_mode:
                     after_user = kc.update_user(userrep=desired_user, realm=realm)
-                else:
-                    after_user = desired_user
-
                 changed = True
+
+            if not after_user:
+                # no change
+                after_user = desired_user
 
         # set user groups
         if not module.check_mode:

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -445,17 +445,17 @@ def main():
     # If there is no value for email_verified, check if we should to set the old default
     if module.params["email_verified"] is None and module.params["email_verified_behavior"] == "compatibility":
         module.params["email_verified"] = False
-    
-    ignored_arguments = list(keycloak_argument_spec().keys()) + ["state", "realm", "force", "groups", "email_verified_behavior"]
+
+    ignored_arguments = list(keycloak_argument_spec().keys()) + [
+        "state",
+        "realm",
+        "force",
+        "groups",
+        "email_verified_behavior",
+    ]
 
     # Filter and map the parameters names that apply to the user
-    user_params = [
-        x
-        for x in module.params
-        if x
-        not in ignored_arguments
-        and module.params.get(x) is not None
-    ]
+    user_params = [x for x in module.params if x not in ignored_arguments and module.params.get(x) is not None]
 
     before_user = kc.get_user_by_username(username=username, realm=realm)
 

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -511,7 +511,7 @@ def main():
             result["msg"] = f"User {before_user['username']} deleted"
             changed = True
     else:
-        if not before_user or force and username is None:
+        if (not before_user or force) and username is None:
             module.fail_json(msg="username must be specified when creating a new user")
 
         if force and before_user and not module.check_mode:  # If the force option is set to true

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -513,7 +513,7 @@ def main():
     else:
         if not before_user or force and username is None:
             module.fail_json(msg="username must be specified when creating a new user")
-        
+
         if force and before_user and not module.check_mode:  # If the force option is set to true
             # Delete the existing user
             kc.delete_user(user_id=before_user["id"], realm=realm)

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -498,29 +498,19 @@ def main():
     # Default values for user_created
     result["user_created"] = False
     changed = False
+    after_user = {}
 
-    # Cater for when it doesn't exist (an empty dict)
     if state == "absent":
         if not before_user:
             # Do nothing and exit
-            if module._diff:
-                result["diff"] = dict(before="", after="")
-            result["changed"] = False
-            result["end_state"] = {}
-            result["msg"] = "Role does not exist, doing nothing."
-            module.exit_json(**result)
+            result["msg"] = "User does not exist, doing nothing."
         else:
             # Delete user
-            if module._diff:
-                result["diff"] = dict(before=before_user, after="")
-
             if not module.check_mode:
                 kc.delete_user(user_id=before_user["id"], realm=realm)
-                result["msg"] = f"User {before_user['username']} deleted"
+            result["msg"] = f"User {before_user['username']} deleted"
             changed = True
-
     else:
-        after_user = {}
         if force and before_user and not module.check_mode:  # If the force option is set to true
             # Delete the existing user
             kc.delete_user(user_id=before_user["id"], realm=realm)
@@ -535,18 +525,17 @@ def main():
             if module._diff:
                 result["diff"] = dict(before=before_user, after=desired_user)
 
-            if module.check_mode:
-                # Set user_created flag explicit for check_mode
-                # create_user could have failed, but we don't know for sure until we try to create the user.'
-                result["user_created"] = True
-            else:
+            if not module.check_mode:
                 # Create the user
                 after_user = kc.create_user(userrep=desired_user, realm=realm)
-                result["msg"] = f"User {desired_user['username']} created"
-                # Add user ID to new representation
+                # Add user ID to desired_user for group updates
                 desired_user["id"] = after_user["id"]
-                # Set user_created flag
-                result["user_created"] = True
+            else:
+                after_user = desired_user
+            
+            result["msg"] = f"User {desired_user['username']} created"
+            # Set user_created flag
+            result["user_created"] = True
         else:
             # Update an existing user
             excludes = [
@@ -560,9 +549,6 @@ def main():
                 "clientConsents",
                 "federatedIdentities",
             ]
-            # Add user ID to new representation
-            desired_user["id"] = before_user["id"]
-
             # Compare users
             if not (
                 is_struct_included(desired_user, before_user, excludes, empty_list_result=False)
@@ -570,45 +556,37 @@ def main():
                 # Update the user
                 if not module.check_mode:
                     after_user = kc.update_user(userrep=desired_user, realm=realm)
-
-                changed = True
-
-        if not module.check_mode:
-            # set user groups
-            if kc.update_user_groups_membership(userrep=desired_user, groups=groups, realm=realm):
-                changed = True
-
-        if module._diff:
-            present_groups = [g["name"] for g in groups if g["state"] == "present"]
-            absent_groups = [g["name"] for g in groups if g["state"] == "absent"]
-
-            desired_user["groups"] = (set(before_groups) | set(present_groups)) - set(absent_groups)
-
-            if module.check_mode:
-                # after_user will not have changed, so use the desired user
-                result["diff"] = dict(before=before_user, after=desired_user)
-                changed = changed or not is_struct_included(
-                    groups, before_user["groups"], excludes, empty_list_result=False
-                )
-            else:
-                after_groups = (
-                    kc.get_user_groups(user_id=desired_user["id"], realm=realm) if "id" in desired_user else []
-                )
-                if after_user:
-                    after_user["groups"] = after_groups
-                    result["diff"] = dict(before=before_user, after=after_user)
                 else:
-                    result["diff"] = dict(
-                        before={"groups": sorted(before_groups)}, after={"groups": sorted(after_groups)}
-                    )
+                    after_user = desired_user
 
-        result["end_state"] = after_user
+                changed = True
+        
+        # set user groups
+        if not module.check_mode:
+            changed |= kc.update_user_groups_membership(userrep=desired_user, groups=groups, realm=realm)
+
+        present_groups = [g["name"] for g in groups if g["state"] == "present"]
+        absent_groups = [g["name"] for g in groups if g["state"] == "absent"]
+
+        desired_user["groups"] = (set(before_groups) | set(present_groups)) - set(absent_groups)
+
+        if module.check_mode:
+            # after_user will not have changed, so use the desired user
+            changed |= not is_struct_included(
+                groups, before_user["groups"], excludes, empty_list_result=False
+            )
+        else:
+            after_user["groups"] = kc.get_user_groups(user_id=desired_user["id"], realm=realm) if "id" in desired_user else []
+
+    
+    if not result["msg"]:
         if changed:
             result["msg"] = f"User {desired_user['username']} updated"
         else:
             result["msg"] = f"No changes made for user {desired_user['username']}"
-
+    result["end_state"] = after_user
     result["changed"] = changed
+    result["diff"] = dict(before=before_user, after=after_user)
     module.exit_json(**result)
 
 

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -571,12 +571,12 @@ def main():
         desired_user["groups"] = (set(before_groups) | set(present_groups)) - set(absent_groups)
 
         if module.check_mode:
-            # after_user will not have changed, so use the desired user
-            changed |= not is_struct_included(groups, before_user["groups"], excludes, empty_list_result=False)
-        else:
-            after_user["groups"] = (
-                kc.get_user_groups(user_id=desired_user["id"], realm=realm) if "id" in desired_user else []
+            # check if group meberships would have changed
+            changed |= not is_struct_included(
+                desired_user["groups"], before_user["groups"], excludes, empty_list_result=False
             )
+        else:
+            after_user["groups"] = kc.get_user_groups(user_id=desired_user["id"], realm=realm)
 
     if not result["msg"]:
         if changed:

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -511,20 +511,15 @@ def main():
             result["msg"] = f"User {before_user['username']} deleted"
             changed = True
     else:
+        if not before_user or force and username is None:
+            module.fail_json(msg="username must be specified when creating a new user")
+        
         if force and before_user and not module.check_mode:  # If the force option is set to true
             # Delete the existing user
             kc.delete_user(user_id=before_user["id"], realm=realm)
 
         if not before_user or force:
             # Create a new user
-            changed = True
-
-            if username is None:
-                module.fail_json(msg="username must be specified when creating a new user")
-
-            if module._diff:
-                result["diff"] = dict(before=before_user, after=desired_user)
-
             if not module.check_mode:
                 # Create the user
                 after_user = kc.create_user(userrep=desired_user, realm=realm)
@@ -534,8 +529,8 @@ def main():
                 after_user = desired_user
 
             result["msg"] = f"User {desired_user['username']} created"
-            # Set user_created flag
             result["user_created"] = True
+            changed = True
         else:
             # Update an existing user
             excludes = [

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -36,7 +36,7 @@ options:
   email_verified:
     description:
       - Set or reset the I(emailVerified) flag of the user.
-      - When O(email_verified_behavior) is set to no_defaults,
+      - When O(email_verified_behavior) is set to C(no_defaults),
         that means the default value here becomes C(None) and
         that causes the module not to change any existing value for that attribute.
     type: bool
@@ -207,7 +207,7 @@ options:
         user expects different behavior from keycloak by default.
       - The default value of this option is C(compatibility), which will ensure that the old default value
         for O(email_verified) is used.
-      - When set to O(no_defaults), the module will not change existing values of O(email_verified) if no value is specified.
+      - When set to C(no_defaults), the module will not change existing values of O(email_verified) if no value is specified.
     type: str
     choices:
       - compatibility

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -35,9 +35,8 @@ options:
     type: bool
   email_verified:
     description:
-      - Set or reset the I(emailVerified) flag of the user.
-      - When O(email_verified_behavior) is set to C(no_defaults),
-        that means the default value here becomes C(None) and
+      - Set or reset the C(emailVerified) flag of the user.
+      - When O(email_verified_behavior=no_defaults), the default value of this option becomes C(null) and
         that causes the module not to change any existing value for that attribute.
     type: bool
     aliases:
@@ -205,9 +204,9 @@ options:
     description:
       - The O(email_verified) option used to have a default value. This caused problems when the
         user expects different behavior from keycloak by default.
-      - The default value of this option is C(compatibility), which will ensure that the old default value
+      - The default value of this option is V(compatibility), which will ensure that the old default value
         for O(email_verified) is used.
-      - When set to C(no_defaults), the module will not change existing values of O(email_verified) if no value is specified.
+      - When set to V(no_defaults), the module will not change existing values of O(email_verified) if no value is specified.
     type: str
     choices:
       - compatibility

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -36,8 +36,9 @@ options:
   email_verified:
     description:
       - Set or reset the I(emailVerified) flag of the user.
-      - If O(email_verified_behavior) is set to V(compatiblity) (the default value), this
-        option has a default of V(false).
+      - When O(email_verified_behavior) is set to no_defaults,
+        that means the default value here becomes C(None) and
+        that causes the module not to change any existing value for that attribute.
     type: bool
     aliases:
       - emailVerified
@@ -206,6 +207,7 @@ options:
         user expects different behavior from keycloak by default.
       - The default value of this option is C(compatibility), which will ensure that the old default value
         for O(email_verified) is used.
+      - When set to O(no_defaults), the module will not change existing values of O(email_verified) if no value is specified.
     type: str
     choices:
       - compatibility

--- a/tests/integration/targets/keycloak_user/tasks/main.yml
+++ b/tests/integration/targets/keycloak_user/tasks/main.yml
@@ -84,7 +84,7 @@
     that:
       - create_result.changed
       - create_result.end_state.username == 'test'
-      - create_result.end_state.attributes | length == 3
+      - create_result.end_state.userProfileMetadata.attributes | length == 4
       - create_result.end_state.groups | length == 2
 
 - name: Delete User
@@ -168,3 +168,91 @@
   assert:
     that:
       - plus_delete_result.changed
+
+
+- name: Create user again
+  community.general.keycloak_user:
+    auth_keycloak_url: "{{ url }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    auth_realm: "{{ admin_realm }}"
+    username: "{{ keycloak_username }}"
+    realm: "{{ realm }}"
+    first_name: Ceciestes
+    last_name: Untestes
+    email: ceciestuntestes@test.com
+    state: present
+    email_verified_behavior: no_defaults
+  register: create_result
+
+- name: Assert user is created without email_verified
+  assert:
+    that:
+      - create_result.changed
+      - create_result.end_state.username == 'test'
+      - create_result.end_state.email_verified == False
+
+- name: Set email_verified
+  community.general.keycloak_user:
+    auth_keycloak_url: "{{ url }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    auth_realm: "{{ admin_realm }}"
+    username: "{{ keycloak_username }}"
+    realm: "{{ realm }}"
+    first_name: Ceciestes
+    last_name: Untestes
+    email: ceciestuntestes@test.com
+    groups: "{{ keycloak_user_groups }}"
+    attributes: "{{ keycloak_user_attributes }}"
+    email_verified: True
+    state: present
+  register: create_result
+
+- name: Assert email_verified is set
+  assert:
+    that:
+      - create_result.changed
+      - create_result.end_state.email_verified == True
+
+
+- name: Leave email_verified as it is
+  community.general.keycloak_user:
+    auth_keycloak_url: "{{ url }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    auth_realm: "{{ admin_realm }}"
+    username: "{{ keycloak_username }}"
+    realm: "{{ realm }}"
+    first_name: Ceciestes
+    last_name: Untestes
+    email: ceciestuntestes@test.com
+    state: present
+    email_verified_behavior: no_defaults
+  register: create_result
+
+- name: Assert email_verified is still set
+  assert:
+    that:
+      - not create_result.changed
+      - create_result.end_state.email_verified == True
+
+- name: Test old email_verified behavior
+  community.general.keycloak_user:
+    auth_keycloak_url: "{{ url }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    auth_realm: "{{ admin_realm }}"
+    username: "{{ keycloak_username }}"
+    realm: "{{ realm }}"
+    first_name: Ceciestes
+    last_name: Untestes
+    email: ceciestuntestes@test.com
+    state: present
+  register: create_result
+
+- name: Assert email_verified is reset
+  assert:
+    that:
+      - create_result.changed
+      - create_result.end_state.email_verified == False

--- a/tests/integration/targets/keycloak_user/tasks/main.yml
+++ b/tests/integration/targets/keycloak_user/tasks/main.yml
@@ -80,7 +80,7 @@
     var: create_result
 
 - name: Assert user is created
-  assert:
+  ansible.builtin.assert:
     that:
       - create_result.changed
       - create_result.end_state.username == 'test'
@@ -108,7 +108,7 @@
     var: delete_result
 
 - name: Assert user is deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - delete_result.changed
       - delete_result.end_state | length == 0
@@ -128,7 +128,7 @@
   register: plus_create_result
 
 - name: Assert plus-addressed user is created
-  assert:
+  ansible.builtin.assert:
     that:
       - plus_create_result.changed
       - plus_create_result.end_state.username == 'testuser+tag'
@@ -149,7 +149,7 @@
   register: plus_idempotent_result
 
 - name: Assert plus-addressed user is idempotent
-  assert:
+  ansible.builtin.assert:
     that:
       - plus_idempotent_result is not changed
 
@@ -165,10 +165,9 @@
   register: plus_delete_result
 
 - name: Assert plus-addressed user is deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - plus_delete_result.changed
-
 
 - name: Create user again
   community.general.keycloak_user:
@@ -186,11 +185,11 @@
   register: create_result
 
 - name: Assert user is created without email_verified
-  assert:
+  ansible.builtin.assert:
     that:
       - create_result.changed
       - create_result.end_state.username == 'test'
-      - create_result.end_state.email_verified == False
+      - create_result.end_state.emailVerified == false
 
 - name: Set email_verified
   community.general.keycloak_user:
@@ -205,16 +204,15 @@
     email: ceciestuntestes@test.com
     groups: "{{ keycloak_user_groups }}"
     attributes: "{{ keycloak_user_attributes }}"
-    email_verified: True
+    email_verified: true
     state: present
   register: create_result
 
 - name: Assert email_verified is set
-  assert:
+  ansible.builtin.assert:
     that:
       - create_result.changed
-      - create_result.end_state.email_verified == True
-
+      - create_result.end_state.emailVerified == True
 
 - name: Leave email_verified as it is
   community.general.keycloak_user:
@@ -232,10 +230,10 @@
   register: create_result
 
 - name: Assert email_verified is still set
-  assert:
+  ansible.builtin.assert:
     that:
       - not create_result.changed
-      - create_result.end_state.email_verified == True
+      - create_result.end_state.emailVerified == True
 
 - name: Test old email_verified behavior
   community.general.keycloak_user:
@@ -252,7 +250,7 @@
   register: create_result
 
 - name: Assert email_verified is reset
-  assert:
+  ansible.builtin.assert:
     that:
       - create_result.changed
-      - create_result.end_state.email_verified == False
+      - create_result.end_state.emailVerified == False

--- a/tests/integration/targets/keycloak_user/tasks/main.yml
+++ b/tests/integration/targets/keycloak_user/tasks/main.yml
@@ -254,3 +254,69 @@
     that:
       - create_result.changed
       - create_result.end_state.emailVerified == False
+
+- name: Test setting required_actions
+  community.general.keycloak_user:
+    auth_keycloak_url: "{{ url }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    auth_realm: "{{ admin_realm }}"
+    username: "{{ keycloak_username }}"
+    realm: "{{ realm }}"
+    first_name: Ceciestes
+    last_name: Untestes
+    email: ceciestuntestes@test.com
+    required_actions:
+      - UPDATE_PASSWORD
+      - VERIFY_EMAIL
+    state: present
+  register: create_result
+
+- name: Assert required_actions are set
+  ansible.builtin.assert:
+    that:
+      - create_result.changed
+      - "'UPDATE_PASSWORD' in create_result.end_state.requiredActions"
+      - "'VERIFY_EMAIL' in create_result.end_state.requiredActions"
+
+- name: Test required_actions unchanged
+  community.general.keycloak_user:
+    auth_keycloak_url: "{{ url }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    auth_realm: "{{ admin_realm }}"
+    username: "{{ keycloak_username }}"
+    realm: "{{ realm }}"
+    first_name: Ceciestes
+    last_name: Untestes
+    email: ceciestuntestes@test.com
+    state: present
+  register: create_result
+
+- name: Assert required_actions are still set
+  ansible.builtin.assert:
+    that:
+      - not create_result.changed
+      - "'UPDATE_PASSWORD' in create_result.end_state.requiredActions"
+      - "'VERIFY_EMAIL' in create_result.end_state.requiredActions"
+
+- name: Test required_actions reset
+  community.general.keycloak_user:
+    auth_keycloak_url: "{{ url }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    auth_realm: "{{ admin_realm }}"
+    username: "{{ keycloak_username }}"
+    realm: "{{ realm }}"
+    first_name: Ceciestes
+    last_name: Untestes
+    email: ceciestuntestes@test.com
+    state: present
+    required_actions: []
+  register: create_result
+
+- name: Assert required_actions are reset
+  ansible.builtin.assert:
+    that:
+      - create_result.changed
+      - create_result.end_state.requiredActions == []

--- a/tests/unit/plugins/modules/test_keycloak_user.py
+++ b/tests/unit/plugins/modules/test_keycloak_user.py
@@ -146,7 +146,7 @@ class TestKeycloakUser(ModuleTestCase):
         self.assertEqual(mock_get_user_by_username.call_count, 1)
         self.assertEqual(mock_create_user.call_count, 1)
         self.assertEqual(mock_update_user_groups_membership.call_count, 1)
-        self.assertEqual(mock_get_user_groups.call_count, 1)
+        self.assertEqual(mock_get_user_groups.call_count, 0)
         self.assertEqual(mock_update_user.call_count, 0)
         self.assertEqual(mock_delete_user.call_count, 0)
 

--- a/tests/unit/plugins/modules/test_keycloak_user.py
+++ b/tests/unit/plugins/modules/test_keycloak_user.py
@@ -354,7 +354,7 @@ class TestKeycloakUser(ModuleTestCase):
         self.assertEqual(mock_get_user_by_username.call_count, 1)
         self.assertEqual(mock_create_user.call_count, 0)
         self.assertEqual(mock_update_user_groups_membership.call_count, 0)
-        self.assertEqual(mock_get_user_groups.call_count, 0)
+        self.assertEqual(mock_get_user_groups.call_count, 1)
         self.assertEqual(mock_update_user.call_count, 0)
         self.assertEqual(mock_delete_user.call_count, 1)
 

--- a/tests/unit/plugins/modules/test_keycloak_user.py
+++ b/tests/unit/plugins/modules/test_keycloak_user.py
@@ -146,14 +146,14 @@ class TestKeycloakUser(ModuleTestCase):
         self.assertEqual(mock_get_user_by_username.call_count, 1)
         self.assertEqual(mock_create_user.call_count, 1)
         self.assertEqual(mock_update_user_groups_membership.call_count, 1)
-        self.assertEqual(mock_get_user_groups.call_count, 0)
+        self.assertEqual(mock_get_user_groups.call_count, 1)
         self.assertEqual(mock_update_user.call_count, 0)
         self.assertEqual(mock_delete_user.call_count, 0)
 
         # Verify that the module's changed status matches what is expected
         self.assertIs(exec_info.exception.args[0]["changed"], changed)
 
-    def test_add_exiting_user_no_change(self):
+    def test_add_existing_user_no_change(self):
         """Add a new user"""
 
         module_args = {
@@ -179,7 +179,7 @@ class TestKeycloakUser(ModuleTestCase):
             }
         ]
         return_value_update_user_groups_membership = [False]
-        return_get_user_groups = [[]]
+        return_get_user_groups = [[], []]
         return_create_user = None
         return_delete_user = None
         return_update_user = None
@@ -210,7 +210,7 @@ class TestKeycloakUser(ModuleTestCase):
         self.assertEqual(mock_get_user_by_username.call_count, 1)
         self.assertEqual(mock_create_user.call_count, 0)
         self.assertEqual(mock_update_user_groups_membership.call_count, 1)
-        self.assertEqual(mock_get_user_groups.call_count, 1)
+        self.assertEqual(mock_get_user_groups.call_count, 2)
         self.assertEqual(mock_update_user.call_count, 0)
         self.assertEqual(mock_delete_user.call_count, 0)
 
@@ -245,7 +245,7 @@ class TestKeycloakUser(ModuleTestCase):
             }
         ]
         return_value_update_user_groups_membership = [True]
-        return_get_user_groups = [["group1"]]
+        return_get_user_groups = [[],["group1"]]
         return_create_user = None
         return_delete_user = None
         return_update_user = [
@@ -290,7 +290,7 @@ class TestKeycloakUser(ModuleTestCase):
         self.assertEqual(mock_get_user_by_username.call_count, 1)
         self.assertEqual(mock_create_user.call_count, 0)
         self.assertEqual(mock_update_user_groups_membership.call_count, 1)
-        self.assertEqual(mock_get_user_groups.call_count, 1)
+        self.assertEqual(mock_get_user_groups.call_count, 2)
         self.assertEqual(mock_update_user.call_count, 1)
         self.assertEqual(mock_delete_user.call_count, 0)
 

--- a/tests/unit/plugins/modules/test_keycloak_user.py
+++ b/tests/unit/plugins/modules/test_keycloak_user.py
@@ -245,7 +245,7 @@ class TestKeycloakUser(ModuleTestCase):
             }
         ]
         return_value_update_user_groups_membership = [True]
-        return_get_user_groups = [[],["group1"]]
+        return_get_user_groups = [[], ["group1"]]
         return_create_user = None
         return_delete_user = None
         return_update_user = [


### PR DESCRIPTION
##### SUMMARY

This fixes #11747.
`email_verified` is now optional, which allows not overwriting the value found on the server.
This change is backwards compatible.

Secondly, this also tries to fix the check_mode and diff for this module, which now does not change any user data (create or update users) and displays diffs for all possible scenarios.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.

     -->
###### changelog-fragment

minor_changes:
  - keycloak_user - make `email_verified` and `required_actions` optional and fix check_mode and diff (https://github.com/ansible-collections/community.general/issues/11747).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
keycloak_user module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
