### PR TITLE
consul_kv: add ca_path option for custom CA certificate

### DIFF
--- a/changelogs/fragments/11817-consul-kv-ca-path.yml
+++ b/changelogs/fragments/11817-consul-kv-ca-path.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - consul_kv - add ``ca_path`` option to specify a CA bundle for HTTPS connections (https://github.com/ansible-collections/community.general/pull/11817).
+  - consul_kv lookup plugin - add ``ca_path`` option to specify a CA bundle for HTTPS connections (https://github.com/ansible-collections/community.general/issues/2876, https://github.com/ansible-collections/community.general/pull/11817).

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -64,6 +64,15 @@ options:
     ini:
       - section: lookup_consul
         key: validate_certs
+  ca_path:
+    description: The CA bundle to use for HTTPS connections.
+    type: str
+    version_added: "12.6.0"
+    env:
+      - name: ANSIBLE_CONSUL_CA_PATH
+    ini:
+      - section: lookup_consul
+        key: ca_path
   client_cert:
     description: The client cert to verify the TLS connection.
     type: str
@@ -146,13 +155,16 @@ class LookupModule(LookupBase):
                 port = u.port
 
         validate_certs = self.get_option("validate_certs")
+        ca_path = self.get_option("ca_path")
         client_cert = self.get_option("client_cert")
+
+        verify = ca_path if ca_path else validate_certs
 
         values = []
         try:
             for term in terms:
                 params = self.parse_params(term)
-                consul_api = consul.Consul(host=host, port=port, scheme=scheme, verify=validate_certs, cert=client_cert)
+                consul_api = consul.Consul(host=host, port=port, scheme=scheme, verify=verify, cert=client_cert)
 
                 results = consul_api.kv.get(
                     params["key"],

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -57,7 +57,9 @@ options:
       - If you use E(ANSIBLE_CONSUL_URL) this value is used from there.
   validate_certs:
     default: true
-    description: Whether to verify the TLS connection or not.
+    description:
+      - Whether to verify the TLS connection or not.
+      - Instead of setting this to V(false), please consider using O(ca_path) instead.
     type: bool
     env:
       - name: ANSIBLE_CONSUL_VALIDATE_CERTS
@@ -158,7 +160,7 @@ class LookupModule(LookupBase):
         ca_path = self.get_option("ca_path")
         client_cert = self.get_option("client_cert")
 
-        verify = ca_path if ca_path else validate_certs
+        verify = (ca_path or validate_certs) if validate_certs else False
 
         values = []
         try:

--- a/plugins/modules/consul_kv.py
+++ b/plugins/modules/consul_kv.py
@@ -94,7 +94,8 @@ options:
     default: http
   validate_certs:
     description:
-      - Whether to verify the tls certificate of the Consul agent.
+      - Whether to verify the TLS certificate of the Consul agent.
+      - Instead of setting this to V(false), please consider using O(ca_path) instead.
     type: bool
     default: true
   ca_path:
@@ -269,7 +270,8 @@ def remove_value(module):
 
 def get_consul_api(module):
     ca_path = module.params.get("ca_path")
-    verify = ca_path if ca_path else module.params.get("validate_certs")
+    validate_certs = module.params.get("validate_certs")
+    verify = (ca_path or validate_certs) if validate_certs else False
     return consul.Consul(
         host=module.params.get("host"),
         port=module.params.get("port"),

--- a/plugins/modules/consul_kv.py
+++ b/plugins/modules/consul_kv.py
@@ -97,6 +97,11 @@ options:
       - Whether to verify the tls certificate of the Consul agent.
     type: bool
     default: true
+  ca_path:
+    description:
+      - The CA bundle to use for HTTPS connections.
+    type: str
+    version_added: "12.6.0"
   datacenter:
     description:
       - The name of the datacenter to query. If unspecified, the query defaults to the datacenter of the Consul agent on O(host).
@@ -263,11 +268,13 @@ def remove_value(module):
 
 
 def get_consul_api(module):
+    ca_path = module.params.get("ca_path")
+    verify = ca_path if ca_path else module.params.get("validate_certs")
     return consul.Consul(
         host=module.params.get("host"),
         port=module.params.get("port"),
         scheme=module.params.get("scheme"),
-        verify=module.params.get("validate_certs"),
+        verify=verify,
         token=module.params.get("token"),
         dc=module.params.get("datacenter"),
     )
@@ -291,6 +298,7 @@ def main():
             host=dict(type="str", default="localhost"),
             scheme=dict(type="str", default="http"),
             validate_certs=dict(type="bool", default=True),
+            ca_path=dict(type="str"),
             port=dict(type="int", default=8500),
             recurse=dict(type="bool"),
             retrieve=dict(type="bool", default=True),


### PR DESCRIPTION
##### SUMMARY

Adds a `ca_path` parameter to both `community.general.consul_kv` module and `community.general.consul_kv` lookup plugin, allowing users to specify a CA bundle path for HTTPS connections with custom/self-signed certificates.

Previously, `validate_certs` was the only TLS-related option (`type: bool`), with no way to supply a custom CA certificate. The fix mirrors the pattern already established in the other consul modules via the `community.general.consul` doc fragment and `module_utils/consul.py`.

Fixes #2876

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
consul_kv
consul_kv lookup