### PR TITLE
openbsd_pkg, sorcery: ensure standard locale in run_command (group4-batch2)

### DIFF
--- a/changelogs/fragments/11767-group4-batch2-locale.yml
+++ b/changelogs/fragments/11767-group4-batch2-locale.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - openbsd_pkg - ensure ``LANGUAGE=C`` and ``LC_ALL=C`` are set when running commands that parse output (https://github.com/ansible-collections/community.general/issues/11737, https://github.com/ansible-collections/community.general/pull/11767).
+  - sorcery - ensure ``LANGUAGE=C`` and ``LC_ALL=C`` are set when running commands that parse output (https://github.com/ansible-collections/community.general/issues/11737, https://github.com/ansible-collections/community.general/pull/11767).

--- a/changelogs/fragments/group4-batch2-locale.yml
+++ b/changelogs/fragments/group4-batch2-locale.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - openbsd_pkg - ensure ``LANGUAGE=C`` and ``LC_ALL=C`` are set when running commands that parse output (https://github.com/russoz-ansible/community.general/pull/1, https://github.com/ansible-collections/community.general/issues/11737).
+  - sorcery - ensure ``LANGUAGE=C`` and ``LC_ALL=C`` are set when running commands that parse output (https://github.com/russoz-ansible/community.general/pull/1, https://github.com/ansible-collections/community.general/issues/11737).

--- a/changelogs/fragments/group4-batch2-locale.yml
+++ b/changelogs/fragments/group4-batch2-locale.yml
@@ -1,3 +1,0 @@
-bugfixes:
-  - openbsd_pkg - ensure ``LANGUAGE=C`` and ``LC_ALL=C`` are set when running commands that parse output (https://github.com/russoz-ansible/community.general/pull/1, https://github.com/ansible-collections/community.general/issues/11737).
-  - sorcery - ensure ``LANGUAGE=C`` and ``LC_ALL=C`` are set when running commands that parse output (https://github.com/russoz-ansible/community.general/pull/1, https://github.com/ansible-collections/community.general/issues/11737).

--- a/plugins/modules/openbsd_pkg.py
+++ b/plugins/modules/openbsd_pkg.py
@@ -166,7 +166,7 @@ def execute_command(cmd, module):
     # We set TERM to 'dumb' to keep pkg_add happy if the machine running
     # ansible is using a TERM that the managed machine does not know about,
     # e.g.: "No progress meter: failed termcap lookup on xterm-kitty".
-    return module.run_command(cmd_args, environ_update={"TERM": "dumb"})
+    return module.run_command(cmd_args, environ_update={"TERM": "dumb", "LANGUAGE": "C", "LC_ALL": "C"})
 
 
 def get_all_installed(module):

--- a/plugins/modules/sorcery.py
+++ b/plugins/modules/sorcery.py
@@ -703,7 +703,7 @@ def main():
         SORCERY[c] = module.get_bin_path(c, True)
 
     # prepare environment: run sorcery commands without asking questions
-    module.run_command_environ_update = dict(PROMPT_DELAY="0", VOYEUR="0")
+    module.run_command_environ_update = dict(PROMPT_DELAY="0", VOYEUR="0", LANGUAGE="C", LC_ALL="C")
 
     params = module.params
 


### PR DESCRIPTION
##### SUMMARY
Ensure the correct locale is used by setting ``LANGUAGE`` and ``LC_ALL`` variables, preventing locale-dependent output parsing failures on non-C-locale systems.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/openbsd_pkg.py
plugins/modules/sorcery.py