### PR TITLE
Ensure standard locale in run_command (group5-batch3)

### DIFF
--- a/changelogs/fragments/11774-group5-batch3-locale.yml
+++ b/changelogs/fragments/11774-group5-batch3-locale.yml
@@ -1,0 +1,16 @@
+bugfixes:
+  - homectl - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11774).
+  - java_cert - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11774).
+  - keyring - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11774).
+  - launchd - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11774).
+  - listen_ports_facts - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11774).

--- a/plugins/modules/homectl.py
+++ b/plugins/modules/homectl.py
@@ -614,6 +614,7 @@ def main():
             ("resize", True, ["disksize"]),
         ],
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     if not HAS_CRYPT and not HAS_LEGACYCRYPT:
         module.fail_json(

--- a/plugins/modules/java_cert.py
+++ b/plugins/modules/java_cert.py
@@ -500,6 +500,7 @@ def main():
         supports_check_mode=True,
         add_file_common_args=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     url = module.params.get("cert_url")
     path = module.params.get("cert_path")

--- a/plugins/modules/keyring.py
+++ b/plugins/modules/keyring.py
@@ -190,6 +190,7 @@ def run_module():
     )
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     if not HAS_KEYRING:
         module.fail_json(msg=missing_required_lib("keyring"), exception=KEYRING_IMP_ERR)

--- a/plugins/modules/launchd.py
+++ b/plugins/modules/launchd.py
@@ -466,6 +466,7 @@ def main():
             ["state", "enabled"],
         ],
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     service = module.params["name"]
     plist_filename = module.params["plist"]

--- a/plugins/modules/listen_ports_facts.py
+++ b/plugins/modules/listen_ports_facts.py
@@ -343,6 +343,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     if module.params["include_non_listening"]:
         command_args = ["-p", "-u", "-n", "-t", "-a"]


### PR DESCRIPTION
##### SUMMARY

Set `LANGUAGE=C` and `LC_ALL=C` via `module.run_command_environ_update` in five modules to ensure locale-independent output parsing. Fixes potential failures on systems with non-C locales where command output may be translated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
homectl
java_cert
keyring
launchd
listen_ports_facts

##### ADDITIONAL INFORMATION

All five modules parse `run_command()` output and are susceptible to locale-dependent failures. The fix sets `module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}` immediately after `AnsibleModule(...)` instantiation in each module (in `run_module()` for `keyring`, which has no traditional `main()`).