### PR TITLE
Ensure standard locale in run_command (group5-batch11)

### DIFF
--- a/changelogs/fragments/11782-group5-batch11-locale.yml
+++ b/changelogs/fragments/11782-group5-batch11-locale.yml
@@ -1,0 +1,13 @@
+bugfixes:
+  - apt_repo - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11782).
+  - easy_install - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11782).
+  - pear - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11782).
+  - zypper_repository_info - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11782).

--- a/plugins/modules/apt_repo.py
+++ b/plugins/modules/apt_repo.py
@@ -122,6 +122,7 @@ def main():
             update=dict(type="bool", default=False),
         ),
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     if not os.path.exists(APT_REPO_PATH):
         module.fail_json(msg="cannot find /usr/bin/apt-repo")

--- a/plugins/modules/easy_install.py
+++ b/plugins/modules/easy_install.py
@@ -139,6 +139,7 @@ def main():
     )
 
     module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     name = module.params["name"]
     env = module.params["virtualenv"]

--- a/plugins/modules/pear.py
+++ b/plugins/modules/pear.py
@@ -298,6 +298,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     p = module.params
 

--- a/plugins/modules/zypper_repository_info.py
+++ b/plugins/modules/zypper_repository_info.py
@@ -115,6 +115,7 @@ def _parse_repos(module):
 
 def main():
     module = AnsibleModule(argument_spec=dict(), supports_check_mode=True)
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     deps.validate(parseXML)
 


### PR DESCRIPTION
##### SUMMARY

Set `LANGUAGE=C` and `LC_ALL=C` via `module.run_command_environ_update` in four modules to ensure locale-independent output parsing. Fixes potential failures on systems with non-C locales where command output may be translated.

Related: #11737

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apt_repo
easy_install
pear
zypper_repository_info

##### ADDITIONAL INFORMATION

All four modules parse `run_command()` output and are susceptible to locale-dependent failures. The fix sets `module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}` immediately after `AnsibleModule(...)` instantiation in `main()`.