### PR TITLE
lvol: fix LVM version regex to handle date formats without dashes

### DIFF
--- a/changelogs/fragments/11823-lvol-lvm-version-regex.yml
+++ b/changelogs/fragments/11823-lvol-lvm-version-regex.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lvol - fix LVM version parsing (https://github.com/ansible-collections/community.general/issues/5445, https://github.com/ansible-collections/community.general/pull/11823).

--- a/plugins/modules/lvol.py
+++ b/plugins/modules/lvol.py
@@ -277,7 +277,7 @@ def get_lvm_version(module):
     rc, out, err = module.run_command([ver_cmd, "version"])
     if rc != 0:
         return None
-    m = re.search(r"LVM version:\s+(\d+)\.(\d+)\.(\d+).*(\d{4}-\d{2}-\d{2})", out)
+    m = re.search(r"LVM version:\s+(\d+)\.(\d+)\.(\d+)", out)
     if not m:
         return None
     return mkversion(m.group(1), m.group(2), m.group(3))


### PR DESCRIPTION
##### SUMMARY

The regex used in `get_lvm_version()` required the date portion of the LVM version string to match `YYYY-MM-DD` format:

```python
re.search(r"LVM version:\s+(\d+)\.(\d+)\.(\d+).*(\d{4}-\d{2}-\d{2})", out)
```

Some LVM builds report the date without dashes (e.g. `2.03.092 20200326`), causing the regex to fail and the module to abort with `"Failed to get LVM version number"`.

The date capture group was also dead code — `m.group(4)` was never used; only groups 1–3 (the version numbers) were passed to `mkversion()`. Dropping the date portion fixes the breakage with no functional change.

Fixes #5445

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lvol