### PR TITLE
Ensure standard locale in run_command (group5-batch12)

### DIFF
--- a/changelogs/fragments/11783-group5-batch12-locale.yml
+++ b/changelogs/fragments/11783-group5-batch12-locale.yml
@@ -1,0 +1,13 @@
+bugfixes:
+  - bower - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11783).
+  - bundler - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11783).
+  - homebrew_tap - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11783).
+  - kibana_plugin - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11783).

--- a/plugins/modules/bower.py
+++ b/plugins/modules/bower.py
@@ -202,6 +202,7 @@ def main():
         version=dict(),
     )
     module = AnsibleModule(argument_spec=arg_spec)
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     name = module.params["name"]
     offline = module.params["offline"]

--- a/plugins/modules/bundler.py
+++ b/plugins/modules/bundler.py
@@ -143,6 +143,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     state = module.params.get("state")
     chdir = module.params.get("chdir")

--- a/plugins/modules/homebrew_tap.py
+++ b/plugins/modules/homebrew_tap.py
@@ -230,6 +230,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     path = module.params["path"]
     if path:

--- a/plugins/modules/kibana_plugin.py
+++ b/plugins/modules/kibana_plugin.py
@@ -232,6 +232,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     name = module.params["name"]
     state = module.params["state"]


### PR DESCRIPTION
##### SUMMARY

Set `LANGUAGE=C` and `LC_ALL=C` via `module.run_command_environ_update` in four modules to ensure locale-independent output parsing. Fixes potential failures on systems with non-C locales where command output may be translated.

Related: #11737

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
bower
bundler
homebrew_tap
kibana_plugin

##### ADDITIONAL INFORMATION

All four modules parse `run_command()` output and are susceptible to locale-dependent failures. The fix sets `module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}` immediately after `AnsibleModule(...)` instantiation in `main()`.

Note: the modules modified in this PR do not have automated tests.