### PR TITLE
Ensure standard locale in run_command (group5-batch13)

### DIFF
--- a/changelogs/fragments/11784-group5-batch13-locale.yml
+++ b/changelogs/fragments/11784-group5-batch13-locale.yml
@@ -1,0 +1,10 @@
+bugfixes:
+  - awall - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11784).
+  - openwrt_init - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11784).
+  - pip_package_info - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11784).

--- a/plugins/modules/awall.py
+++ b/plugins/modules/awall.py
@@ -135,6 +135,7 @@ def main():
         required_one_of=[["name", "activate"]],
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     global AWALL_PATH
     AWALL_PATH = module.get_bin_path("awall", required=True)

--- a/plugins/modules/openwrt_init.py
+++ b/plugins/modules/openwrt_init.py
@@ -103,6 +103,7 @@ def main():
         supports_check_mode=True,
         required_one_of=[("state", "enabled")],
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     # initialize
     service = module.params["name"]

--- a/plugins/modules/pip_package_info.py
+++ b/plugins/modules/pip_package_info.py
@@ -123,6 +123,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
     packages = {}
     results = {"packages": {}}
     clients = module.params["clients"]


### PR DESCRIPTION
##### SUMMARY

Set `LANGUAGE=C` and `LC_ALL=C` via `module.run_command_environ_update` in three modules to ensure locale-independent output parsing. Fixes potential failures on systems with non-C locales where command output may be translated.

Related: #11737

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
awall
openwrt_init
pip_package_info

##### ADDITIONAL INFORMATION

All three modules parse `run_command()` output and are susceptible to locale-dependent failures. The fix sets `module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}` immediately after `AnsibleModule(...)` instantiation in `main()`.

Note: the modules modified in this PR do not have automated tests.