### PR TITLE
Ensure standard locale in run_command (group5-batch15)

### DIFF
--- a/changelogs/fragments/11786-group5-batch15-locale.yml
+++ b/changelogs/fragments/11786-group5-batch15-locale.yml
@@ -1,0 +1,10 @@
+bugfixes:
+  - keyring_info - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11786).
+  - onepassword_info - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11786).
+  - riak - set ``LANGUAGE`` and ``LC_ALL`` to ``C`` in ``run_command()`` calls to ensure locale-independent output parsing
+    (https://github.com/ansible-collections/community.general/issues/11737,
+    https://github.com/ansible-collections/community.general/pull/11786).

--- a/plugins/modules/keyring_info.py
+++ b/plugins/modules/keyring_info.py
@@ -106,6 +106,7 @@ def run_module():
     )
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     if not HAS_KEYRING:
         module.fail_json(msg=missing_required_lib("keyring"), exception=KEYRING_IMP_ERR)

--- a/plugins/modules/onepassword_info.py
+++ b/plugins/modules/onepassword_info.py
@@ -380,6 +380,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     results = {"onepassword": OnePasswordInfo().run()}
 

--- a/plugins/modules/riak.py
+++ b/plugins/modules/riak.py
@@ -106,6 +106,7 @@ def main():
             validate_certs=dict(default=True, type="bool"),
         )
     )
+    module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
     command = module.params.get("command")
     http_conn = module.params.get("http_conn")


### PR DESCRIPTION
##### SUMMARY

Set `LANGUAGE=C` and `LC_ALL=C` via `module.run_command_environ_update` in three modules to ensure locale-independent output parsing. Fixes potential failures on systems with non-C locales where command output may be translated.

Related: #11737

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
keyring_info
onepassword_info
riak

##### ADDITIONAL INFORMATION

All three modules parse `run_command()` output and are susceptible to locale-dependent failures. The fix sets `module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}` immediately after `AnsibleModule(...)` instantiation in `main()` (or `run_module()` for `keyring_info`).

Note: the modules modified in this PR do not have automated tests.