### PR TITLE
[stable-11] Replace default favicon URL again (#11909)

### DIFF
--- a/changelogs/fragments/11909-fix-favicon-url.yml
+++ b/changelogs/fragments/11909-fix-favicon-url.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "mattermost, rocketchat, slack - update default ``icon_url`` to ansible favicon (https://github.com/ansible-collections/community.general/pull/11909)."

--- a/plugins/modules/mattermost.py
+++ b/plugins/modules/mattermost.py
@@ -66,7 +66,7 @@ options:
     type: str
     description:
       - URL for the message sender's icon.
-    default: https://docs.ansible.com/favicon.ico
+    default: https://docs.ansible.com/favicon/favicon.ico
   priority:
     type: str
     description:
@@ -139,7 +139,7 @@ def main():
             text=dict(type='str'),
             channel=dict(type='str'),
             username=dict(type='str', default='Ansible'),
-            icon_url=dict(type='str', default='https://docs.ansible.com/favicon.ico'),
+            icon_url=dict(type='str', default='https://docs.ansible.com/favicon/favicon.ico'),
             priority=dict(type='str', choices=['important', 'urgent']),
             validate_certs=dict(default=True, type='bool'),
             attachments=dict(type='list', elements='dict'),

--- a/plugins/modules/rocketchat.py
+++ b/plugins/modules/rocketchat.py
@@ -63,7 +63,7 @@ options:
     type: str
     description:
       - URL for the message sender's icon.
-    default: "https://docs.ansible.com/favicon.ico"
+    default: "https://docs.ansible.com/favicon/favicon.ico"
   icon_emoji:
     type: str
     description:
@@ -226,7 +226,7 @@ def main():
             msg=dict(type='str'),
             channel=dict(type='str'),
             username=dict(type='str', default='Ansible'),
-            icon_url=dict(type='str', default='https://docs.ansible.com/favicon.ico'),
+            icon_url=dict(type='str', default='https://docs.ansible.com/favicon/favicon.ico'),
             icon_emoji=dict(type='str'),
             link_names=dict(type='int', default=1, choices=[0, 1]),
             validate_certs=dict(default=True, type='bool'),

--- a/plugins/modules/slack.py
+++ b/plugins/modules/slack.py
@@ -87,7 +87,7 @@ options:
     type: str
     description:
       - URL for the message sender's icon.
-    default: https://docs.ansible.com/favicon.ico
+    default: https://docs.ansible.com/favicon/favicon.ico
   icon_emoji:
     type: str
     description:
@@ -457,7 +457,7 @@ def main():
             channel=dict(type='str'),
             thread_id=dict(type='str'),
             username=dict(type='str', default='Ansible'),
-            icon_url=dict(type='str', default='https://docs.ansible.com/favicon.ico'),
+            icon_url=dict(type='str', default='https://docs.ansible.com/favicon/favicon.ico'),
             icon_emoji=dict(type='str'),
             link_names=dict(type='int', default=1, choices=[0, 1]),
             parse=dict(type='str', choices=['none', 'full']),


### PR DESCRIPTION
##### SUMMARY
Backport of #11909 to stable-11.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mattermost
rocketchat
slack
