### PR TITLE
crypttab: fix option parsing when value contains multiple equal signs

### DIFF
--- a/changelogs/fragments/11926-crypttab-fix-opts-equal-sign.yml
+++ b/changelogs/fragments/11926-crypttab-fix-opts-equal-sign.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - crypttab - fix parsing of options whose value contains an equal sign (https://github.com/ansible-collections/community.general/issues/4963, https://github.com/ansible-collections/community.general/pull/11926).

--- a/plugins/modules/crypttab.py
+++ b/plugins/modules/crypttab.py
@@ -281,7 +281,7 @@ class Options(dict):
         self.itemlist = []
         if opts_string is not None:
             for opt in opts_string.split(","):
-                kv = opt.split("=")
+                kv = opt.split("=", 1)
                 if len(kv) > 1:
                     k, v = (kv[0], kv[1])
                 else:


### PR DESCRIPTION
##### SUMMARY

The `Options` class split option strings on every `=`, discarding everything after the second `=`. Options like `header=/header.img:UUID=0000-0000` were silently truncated to `header=/header.img:UUID`, which corrupted the resulting crypttab entry.

Fix: use `split("=", 1)` to split only on the first `=`, preserving the full value.

Fixes #4963

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
crypttab

##### ADDITIONAL INFORMATION

```paste below

```