### PR TITLE
gitlab_project_variable - use find_project() for graceful error handling

### DIFF
--- a/changelogs/fragments/11878-gitlab_project_variable-find_project.yml
+++ b/changelogs/fragments/11878-gitlab_project_variable-find_project.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - gitlab_project_variable - use ``find_project()`` from module utils for project lookup, consistent
+    with all other GitLab modules in the collection
+    (https://github.com/ansible-collections/community.general/issues/3157,
+    https://github.com/ansible-collections/community.general/pull/11878).

--- a/plugins/modules/gitlab_project_variable.py
+++ b/plugins/modules/gitlab_project_variable.py
@@ -256,7 +256,7 @@ class GitlabProjectVariables:
     def get_project(self, project_name):
         project = find_project(self.repo, project_name)
         if project is None:
-            self._module.fail_json(msg=f"Project {project_name!r} not found or insufficient permissions.")
+            self._module.fail_json(msg=f"Project {project_name} not found or insufficient permissions.")
         return project
 
     def list_all_project_variables(self):

--- a/plugins/modules/gitlab_project_variable.py
+++ b/plugins/modules/gitlab_project_variable.py
@@ -240,6 +240,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
     auth_argument_spec,
     filter_returned_variables,
+    find_project,
     gitlab_authentication,
     list_all_kwargs,
     vars_to_variables,
@@ -249,11 +250,14 @@ from ansible_collections.community.general.plugins.module_utils.gitlab import (
 class GitlabProjectVariables:
     def __init__(self, module, gitlab_instance):
         self.repo = gitlab_instance
-        self.project = self.get_project(module.params["project"])
         self._module = module
+        self.project = self.get_project(module.params["project"])
 
     def get_project(self, project_name):
-        return self.repo.projects.get(project_name)
+        project = find_project(self.repo, project_name)
+        if project is None:
+            self._module.fail_json(msg=f"Project {project_name!r} not found or insufficient permissions.")
+        return project
 
     def list_all_project_variables(self):
         return list(self.project.variables.list(**list_all_kwargs))


### PR DESCRIPTION
##### SUMMARY

This PR attempts to address issue #3157, where `community.general.gitlab_project_variable` raises an unhandled `GitlabGetError` traceback when the project is not found, instead of failing gracefully with a meaningful error message.

The change is small: `GitlabProjectVariables.get_project()` previously called `self.repo.projects.get(project_name)` directly. Every other GitLab module in this collection uses the `find_project()` helper from `module_utils/gitlab`, which catches lookup failures and returns `None`. This PR aligns `gitlab_project_variable` with that pattern and adds an explicit `fail_json` when `None` is returned.

**Important caveat:** there are currently no unit tests for this module, and the original reporter's environment is no longer available for verification. The root cause of issue #3157 may or may not be exactly this missing call — the issue is old (2021), the reporter's environment was a self-hosted GitLab with a multi-level group namespace, and the discussion in the thread was inconclusive. If you were affected by this or a similar problem, we would very much appreciate you testing this change and reporting back whether it helps.

Fixes #3157

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_project_variable

##### ADDITIONAL INFORMATION

The `find_project()` helper from `module_utils/gitlab` is already used by:
`gitlab_deploy_key`, `gitlab_hook`, `gitlab_issue`, `gitlab_label`, `gitlab_merge_request`, `gitlab_milestone`, `gitlab_project`, `gitlab_project_access_token`, `gitlab_project_badge`.

`gitlab_project_variable` was the only module that bypassed it.

```paste below

```