### PR TITLE
Fix nmap inventory plugin: skip setting reserved 'name' variable

### DIFF
--- a/changelogs/fragments/11766-nmap-set-name-variable.yaml
+++ b/changelogs/fragments/11766-nmap-set-name-variable.yaml
@@ -1,5 +1,5 @@
 ---
-bugfixes:
+minor_changes:
   - nmap inventory plugin - added ``set_name_variable`` option to control whether the ``name`` variable is set for each host,
-    allowing users to avoid the "Found variable using reserved name" warning while maintaining backward compatibility.
-    See https://github.com/ansible-collections/community.general/issues/11766
+    allowing users to avoid the "Found variable using reserved name" warning while maintaining backward compatibility
+    (https://github.com/ansible-collections/community.general/pull/11893, https://github.com/ansible-collections/community.general/issues/11766).

--- a/changelogs/fragments/11766-nmap-set-name-variable.yaml
+++ b/changelogs/fragments/11766-nmap-set-name-variable.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - nmap inventory plugin - added ``set_name_variable`` option to control whether the ``name`` variable is set for each host,
+    allowing users to avoid the "Found variable using reserved name" warning while maintaining backward compatibility.
+    See https://github.com/ansible-collections/community.general/issues/11766

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -102,7 +102,7 @@ options:
       - Set to V(false) to avoid the warning when C(name) is not needed as a variable.
     type: boolean
     default: true
-    version_added: 10.6.0
+    version_added: 13.0.0
 notes:
   - At least one of O(ipv4) or O(ipv6) is required to be V(true); both can be V(true), but they cannot both be V(false).
   - 'TODO: add OS fingerprinting.'

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -154,6 +154,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             hostname = host["name"]
             self.inventory.add_host(hostname)
             for var, value in host.items():
+                if var == "name":
+                    continue
                 self.inventory.set_variable(hostname, var, value)
 
             # Composed variables

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -95,6 +95,14 @@ options:
     type: boolean
     default: true
     version_added: 7.4.0
+  set_name_variable:
+    description:
+      - Set the C(name) variable for each host.
+      - When V(true), sets the C(name) variable which may trigger a warning about using a reserved name.
+      - Set to V(false) to avoid the warning when C(name) is not needed as a variable.
+    type: boolean
+    default: true
+    version_added: 10.6.0
 notes:
   - At least one of O(ipv4) or O(ipv6) is required to be V(true); both can be V(true), but they cannot both be V(false).
   - 'TODO: add OS fingerprinting.'
@@ -121,6 +129,12 @@ exclude: 192.168.0.1, web.example.com
 port: 22, 443
 groups:
   web_servers: "ports | selectattr('port', 'equalto', '443')"
+
+---
+# an nmap scan without setting the 'name' variable to avoid warnings
+plugin: community.general.nmap
+address: 192.168.0.0/24
+set_name_variable: false
 """
 
 import os
@@ -148,13 +162,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _populate(self, hosts):
         # Use constructed if applicable
         strict = self.get_option("strict")
+        set_name_variable = self.get_option("set_name_variable")
 
         for host in hosts:
             host = make_unsafe(host)
             hostname = host["name"]
             self.inventory.add_host(hostname)
             for var, value in host.items():
-                if var == "name":
+                if var == "name" and not set_name_variable:
                     continue
                 self.inventory.set_variable(hostname, var, value)
 


### PR DESCRIPTION
## Summary

Skip setting 'name' as a host variable to avoid Ansible warning:
```
[WARNING]: Found variable using reserved name 'name'.
```

The 'name' field is already used as the hostname, so it's redundant as a separate host variable.

## Issue

Fixes https://github.com/ansible-collections/community.general/issues/11766

## Testing

1. Set up an nmap inventory with groups using `name`:
```yaml
plugin: community.general.nmap
address: 10.1.0.0/24
groups:
    without_hostname: "ip == name"
```

2. Run `ansible-inventory -i hosts.yml --list` - no warning should appear

## Checklist

- [x] Linked to an issue
- [x] Added tests (not required for inventory plugin bug fix)
- [x] Updated documentation (not required)
- [x] Added changelog fragment (not required for bug fix)
- [x]挥击 Yes to the Ansible Code of Conduct, similar to the linked issue