### PR TITLE
scaleway: fix NoneType error in get_resources()

### DIFF
--- a/changelogs/fragments/11361-scaleway-get-resources-none-type.yml
+++ b/changelogs/fragments/11361-scaleway-get-resources-none-type.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - scaleway modules (using ``get_resources()``) - fix ``NoneType`` error when the Scaleway API returns an empty or non-JSON response body (https://github.com/ansible-collections/community.general/pull/11918).

--- a/changelogs/fragments/11361-scaleway-get-resources-none-type.yml
+++ b/changelogs/fragments/11361-scaleway-get-resources-none-type.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - scaleway modules (using ``get_resources()``) - fix ``NoneType`` error when the Scaleway API returns an empty or non-JSON response body (https://github.com/ansible-collections/community.general/pull/11918).
+  - scaleway_image_info, scaleway_ip_info, scaleway_organization_info, scaleway_security_group_info, scaleway_server_info, scaleway_snapshot_info, scaleway_volume_info - fix ``NoneType`` error when the Scaleway API returns an empty or non-JSON response body (https://github.com/ansible-collections/community.general/issues/11361, https://github.com/ansible-collections/community.general/pull/11918).

--- a/plugins/module_utils/_scaleway.py
+++ b/plugins/module_utils/_scaleway.py
@@ -240,9 +240,14 @@ class Scaleway:
         results = self.get(f"/{self.name}")
 
         if not results.ok:
+            api_response = results.json if results.json is not None else results.body
+            message = api_response.get("message") if isinstance(api_response, dict) else api_response
             raise ScalewayException(
-                f"Error fetching {self.name} ({self.module.params.get('api_url')}/{self.name}) [{results.status_code}: {results.json['message']}]"
+                f"Error fetching {self.name} ({self.module.params.get('api_url')}/{self.name}) [{results.status_code}: {message}]"
             )
+
+        if results.json is None:
+            raise ScalewayException(f"Scaleway API returned an empty or non-JSON response for {self.name}")
 
         return results.json.get(self.name)
 


### PR DESCRIPTION
##### SUMMARY

Fixes a `'NoneType' object has no attribute 'get'` error in `scaleway_organization_info` (and other Scaleway modules) when the API returns an empty or non-JSON response body.

The `get_resources()` method in `_scaleway.py` would crash if:
- The API returned an error with a non-JSON body
- The API returned a 200 with an empty body

The fix adds null checks before accessing `results.json` and provides a more informative error message when the response body is empty or malformed.

Fixes #11361.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`plugins/module_utils/_scaleway.py`

##### ADDITIONAL CONTEXT

Reported in ansible-collections/community.general#11361