### PR TITLE
Ensure standard locale in run_command (group5-batch16)

### DIFF
--- a/changelogs/fragments/11787-group5-batch16-locale.yml
+++ b/changelogs/fragments/11787-group5-batch16-locale.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - btrfs module_utils - set ``LANGUAGE`` and ``LC_ALL`` environment variables to ``C`` in all ``run_command()`` calls (https://github.com/ansible-collections/community.general/issues/11737, https://github.com/ansible-collections/community.general/pull/11787).

--- a/plugins/module_utils/btrfs.py
+++ b/plugins/module_utils/btrfs.py
@@ -35,6 +35,7 @@ class BtrfsCommands:
 
     def __init__(self, module: AnsibleModule) -> None:
         self.__module = module
+        self.__module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
         self.__btrfs: str = self.__module.get_bin_path("btrfs", required=True)
 
     def filesystem_show(self) -> list[dict[str, t.Any]]:


### PR DESCRIPTION
### Summary

Set `LANGUAGE` and `LC_ALL` environment variables to `C` in all `run_command()` calls in `plugins/module_utils/btrfs.py`.

Related: #11737

### Issue Type

Bug Fix

### Component Name

plugins/module_utils/btrfs.py

### Ansible Version

```console (paste below)
N/A
```

### Community.General Version

```console (paste below)
N/A
```

### Configuration

```ini (paste below)
N/A
```

### OS / Environment

N/A

### Summary of Changes

Added `module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}` in `BtrfsCommands.__init__()`, which covers all `run_command()` calls across the three btrfs utility classes.

### Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/ansible-collections/community.general/blob/main/CONTRIBUTING.md).
- [x] The changes are backwards compatible.
- [x] I have verified my changes work correctly.