### PR TITLE
gitlab_project_members: fail when multiple projects match by name

### DIFF
--- a/changelogs/fragments/11851-gitlab-project-members-ambiguous.yml
+++ b/changelogs/fragments/11851-gitlab-project-members-ambiguous.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - gitlab_project_members - fail with a clear error when multiple projects match the given name, instead of silently operating on the first result
+    (https://github.com/ansible-collections/community.general/issues/2767,
+    https://github.com/ansible-collections/community.general/pull/11851).

--- a/plugins/modules/gitlab_project_members.py
+++ b/plugins/modules/gitlab_project_members.py
@@ -179,8 +179,13 @@ class GitLabProjectMembers:
             return project_exists.id
         except gitlab.exceptions.GitlabGetError:
             project_exists = self._gitlab.projects.list(search=project_name, all=False)
-            if project_exists:
+            if len(project_exists) == 1:
                 return project_exists[0].id
+            if len(project_exists) > 1:
+                self._module.fail_json(
+                    msg=f"More than one project matches '{project_name}'. "
+                    "Use the full path ('group/project') to disambiguate."
+                )
 
     def get_user_id(self, gitlab_user):
         user_exists = self._gitlab.users.list(username=gitlab_user, all=False)

--- a/plugins/modules/gitlab_project_members.py
+++ b/plugins/modules/gitlab_project_members.py
@@ -183,8 +183,10 @@ class GitLabProjectMembers:
                 return project_exists[0].id
             if len(project_exists) > 1:
                 self._module.fail_json(
-                    msg=f"More than one project matches '{project_name}'. "
-                    "Use the full path ('group/project') to disambiguate."
+                    msg=(
+                        f"More than one project matches '{project_name}'. "
+                        "Use the full path ('group/project') to disambiguate."
+                    )
                 )
 
     def get_user_id(self, gitlab_user):


### PR DESCRIPTION
##### SUMMARY

When the `project` parameter is a bare name (not a full path) and the GitLab API search returns more than one match, the module now fails with a clear error asking the user to provide the full path (`group/project`) to disambiguate, instead of silently operating on the first result.

Fixes #2767

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_project_members

##### ADDITIONAL INFORMATION

Previously, with projects like `GroupA/Common` and `GroupB/Common`, passing `project: Common` would silently modify whichever project the API returned first. Now it fails with:

```
More than one project matches 'Common'. Use the full path ('group/project') to disambiguate.
```

Users can already pass the full path (e.g. `project: GroupA/Common`) which works via `projects.get()` — this change just prevents the dangerous silent fallback.