### PR TITLE
Ensure standard locale in run_command (group5-batch2)

### DIFF
--- a/changelogs/fragments/11773-group5-batch2-locale.yml
+++ b/changelogs/fragments/11773-group5-batch2-locale.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - cronvar - ensure ``LANGUAGE=C`` and ``LC_ALL=C`` are set when running commands that parse output (https://github.com/ansible-collections/community.general/issues/11737, https://github.com/ansible-collections/community.general/pull/11773).
+  - dnf_versionlock - ensure ``LANGUAGE=C`` and ``LC_ALL=C`` are set when running commands that parse output (https://github.com/ansible-collections/community.general/issues/11737, https://github.com/ansible-collections/community.general/pull/11773).
+  - dpkg_divert - ensure ``LANGUAGE=C`` and ``LC_ALL=C`` are set when running commands that parse output (https://github.com/ansible-collections/community.general/issues/11737, https://github.com/ansible-collections/community.general/pull/11773).
+  - flatpak_remote - ensure ``LANGUAGE=C`` and ``LC_ALL=C`` are set when running commands that parse output (https://github.com/ansible-collections/community.general/issues/11737, https://github.com/ansible-collections/community.general/pull/11773).
+  - hg - ensure ``LANGUAGE=C`` and ``LC_ALL=C`` are set when running commands that parse output (https://github.com/ansible-collections/community.general/issues/11737, https://github.com/ansible-collections/community.general/pull/11773).

--- a/plugins/modules/cronvar.py
+++ b/plugins/modules/cronvar.py
@@ -360,6 +360,7 @@ def main():
         mutually_exclusive=[["insertbefore", "insertafter"]],
         supports_check_mode=False,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     name = module.params["name"]
     value = module.params["value"]

--- a/plugins/modules/dnf_versionlock.py
+++ b/plugins/modules/dnf_versionlock.py
@@ -257,6 +257,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     patterns = module.params["name"]
     raw = module.params["raw"]

--- a/plugins/modules/dpkg_divert.py
+++ b/plugins/modules/dpkg_divert.py
@@ -171,6 +171,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     path = module.params["path"]
     state = module.params["state"]

--- a/plugins/modules/flatpak_remote.py
+++ b/plugins/modules/flatpak_remote.py
@@ -199,6 +199,7 @@ def main():
         # This module supports check mode
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     name = module.params["name"]
     flatpakrepo_url = module.params["flatpakrepo_url"]

--- a/plugins/modules/hg.py
+++ b/plugins/modules/hg.py
@@ -219,6 +219,7 @@ def main():
             executable=dict(type="str"),
         ),
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
     repo = module.params["repo"]
     dest = module.params["dest"]
     revision = module.params["revision"]


### PR DESCRIPTION
##### SUMMARY
Ensure the correct locale is used by setting ``LANGUAGE`` and ``LC_ALL`` variables, preventing locale-dependent output parsing failures on non-C-locale systems.

Part of #11737.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/cronvar.py
plugins/modules/dnf_versionlock.py
plugins/modules/dpkg_divert.py
plugins/modules/flatpak_remote.py
plugins/modules/hg.py