### PR TITLE
[stable-11] CI: Temporarily skip failing callback unit tests for ansible-core 2.21+

### DIFF
--- a/tests/unit/plugins/callback/test_elastic.py
+++ b/tests/unit/plugins/callback/test_elastic.py
@@ -7,13 +7,19 @@ __metaclass__ = type
 
 from ansible.playbook.task import Task
 from ansible.executor.task_result import TaskResult
+from ansible.release import __version__ as ansible_release
 from ansible_collections.community.internal_test_tools.tests.unit.compat import unittest
 from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch, MagicMock, Mock
 from ansible_collections.community.general.plugins.callback.elastic import ElasticSource, TaskData
 from collections import OrderedDict
 import sys
+import pytest
 
 ELASTIC_MINIMUM_PYTHON_VERSION = (3, 6)
+
+if tuple(int(x) for x in ansible_release.split(".")[:2]) >= (2, 21):
+    # https://github.com/ansible/ansible/issues/86761
+    pytest.skip("Temporarily skipping callback tests for ansible-core >= 2.21", allow_module_level=True)
 
 
 class TestOpentelemetry(unittest.TestCase):

--- a/tests/unit/plugins/callback/test_loganalytics.py
+++ b/tests/unit/plugins/callback/test_loganalytics.py
@@ -5,13 +5,19 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import pytest
 from ansible.executor.task_result import TaskResult
+from ansible.release import __version__ as ansible_release
 from ansible_collections.community.internal_test_tools.tests.unit.compat import unittest
 from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch, Mock
 from ansible_collections.community.general.plugins.callback.loganalytics import AzureLogAnalyticsSource
 
 from datetime import datetime
 import json
+
+if tuple(int(x) for x in ansible_release.split(".")[:2]) >= (2, 21):
+    # https://github.com/ansible/ansible/issues/86761
+    pytest.skip("Temporarily skipping callback tests for ansible-core >= 2.21", allow_module_level=True)
 
 
 class TestAzureLogAnalytics(unittest.TestCase):

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -8,13 +8,19 @@ __metaclass__ = type
 
 from ansible.playbook.task import Task
 from ansible.executor.task_result import TaskResult
+from ansible.release import __version__ as ansible_release
 from ansible_collections.community.internal_test_tools.tests.unit.compat import unittest
 from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch, MagicMock, Mock
 from ansible_collections.community.general.plugins.callback.opentelemetry import OpenTelemetrySource, TaskData
 from collections import OrderedDict
 import sys
+import pytest
 
 OPENTELEMETRY_MINIMUM_PYTHON_VERSION = (3, 7)
+
+if tuple(int(x) for x in ansible_release.split(".")[:2]) >= (2, 21):
+    # https://github.com/ansible/ansible/issues/86761
+    pytest.skip("Temporarily skipping callback tests for ansible-core >= 2.21", allow_module_level=True)
 
 
 class TestOpentelemetry(unittest.TestCase):

--- a/tests/unit/plugins/callback/test_splunk.py
+++ b/tests/unit/plugins/callback/test_splunk.py
@@ -5,13 +5,19 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import pytest
 from ansible.executor.task_result import TaskResult
+from ansible.release import __version__ as ansible_release
 from ansible_collections.community.internal_test_tools.tests.unit.compat import unittest
 from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch, Mock
 from ansible_collections.community.general.plugins.callback.splunk import SplunkHTTPCollectorSource
 from datetime import datetime
 
 import json
+
+if tuple(int(x) for x in ansible_release.split(".")[:2]) >= (2, 21):
+    # https://github.com/ansible/ansible/issues/86761
+    pytest.skip("Temporarily skipping callback tests for ansible-core >= 2.21", allow_module_level=True)
 
 
 class TestSplunkClient(unittest.TestCase):


### PR DESCRIPTION
##### SUMMARY
Backport of #11842 to stable-11.

Ref: #11843.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
unit tests