### PR TITLE
lvm_pv - use CmdRunner

### DIFF
--- a/changelogs/fragments/11811-lvm_pv-use-cmdrunner.yml
+++ b/changelogs/fragments/11811-lvm_pv-use-cmdrunner.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - lvm_pv - migrate to ``CmdRunner`` using shared runners from ``module_utils/_lvm`` (https://github.com/ansible-collections/community.general/pull/11811).
+  - _lvm module utils - rename ``devices`` to ``device`` in ``pvcreate_runner``; bake ``-y`` into ``pvremove_runner`` command (https://github.com/ansible-collections/community.general/pull/11811).

--- a/changelogs/fragments/11811-lvm_pv-use-cmdrunner.yml
+++ b/changelogs/fragments/11811-lvm_pv-use-cmdrunner.yml
@@ -1,3 +1,2 @@
 minor_changes:
   - lvm_pv - migrate to ``CmdRunner`` using shared runners from ``module_utils/_lvm`` (https://github.com/ansible-collections/community.general/pull/11811).
-  - _lvm module utils - rename ``devices`` to ``device`` in ``pvcreate_runner``; bake ``-y`` into ``pvremove_runner`` command (https://github.com/ansible-collections/community.general/pull/11811).

--- a/plugins/module_utils/_lvm.py
+++ b/plugins/module_utils/_lvm.py
@@ -54,7 +54,7 @@ def pvcreate_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
     Runner for C(pvcreate). Used by: community.general.lvg, community.general.lvm_pv,
     community.general.filesystem.
 
-    Suggested arg_formats keys: force yes devices
+    Suggested arg_formats keys: force yes device
     """
     return CmdRunner(
         module,
@@ -62,7 +62,7 @@ def pvcreate_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
         arg_formats=dict(
             force=cmd_runner_fmt.as_bool("-f"),
             yes=cmd_runner_fmt.as_bool("--yes"),
-            devices=cmd_runner_fmt.as_list(),
+            device=cmd_runner_fmt.as_list(),
         ),
         **kwargs,
     )
@@ -108,15 +108,15 @@ def pvremove_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
     """
     Runner for C(pvremove). Used by: community.general.lvm_pv.
 
-    Suggested arg_formats keys: yes force device
+    Suggested arg_formats keys: force device
 
-    Note: C(force=True) passes C(-ff), which removes PVs even when part of a VG.
+    Note: C(-y) is always passed (non-interactive). C(force=True) passes C(-ff),
+    which removes PVs even when part of a VG.
     """
     return CmdRunner(
         module,
-        command="pvremove",
+        command=["pvremove", "-y"],
         arg_formats=dict(
-            yes=cmd_runner_fmt.as_bool("-y"),
             force=cmd_runner_fmt.as_bool("-ff"),
             device=cmd_runner_fmt.as_list(),
         ),

--- a/plugins/modules/lvm_pv.py
+++ b/plugins/modules/lvm_pv.py
@@ -73,18 +73,12 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 
-
-def get_pv_status(module, device):
-    """Check if the device is already a PV."""
-    cmd = ["pvs", "--noheadings", "--readonly", device]
-    return module.run_command(cmd)[0] == 0
-
-
-def get_pv_size(module, device):
-    """Get current PV size in bytes."""
-    cmd = ["pvs", "--noheadings", "--nosuffix", "--units", "b", "-o", "pv_size", device]
-    rc, out, err = module.run_command(cmd, check_rc=True)
-    return int(out.strip())
+from ansible_collections.community.general.plugins.module_utils._lvm import (
+    pvcreate_runner,
+    pvremove_runner,
+    pvresize_runner,
+    pvs_runner,
+)
 
 
 def rescan_device(module, device):
@@ -129,16 +123,30 @@ def main():
 
     device = module.params["device"]
     state = module.params["state"]
-    force = module.params["force"]
     resize = module.params["resize"]
     changed = False
     actions = []
+
+    pvs = pvs_runner(module)
+    pvcreate = pvcreate_runner(module)
+    pvresize = pvresize_runner(module)
+    pvremove = pvremove_runner(module)
+
+    def get_pv_status():
+        with pvs("noheadings readonly devices", check_rc=False) as ctx:
+            rc, dummy, dummy = ctx.run(devices=[device])
+        return rc == 0
+
+    def get_pv_size():
+        with pvs("noheadings nosuffix readonly units fields devices") as ctx:
+            dummy, out, dummy = ctx.run(units="b", fields="pv_size", devices=[device])
+        return int(out.strip())
 
     # Validate device existence for present state
     if state == "present" and not os.path.exists(device):
         module.fail_json(msg=f"Device {device} not found")
 
-    is_pv = get_pv_status(module, device)
+    is_pv = get_pv_status()
 
     if state == "present":
         # Create PV if needed
@@ -147,11 +155,7 @@ def main():
                 changed = True
                 actions.append("would be created")
             else:
-                cmd = ["pvcreate"]
-                if force:
-                    cmd.append("-f")
-                cmd.append(device)
-                rc, out, err = module.run_command(cmd, check_rc=True)
+                pvcreate("force device", check_rc=True).run()
                 changed = True
                 actions.append("created")
             is_pv = True
@@ -163,12 +167,12 @@ def main():
                 changed = True
                 actions.append("would be resized")
             else:
-                # Perform device rescan if each time
+                # Perform device rescan each time
                 if rescan_device(module, device):
                     actions.append("rescanned")
-                original_size = get_pv_size(module, device)
-                rc, out, err = module.run_command(["pvresize", device], check_rc=True)
-                new_size = get_pv_size(module, device)
+                original_size = get_pv_size()
+                pvresize("device", check_rc=True).run()
+                new_size = get_pv_size()
                 if new_size != original_size:
                     changed = True
                     actions.append("resized")
@@ -179,12 +183,8 @@ def main():
                 changed = True
                 actions.append("would be removed")
             else:
-                cmd = ["pvremove", "-y"]
-                if force:
-                    cmd.append("-ff")
+                pvremove("force device", check_rc=True).run()
                 changed = True
-                cmd.append(device)
-                rc, out, err = module.run_command(cmd, check_rc=True)
                 actions.append("removed")
 
     # Generate final message


### PR DESCRIPTION
##### SUMMARY

Migrates `community.general.lvm_pv` to use `CmdRunner` via the shared runners in `module_utils/_lvm`.

- Replaces raw `module.run_command()` calls with `pvs_runner`, `pvcreate_runner`, `pvresize_runner`, and `pvremove_runner`
- `get_pv_status()` and `get_pv_size()` become closures inside `main()`, capturing `device` and the runner instances
- `CmdRunner`'s `force_lang="C"` replaces the manual locale env dict
- Two small fixes to `_lvm.py` discovered during migration:
  - `pvcreate_runner`: renamed `devices` → `device` (callers always pass a single device)
  - `pvremove_runner`: baked `-y` into the command (always required for non-interactive use); removed `yes` from `arg_formats`

##### ISSUE TYPE
- Refactoring Pull Request

##### COMPONENT NAME
lvm_pv
module_utils/_lvm