### PR TITLE
Ensure standard locale in run_command (group5-batch10)

### DIFF
--- a/changelogs/fragments/11781-group5-batch10-locale.yml
+++ b/changelogs/fragments/11781-group5-batch10-locale.yml
@@ -1,0 +1,22 @@
+bugfixes:
+  - imgadm - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11781).
+  - lbu - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11781).
+  - portage - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11781).
+  - portinstall - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11781).
+  - smartos_image_info - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11781).
+  - syspatch - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11781).
+  - xbps - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11781).

--- a/plugins/modules/imgadm.py
+++ b/plugins/modules/imgadm.py
@@ -276,6 +276,7 @@ def main():
         # provide a "noop" (or equivalent) mode to do a dry-run.
         supports_check_mode=False,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     imgadm = Imgadm(module)
 

--- a/plugins/modules/lbu.py
+++ b/plugins/modules/lbu.py
@@ -86,6 +86,7 @@ def run_module():
         },
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     changed = False
 

--- a/plugins/modules/portage.py
+++ b/plugins/modules/portage.py
@@ -587,6 +587,7 @@ def main():
         ],
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     if not HAS_PORTAGE:
         if sys.executable != "/usr/bin/python" and not has_respawned():

--- a/plugins/modules/portinstall.py
+++ b/plugins/modules/portinstall.py
@@ -191,6 +191,7 @@ def main():
             use_packages=dict(type="bool", default=True),
         )
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     p = module.params
 

--- a/plugins/modules/smartos_image_info.py
+++ b/plugins/modules/smartos_image_info.py
@@ -109,6 +109,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     image_facts = ImageFacts(module)
 

--- a/plugins/modules/syspatch.py
+++ b/plugins/modules/syspatch.py
@@ -75,6 +75,7 @@ def run_module():
         argument_spec=module_args,
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     result = syspatch_run(module)
 

--- a/plugins/modules/xbps.py
+++ b/plugins/modules/xbps.py
@@ -361,6 +361,7 @@ def main():
         required_one_of=[["name", "update_cache", "upgrade"]],
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     xbps_path = dict()
     xbps_path["install"] = module.get_bin_path("xbps-install", True)


### PR DESCRIPTION
##### SUMMARY

Set `LANGUAGE=C` and `LC_ALL=C` via `module.run_command_environ_update` in seven modules to ensure locale-independent output parsing. Fixes potential failures on systems with non-C locales where command output may be translated.

Related: #11737

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
imgadm
lbu
portage
portinstall
smartos_image_info
syspatch
xbps

##### ADDITIONAL INFORMATION

All seven modules parse `run_command()` output and are susceptible to locale-dependent failures. The fix sets `module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}` immediately after `AnsibleModule(...)` instantiation in `main()`.