### PR TITLE
iso_extract: strip leading path separator from file entries

### DIFF
--- a/changelogs/fragments/11825-iso-extract-leading-slash.yml
+++ b/changelogs/fragments/11825-iso-extract-leading-slash.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - iso_extract - strip leading path separator from file entries so files with a leading ``/`` are extracted correctly (https://github.com/ansible-collections/community.general/issues/5283, https://github.com/ansible-collections/community.general/pull/11825).

--- a/plugins/modules/iso_extract.py
+++ b/plugins/modules/iso_extract.py
@@ -48,6 +48,7 @@ options:
     description:
       - A list of files to extract from the image.
       - Extracting directories does not work.
+      - File paths should not include a leading V(/); any leading path separator is automatically stripped.
     type: list
     elements: str
     required: true
@@ -138,11 +139,11 @@ def main():
         module.fail_json(msg=f"ISO image '{image}' does not exist")
 
     result["files"] = []
-    extract_files = list(files)
+    extract_files = [f.lstrip(os.sep) for f in files]
 
     if not force:
         # Check if we have to process any files based on existence
-        for f in files:
+        for f in extract_files[:]:
             dest_file = os.path.join(dest, os.path.basename(f))
             if os.path.exists(dest_file):
                 result["files"].append(

--- a/tests/integration/targets/iso_extract/tasks/tests.yml
+++ b/tests/integration/targets/iso_extract/tasks/tests.yml
@@ -38,3 +38,19 @@
     that:
       - iso_extract_test0_again is changed
   when: in_check_mode
+
+- name: Extract the iso using files with leading slash
+  iso_extract:
+    image: '{{ output_test_dir }}/test.iso'
+    dest: '{{ output_test_dir }}'
+    files:
+      - /1.txt
+      - /2.txt
+    force: true
+  register: iso_extract_leading_slash
+
+- name: Test iso_extract with leading slash succeeds (normal mode)
+  assert:
+    that:
+      - iso_extract_leading_slash is not failed
+  when: not in_check_mode


### PR DESCRIPTION
##### SUMMARY

When files are specified with a leading `/` (e.g. `/casper/initrd`), Python's `os.path.join(tmp_dir, f)` discards `tmp_dir` entirely, causing the module to report extraction failure even when 7z succeeded.

Fix: normalize all entries in `files` by stripping any leading `os.sep` immediately after collecting them, so both the 7z command arguments and subsequent path joins use clean relative paths.

Fixes #5283

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
iso_extract

##### ADDITIONAL INFORMATION

Python behaviour that causes the bug:
```python
>>> os.path.join('/tmp/abc', '/casper/initrd')
'/casper/initrd'   # tmp_dir silently dropped
```

The fix applies `lstrip(os.sep)` to every entry when building `extract_files`, which covers both the 7z invocation and the path-join loop. An integration test case with leading-slash file paths is included.