### PR TITLE
Fix: Prevent nmap inventory plugin from adding unwanted host discovery probes

### DIFF
--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -84,7 +84,7 @@ options:
   skip_host_discovery:
     description: Prevent host discovery probes
     type: boolean
-    version_added:
+    version_added: 12.6.0
   dns_resolve:
     description: Whether to always (V(true)) or never (V(false)) do DNS resolution.
     type: boolean

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -322,4 +322,3 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self._cache[cache_key] = results
 
         self._populate(results)
-

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -256,10 +256,17 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             if self.get_option('skip_host_discovery'):
                 cmd.append('-Pn')
 
+<<<<<<< HEAD
             if not self.get_option('use_arp_ping'):
                 cmd.append('--disable-arp-ping')
 
             cmd.append(self.get_option('address'))
+=======
+            if self.get_option('skip_host_discovery'):
+                cmd.append('-Pn')
+
+            cmd.append(self.get_option("address"))
+>>>>>>> d927399e2 (Fix: Prevent nmap inventory plugin from adding unwanted host discovery probes)
             try:
                 # execute
                 p = Popen(cmd, stdout=PIPE, stderr=PIPE)

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -250,8 +250,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             if not self.get_option("use_arp_ping"):
                 cmd.append("--disable-arp-ping")
-            if self.get_option('skip_host_discovery'):
-                cmd.append('-Pn')
+
+            if self.get_option("skip_host_discovery"):
+                cmd.append("-Pn")
 
             cmd.append(self.get_option("address"))
             try:

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
@@ -18,7 +17,7 @@ requirements:
   - nmap CLI installed
 options:
   plugin:
