### PR TITLE
Ensure standard locale in run_command (group5-batch5)

### DIFF
--- a/changelogs/fragments/11776-group5-batch5-locale.yml
+++ b/changelogs/fragments/11776-group5-batch5-locale.yml
@@ -1,0 +1,16 @@
+bugfixes:
+  - pnpm - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11776).
+  - sysrc - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11776).
+  - timezone - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11776).
+  - xattr - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11776).
+  - yarn - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11776).

--- a/plugins/modules/pnpm.py
+++ b/plugins/modules/pnpm.py
@@ -327,6 +327,7 @@ def main():
     )
     arg_spec["global"] = dict(default=False, type="bool")
     module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     name = module.params["name"]
     alias = module.params["alias"]

--- a/plugins/modules/sysrc.py
+++ b/plugins/modules/sysrc.py
@@ -119,6 +119,7 @@ class Sysrc(StateModuleHelper):
         if not re.match(r"^\w+$", self.vars.name, re.ASCII):
             self.module.fail_json(msg="Name may only contain alpha-numeric and underscore characters")
 
+        self.module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
         self.sysrc = self.module.get_bin_path("sysrc", True)
 
     def _contains(self):

--- a/plugins/modules/timezone.py
+++ b/plugins/modules/timezone.py
@@ -863,6 +863,7 @@ def main():
         required_one_of=[["hwclock", "name"]],
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
     tz = Timezone(module)
 
     # Check the current state

--- a/plugins/modules/xattr.py
+++ b/plugins/modules/xattr.py
@@ -178,6 +178,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
     path = module.params.get("path")
     namespace = module.params.get("namespace")
     key = module.params.get("key")

--- a/plugins/modules/yarn.py
+++ b/plugins/modules/yarn.py
@@ -280,6 +280,7 @@ def main():
     )
     arg_spec["global"] = dict(default=False, type="bool")
     module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     name = module.params["name"]
     path = module.params["path"]


### PR DESCRIPTION
##### SUMMARY

Set `LANGUAGE=C` and `LC_ALL=C` via `run_command_environ_update` in five modules to ensure locale-independent output parsing. Fixes potential failures on systems with non-C locales where command output may be translated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pnpm
sysrc
timezone
xattr
yarn

##### ADDITIONAL INFORMATION

All five modules parse `run_command()` output and are susceptible to locale-dependent failures. For `pnpm`, `timezone`, `xattr`, and `yarn`, the fix sets `module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}` immediately after `AnsibleModule(...)` instantiation in `main()`. For `sysrc`, which uses `StateModuleHelper`, the fix is applied in `__init_module__()` via `self.module.run_command_environ_update`.