### PR TITLE
installp: deprecate in favor of ibm.power_aix.installp

### DIFF
--- a/changelogs/fragments/11910-installp-deprecation.yml
+++ b/changelogs/fragments/11910-installp-deprecation.yml
@@ -1,2 +1,2 @@
 deprecated_features:
-  - installp - Deprecated and scheduled for removal in community.general 15.0.0 (https://github.com/ansible-collections/community.general/pull/11910).
+  - installp - deprecated and scheduled for removal in community.general 15.0.0. Use ``ibm.power_aix.installp`` instead (https://github.com/ansible-collections/community.general/pull/11910).

--- a/changelogs/fragments/11910-installp-deprecation.yml
+++ b/changelogs/fragments/11910-installp-deprecation.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - installp - Deprecated and scheduled for removal in community.general 15.0.0 (https://github.com/ansible-collections/community.general/pull/11910).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -402,6 +402,10 @@ plugin_routing:
         warning_text: Use community.general.idrac_redfish_info instead.
     idrac_server_config_profile:
       redirect: dellemc.openmanage.idrac_server_config_profile
+    installp:
+      deprecation:
+        removal_version: 15.0.0
+        warning_text: Use ibm.power_aix.installp instead. The C(ibm.power_aix) collection is actively maintained by IBM.
     jboss:
       deprecation:
         removal_version: 14.0.0

--- a/plugins/modules/installp.py
+++ b/plugins/modules/installp.py
@@ -13,6 +13,12 @@ author:
 short_description: Manage packages on AIX
 description:
   - Manage packages using 'installp' on AIX.
+deprecated:
+  removed_in: 15.0.0
+  why: The module is not actively maintained.
+  alternative: >-
+    Use C(ibm.power_aix.installp) instead.
+    See U(https://ibm.github.io/ansible-power-aix/modules/installp.html) for details.
 extends_documentation_fragment:
   - community.general._attributes
 attributes:


### PR DESCRIPTION
##### SUMMARY
Deprecates the community.general.installp module and updates module routing metadata to direct users to ibm.power_aix.installp. The deprecation is scheduled for removal in community.general 15.0.0.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
installp

##### ADDITIONAL INFORMATION
Deprecation metadata is added to module documentation and to plugin routing so users receive a clear migration path.

```paste below

```
