### PR TITLE
Ensure standard locale in run_command (group5-batch6)

### DIFF
--- a/changelogs/fragments/11777-group5-batch6-locale.yml
+++ b/changelogs/fragments/11777-group5-batch6-locale.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - yum_versionlock - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11777).
+  - zypper_repository - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11777).

--- a/plugins/modules/yum_versionlock.py
+++ b/plugins/modules/yum_versionlock.py
@@ -151,6 +151,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     state = module.params["state"]
     packages = module.params["name"]

--- a/plugins/modules/zypper_repository.py
+++ b/plugins/modules/zypper_repository.py
@@ -338,6 +338,7 @@ def main():
         supports_check_mode=False,
         required_one_of=[["state", "runrefresh"]],
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     repo = module.params["repo"]
     alias = module.params["name"]


### PR DESCRIPTION
##### SUMMARY

Set `LANGUAGE=C` and `LC_ALL=C` via `module.run_command_environ_update` in two modules to ensure locale-independent output parsing. Fixes potential failures on systems with non-C locales where command output may be translated.

Related: #11737

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
yum_versionlock
zypper_repository

##### ADDITIONAL INFORMATION

Both modules parse `run_command()` output and are susceptible to locale-dependent failures. The fix sets `module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}` immediately after `AnsibleModule(...)` instantiation in `main()`.