### PR TITLE
homebrew_cask: handle placeholder version from brew --version

### DIFF
--- a/changelogs/fragments/11849-homebrew-cask-brew-version.yml
+++ b/changelogs/fragments/11849-homebrew-cask-brew-version.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - homebrew_cask - fix failure when ``brew --version`` returns a placeholder version string
+    (https://github.com/ansible-collections/community.general/issues/4708,
+    https://github.com/ansible-collections/community.general/pull/11849).

--- a/plugins/modules/homebrew_cask.py
+++ b/plugins/modules/homebrew_cask.py
@@ -438,14 +438,18 @@ class HomebrewCask:
             return self.brew_version
 
         cmd = [self.brew_path, "--version"]
-
         dummy, out, dummy = self.module.run_command(cmd, check_rc=True)
 
         pattern = r"Homebrew (.*)(\d+\.\d+\.\d+)(-dirty)?"
         rematch = re.search(pattern, out)
         if not rematch:
             self.module.fail_json(msg="Failed to match regex to get brew version", stdout=out)
-        self.brew_version = rematch.groups()[1]
+
+        prefix, version, dummy = rematch.groups()
+        if ">=" in prefix:
+            version = "99.0.0"
+
+        self.brew_version = version
         return self.brew_version
 
     def _brew_cask_command_is_deprecated(self):


### PR DESCRIPTION
##### SUMMARY

When `brew` is run as the wrong user, git repositories owned by a different user cause `brew --version` to output a placeholder version string:

```
Homebrew >= 4.3.0 (shallow or no git repository)
```

instead of the real version. The `>=` prefix meant the parsed version (e.g. `4.3.0`) was correct numerically but could in older cases produce a value below the 2.6.0 threshold in `_brew_cask_command_is_deprecated()`, causing the module to fall back to the disabled `brew cask` syntax and fail with a confusing error.

Fix: detect `>=` in the prefix captured by the version regex and treat it as a modern installation.

Fixes #4708

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
homebrew_cask

##### ADDITIONAL INFORMATION

Verified current (2026) brew behaviour:
- Normal: `Homebrew 5.1.5-115-gaad0a5c`
- Wrong user: `Homebrew >= 4.3.0 (shallow or no git repository)` (rc=0, empty stderr)

```paste below

```