### PR TITLE
sefcontext: flush in-process matchpathcon cache

### DIFF
--- a/changelogs/fragments/11812-sefcontext-matchpathcon-cache-flush.yml
+++ b/changelogs/fragments/11812-sefcontext-matchpathcon-cache-flush.yml
@@ -2,4 +2,5 @@ bugfixes:
   - sefcontext - flush the in-process ``matchpathcon`` cache after applying changes, so
     subsequent tasks running in the same process (for example via the Mitogen connection
     plugin) see the updated SELinux file context rules instead of stale cached data
-    (https://github.com/ansible-collections/community.general/issues/888).
+    (https://github.com/ansible-collections/community.general/issues/888,
+    https://github.com/ansible-collections/community.general/pull/11812).

--- a/changelogs/fragments/888-sefcontext-matchpathcon-cache-flush.yml
+++ b/changelogs/fragments/888-sefcontext-matchpathcon-cache-flush.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - sefcontext - flush the in-process ``matchpathcon`` cache after applying changes, so
+    subsequent tasks running in the same process (for example via the Mitogen connection
+    plugin) see the updated SELinux file context rules instead of stale cached data
+    (https://github.com/ansible-collections/community.general/issues/888).

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -280,6 +280,10 @@ def semanage_fcontext_modify(module, result, target, ftype, setype, substitute, 
     if module._diff and prepared_diff:
         result["diff"] = dict(prepared=prepared_diff)
 
+    if changed and not module.check_mode:
+        # Flush the in-process matchpathcon cache
+        selinux.matchpathcon_fini()
+
     module.exit_json(changed=changed, seuser=seuser, serange=serange, **result)
 
 
@@ -326,6 +330,10 @@ def semanage_fcontext_delete(module, result, target, ftype, setype, substitute, 
 
     if module._diff and prepared_diff:
         result["diff"] = dict(prepared=prepared_diff)
+
+    if changed and not module.check_mode:
+        # Flush the in-process matchpathcon cache
+        selinux.matchpathcon_fini()
 
     module.exit_json(changed=changed, **result)
 


### PR DESCRIPTION
##### SUMMARY

When multiple Ansible tasks run in a single Python process (for example via the Mitogen connection plugin), the ``matchpathcon()`` libselinux function serves stale cached file context lookups. This means that after ``community.general.sefcontext`` adds or removes a rule, a subsequent ``ansible.builtin.file`` task with ``setype: _default`` may apply the wrong context because it calls ``matchpathcon()`` and gets a hit from the old cache.

Fix: call ``selinux.matchpathcon_fini()`` after any real change (add/modify/delete) to reset the in-process cache. This has no negative side-effects — the cache is simply rebuilt on next use.

Fixes #888

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sefcontext

##### ADDITIONAL INFORMATION

The bug is most easily reproduced with the Mitogen connection plugin (``strategy: mitogen_linear``), which runs all tasks in one long-lived Python process. The fix has been tested by the original reporter and confirmed working.