### PR TITLE
keycloak modules: add missing author credit

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -855,6 +855,8 @@ files:
     maintainers: mattock
   $modules/keycloak_authz_permission_info.py:
     maintainers: mattock
+  $modules/keycloak_client.py:
+    maintainers: koke1997
   $modules/keycloak_client_rolemapping.py:
     maintainers: Gaetan2907
   $modules/keycloak_client_rolescope.py:
@@ -880,7 +882,7 @@ files:
   $modules/keycloak_realm_info.py:
     maintainers: fynncfchen
   $modules/keycloak_realm_key.py:
-    maintainers: mattock
+    maintainers: mattock koke1997
   $modules/keycloak_realm_localization.py:
     maintainers: danekja
   $modules/keycloak_realm_rolemapping.py:
@@ -894,7 +896,7 @@ files:
   $modules/keycloak_user_federation.py:
     maintainers: laurpaum
   $modules/keycloak_user_rolemapping.py:
-    maintainers: bratwurzt
+    maintainers: bratwurzt koke1997
   $modules/keycloak_userprofile.py:
     maintainers: yeoldegrove
   $modules/keyring.py:

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -582,6 +582,7 @@ extends_documentation_fragment:
 
 author:
   - Eike Frost (@eikef)
+  - Ivan Kokalović (@koke1997)
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/keycloak_realm_key.py
+++ b/plugins/modules/keycloak_realm_key.py
@@ -244,6 +244,7 @@ extends_documentation_fragment:
 
 author:
   - Samuli Seppänen (@mattock)
+  - Ivan Kokalović (@koke1997)
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/keycloak_user_rolemapping.py
+++ b/plugins/modules/keycloak_user_rolemapping.py
@@ -105,6 +105,7 @@ extends_documentation_fragment:
 
 author:
   - Dušan Marković (@bratwurzt)
+  - Ivan Kokalović (@koke1997)
 """
 
 EXAMPLES = r"""


### PR DESCRIPTION
I contributed to several Keycloak modules earlier this year but forgot to add myself to the author lists at the time. This PR adds the missing credit.

**PRs I submitted:**
- #11468 — `keycloak_realm_key`: add support for auto-generated key providers
- #11470 — `keycloak_realm_key`: handle missing config fields for default keys
- #11471 — `keycloak_user_rolemapping`: handle None client roles
- #11473 — `keycloak_client`: add `valid_post_logout_redirect_uris` and `backchannel_logout_url`

**Changes:**
- `plugins/modules/keycloak_realm_key.py` — added `Ivan Kokalovic (@koke1997)` to author list
- `plugins/modules/keycloak_user_rolemapping.py` — same
- `plugins/modules/keycloak_client.py` — same

Documentation-only, no code changes.