### PR TITLE
jenkins_credential: improve example and description in documentation

### DIFF
--- a/plugins/modules/jenkins_credential.py
+++ b/plugins/modules/jenkins_credential.py
@@ -203,9 +203,12 @@ EXAMPLES = r"""
       {{ token_result.id }},{{ token_result.name }},{{ token_result.token_uuid }},{{ token_result.token }}
 
 # Note:
-# Jenkins token is intended to be securely stored in encrypted storage or secrets vault outside the playbook, retrieved when needed.
-# Examples below showcasing token retrieval from variable "token_result" are NOT how it should be used to add credentials.
-# Data in "token_result" is inconsistent and unavailable across different playbooks and multiple executions.
+# (1) Jenkins token is intended to be securely stored in encrypted storage
+#     or secrets vault outside the playbook, retrieved when needed.
+# (2) Examples below showcasing token retrieval from
+#     variable "token_result" are NOT how it should be used to add credentials.
+# (3) Data in "token_result" is inconsistent and unavailable
+#     across different playbooks and multiple executions.
 
 - name: Add CUSTOM scope credential
   community.general.jenkins_credential:

--- a/plugins/modules/jenkins_credential.py
+++ b/plugins/modules/jenkins_credential.py
@@ -30,6 +30,7 @@ options:
   id:
     description:
       - The ID of the Jenkins credential or domain.
+      - When generating a new token, do not pass O(id). It is generated automatically.
     type: str
   type:
     description:
@@ -187,18 +188,31 @@ options:
 EXAMPLES = r"""
 - name: Generate token
   community.general.jenkins_credential:
-    id: "test-token"
+    name: "test-token"
     jenkins_user: "admin"
     jenkins_password: "password"
     type: "token"
   register: token_result
+
+- name: Save Jenkins token to CSV (you must secure/encrypt separately)
+  copy:
+    dest: /secure/path/jenkins_tokens.csv
+    mode: '0600'
+    content: |
+      id,name,uuid,token
+      {{ token_result.id }},{{ token_result.name }},{{ token_result.token_uuid }},{{ token_result.token }}
+
+# Note:
+# The intended method is to store the Jenkins token in a secure place outside of the playbook, like an encrypted storage or a secrets vault, then retrieve it from there when needed.
+# Examples below show how to access the token from the variable "token_result", and are NOT the intended approach for using the token to add credentials.
+# Data inside "token_result" will not be consistent or available across different playbooks and multiple executions.
 
 - name: Add CUSTOM scope credential
   community.general.jenkins_credential:
     id: "CUSTOM"
     type: "scope"
     jenkins_user: "admin"
-    token: "{{ token }}"
+    token: "{{ token_result.token }}"
     description: "Custom scope credential"
     inc_path:
       - "include/path"
@@ -227,7 +241,7 @@ EXAMPLES = r"""
     id: "userpass-id"
     type: "user_and_pass"
     jenkins_user: "admin"
-    token: "{{ token }}"
+    token: "{{ token_result.token }}"
     description: "User and password credential"
     username: "user1"
     password: "pass1"
@@ -237,7 +251,7 @@ EXAMPLES = r"""
     id: "file-id"
     type: "file"
     jenkins_user: "admin"
-    token: "{{ token }}"
+    token: "{{ token_result.token }}"
     scope: "CUSTOM"
     description: "File credential"
     file_path: "../vars/my-secret.pem"
@@ -247,7 +261,7 @@ EXAMPLES = r"""
     id: "text-id"
     type: "text"
     jenkins_user: "admin"
-    token: "{{ token }}"
+    token: "{{ token_result.token }}"
     description: "Text credential"
     secret: "mysecrettext"
     location: "folder"
@@ -258,7 +272,7 @@ EXAMPLES = r"""
     id: "githubapp-id"
     type: "github_app"
     jenkins_user: "admin"
-    token: "{{ token }}"
+    token: "{{ token_result.token }}"
     description: "GitHub app credential"
     appID: "12345"
     file_path: "../vars/github.pem"
@@ -269,7 +283,7 @@ EXAMPLES = r"""
     id: "sshkey-id"
     type: "ssh_key"
     jenkins_user: "admin"
-    token: "{{ token }}"
+    token: "{{ token_result.token }}"
     description: "SSH key credential"
     username: "sshuser"
     file_path: "../vars/ssh_key"
@@ -280,7 +294,7 @@ EXAMPLES = r"""
     id: "certificate-id"
     type: "certificate"
     jenkins_user: "admin"