-    description: token that ensures this is a source file for the 'nmap' plugin.
+    description: Token that ensures this is a source file for the P(community.general.nmap#inventory) plugin.
     type: string
     required: true
     choices: ['nmap', 'community.general.nmap']
@@ -46,8 +45,8 @@ options:
   port:
     description:
       - Only scan specific port or port range (C(-p)).
-      - For example, you could pass V(22) for a single port, V(1-65535) for a range of ports,
-        or V(U:53,137,T:21-25,139,8080,S:9) to check port 53 with UDP, ports 21-25 with TCP, port 9 with SCTP, and ports 137, 139, and 8080 with all.
+      - For example, you could pass V(22) for a single port, V(1-65535) for a range of ports, or V(U:53,137,T:21-25,139,8080,S:9)
+        to check port 53 with UDP, ports 21-25 with TCP, port 9 with SCTP, and ports 137, 139, and 8080 with all.
     type: string
     version_added: 6.5.0
   ports:
@@ -55,23 +54,23 @@ options:
     type: boolean
     default: true
   ipv4:
-    description: use IPv4 type addresses
+    description: Use IPv4 type addresses.
     type: boolean
     default: true
   ipv6:
-    description: use IPv6 type addresses
+    description: Use IPv6 type addresses.
     type: boolean
     default: true
   udp_scan:
     description:
-      - Scan via UDP.
+      - Scan using UDP.
       - Depending on your system you might need O(sudo=true) for this to work.
     type: boolean
     default: false
     version_added: 6.1.0
   icmp_timestamp:
     description:
-      - Scan via ICMP Timestamp (C(-PP)).
+      - Scan using ICMP Timestamp (C(-PP)).
       - Depending on your system you might need O(sudo=true) for this to work.
     type: boolean
     default: false
@@ -102,7 +101,7 @@ options:
     version_added: 7.4.0
 notes:
   - At least one of O(ipv4) or O(ipv6) is required to be V(true); both can be V(true), but they cannot both be V(false).
-  - 'TODO: add OS fingerprinting'
+  - 'TODO: add OS fingerprinting.'
 """
 EXAMPLES = r"""
 ---
@@ -130,52 +129,49 @@ groups:
 
 import os
 import re
-
-from subprocess import Popen, PIPE
+from subprocess import PIPE, Popen
 
 from ansible import constants as C
 from ansible.errors import AnsibleParserError
-from ansible.module_utils.common.text.converters import to_native, to_text
-from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.module_utils.common.process import get_bin_path
+from ansible.module_utils.common.text.converters import to_native, to_text
+from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable, Constructable
 
 from ansible_collections.community.general.plugins.plugin_utils.unsafe import make_unsafe
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
-
-    NAME = 'community.general.nmap'
-    find_host = re.compile(r'^Nmap scan report for ([\w,.,-]+)(?: \(([\w,.,:,\[,\]]+)\))?')
-    find_port = re.compile(r'^(\d+)/(\w+)\s+(\w+)\s+(\w+)')
+    NAME = "community.general.nmap"
+    find_host = re.compile(r"^Nmap scan report for ([\w,.,-]+)(?: \(([\w,.,:,\[,\]]+)\))?")
+    find_port = re.compile(r"^(\d+)/(\w+)\s+(\w+)\s+(\w+)")
 
     def __init__(self):
         self._nmap = None
-        super(InventoryModule, self).__init__()
+        super().__init__()
 
     def _populate(self, hosts):
         # Use constructed if applicable
-        strict = self.get_option('strict')
+        strict = self.get_option("strict")
 
         for host in hosts:
             host = make_unsafe(host)
-            hostname = host['name']
+            hostname = host["name"]
             self.inventory.add_host(hostname)
             for var, value in host.items():
                 self.inventory.set_variable(hostname, var, value)
 
             # Composed variables
-            self._set_composite_vars(self.get_option('compose'), host, hostname, strict=strict)
+            self._set_composite_vars(self.get_option("compose"), host, hostname, strict=strict)
 
             # Complex groups based on jinja2 conditionals, hosts that meet the conditional are added to group
-            self._add_host_to_composed_groups(self.get_option('groups'), host, hostname, strict=strict)
+            self._add_host_to_composed_groups(self.get_option("groups"), host, hostname, strict=strict)
 
             # Create groups based on variable values and add the corresponding hosts to it
-            self._add_host_to_keyed_groups(self.get_option('keyed_groups'), host, hostname, strict=strict)
+            self._add_host_to_keyed_groups(self.get_option("keyed_groups"), host, hostname, strict=strict)
 
     def verify_file(self, path):
-
         valid = False
-        if super(InventoryModule, self).verify_file(path):
+        if super().verify_file(path):
             file_name, ext = os.path.splitext(path)
 
             if not ext or ext in C.YAML_FILENAME_EXTENSIONS:
@@ -184,13 +180,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         return valid
 
     def parse(self, inventory, loader, path, cache=True):
-
         try:
-            self._nmap = get_bin_path('nmap')
+            self._nmap = get_bin_path("nmap")
         except ValueError as e:
-            raise AnsibleParserError(f'nmap inventory plugin requires the nmap cli tool to work: {e}')
+            raise AnsibleParserError(f"nmap inventory plugin requires the nmap cli tool to work: {e}") from e
 
-        super(InventoryModule, self).parse(inventory, loader, path, cache=cache)
+        super().parse(inventory, loader, path, cache=cache)
 
         self._read_config_data(path)
 
@@ -198,7 +193,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         # cache may be True or False at this point to indicate if the inventory is being refreshed
         # get the user's cache option too to see if we should save the cache if it is changing
-        user_cache_setting = self.get_option('cache')
+        user_cache_setting = self.get_option("cache")
 
         # read if the user has caching enabled and the cache isn't being refreshed
         attempt_to_read_cache = user_cache_setting and cache
@@ -216,63 +211,55 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             # setup command
             cmd = [self._nmap]
 
-            if self.get_option('sudo'):
-                cmd.insert(0, 'sudo')
+            if self.get_option("sudo"):
+                cmd.insert(0, "sudo")
 
-            if self.get_option('port'):
-                cmd.append('-p')
-                cmd.append(self.get_option('port'))
+            if self.get_option("port"):
+                cmd.append("-p")
+                cmd.append(self.get_option("port"))
 
-            if not self.get_option('ports'):
-                cmd.append('-sP')
+            if not self.get_option("ports"):
+                cmd.append("-sP")
 
-            if self.get_option('ipv4') and not self.get_option('ipv6'):
-                cmd.append('-4')
-            elif self.get_option('ipv6') and not self.get_option('ipv4'):
-                cmd.append('-6')
-            elif not self.get_option('ipv6') and not self.get_option('ipv4'):
-                raise AnsibleParserError('One of ipv4 or ipv6 must be enabled for this plugin')
+            if self.get_option("ipv4") and not self.get_option("ipv6"):
+                cmd.append("-4")
+            elif self.get_option("ipv6") and not self.get_option("ipv4"):
+                cmd.append("-6")
+            elif not self.get_option("ipv6") and not self.get_option("ipv4"):
+                raise AnsibleParserError("One of ipv4 or ipv6 must be enabled for this plugin")
 
-            if self.get_option('exclude'):
-                cmd.append('--exclude')
-                cmd.append(','.join(self.get_option('exclude')))
+            if self.get_option("exclude"):
+                cmd.append("--exclude")
+                cmd.append(",".join(self.get_option("exclude")))
 
-            if self.get_option('dns_resolve'):
-                cmd.append('-n')
+            if self.get_option("dns_resolve"):
+                cmd.append("-n")
 
-            if self.get_option('dns_servers'):
-                cmd.append('--dns-servers')
-                cmd.append(','.join(self.get_option('dns_servers')))
+            if self.get_option("dns_servers"):
+                cmd.append("--dns-servers")
+                cmd.append(",".join(self.get_option("dns_servers")))
 
-            if self.get_option('udp_scan'):
-                cmd.append('-sU')
+            if self.get_option("udp_scan"):
+                cmd.append("-sU")
 
-            if self.get_option('icmp_timestamp'):
-                cmd.append('-PP')
+            if self.get_option("icmp_timestamp"):
+                cmd.append("-PP")
 
-            if self.get_option('open'):
-                cmd.append('--open')
+            if self.get_option("open"):
+                cmd.append("--open")
 
-            if self.get_option('skip_host_discovery'):
-                cmd.append('-Pn')
-
-<<<<<<< HEAD
-            if not self.get_option('use_arp_ping'):
-                cmd.append('--disable-arp-ping')
-
-            cmd.append(self.get_option('address'))
-=======
+            if not self.get_option("use_arp_ping"):
+                cmd.append("--disable-arp-ping")
             if self.get_option('skip_host_discovery'):
                 cmd.append('-Pn')
 
             cmd.append(self.get_option("address"))
->>>>>>> d927399e2 (Fix: Prevent nmap inventory plugin from adding unwanted host discovery probes)
             try:
                 # execute
                 p = Popen(cmd, stdout=PIPE, stderr=PIPE)
                 stdout, stderr = p.communicate()
                 if p.returncode != 0:
-                    raise AnsibleParserError(f'Failed to run nmap, rc={p.returncode}: {to_native(stderr)}')
+                    raise AnsibleParserError(f"Failed to run nmap, rc={p.returncode}: {to_native(stderr)}")
 
                 # parse results
                 host = None
@@ -281,18 +268,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 results = []
 
                 try:
-                    t_stdout = to_text(stdout, errors='surrogate_or_strict')
+                    t_stdout = to_text(stdout, errors="surrogate_or_strict")
                 except UnicodeError as e:
-                    raise AnsibleParserError(f'Invalid (non unicode) input returned: {e}')
+                    raise AnsibleParserError(f"Invalid (non unicode) input returned: {e}") from e
 
                 for line in t_stdout.splitlines():
                     hits = self.find_host.match(line)
                     if hits:
                         if host is not None and ports:
-                            results[-1]['ports'] = ports
+                            results[-1]["ports"] = ports
 
                         # if dns only shows arpa, just use ip instead as hostname
-                        if hits.group(1).endswith('.in-addr.arpa'):
+                        if hits.group(1).endswith(".in-addr.arpa"):
                             host = hits.group(2)
                         else:
                             host = hits.group(1)
@@ -306,27 +293,32 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                         if host is not None:
                             # update inventory
                             results.append(dict())
-                            results[-1]['name'] = host
-                            results[-1]['ip'] = ip
+                            results[-1]["name"] = host
+                            results[-1]["ip"] = ip
                             ports = []
                         continue
 
                     host_ports = self.find_port.match(line)
                     if host is not None and host_ports:
-                        ports.append({'port': host_ports.group(1),
-                                      'protocol': host_ports.group(2),
-                                      'state': host_ports.group(3),
-                                      'service': host_ports.group(4)})
+                        ports.append(
+                            {
+                                "port": host_ports.group(1),
+                                "protocol": host_ports.group(2),
+                                "state": host_ports.group(3),
+                                "service": host_ports.group(4),
+                            }
+                        )
                         continue
 
                 # if any leftovers
                 if host and ports:
-                    results[-1]['ports'] = ports
+                    results[-1]["ports"] = ports
 
             except Exception as e:
-                raise AnsibleParserError(f"failed to parse {to_native(path)}: {e} ")
+                raise AnsibleParserError(f"failed to parse {to_native(path)}: {e} ") from e
 
         if cache_needs_update:
             self._cache[cache_key] = results
 
         self._populate(results)
+

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
@@ -17,7 +18,7 @@ requirements:
   - nmap CLI installed
 options:
   plugin:
-    description: Token that ensures this is a source file for the P(community.general.nmap#inventory) plugin.
+    description: token that ensures this is a source file for the 'nmap' plugin.
     type: string
     required: true
     choices: ['nmap', 'community.general.nmap']
@@ -45,8 +46,8 @@ options:
   port:
     description:
       - Only scan specific port or port range (C(-p)).
-      - For example, you could pass V(22) for a single port, V(1-65535) for a range of ports, or V(U:53,137,T:21-25,139,8080,S:9)
-        to check port 53 with UDP, ports 21-25 with TCP, port 9 with SCTP, and ports 137, 139, and 8080 with all.
+      - For example, you could pass V(22) for a single port, V(1-65535) for a range of ports,
+        or V(U:53,137,T:21-25,139,8080,S:9) to check port 53 with UDP, ports 21-25 with TCP, port 9 with SCTP, and ports 137, 139, and 8080 with all.
     type: string
     version_added: 6.5.0
   ports:
@@ -54,23 +55,23 @@ options:
     type: boolean
     default: true
   ipv4:
-    description: Use IPv4 type addresses.
+    description: use IPv4 type addresses
     type: boolean
     default: true
   ipv6:
-    description: Use IPv6 type addresses.
+    description: use IPv6 type addresses
     type: boolean
     default: true
   udp_scan:
     description:
-      - Scan using UDP.
+      - Scan via UDP.
       - Depending on your system you might need O(sudo=true) for this to work.
     type: boolean
     default: false
     version_added: 6.1.0
   icmp_timestamp:
     description:
-      - Scan using ICMP Timestamp (C(-PP)).
+      - Scan via ICMP Timestamp (C(-PP)).
       - Depending on your system you might need O(sudo=true) for this to work.
     type: boolean
     default: false
@@ -80,6 +81,10 @@ options:
     type: boolean
     default: false
     version_added: 6.5.0
+  skip_host_discovery:
+    description: Prevent host discovery probes
+    type: boolean
+    version_added:
   dns_resolve:
     description: Whether to always (V(true)) or never (V(false)) do DNS resolution.
     type: boolean
@@ -97,7 +102,7 @@ options:
     version_added: 7.4.0
 notes:
   - At least one of O(ipv4) or O(ipv6) is required to be V(true); both can be V(true), but they cannot both be V(false).
-  - 'TODO: add OS fingerprinting.'
+  - 'TODO: add OS fingerprinting'
 """
 EXAMPLES = r"""
 ---
@@ -125,49 +130,52 @@ groups:
 
 import os
 import re
-from subprocess import PIPE, Popen
+
+from subprocess import Popen, PIPE
 
 from ansible import constants as C
 from ansible.errors import AnsibleParserError
-from ansible.module_utils.common.process import get_bin_path
 from ansible.module_utils.common.text.converters import to_native, to_text
-from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable, Constructable
+from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
+from ansible.module_utils.common.process import get_bin_path
 
 from ansible_collections.community.general.plugins.plugin_utils.unsafe import make_unsafe
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
-    NAME = "community.general.nmap"
-    find_host = re.compile(r"^Nmap scan report for ([\w,.,-]+)(?: \(([\w,.,:,\[,\]]+)\))?")
-    find_port = re.compile(r"^(\d+)/(\w+)\s+(\w+)\s+(\w+)")
+
+    NAME = 'community.general.nmap'
+    find_host = re.compile(r'^Nmap scan report for ([\w,.,-]+)(?: \(([\w,.,:,\[,\]]+)\))?')
+    find_port = re.compile(r'^(\d+)/(\w+)\s+(\w+)\s+(\w+)')
 
     def __init__(self):
         self._nmap = None
-        super().__init__()
+        super(InventoryModule, self).__init__()
 
     def _populate(self, hosts):
         # Use constructed if applicable
-        strict = self.get_option("strict")
+        strict = self.get_option('strict')
 
         for host in hosts:
             host = make_unsafe(host)
-            hostname = host["name"]
+            hostname = host['name']
             self.inventory.add_host(hostname)
             for var, value in host.items():
                 self.inventory.set_variable(hostname, var, value)
 
             # Composed variables
-            self._set_composite_vars(self.get_option("compose"), host, hostname, strict=strict)
+            self._set_composite_vars(self.get_option('compose'), host, hostname, strict=strict)
 
             # Complex groups based on jinja2 conditionals, hosts that meet the conditional are added to group
-            self._add_host_to_composed_groups(self.get_option("groups"), host, hostname, strict=strict)
+            self._add_host_to_composed_groups(self.get_option('groups'), host, hostname, strict=strict)
 
             # Create groups based on variable values and add the corresponding hosts to it
-            self._add_host_to_keyed_groups(self.get_option("keyed_groups"), host, hostname, strict=strict)
+            self._add_host_to_keyed_groups(self.get_option('keyed_groups'), host, hostname, strict=strict)
 
     def verify_file(self, path):
+
         valid = False
-        if super().verify_file(path):
+        if super(InventoryModule, self).verify_file(path):
             file_name, ext = os.path.splitext(path)
 
             if not ext or ext in C.YAML_FILENAME_EXTENSIONS:
@@ -176,12 +184,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         return valid
 
     def parse(self, inventory, loader, path, cache=True):
-        try:
-            self._nmap = get_bin_path("nmap")
-        except ValueError as e:
-            raise AnsibleParserError(f"nmap inventory plugin requires the nmap cli tool to work: {e}") from e
 
-        super().parse(inventory, loader, path, cache=cache)
+        try:
+            self._nmap = get_bin_path('nmap')
+        except ValueError as e:
+            raise AnsibleParserError(f'nmap inventory plugin requires the nmap cli tool to work: {e}')
+
+        super(InventoryModule, self).parse(inventory, loader, path, cache=cache)
 
         self._read_config_data(path)
 
@@ -189,7 +198,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         # cache may be True or False at this point to indicate if the inventory is being refreshed
         # get the user's cache option too to see if we should save the cache if it is changing
-        user_cache_setting = self.get_option("cache")
+        user_cache_setting = self.get_option('cache')
 
         # read if the user has caching enabled and the cache isn't being refreshed
         attempt_to_read_cache = user_cache_setting and cache
@@ -207,53 +216,56 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             # setup command
             cmd = [self._nmap]
 
-            if self.get_option("sudo"):
-                cmd.insert(0, "sudo")
+            if self.get_option('sudo'):
+                cmd.insert(0, 'sudo')
 
-            if self.get_option("port"):
-                cmd.append("-p")
-                cmd.append(self.get_option("port"))
+            if self.get_option('port'):
+                cmd.append('-p')
+                cmd.append(self.get_option('port'))
 
-            if not self.get_option("ports"):
-                cmd.append("-sP")
+            if not self.get_option('ports'):
+                cmd.append('-sP')
 
-            if self.get_option("ipv4") and not self.get_option("ipv6"):
-                cmd.append("-4")
-            elif self.get_option("ipv6") and not self.get_option("ipv4"):
-                cmd.append("-6")
-            elif not self.get_option("ipv6") and not self.get_option("ipv4"):
-                raise AnsibleParserError("One of ipv4 or ipv6 must be enabled for this plugin")
+            if self.get_option('ipv4') and not self.get_option('ipv6'):
+                cmd.append('-4')
+            elif self.get_option('ipv6') and not self.get_option('ipv4'):
+                cmd.append('-6')
+            elif not self.get_option('ipv6') and not self.get_option('ipv4'):
+                raise AnsibleParserError('One of ipv4 or ipv6 must be enabled for this plugin')
 
-            if self.get_option("exclude"):
-                cmd.append("--exclude")
-                cmd.append(",".join(self.get_option("exclude")))
+            if self.get_option('exclude'):
+                cmd.append('--exclude')
+                cmd.append(','.join(self.get_option('exclude')))
 
-            if self.get_option("dns_resolve"):
-                cmd.append("-n")
+            if self.get_option('dns_resolve'):
+                cmd.append('-n')
 
-            if self.get_option("dns_servers"):
-                cmd.append("--dns-servers")
-                cmd.append(",".join(self.get_option("dns_servers")))
+            if self.get_option('dns_servers'):
+                cmd.append('--dns-servers')
+                cmd.append(','.join(self.get_option('dns_servers')))
 
-            if self.get_option("udp_scan"):
-                cmd.append("-sU")
+            if self.get_option('udp_scan'):
+                cmd.append('-sU')
 
-            if self.get_option("icmp_timestamp"):
-                cmd.append("-PP")
+            if self.get_option('icmp_timestamp'):
+                cmd.append('-PP')
 
-            if self.get_option("open"):
-                cmd.append("--open")
+            if self.get_option('open'):
+                cmd.append('--open')
 
-            if not self.get_option("use_arp_ping"):
-                cmd.append("--disable-arp-ping")
+            if self.get_option('skip_host_discovery'):
+                cmd.append('-Pn')
 
-            cmd.append(self.get_option("address"))
+            if not self.get_option('use_arp_ping'):
+                cmd.append('--disable-arp-ping')
+
+            cmd.append(self.get_option('address'))
             try:
                 # execute
                 p = Popen(cmd, stdout=PIPE, stderr=PIPE)
                 stdout, stderr = p.communicate()
                 if p.returncode != 0:
-                    raise AnsibleParserError(f"Failed to run nmap, rc={p.returncode}: {to_native(stderr)}")
+                    raise AnsibleParserError(f'Failed to run nmap, rc={p.returncode}: {to_native(stderr)}')
 
                 # parse results
                 host = None
@@ -262,18 +274,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 results = []
 
                 try:
-                    t_stdout = to_text(stdout, errors="surrogate_or_strict")
+                    t_stdout = to_text(stdout, errors='surrogate_or_strict')
                 except UnicodeError as e:
-                    raise AnsibleParserError(f"Invalid (non unicode) input returned: {e}") from e
+                    raise AnsibleParserError(f'Invalid (non unicode) input returned: {e}')
 
                 for line in t_stdout.splitlines():
                     hits = self.find_host.match(line)
                     if hits:
                         if host is not None and ports:
-                            results[-1]["ports"] = ports
+                            results[-1]['ports'] = ports
 
                         # if dns only shows arpa, just use ip instead as hostname
-                        if hits.group(1).endswith(".in-addr.arpa"):
+                        if hits.group(1).endswith('.in-addr.arpa'):
                             host = hits.group(2)
                         else:
                             host = hits.group(1)
@@ -287,29 +299,25 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                         if host is not None:
                             # update inventory
                             results.append(dict())
-                            results[-1]["name"] = host
-                            results[-1]["ip"] = ip
+                            results[-1]['name'] = host
+                            results[-1]['ip'] = ip
                             ports = []
                         continue
 
                     host_ports = self.find_port.match(line)
                     if host is not None and host_ports:
-                        ports.append(
-                            {
-                                "port": host_ports.group(1),
-                                "protocol": host_ports.group(2),
-                                "state": host_ports.group(3),
-                                "service": host_ports.group(4),
-                            }
-                        )
+                        ports.append({'port': host_ports.group(1),
+                                      'protocol': host_ports.group(2),
+                                      'state': host_ports.group(3),
+                                      'service': host_ports.group(4)})
                         continue
 
                 # if any leftovers
                 if host and ports:
-                    results[-1]["ports"] = ports
+                    results[-1]['ports'] = ports
 
             except Exception as e:
-                raise AnsibleParserError(f"failed to parse {to_native(path)}: {e} ") from e
+                raise AnsibleParserError(f"failed to parse {to_native(path)}: {e} ")
 
         if cache_needs_update:
             self._cache[cache_key] = results


### PR DESCRIPTION
##### SUMMARY

Add an arg to skip the default nmap discovery host pre-check testing the port 80, and port 443.
In some cases, this default behaviour will stop the scan and then some open ports will be missed.
Not really a bug fix but very important and usefull option given the reliability of nmap tools.

Fixes #7893

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Skip host discovery probes port 80 and 443 and icmp

##### ADDITIONAL INFORMATION

For example using this feature scanning only one port will give you a simple conversation in a packet capture:
host -> dest    Flags [S]
dest -> host     Flags [S.]
host -> dest     Flags [.]
host -> dest     Flags [R.]

The minima check tcp which tell you the dest is reachable and the port is open.
 
