### PR TITLE
Ensure standard locale in run_command (group5-batch9)

### DIFF
--- a/changelogs/fragments/11780-group5-batch9-locale.yml
+++ b/changelogs/fragments/11780-group5-batch9-locale.yml
@@ -1,0 +1,13 @@
+bugfixes:
+  - beadm - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11780).
+  - pkg5 - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11780).
+  - pkg5_publisher - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11780).
+  - swdepot - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11780).

--- a/plugins/modules/beadm.py
+++ b/plugins/modules/beadm.py
@@ -288,6 +288,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     be = BE(module)
 

--- a/plugins/modules/pkg5.py
+++ b/plugins/modules/pkg5.py
@@ -101,6 +101,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     params = module.params
     packages = []

--- a/plugins/modules/pkg5_publisher.py
+++ b/plugins/modules/pkg5_publisher.py
@@ -84,6 +84,7 @@ def main():
             mirror=dict(type="list", elements="str"),
         )
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     for option in ["origin", "mirror"]:
         if module.params[option] == [""]:

--- a/plugins/modules/swdepot.py
+++ b/plugins/modules/swdepot.py
@@ -136,6 +136,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
     name = module.params["name"]
     state = module.params["state"]
     depot = module.params["depot"]


### PR DESCRIPTION
##### SUMMARY

Set `LANGUAGE=C` and `LC_ALL=C` via `module.run_command_environ_update` in four modules to ensure locale-independent output parsing. Fixes potential failures on systems with non-C locales where command output may be translated.

Related: #11737

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
beadm
pkg5
pkg5_publisher
swdepot

##### ADDITIONAL INFORMATION

All four modules parse `run_command()` output and are susceptible to locale-dependent failures. The fix sets `module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}` immediately after `AnsibleModule(...)` instantiation in `main()`.