### PR TITLE
Ensure standard locale in run_command (group5-batch4)

### DIFF
--- a/changelogs/fragments/11775-group5-batch4-locale.yml
+++ b/changelogs/fragments/11775-group5-batch4-locale.yml
@@ -1,0 +1,16 @@
+bugfixes:
+  - logstash_plugin - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11775).
+  - lvg - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11775).
+  - mas - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11775).
+  - osx_defaults - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11775).
+  - pkgutil - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11775).

--- a/plugins/modules/logstash_plugin.py
+++ b/plugins/modules/logstash_plugin.py
@@ -147,6 +147,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     name = module.params["name"]
     state = module.params["state"]

--- a/plugins/modules/lvg.py
+++ b/plugins/modules/lvg.py
@@ -424,6 +424,7 @@ def main():
         ],
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     vg = module.params["vg"]
     state = module.params["state"]

--- a/plugins/modules/mas.py
+++ b/plugins/modules/mas.py
@@ -265,6 +265,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
     mas = Mas(module)
 
     if module.params["id"]:

--- a/plugins/modules/osx_defaults.py
+++ b/plugins/modules/osx_defaults.py
@@ -498,6 +498,7 @@ def main():
         supports_check_mode=True,
         required_if=(("state", "present", ["value"]),),
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     try:
         defaults = OSXDefaults(module=module)

--- a/plugins/modules/pkgutil.py
+++ b/plugins/modules/pkgutil.py
@@ -205,6 +205,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
     name = module.params["name"]
     state = module.params["state"]
     site = module.params["site"]


### PR DESCRIPTION
##### SUMMARY

Set `LANGUAGE=C` and `LC_ALL=C` via `module.run_command_environ_update` in five modules to ensure locale-independent output parsing. Fixes potential failures on systems with non-C locales where command output may be translated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
logstash_plugin
lvg
mas
osx_defaults
pkgutil

##### ADDITIONAL INFORMATION

All five modules parse `run_command()` output and are susceptible to locale-dependent failures. The fix sets `module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}` immediately after `AnsibleModule(...)` instantiation in `main()`.