### PR TITLE
keycloak_clientscope: add missing consentRequired and consentText parameters

### DIFF
--- a/changelogs/fragments/11818-keycloak-clientscope-consent.yml
+++ b/changelogs/fragments/11818-keycloak-clientscope-consent.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - keycloak_clientscope - add missing ``consentRequired`` and ``consentText`` suboptions to the ``protocol_mappers`` option
+    (https://github.com/ansible-collections/community.general/pull/11818).

--- a/plugins/modules/keycloak_clientscope.py
+++ b/plugins/modules/keycloak_clientscope.py
@@ -138,6 +138,16 @@ options:
             protocol mapper configuration through check-mode in the RV(existing) return value.
         type: dict
 
+      consentRequired:
+        description:
+          - Specifies whether a user needs to provide consent to a client for this mapper to be active.
+        type: bool
+
+      consentText:
+        description:
+          - The human-readable name of the consent the user is presented to accept.
+        type: str
+
   attributes:
     type: dict
     description:
@@ -231,6 +241,7 @@ EXAMPLES = r"""
         name: family name
         protocol: openid-connect
         protocolMapper: oidc-usermodel-property-mapper
+        consentRequired: true
       - config:
           attribute.name: Role
           attribute.nameformat: Basic
@@ -238,6 +249,7 @@ EXAMPLES = r"""
         name: role list
         protocol: saml
         protocolMapper: saml-role-list-mapper
+        consentRequired: false
     attributes:
       attrib1: value1
       attrib2: value2
@@ -355,6 +367,8 @@ def main():
         protocol=dict(type="str", choices=["openid-connect", "saml", "wsfed", "docker-v2"]),
         protocolMapper=dict(type="str"),
         config=dict(type="dict"),
+        consentRequired=dict(type="bool"),
+        consentText=dict(type="str"),
     )
 
     meta_args = dict(


### PR DESCRIPTION
##### SUMMARY
Adds consentRequired and consentText parameters to the protocol mapper spec in keycloak_clientscope. Since the code for handling these parameters was already present (likely copied from keycloak_client, where the parameters were already implemented), I am considering this a bugfix.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
keycloak_clientscope
