### PR TITLE
Ensure standard locale in run_command (group5-batch8)

### DIFF
--- a/changelogs/fragments/11779-group5-batch8-locale.yml
+++ b/changelogs/fragments/11779-group5-batch8-locale.yml
@@ -1,0 +1,10 @@
+bugfixes:
+  - capabilities - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11779).
+  - ip_netns - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11779).
+  - lxc_container - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11779).

--- a/plugins/modules/capabilities.py
+++ b/plugins/modules/capabilities.py
@@ -183,6 +183,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     CapabilitiesModule(module)
 

--- a/plugins/modules/ip_netns.py
+++ b/plugins/modules/ip_netns.py
@@ -122,6 +122,7 @@ def main():
         },
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     network_namespace = Namespace(module)
     if module.check_mode:

--- a/plugins/modules/lxc_container.py
+++ b/plugins/modules/lxc_container.py
@@ -1432,6 +1432,7 @@ def main():
         supports_check_mode=False,
         required_if=([("archive", True, ["archive_path"])]),
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     if not HAS_LXC:
         module.fail_json(msg="The `lxc` module is not importable. Check the requirements.")


### PR DESCRIPTION
##### SUMMARY

Set `LANGUAGE=C` and `LC_ALL=C` via `module.run_command_environ_update` in three modules to ensure locale-independent output parsing. Fixes potential failures on systems with non-C locales where command output may be translated.

Related: #11737

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
capabilities
ip_netns
lxc_container

##### ADDITIONAL INFORMATION

All three modules parse `run_command()` output and are susceptible to locale-dependent failures. The fix sets `module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}` immediately after `AnsibleModule(...)` instantiation in `main()`.