### PR TITLE
filesystem - migrate LVM.get_fs_size() to use CmdRunner

### DIFF
--- a/changelogs/fragments/11888-filesystem-use-cmdrunner.yml
+++ b/changelogs/fragments/11888-filesystem-use-cmdrunner.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - filesystem - migrate ``LVM.get_fs_size()`` to use ``CmdRunner``, ensuring locale-independent output parsing (https://github.com/ansible-collections/community.general/pull/11888).

--- a/plugins/modules/filesystem.py
+++ b/plugins/modules/filesystem.py
@@ -154,6 +154,7 @@ import stat
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.community.general.plugins.module_utils._lvm import pvs_runner
 from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 
 
@@ -569,14 +570,15 @@ class LVM(Filesystem):
     CHANGE_UUID_OPTION = "-u"
     CHANGE_UUID_OPTION_HAS_ARG = False
 
+    def __init__(self, module):
+        super().__init__(module)
+        self._pvs = pvs_runner(module)
+
     def get_fs_size(self, dev):
         """Get and return PV size, in bytes."""
-        cmd = self.module.get_bin_path(self.INFO, required=True)
-        dummy, size, dummy = self.module.run_command(
-            [cmd, "--noheadings", "-o", "pv_size", "--units", "b", "--nosuffix", str(dev)], check_rc=True
-        )
-        pv_size = int(size)
-        return pv_size
+        with self._pvs("noheadings nosuffix units fields devices") as ctx:
+            dummy, size, dummy = ctx.run(units="b", fields="pv_size", devices=[str(dev)])
+        return int(size.strip())
 
 
 class Swap(Filesystem):


### PR DESCRIPTION
##### SUMMARY

Migrates `LVM.get_fs_size()` in the `community.general.filesystem` module to use `pvs_runner` from `plugins/module_utils/_lvm.py` instead of calling `run_command()` directly.

This ensures `pvs` is invoked with `force_lang="C"` automatically (via `CmdRunner`), eliminating locale-dependent output parsing. Part of the broader LVM CmdRunner migration tracked in #11482.

##### ISSUE TYPE
- Refactoring Pull Request

##### COMPONENT NAME
filesystem

##### ADDITIONAL INFORMATION

Related PRs in this series:
- `lvm_pv` — #11811 (merged)
- `lvg` — #11835 (merged)
- `lvol` — #11887 (open)