### PR TITLE
lxd_container: document that config values must be strings

### DIFF
--- a/plugins/modules/lxd_container.py
+++ b/plugins/modules/lxd_container.py
@@ -41,6 +41,9 @@ options:
   config:
     description:
       - 'The config for the instance (for example V({"limits.cpu": "2"})).'
+      - All values in O(config) must be strings, as required by the LXD/Incus API.
+        Using non-string values (such as integers or booleans) will cause an API error.
+        Make sure to quote numeric and boolean values in YAML (for example, use V("2") instead of V(2)).
       - See U(https://documentation.ubuntu.com/lxd/en/latest/api/#/instances/instance_get).
       - If the instance already exists and its "config" values in metadata obtained from the LXD API
         U(https://documentation.ubuntu.com/lxd/en/latest/api/#/instances/instance_get)


### PR DESCRIPTION
##### SUMMARY

Adds an explicit note to the `config` parameter documentation that all values must be strings, as required by the LXD/Incus API. Non-string values (integers, booleans) cause an API error. The note also reminds users to quote values in YAML.

Fixes #8307

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lxd_container