### PR TITLE
lvg: clarify desired-state semantics of pvs parameter in docs

### DIFF
--- a/plugins/modules/lvg.py
+++ b/plugins/modules/lvg.py
@@ -32,7 +32,9 @@ options:
       - List of comma-separated devices to use as physical devices in this volume group.
       - Required when creating or resizing volume group.
       - The module runs C(pvcreate) if needed.
-      - O(remove_extra_pvs) controls whether or not unspecified physical devices are removed from the volume group.
+      - This parameter defines the B(desired state) of the physical volumes in the volume group.
+        When the volume group already exists, physical volumes not listed here are removed from it by default.
+        To add physical volumes without removing existing unlisted ones, set O(remove_extra_pvs=false).
     type: list
     elements: str
   pesize:


### PR DESCRIPTION
##### SUMMARY

Clarifies the documentation for the `pvs` parameter to make it explicit that it defines the **desired state** of physical volumes in the volume group: when the VG already exists, PVs not listed are removed by default.

This was a frequent source of confusion (see #2991), where users expected specifying only a new PV to extend the VG, but the existing PVs were removed instead.

The updated description also cross-references `remove_extra_pvs=false` as the way to add PVs without removing unlisted ones.

Fixes #2991

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lvg

##### ADDITIONAL INFORMATION

No code changes — documentation only.