### PR TITLE
udm_user - fix alias-to-canonical param name mismatch

### DIFF
--- a/changelogs/fragments/11859-udm_user-param-name-fix.yml
+++ b/changelogs/fragments/11859-udm_user-param-name-fix.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - udm_user - fix alias-to-canonical parameter name mismatch that caused all camelCase-aliased
+    parameters such as ``display_name`` and ``primary_group`` to be silently ignored
+    (https://github.com/ansible-collections/community.general/issues/2950,
+    https://github.com/ansible-collections/community.general/issues/3691,
+    https://github.com/ansible-collections/community.general/pull/11859).

--- a/plugins/modules/udm_user.py
+++ b/plugins/modules/udm_user.py
@@ -444,19 +444,27 @@ def main():
             else:
                 obj = umc_module_for_edit("users/user", user_dn)
 
-            if module.params["displayName"] is None:
-                module.params["displayName"] = f"{module.params['firstname']} {module.params['lastname']}"
+            if module.params["display_name"] is None:
+                module.params["display_name"] = f"{module.params['firstname']} {module.params['lastname']}"
             if module.params["unixhome"] is None:
                 module.params["unixhome"] = f"/home/{module.params['username']}"
+            # Build a mapping from alias names to canonical param names,
+            # so that UDM object keys (camelCase) can be resolved to the
+            # corresponding module.params keys (snake_case).
+            alias_to_param = {}
+            for param_name, param_spec in module.argument_spec.items():
+                for alias in param_spec.get("aliases", []):
+                    alias_to_param[alias] = param_name
             for k in obj.keys():
+                param_name = alias_to_param.get(k, k)
                 if (
                     k != "password"
                     and k != "groups"
                     and k != "overridePWHistory"
-                    and k in module.params
-                    and module.params[k] is not None
+                    and param_name in module.params
+                    and module.params[param_name] is not None
                 ):
-                    obj[k] = module.params[k]
+                    obj[k] = module.params[param_name]
             # handle some special values
             obj["e-mail"] = module.params["email"]
             if "userexpiry" in obj and obj.get("userexpiry") is None:


### PR DESCRIPTION
##### SUMMARY

The loop that maps UDM object properties to module params iterated over UDM keys (camelCase, e.g. `displayName`, `primaryGroup`) and looked them up directly in `module.params`, which is keyed by canonical names (snake_case, e.g. `display_name`, `primary_group`). This caused all aliased params to be silently ignored.

This PR:
- Builds an alias-to-canonical mapping from `argument_spec` and uses it to resolve UDM keys to the correct `module.params` entries
- Fixes the direct `module.params["displayName"]` access which raised `KeyError` when the user did not explicitly use the alias form

Fixes #2950
Fixes #3691

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
udm_user

##### ADDITIONAL INFORMATION

All module params that had a camelCase alias matching the UDM object key were affected, including: `display_name`, `primary_group`, `department_number`, `employee_number`, `employee_type`, `home_share`, `home_share_path`, `home_telephone_number`, `mail_alternative_address`, `mail_home_server`, `mail_primary_address`, `mobile_telephone_number`, `pwd_change_next_login`, `room_number`, `samba_privileges`, `samba_user_workstations`.