### PR TITLE
lvol: fix thin-pool creation with percentage size

### DIFF
--- a/changelogs/fragments/11925-lvol-thinpool-percentage-size.yml
+++ b/changelogs/fragments/11925-lvol-thinpool-percentage-size.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lvol - fix thin-pool creation when ``size`` is a percentage (https://github.com/ansible-collections/community.general/issues/11923, https://github.com/ansible-collections/community.general/pull/11925).

--- a/plugins/modules/lvol.py
+++ b/plugins/modules/lvol.py
@@ -505,15 +505,26 @@ def main():
                             vg=[f"{vg}/{thinpool}"],
                         )
                 else:
-                    with lvcreate("test yes size_L opts thin vg pvs") as ctx:
-                        rc, dummy, err = ctx.run(
-                            test=module.check_mode,
-                            yes=use_yes,
-                            size_L=size_value,
-                            opts=opts,
-                            vg=[f"{vg}/{thinpool}"],
-                            pvs=pvs,
-                        )
+                    if size_opt == "l":
+                        with lvcreate("test yes size_l opts thin vg pvs") as ctx:
+                            rc, dummy, err = ctx.run(
+                                test=module.check_mode,
+                                yes=use_yes,
+                                size_l=size_value,
+                                opts=opts,
+                                vg=[f"{vg}/{thinpool}"],
+                                pvs=pvs,
+                            )
+                    else:
+                        with lvcreate("test yes size_L opts thin vg pvs") as ctx:
+                            rc, dummy, err = ctx.run(
+                                test=module.check_mode,
+                                yes=use_yes,
+                                size_L=size_value,
+                                opts=opts,
+                                vg=[f"{vg}/{thinpool}"],
+                                pvs=pvs,
+                            )
             else:
                 if size_opt == "l":
                     with lvcreate("test yes lv size_l opts vg pvs") as ctx:

--- a/tests/integration/targets/lvol/tasks/main.yml
+++ b/tests/integration/targets/lvol/tasks/main.yml
@@ -18,6 +18,8 @@
   block:
     - import_tasks: setup.yml
 
+    - import_tasks: test_thinpool.yml
+
     - import_tasks: test_pvs.yml
 
   always:

--- a/tests/integration/targets/lvol/tasks/test_thinpool.yml
+++ b/tests/integration/targets/lvol/tasks/test_thinpool.yml
@@ -91,6 +91,7 @@
     lv: testthinvol1
     thinpool: testthinpool1
     size: 5m
+    shrink: false
   register: thinvol_idempotent
 
 - name: Assert thin volume creation is idempotent

--- a/tests/integration/targets/lvol/tasks/test_thinpool.yml
+++ b/tests/integration/targets/lvol/tasks/test_thinpool.yml
@@ -1,0 +1,99 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Regression tests for thin-pool creation with percentage-based sizes (GH-11923)
+
+- name: Create thin pool with percentage of VG size
+  community.general.lvol:
+    vg: testvg1
+    thinpool: testthinpool1
+    size: 40%VG
+  register: thinpool_pct_vg_create
+
+- name: Assert thin pool with percentage of VG created
+  assert:
+    that:
+      - thinpool_pct_vg_create is success
+      - thinpool_pct_vg_create is changed
+
+- name: Create thin pool with percentage of VG size - idempotency
+  community.general.lvol:
+    vg: testvg1
+    thinpool: testthinpool1
+    size: 40%VG
+  register: thinpool_pct_vg_idempotent
+
+- name: Assert thin pool with percentage of VG creation is idempotent
+  assert:
+    that:
+      - thinpool_pct_vg_idempotent is success
+      - thinpool_pct_vg_idempotent is not changed
+
+- name: Create thin pool with percentage of free space
+  community.general.lvol:
+    vg: testvg2
+    thinpool: testthinpool2
+    size: 40%FREE
+  register: thinpool_pct_free_create
+
+- name: Assert thin pool with percentage of free space created
+  assert:
+    that:
+      - thinpool_pct_free_create is success
+      - thinpool_pct_free_create is changed
+
+- name: Create thin pool with absolute size
+  community.general.lvol:
+    vg: testvg2
+    thinpool: testthinpool3
+    size: 10m
+  register: thinpool_abs_create
+
+- name: Assert thin pool with absolute size created
+  assert:
+    that:
+      - thinpool_abs_create is success
+      - thinpool_abs_create is changed
+
+- name: Create thin pool with absolute size - idempotency
+  community.general.lvol:
+    vg: testvg2
+    thinpool: testthinpool3
+    size: 10m
+  register: thinpool_abs_idempotent
+
+- name: Assert thin pool with absolute size creation is idempotent
+  assert:
+    that:
+      - thinpool_abs_idempotent is success
+      - thinpool_abs_idempotent is not changed
+
+- name: Create thin volume inside thin pool
+  community.general.lvol:
+    vg: testvg1
+    lv: testthinvol1
+    thinpool: testthinpool1
+    size: 5m
+  register: thinvol_create
+
+- name: Assert thin volume created
+  assert:
+    that:
+      - thinvol_create is success
+      - thinvol_create is changed
+
+- name: Create thin volume inside thin pool - idempotency
+  community.general.lvol:
+    vg: testvg1
+    lv: testthinvol1
+    thinpool: testthinpool1
+    size: 5m
+  register: thinvol_idempotent
+
+- name: Assert thin volume creation is idempotent
+  assert:
+    that:
+      - thinvol_idempotent is success
+      - thinvol_idempotent is not changed

