### PR TITLE
iso_extract: retry umount on busy filesystem before cleanup

### DIFF
--- a/changelogs/fragments/11837-iso-extract-umount-retry.yml
+++ b/changelogs/fragments/11837-iso-extract-umount-retry.yml
@@ -1,5 +1,4 @@
 bugfixes:
-  - iso_extract - retry ``umount`` up to 5 times with 1-second pauses when the
-    filesystem is busy, preventing spurious ``OSError`` on cleanup
+  - iso_extract - retry ``umount`` up to 5 times preventing ``OSError`` on cleanup
     (https://github.com/ansible-collections/community.general/issues/5333,
     https://github.com/ansible-collections/community.general/pull/11837).

--- a/changelogs/fragments/11837-iso-extract-umount-retry.yml
+++ b/changelogs/fragments/11837-iso-extract-umount-retry.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - iso_extract - retry ``umount`` up to 5 times with 1-second pauses when the
+    filesystem is busy, preventing spurious ``OSError`` on cleanup
+    (https://github.com/ansible-collections/community.general/issues/5333,
+    https://github.com/ansible-collections/community.general/pull/11837).

--- a/plugins/modules/iso_extract.py
+++ b/plugins/modules/iso_extract.py
@@ -93,6 +93,7 @@ RETURN = r"""
 import os.path
 import shutil
 import tempfile
+import time
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -219,7 +220,14 @@ def main():
                 result["changed"] = True
     finally:
         if not binary:
-            module.run_command([module.get_bin_path("umount"), tmp_dir])
+            umount_cmd = [module.get_bin_path("umount"), tmp_dir]
+            for dummy in range(5):
+                rc, dummy, dummy = module.run_command(umount_cmd)
+                if rc == 0:
+                    break
+                time.sleep(1)
+            else:
+                module.warn(f"Failed to unmount ISO image from '{tmp_dir}' after 5 attempts.")
 
         shutil.rmtree(tmp_dir)
 


### PR DESCRIPTION
##### SUMMARY

Fixes #5333

When using the `mount` path (no 7zip), the `umount` call in the `finally` block was fire-and-forget — its return code was never checked. On a busy system, `umount` can return rc=32 ("target is busy"), leaving the ISO still mounted. The immediately following `shutil.rmtree` then hits a read-only filesystem and raises `OSError: [Errno 30]`.

Fix: retry `umount` up to 5 times with 1-second pauses between attempts. If all attempts fail, emit a `module.warn()` (rather than crashing with a confusing traceback).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
iso_extract

##### ADDITIONAL INFORMATION

Confirmed by a second reporter (#5333 comments): `umount` was returning rc=32 with `umount: target is busy.` Their workaround was retries with 5-second sleeps; this fix implements a similar approach with 1-second intervals built into the module.