### PR TITLE
Ensure standard locale in run_command (group5-batch14)

### DIFF
--- a/changelogs/fragments/11785-group5-batch14-locale.yml
+++ b/changelogs/fragments/11785-group5-batch14-locale.yml
@@ -1,0 +1,10 @@
+bugfixes:
+  - bzr - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11785).
+  - lldp - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11785).
+  - ohai - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11785).

--- a/plugins/modules/bzr.py
+++ b/plugins/modules/bzr.py
@@ -147,6 +147,7 @@ def main():
             executable=dict(type="str"),
         )
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     dest = module.params["dest"]
     parent = module.params["name"]

--- a/plugins/modules/lldp.py
+++ b/plugins/modules/lldp.py
@@ -95,6 +95,7 @@ def gather_lldp(module):
 def main():
     module_args = dict(multivalues=dict(type="bool", default=False))
     module = AnsibleModule(module_args)
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     lldp_output = gather_lldp(module)
     try:

--- a/plugins/modules/ohai.py
+++ b/plugins/modules/ohai.py
@@ -38,6 +38,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 def main():
     module = AnsibleModule(argument_spec=dict())
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
     cmd = ["/usr/bin/env", "ohai"]
     rc, out, err = module.run_command(cmd, check_rc=True)
     module.exit_json(**json.loads(out))


### PR DESCRIPTION
##### SUMMARY

Set `LANGUAGE=C` and `LC_ALL=C` via `module.run_command_environ_update` in three modules to ensure locale-independent output parsing. Fixes potential failures on systems with non-C locales where command output may be translated.

Related: #11737

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
bzr
lldp
ohai

##### ADDITIONAL INFORMATION

All three modules parse `run_command()` output and are susceptible to locale-dependent failures. The fix sets `module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}` immediately after `AnsibleModule(...)` instantiation in `main()`.

Note: the modules modified in this PR do not have automated tests.