### PR TITLE
homebrew_cask: fix sudo_password failing with special characters

### DIFF
--- a/changelogs/fragments/11850-homebrew-cask-sudo-password.yml
+++ b/changelogs/fragments/11850-homebrew-cask-sudo-password.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - homebrew_cask - fix ``sudo_password`` failing when the password contains single quotes or
+    other special shell characters
+    (https://github.com/ansible-collections/community.general/issues/4957,
+    https://github.com/ansible-collections/community.general/pull/11850).

--- a/plugins/modules/homebrew_cask.py
+++ b/plugins/modules/homebrew_cask.py
@@ -150,6 +150,7 @@ EXAMPLES = r"""
 
 import os
 import re
+import shlex
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
@@ -477,7 +478,7 @@ class HomebrewCask:
         rc, out, err = "", "", ""
 
         with tempfile.NamedTemporaryFile() as sudo_askpass_file:
-            sudo_askpass_file.write(to_bytes(f"#!/bin/sh\ncat <<'SUDO_PASS'\n{self.sudo_password}\nSUDO_PASS\n"))
+            sudo_askpass_file.write(to_bytes(f"#!/bin/sh\necho {shlex.quote(self.sudo_password)}\n"))
             sudo_askpass_file.flush()
             os.chmod(sudo_askpass_file.name, 0o700)
 

--- a/plugins/modules/homebrew_cask.py
+++ b/plugins/modules/homebrew_cask.py
@@ -476,13 +476,11 @@ class HomebrewCask:
         rc, out, err = "", "", ""
 
         with tempfile.NamedTemporaryFile() as sudo_askpass_file:
-            sudo_askpass_file.write(b"#!/bin/sh\n\necho '%s'\n" % to_bytes(self.sudo_password))
+            sudo_askpass_file.write(to_bytes(f"#!/bin/sh\ncat <<'SUDO_PASS'\n{self.sudo_password}\nSUDO_PASS\n"))
+            sudo_askpass_file.flush()
             os.chmod(sudo_askpass_file.name, 0o700)
-            sudo_askpass_file.file.close()
 
             rc, out, err = self.module.run_command(cmd, environ_update={"SUDO_ASKPASS": sudo_askpass_file.name})
-
-            self.module.add_cleanup_file(sudo_askpass_file.name)
 
         return (rc, out, err)
 

--- a/plugins/modules/homebrew_cask.py
+++ b/plugins/modules/homebrew_cask.py
@@ -141,10 +141,11 @@ EXAMPLES = r"""
     greedy: true
 
 - name: Using sudo password for installing cask
+  # ansible_become_password must be set in inventory or group_vars; it is not populated by -K
   community.general.homebrew_cask:
     name: wireshark
     state: present
-    sudo_password: "{{ ansible_become_pass }}"
+    sudo_password: "{{ ansible_become_password }}"
 """
 
 import os


### PR DESCRIPTION
##### SUMMARY

The SUDO_ASKPASS helper script embedded the password inside single quotes:

```sh
#!/bin/sh
echo 'the password'
```

Single quotes in shell permit no escaping — any `'` in the password immediately breaks the script syntax, producing `unexpected EOF while looking for matching` errors and a failed sudo invocation.

Fix: use `shlex.quote()` to properly escape the password for shell embedding.

Also:
- Replace `.file.close()` with `.flush()` — correct semantics for ensuring the write buffer is on disk before the subprocess reads the file, without leaving the `NamedTemporaryFile` in a half-closed state
- Remove the redundant `add_cleanup_file()` call — the `with` block context manager already deletes the file on exit
- Fix the docs example to use `ansible_become_password` (the correct variable name) and clarify it is not populated by `-K`

Fixes #4957

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
homebrew_cask

##### ADDITIONAL INFORMATION

```paste below

```