### PR TITLE
Fix FQCNs in examples

### DIFF
--- a/plugins/modules/packet_volume_attachment.py
+++ b/plugins/modules/packet_volume_attachment.py
@@ -83,7 +83,7 @@ EXAMPLES = r"""
 
   tasks:
     - name: Create volume
-      packet_volume:
+      community.general.packet_volume:
         description: "{{ volname }}"
         project_id: "{{ project_id }}"
         facility: ewr1
@@ -95,7 +95,7 @@ EXAMPLES = r"""
           snapshot_frequency: 1day
 
     - name: Create a device
-      packet_device:
+      community.general.packet_device:
         project_id: "{{ project_id }}"
         hostnames: "{{ devname }}"
         operating_system: ubuntu_16_04


### PR DESCRIPTION
##### SUMMARY
I noticed that one module had FQCNs missing in its examples.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
packet_volume_attachment