--- a/tests/integration/targets/lvol/tasks/test_thinpool.yml
+++ b/tests/integration/targets/lvol/tasks/test_thinpool.yml
@@ -48,7 +48,7 @@
   community.general.lvol:
     vg: testvg2
     thinpool: testthinpool3
-    size: 10m
+    size: 4m
   register: thinpool_abs_create
 
 - name: Assert thin pool with absolute size created
@@ -61,7 +61,7 @@
   community.general.lvol:
     vg: testvg2
     thinpool: testthinpool3
-    size: 10m
+    size: 4m
   register: thinpool_abs_idempotent
 
 - name: Assert thin pool with absolute size creation is idempotent

--- a/tests/integration/targets/lvol/tasks/test_thinpool.yml
+++ b/tests/integration/targets/lvol/tasks/test_thinpool.yml
@@ -9,7 +9,7 @@
   community.general.lvol:
     vg: testvg1
     thinpool: testthinpool1
-    size: 40%VG
+    size: 20%VG
   register: thinpool_pct_vg_create
 
 - name: Assert thin pool with percentage of VG created
@@ -22,7 +22,7 @@
   community.general.lvol:
     vg: testvg1
     thinpool: testthinpool1
-    size: 40%VG
+    size: 20%VG
   register: thinpool_pct_vg_idempotent
 
 - name: Assert thin pool with percentage of VG creation is idempotent
@@ -35,7 +35,7 @@
   community.general.lvol:
     vg: testvg2
     thinpool: testthinpool2
-    size: 40%FREE
+    size: 20%FREE
   register: thinpool_pct_free_create
 
 - name: Assert thin pool with percentage of free space created

--- a/tests/integration/targets/lvol/tasks/test_thinpool.yml
+++ b/tests/integration/targets/lvol/tasks/test_thinpool.yml
@@ -62,6 +62,7 @@
     vg: testvg2
     thinpool: testthinpool3
     size: 4m
+    shrink: false
   register: thinpool_abs_idempotent
 
 - name: Assert thin pool with absolute size creation is idempotent


### PR DESCRIPTION
##### SUMMARY

When creating a thin pool with a percentage-based size (e.g. `95%VG`), the module was unconditionally passing the value via `--size` (`-L`), which LVM rejects. Percentage sizes require `--extents` (`-l`).

The thinpool-creation branch now checks `size_opt` and uses `size_l` (`-l`) when the size is a percentage, matching the logic already in place for snapshot and regular LV creation.

Fixes #11923

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lvol

##### ADDITIONAL INFORMATION

This is a regression introduced by the CmdRunner migration in PR #11887. The `else` branch for thin-pool creation (no `lv`, only `thinpool`) was missing the `size_opt == "l"` guard that all other creation paths already had.