-    token: "{{ token }}"
+    token: "{{ token_result.token }}"
     description: "Certificate credential"
     password: "12345678901234"
     file_path: "../vars/certificate.p12"
@@ -290,7 +304,7 @@ EXAMPLES = r"""
     id: "certificate-id-pem"
     type: "certificate"
     jenkins_user: "admin"
-    token: "{{ token }}"
+    token: "{{ token_result.token }}"
     description: "Certificate credential (pem)"
     file_path: "../vars/cert.pem"
     private_key_path: "../vars/private.key"

--- a/plugins/modules/jenkins_credential.py
+++ b/plugins/modules/jenkins_credential.py
@@ -195,7 +195,7 @@ EXAMPLES = r"""
   register: token_result
 
 - name: Save Jenkins token to CSV (you must secure/encrypt separately)
-  copy:
+  ansible.builtin.copy:
     dest: /secure/path/jenkins_tokens.csv
     mode: '0600'
     content: |

--- a/plugins/modules/jenkins_credential.py
+++ b/plugins/modules/jenkins_credential.py
@@ -203,9 +203,9 @@ EXAMPLES = r"""
       {{ token_result.id }},{{ token_result.name }},{{ token_result.token_uuid }},{{ token_result.token }}
 
 # Note:
-# The intended method is to store the Jenkins token in a secure place outside of the playbook, like an encrypted storage or a secrets vault, then retrieve it from there when needed.
-# Examples below show how to access the token from the variable "token_result", and are NOT the intended approach for using the token to add credentials.
-# Data inside "token_result" will not be consistent or available across different playbooks and multiple executions.
+# Jenkins token is intended to be securely stored in encrypted storage or secrets vault outside the playbook, retrieved when needed.
+# Examples below showcasing token retrieval from variable "token_result" are NOT how it should be used to add credentials.
+# Data in "token_result" is inconsistent and unavailable across different playbooks and multiple executions.
 
 - name: Add CUSTOM scope credential
   community.general.jenkins_credential:

--- a/plugins/modules/jenkins_credential.py
+++ b/plugins/modules/jenkins_credential.py
@@ -194,13 +194,16 @@ EXAMPLES = r"""
     type: "token"
   register: token_result
 
-- name: Save Jenkins token to CSV (you must secure/encrypt separately)
+- name: Save Jenkins token to INI file (you must secure/encrypt separately)
+  vars:
+    jenkins_token_ini: # Defining dict for to_ini filter
+      api_token:
+        uuid: "{{ token_result.token_uuid }}"
+        token: "{{ token_result.token }}"
   ansible.builtin.copy:
-    dest: /secure/path/jenkins_tokens.csv
+    dest: "/secure/path/jenkins_token.ini"
     mode: '0600'
-    content: |
-      id,name,uuid,token
-      {{ token_result.id }},{{ token_result.name }},{{ token_result.token_uuid }},{{ token_result.token }}
+    content: "{{ jenkins_token_ini | community.general.to_ini }}"
 
 # Note:
 # (1) Jenkins token is intended to be securely stored in encrypted storage


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Fixed token generation syntax to use `name` instead of `id`.
- Changed `token: {{ token }}` to `token: {{ token_result.token }}` to demonstrate accessing token from the registered variable, essentially making the entire Example section a playbook capable of full execution.
- Added notes in the Example section clarifying the intended approach for storing and accessing tokens, in context of the change above.
- Mentioned about not using `id` for token generation in the parameter's description.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #11903

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
jenkins_credential

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
- The token generation example was using `id` instead of `name`, contrary to the [parameter's description](https://docs.ansible.com/projects/ansible/latest/collections/community/general/jenkins_credential_module.html#parameter-name).
- A placeholder for generated token was being used to demonstrate passing Jenkins token for adding credentials. Replaced the placeholder with the syntax of accessing the token from the variable registering it in the token-generation example, to improve understanding of the data returned by Jenkins after generation.
- To prevent misunderstanding from the change above, added comments in the example YAML to clarify the intended approach of storing and retrieving tokens after generation.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
