### PR TITLE
Ensure standard locale in run_command (group5-batch7)

### DIFF
--- a/changelogs/fragments/11778-group5-batch7-locale.yml
+++ b/changelogs/fragments/11778-group5-batch7-locale.yml
@@ -1,0 +1,13 @@
+bugfixes:
+  - zfs - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11778).
+  - zfs_delegate_admin - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11778).
+  - zfs_facts - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11778).
+  - zpool_facts - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11778).

--- a/plugins/modules/zfs.py
+++ b/plugins/modules/zfs.py
@@ -254,6 +254,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     state = module.params.get("state")
     name = module.params.get("name")

--- a/plugins/modules/zfs_delegate_admin.py
+++ b/plugins/modules/zfs_delegate_admin.py
@@ -259,6 +259,7 @@ def main():
         supports_check_mode=False,
         required_if=[("state", "present", ["permissions"])],
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
     zfs_delegate_admin = ZfsDelegateAdmin(module)
     zfs_delegate_admin.run()
 

--- a/plugins/modules/zfs_facts.py
+++ b/plugins/modules/zfs_facts.py
@@ -217,6 +217,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     if "all" in module.params["type"] and len(module.params["type"]) > 1:
         module.fail_json(msg="Value 'all' for parameter 'type' is mutually exclusive with other values")

--- a/plugins/modules/zpool_facts.py
+++ b/plugins/modules/zpool_facts.py
@@ -162,6 +162,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     zpool_facts = ZPoolFacts(module)
 


### PR DESCRIPTION
##### SUMMARY

Set `LANGUAGE=C` and `LC_ALL=C` via `module.run_command_environ_update` in four ZFS modules to ensure locale-independent output parsing. Fixes potential failures on systems with non-C locales where command output may be translated.

Related: #11737

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zfs
zfs_delegate_admin
zfs_facts
zpool_facts

##### ADDITIONAL INFORMATION

All four modules parse `run_command()` output and are susceptible to locale-dependent failures. The fix sets `module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}` immediately after `AnsibleModule(...)` instantiation in `main()`.