### PR TITLE
homebrew_cask: fix false failure on upgrade of latest-versioned casks

### DIFF
--- a/changelogs/fragments/11838-homebrew-cask-upgrade-latest.yml
+++ b/changelogs/fragments/11838-homebrew-cask-upgrade-latest.yml
@@ -1,5 +1,5 @@
 bugfixes:
-  - homebrew_cask - fix false task failure when upgrading casks with ``version :latest``;
+  - homebrew_cask - fix false task failure when upgrading casks with ``version=latest``;
     the post-upgrade check incorrectly re-ran ``brew outdated`` (which always lists ``latest``
     casks as outdated under ``--greedy``), now uses the command exit code instead
     (https://github.com/ansible-collections/community.general/issues/1647,

--- a/changelogs/fragments/11838-homebrew-cask-upgrade-latest.yml
+++ b/changelogs/fragments/11838-homebrew-cask-upgrade-latest.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - homebrew_cask - fix false task failure when upgrading casks with ``version :latest``;
+    the post-upgrade check incorrectly re-ran ``brew outdated`` (which always lists ``latest``
+    casks as outdated under ``--greedy``), now uses the command exit code instead
+    (https://github.com/ansible-collections/community.general/issues/1647,
+    https://github.com/ansible-collections/community.general/pull/11838).

--- a/plugins/modules/homebrew_cask.py
+++ b/plugins/modules/homebrew_cask.py
@@ -652,7 +652,7 @@ class HomebrewCask:
         else:
             rc, out, err = self.module.run_command(cmd)
 
-        if self._current_cask_is_installed() and not self._current_cask_is_outdated():
+        if rc == 0:
             self.changed_count += 1
             self.changed = True
             self.message = f"Cask upgraded: {self.current_cask}"


### PR DESCRIPTION
##### SUMMARY

Fixes the false failure when upgrading a cask whose version is `latest` (with `state: latest` or `state: upgraded` and `greedy: true`).

The post-upgrade success check was:
```python
if self._current_cask_is_installed() and not self._current_cask_is_outdated():
```
For `latest`-versioned casks, `brew outdated --greedy` may still list the cask as outdated even after a successful upgrade, so this check always fell through to the failure branch — reporting a harmless stderr warning (e.g. `Warning: No checksum defined for cask '...', skipping verification.`) as the task error message.

Fix: use `rc == 0` to determine success, consistent with how `_upgrade_all()` already works.

Fixes #1647

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
homebrew_cask

##### ADDITIONAL INFORMATION

The inconsistency between `_upgrade_all()` (uses `rc == 0`) and `_upgrade_current_cask()` (used the re-check) was the root cause.

```paste below

```