### PR TITLE
[stable-11] Move ansible-core 2.18 to EOL CI (#11901)

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -96,19 +96,6 @@ stages:
             - test: 2
             - test: 3
             - test: 4
-  - stage: Sanity_2_18
-    displayName: Sanity 2.18
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Test {0}
-          testFormat: 2.18/sanity/{0}
-          targets:
-            - test: 1
-            - test: 2
-            - test: 3
-            - test: 4
 ### Units
   - stage: Units_2_21
     displayName: Units 2.21
@@ -145,18 +132,6 @@ stages:
         parameters:
           nameFormat: Python {0}
           testFormat: 2.19/units/{0}/1
-          targets:
-            - test: 3.8
-            - test: "3.11"
-            - test: "3.13"
-  - stage: Units_2_18
-    displayName: Units 2.18
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.18/units/{0}/1
           targets:
             - test: 3.8
             - test: "3.11"
@@ -239,22 +214,6 @@ stages:
             - 1
             - 2
             - 3
-  - stage: Remote_2_18
-    displayName: Remote 2.18
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.18/{0}
-          targets:
-            # - name: macOS 14.3
-            #   test: macos/14.3
-            - name: FreeBSD 14.1
-              test: freebsd/14.1
-          groups:
-            - 1
-            - 2
-            - 3
 
 ### Docker
   - stage: Docker_2_21
@@ -305,24 +264,6 @@ stages:
               test: fedora41
             - name: Alpine 3.21
               test: alpine321
-          groups:
-            - 1
-            - 2
-            - 3
-  - stage: Docker_2_18
-    displayName: Docker 2.18
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.18/linux/{0}
-          targets:
-            - name: Fedora 40
-              test: fedora40
-            - name: Alpine 3.20
-              test: alpine320
-            - name: Ubuntu 24.04
-              test: ubuntu2404
           groups:
             - 1
             - 2
@@ -386,17 +327,6 @@ stages:
 #          targets:
 #            - test: '3.9'
 #            - test: '3.13'
-#  - stage: Generic_2_18
-#    displayName: Generic 2.18
-#    dependsOn: []
-#    jobs:
-#      - template: templates/matrix.yml
-#        parameters:
-#          nameFormat: Python {0}
-#          testFormat: 2.18/generic/{0}/1
-#          targets:
-#            - test: '3.8'
-#            - test: '3.13'
 
   - stage: Summary
     condition: succeededOrFailed()
@@ -404,25 +334,20 @@ stages:
       - Sanity_2_21
       - Sanity_2_20
       - Sanity_2_19
-      - Sanity_2_18
       - Units_2_21
       - Units_2_20
       - Units_2_19
-      - Units_2_18
       - Remote_2_21_extra_vms
       - Remote_2_21
       - Remote_2_20
       - Remote_2_19
-      - Remote_2_18
       - Docker_2_21
       - Docker_2_20
       - Docker_2_19
-      - Docker_2_18
       - Docker_community_2_21
 # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
 #      - Generic_2_21
 #      - Generic_2_20
 #      - Generic_2_19
-#      - Generic_2_18
     jobs:
       - template: templates/coverage.yml

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -31,6 +31,7 @@ jobs:
         ansible:
           - '2.16'
           - '2.17'
+          - '2.18'
     runs-on: ubuntu-latest
     steps:
       - name: Perform sanity testing
@@ -70,6 +71,12 @@ jobs:
             python: '3.10'
           - ansible: '2.17'
             python: '3.12'
+          - ansible: '2.18'
+            python: '3.8'
+          - ansible: '2.18'
+            python: '3.11'
+          - ansible: '2.18'
+            python: '3.13'
 
     steps:
       - name: >-
@@ -178,6 +185,43 @@ jobs:
             target: azp/posix/2/
           - ansible: '2.17'
             docker: ubuntu2004
+            python: ''
+            target: azp/posix/3/
+          # 2.18
+          - ansible: '2.18'
+            docker: fedora40
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.18'
+            docker: fedora40
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.18'
+            docker: fedora40
+            python: ''
+            target: azp/posix/3/
+          - ansible: '2.18'
+            docker: ubuntu2404
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.18'
+            docker: ubuntu2404
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.18'
+            docker: ubuntu2404
+            python: ''
+            target: azp/posix/3/
+          - ansible: '2.18'
+            docker: alpine320
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.18'
+            docker: alpine320
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.18'
+            docker: alpine320
             python: ''
             target: azp/posix/3/
 


### PR DESCRIPTION
##### SUMMARY
Backport of #11901 to stable-11.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
