### PR TITLE
udm_user, homectl - replace crypt/legacycrypt with passlib

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -379,6 +379,8 @@ files:
   $module_utils/jenkins.py:
     labels: jenkins
     maintainers: russoz
+  $module_utils/_crypt.py:
+    maintainers: russoz
   $module_utils/_lxc.py:
     maintainers: russoz
   $module_utils/_lvm.py:

--- a/changelogs/fragments/11860-udm_user-replace-crypt.yml
+++ b/changelogs/fragments/11860-udm_user-replace-crypt.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - udm_user - replace removed stdlib ``crypt`` module with ``passlib`` for password
+    verification, fixing compatibility with Python 3.13+
+    (https://github.com/ansible-collections/community.general/issues/4690,
+    https://github.com/ansible-collections/community.general/pull/11860).

--- a/changelogs/fragments/11860-udm_user-replace-crypt.yml
+++ b/changelogs/fragments/11860-udm_user-replace-crypt.yml
@@ -1,5 +1,8 @@
 bugfixes:
-  - udm_user - replace removed stdlib ``crypt`` module with ``passlib`` for password
-    verification, fixing compatibility with Python 3.13+
+  - homectl - replace removed stdlib ``crypt`` module with the new ``_crypt`` module utils,
+    fixing compatibility with Python 3.13+
+    (https://github.com/ansible-collections/community.general/pull/11860).
+  - udm_user - replace removed stdlib ``crypt`` module with the new ``_crypt`` module utils,
+    fixing compatibility with Python 3.13+
     (https://github.com/ansible-collections/community.general/issues/4690,
     https://github.com/ansible-collections/community.general/pull/11860).

--- a/changelogs/fragments/11860-udm_user-replace-crypt.yml
+++ b/changelogs/fragments/11860-udm_user-replace-crypt.yml
@@ -1,8 +1,6 @@
 bugfixes:
-  - homectl - replace removed stdlib ``crypt`` module with the new ``_crypt`` module utils,
-    fixing compatibility with Python 3.13+
+  - homectl - allow to use passlib instead of legacycrypt for Python 3.13+
     (https://github.com/ansible-collections/community.general/pull/11860).
-  - udm_user - replace removed stdlib ``crypt`` module with the new ``_crypt`` module utils,
-    fixing compatibility with Python 3.13+
+  - udm_user - allow to use passlib instead of legacycrypt for Python 3.13+
     (https://github.com/ansible-collections/community.general/issues/4690,
     https://github.com/ansible-collections/community.general/pull/11860).

--- a/plugins/module_utils/_crypt.py
+++ b/plugins/module_utils/_crypt.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026, Alexei Znamensky <russoz@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+__all__ = ["CryptContext"]
+
+try:
+    from passlib.context import CryptContext
+
+except ImportError:
+    try:
+        try:
+            import crypt as _crypt_mod
+        except ImportError:
+            import legacycrypt as _crypt_mod
+
+        _SCHEME_TO_METHOD = {
+            "sha512_crypt": _crypt_mod.METHOD_SHA512,
+            "sha256_crypt": _crypt_mod.METHOD_SHA256,
+            "md5_crypt": _crypt_mod.METHOD_MD5,
+            "des_crypt": _crypt_mod.METHOD_CRYPT,
+        }
+
+        class CryptContext:  # type: ignore[no-redef]
+            @staticmethod
+            def verify(password, password_hash):
+                return _crypt_mod.crypt(password, password_hash) == password_hash
+
+            @staticmethod
+            def hash(password, scheme="sha512_crypt", rounds=10000):
+                method = _SCHEME_TO_METHOD.get(scheme)
+                if method is None:
+                    raise ValueError(f"Unsupported scheme: {scheme}")
+                salt = _crypt_mod.mksalt(method, rounds=rounds)
+                return _crypt_mod.crypt(password, salt)
+    except ImportError:
+        CryptContext = None

--- a/plugins/module_utils/_crypt.py
+++ b/plugins/module_utils/_crypt.py
@@ -4,8 +4,9 @@
 
 from __future__ import annotations
 
-__all__ = ["CryptContext"]
+__all__ = ["CryptContext", "has_crypt_context"]
 
+has_crypt_context = True
 try:
     from passlib.context import CryptContext
 
@@ -35,5 +36,10 @@ except ImportError:
                     raise ValueError(f"Unsupported scheme: {scheme}")
                 salt = _crypt_mod.mksalt(method, rounds=rounds)
                 return _crypt_mod.crypt(password, salt)
+
     except ImportError:
-        CryptContext = None
+
+        class CryptContext:  # type: ignore[no-redef]
+            pass
+
+        has_crypt_context = False

--- a/plugins/modules/homectl.py
+++ b/plugins/modules/homectl.py
@@ -275,9 +275,9 @@ from ansible.module_utils.common.text.formatters import human_to_bytes
 from ansible_collections.community.general.plugins.module_utils import deps
 
 with deps.declare("crypt_context"):
-    from ansible_collections.community.general.plugins.module_utils._crypt import CryptContext
+    from ansible_collections.community.general.plugins.module_utils._crypt import CryptContext, has_crypt_context
 
-    if CryptContext is None:
+    if not has_crypt_context:
         raise ImportError("Failed to import any of: passlib, crypt, legacycrypt")
 
 

--- a/plugins/modules/homectl.py
+++ b/plugins/modules/homectl.py
@@ -18,7 +18,8 @@ notes:
   - This module uses L(passlib, https://pypi.org/project/passlib/) for password hashing when available,
     falling back to the Python C(crypt) module or L(legacycrypt, https://pypi.org/project/legacycrypt/).
 requirements:
-  - passlib (Python library, recommended) or crypt/legacycrypt
+  - passlib (Python library, recommended), or legacycrypt on Python 3.13 or newer
+  - It requires no dependency on Python 3.12 and earlier, but then it relies on the deprecated stdlib library C(crypt).
 extends_documentation_fragment:
   - community.general.attributes
 attributes:

--- a/plugins/modules/homectl.py
+++ b/plugins/modules/homectl.py
@@ -15,10 +15,10 @@ version_added: 4.4.0
 description:
   - Manages a user's home directory managed by systemd-homed.
 notes:
-  - This module requires the deprecated L(crypt Python module, https://docs.python.org/3.12/library/crypt.html) library which
-    was removed from Python 3.13. For Python 3.13 or newer, you need to install L(legacycrypt, https://pypi.org/project/legacycrypt/).
+  - This module uses L(passlib, https://pypi.org/project/passlib/) for password hashing when available,
+    falling back to the Python C(crypt) module or L(legacycrypt, https://pypi.org/project/legacycrypt/).
 requirements:
-  - legacycrypt (on Python 3.13 or newer)
+  - passlib (Python library, recommended) or crypt/legacycrypt
 extends_documentation_fragment:
   - community.general.attributes
 attributes:
@@ -268,38 +268,23 @@ data:
 """
 
 import json
-import traceback
 
-from ansible.module_utils.basic import AnsibleModule, jsonify, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule, jsonify
 from ansible.module_utils.common.text.formatters import human_to_bytes
 
-CRYPT_IMPORT_ERROR: str | None
-try:
-    import crypt
-except ImportError:
-    HAS_CRYPT = False
-    CRYPT_IMPORT_ERROR = traceback.format_exc()
-else:
-    HAS_CRYPT = True
-    CRYPT_IMPORT_ERROR = None
+from ansible_collections.community.general.plugins.module_utils import deps
 
-LEGACYCRYPT_IMPORT_ERROR: str | None
-try:
-    import legacycrypt
+with deps.declare("crypt_context"):
+    from ansible_collections.community.general.plugins.module_utils._crypt import CryptContext
 
-    if not HAS_CRYPT:
-        crypt = legacycrypt
-except ImportError:
-    HAS_LEGACYCRYPT = False
-    LEGACYCRYPT_IMPORT_ERROR = traceback.format_exc()
-else:
-    HAS_LEGACYCRYPT = True
-    LEGACYCRYPT_IMPORT_ERROR = None
+    if CryptContext is None:
+        raise ImportError("Failed to import any of: passlib, crypt, legacycrypt")
 
 
 class Homectl:
-    def __init__(self, module):
+    def __init__(self, module, crypt_context):
         self.module = module
+        self.crypt_context = crypt_context
         self.state = module.params["state"]
         self.name = module.params["name"]
         self.password = module.params["password"]
@@ -364,14 +349,10 @@ class Homectl:
         return self.module.run_command(cmd, data=record)
 
     def _hash_password(self, password):
-        method = crypt.METHOD_SHA512
-        salt = crypt.mksalt(method, rounds=10000)
-        pw_hash = crypt.crypt(password, salt)
-        return pw_hash
+        return self.crypt_context.hash(password, scheme="sha512_crypt", rounds=10000)
 
     def _check_password(self, pwhash):
-        hash = crypt.crypt(self.password, pwhash)
-        return pwhash == hash
+        return self.crypt_context.verify(self.password, pwhash)
 
     def remove_user(self):
         cmd = [self.module.get_bin_path("homectl", True)]
@@ -616,13 +597,10 @@ def main():
     )
     module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
 
-    if not HAS_CRYPT and not HAS_LEGACYCRYPT:
-        module.fail_json(
-            msg=missing_required_lib("crypt (part of standard library up to Python 3.12) or legacycrypt (PyPI)"),
-            exception=CRYPT_IMPORT_ERROR,
-        )
+    deps.validate(module)
 
-    homectl = Homectl(module)
+    crypt_context = CryptContext(schemes=["sha512_crypt", "sha256_crypt", "md5_crypt", "des_crypt"])
+    homectl = Homectl(module, crypt_context)
     homectl.result["state"] = homectl.state
 
     # First we need to make sure homed service is active

--- a/plugins/modules/homectl.py
+++ b/plugins/modules/homectl.py
@@ -19,7 +19,7 @@ notes:
     falling back to the Python C(crypt) module or L(legacycrypt, https://pypi.org/project/legacycrypt/).
 requirements:
   - passlib (Python library, recommended), or legacycrypt on Python 3.13 or newer
-  - It requires no dependency on Python 3.12 and earlier, but then it relies on the deprecated stdlib library C(crypt).
+  - It requires no dependency on Python 3.12 and earlier, but then it relies on the deprecated standard library C(crypt).
 extends_documentation_fragment:
   - community.general.attributes
 attributes:

--- a/plugins/modules/udm_user.py
+++ b/plugins/modules/udm_user.py
@@ -15,8 +15,11 @@ short_description: Manage posix users on a univention corporate server
 description:
   - This module allows to manage posix users on a univention corporate server (UCS). It uses the Python API of the UCS to
     create a new object or edit it.
+notes:
+  - This module uses L(passlib, https://pypi.org/project/passlib/) for password hashing when available,
+    falling back to the Python C(crypt) module or L(legacycrypt, https://pypi.org/project/legacycrypt/).
 requirements:
-  - passlib (Python library)
+  - passlib (Python library, recommended) or crypt/legacycrypt
 extends_documentation_fragment:
   - community.general.attributes
 attributes:
@@ -313,20 +316,25 @@ EXAMPLES = r"""
 
 RETURN = """#"""
 
+
 from datetime import date, timedelta
 
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.community.general.plugins.module_utils import deps
+
+with deps.declare("crypt_context"):
+    from ansible_collections.community.general.plugins.module_utils._crypt import CryptContext
+
+    if CryptContext is None:
+        raise ImportError("Failed to import any of: passlib, crypt, legacycrypt")
+
 from ansible_collections.community.general.plugins.module_utils.univention_umc import (
     base_dn,
     ldap_search,
     umc_module_for_add,
     umc_module_for_edit,
 )
-
-with deps.declare("passlib", url="https://pypi.org/project/passlib/"):
-    from passlib.context import CryptContext
 
 
 def main():

--- a/plugins/modules/udm_user.py
+++ b/plugins/modules/udm_user.py
@@ -19,7 +19,8 @@ notes:
   - This module uses L(passlib, https://pypi.org/project/passlib/) for password hashing when available,
     falling back to the Python C(crypt) module or L(legacycrypt, https://pypi.org/project/legacycrypt/).
 requirements:
-  - passlib (Python library, recommended) or crypt/legacycrypt
+  - passlib (Python library, recommended), or legacycrypt on Python 3.13 or newer
+  - It requires no dependency on Python 3.12 and earlier, but then it relies on the deprecated stdlib library C(crypt).
 extends_documentation_fragment:
   - community.general.attributes
 attributes:

--- a/plugins/modules/udm_user.py
+++ b/plugins/modules/udm_user.py
@@ -324,9 +324,9 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils import deps
 
 with deps.declare("crypt_context"):
-    from ansible_collections.community.general.plugins.module_utils._crypt import CryptContext
+    from ansible_collections.community.general.plugins.module_utils._crypt import CryptContext, has_crypt_context
 
-    if CryptContext is None:
+    if not has_crypt_context:
         raise ImportError("Failed to import any of: passlib, crypt, legacycrypt")
 
 from ansible_collections.community.general.plugins.module_utils.univention_umc import (

--- a/plugins/modules/udm_user.py
+++ b/plugins/modules/udm_user.py
@@ -20,7 +20,7 @@ notes:
     falling back to the Python C(crypt) module or L(legacycrypt, https://pypi.org/project/legacycrypt/).
 requirements:
   - passlib (Python library, recommended), or legacycrypt on Python 3.13 or newer
-  - It requires no dependency on Python 3.12 and earlier, but then it relies on the deprecated stdlib library C(crypt).
+  - It requires no dependency on Python 3.12 and earlier, but then it relies on the deprecated standard library C(crypt).
 extends_documentation_fragment:
   - community.general.attributes
 attributes:

--- a/plugins/modules/udm_user.py
+++ b/plugins/modules/udm_user.py
@@ -15,11 +15,8 @@ short_description: Manage posix users on a univention corporate server
 description:
   - This module allows to manage posix users on a univention corporate server (UCS). It uses the Python API of the UCS to
     create a new object or edit it.
-notes:
-  - This module requires the deprecated L(crypt Python module, https://docs.python.org/3.12/library/crypt.html) library which
-    was removed from Python 3.13. For Python 3.13 or newer, you need to install L(legacycrypt, https://pypi.org/project/legacycrypt/).
 requirements:
-  - legacycrypt (on Python 3.13 or newer)
+  - passlib (Python library)
 extends_documentation_fragment:
   - community.general.attributes
 attributes:
@@ -316,11 +313,11 @@ EXAMPLES = r"""
 
 RETURN = """#"""
 
-import traceback
 from datetime import date, timedelta
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.community.general.plugins.module_utils import deps
 from ansible_collections.community.general.plugins.module_utils.univention_umc import (
     base_dn,
     ldap_search,
@@ -328,28 +325,8 @@ from ansible_collections.community.general.plugins.module_utils.univention_umc i
     umc_module_for_edit,
 )
 
-CRYPT_IMPORT_ERROR: str | None
-try:
-    import crypt
-except ImportError:
-    HAS_CRYPT = False
-    CRYPT_IMPORT_ERROR = traceback.format_exc()
-else:
-    HAS_CRYPT = True
-    CRYPT_IMPORT_ERROR = None
-
-LEGACYCRYPT_IMPORT_ERROR: str | None
-try:
-    import legacycrypt
-
-    if not HAS_CRYPT:
-        crypt = legacycrypt
-except ImportError:
-    HAS_LEGACYCRYPT = False
-    LEGACYCRYPT_IMPORT_ERROR = traceback.format_exc()
-else:
-    HAS_LEGACYCRYPT = True
-    LEGACYCRYPT_IMPORT_ERROR = None
+with deps.declare("passlib", url="https://pypi.org/project/passlib/"):
+    from passlib.context import CryptContext
 
 
 def main():
@@ -410,11 +387,9 @@ def main():
         required_if=([("state", "present", ["firstname", "lastname", "password"])]),
     )
 
-    if not HAS_CRYPT and not HAS_LEGACYCRYPT:
-        module.fail_json(
-            msg=missing_required_lib("crypt (part of standard library up to Python 3.12) or legacycrypt (PyPI)"),
-            exception=LEGACYCRYPT_IMPORT_ERROR,
-        )
+    deps.validate(module)
+
+    crypt_context = CryptContext(schemes=["sha512_crypt", "sha256_crypt", "md5_crypt", "des_crypt"])
 
     username = module.params["username"]
     position = module.params["position"]
@@ -466,7 +441,7 @@ def main():
                 obj["password"] = password
             if module.params["update_password"] == "always":
                 old_password = obj["password"].split("}", 2)[1]
-                if crypt.crypt(password, old_password) != old_password:
+                if not crypt_context.verify(password, old_password):
                     obj["overridePWHistory"] = module.params["overridePWHistory"]
                     obj["overridePWLength"] = module.params["overridePWLength"]
                     obj["password"] = password

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,6 +1,6 @@
+plugins/module_utils/_crypt.py import-3.11  # Uses deprecated stdlib library 'crypt'
+plugins/module_utils/_crypt.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
-plugins/modules/homectl.py import-3.11  # Uses deprecated stdlib library 'crypt'
-plugins/modules/homectl.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -5,8 +5,6 @@ plugins/modules/iptables_state.py validate-modules:undocumented-parameter       
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rhevm.py validate-modules:parameter-state-invalid-choice
-plugins/modules/udm_user.py import-3.11  # Uses deprecated stdlib library 'crypt'
-plugins/modules/udm_user.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/xfconf.py validate-modules:return-syntax-error
 plugins/plugin_utils/unsafe.py pep8:E704
 tests/unit/plugins/modules/test_gio_mime.yaml no-smart-quotes

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,6 +1,6 @@
+plugins/module_utils/_crypt.py import-3.11  # Uses deprecated stdlib library 'crypt'
+plugins/module_utils/_crypt.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
-plugins/modules/homectl.py import-3.11  # Uses deprecated stdlib library 'crypt'
-plugins/modules/homectl.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -5,8 +5,6 @@ plugins/modules/iptables_state.py validate-modules:undocumented-parameter       
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rhevm.py validate-modules:parameter-state-invalid-choice
-plugins/modules/udm_user.py import-3.11  # Uses deprecated stdlib library 'crypt'
-plugins/modules/udm_user.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/xfconf.py validate-modules:return-syntax-error
 plugins/plugin_utils/unsafe.py pep8:E704
 tests/unit/plugins/modules/test_gio_mime.yaml no-smart-quotes

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -1,6 +1,6 @@
+plugins/module_utils/_crypt.py import-3.11  # Uses deprecated stdlib library 'crypt'
+plugins/module_utils/_crypt.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
-plugins/modules/homectl.py import-3.11  # Uses deprecated stdlib library 'crypt'
-plugins/modules/homectl.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -5,7 +5,5 @@ plugins/modules/iptables_state.py validate-modules:undocumented-parameter       
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rhevm.py validate-modules:parameter-state-invalid-choice
-plugins/modules/udm_user.py import-3.11  # Uses deprecated stdlib library 'crypt'
-plugins/modules/udm_user.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/xfconf.py validate-modules:return-syntax-error
 tests/unit/plugins/modules/test_gio_mime.yaml no-smart-quotes

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,6 +1,6 @@
+plugins/module_utils/_crypt.py import-3.11  # Uses deprecated stdlib library 'crypt'
+plugins/module_utils/_crypt.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
-plugins/modules/homectl.py import-3.11  # Uses deprecated stdlib library 'crypt'
-plugins/modules/homectl.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -5,7 +5,5 @@ plugins/modules/iptables_state.py validate-modules:undocumented-parameter       
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rhevm.py validate-modules:parameter-state-invalid-choice
-plugins/modules/udm_user.py import-3.11  # Uses deprecated stdlib library 'crypt'
-plugins/modules/udm_user.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/xfconf.py validate-modules:return-syntax-error
 tests/unit/plugins/modules/test_gio_mime.yaml no-smart-quotes

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,9 +1,9 @@
+plugins/module_utils/_crypt.py import-3.11  # Uses deprecated stdlib library 'crypt'
+plugins/module_utils/_crypt.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/module_utils/_lxc.py pylint:ansible-bad-function  # needs to use Popen() to stream logs
 plugins/modules/ansible_galaxy_install.py validate-modules:bad-return-value-key  # TODO: rename offending return values if possible, or adjust this comment in case the name is OK
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/gandi_livedns.py validate-modules:bad-return-value-key  # TODO: rename offending return values if possible, or adjust this comment in case the name is OK
-plugins/modules/homectl.py import-3.11  # Uses deprecated stdlib library 'crypt'
-plugins/modules/homectl.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/interfaces_file.py validate-modules:bad-return-value-key  # TODO: rename offending return values if possible, or adjust this comment in case the name is OK
 plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
 plugins/modules/keycloak_realm_info.py validate-modules:bad-return-value-key  # TODO: rename offending return values if possible, or adjust this comment in case the name is OK

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -13,7 +13,5 @@ plugins/modules/omapi_host.py validate-modules:bad-return-value-key  # TODO: ren
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rhevm.py validate-modules:parameter-state-invalid-choice
-plugins/modules/udm_user.py import-3.11  # Uses deprecated stdlib library 'crypt'
-plugins/modules/udm_user.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/xfconf.py validate-modules:return-syntax-error
 tests/unit/plugins/modules/test_gio_mime.yaml no-smart-quotes

--- a/tests/sanity/ignore-2.22.txt
+++ b/tests/sanity/ignore-2.22.txt
@@ -1,9 +1,9 @@
+plugins/module_utils/_crypt.py import-3.11  # Uses deprecated stdlib library 'crypt'
+plugins/module_utils/_crypt.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/module_utils/_lxc.py pylint:ansible-bad-function  # needs to use Popen() to stream logs
 plugins/modules/ansible_galaxy_install.py validate-modules:bad-return-value-key  # TODO: rename offending return values if possible, or adjust this comment in case the name is OK
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/gandi_livedns.py validate-modules:bad-return-value-key  # TODO: rename offending return values if possible, or adjust this comment in case the name is OK
-plugins/modules/homectl.py import-3.11  # Uses deprecated stdlib library 'crypt'
-plugins/modules/homectl.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/interfaces_file.py validate-modules:bad-return-value-key  # TODO: rename offending return values if possible, or adjust this comment in case the name is OK
 plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
 plugins/modules/keycloak_realm_info.py validate-modules:bad-return-value-key  # TODO: rename offending return values if possible, or adjust this comment in case the name is OK

--- a/tests/sanity/ignore-2.22.txt
+++ b/tests/sanity/ignore-2.22.txt
@@ -13,7 +13,5 @@ plugins/modules/omapi_host.py validate-modules:bad-return-value-key  # TODO: ren
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rhevm.py validate-modules:parameter-state-invalid-choice
-plugins/modules/udm_user.py import-3.11  # Uses deprecated stdlib library 'crypt'
-plugins/modules/udm_user.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/xfconf.py validate-modules:return-syntax-error
 tests/unit/plugins/modules/test_gio_mime.yaml no-smart-quotes


### PR DESCRIPTION
##### SUMMARY

The stdlib `crypt` module was removed in Python 3.13. The existing `legacycrypt` fallback required users to install an extra package that itself wraps a deprecated API.

Replace the entire `crypt`/`legacycrypt` import chain with `passlib` (already used elsewhere in the collection, e.g. `htpasswd`) and use `CryptContext.verify()` for password comparison. This supports the same hash schemes that `crypt.crypt()` did: SHA-512, SHA-256, MD5, and DES.

Fixes #4690

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
udm_user

##### ADDITIONAL INFORMATION

Depends on #11859 (should be merged first to avoid conflicts, though the changes don't overlap).