### PR TITLE
selective callback plugin: route output through `display` to honour `ANSIBLE_LOG_PATH`

### DIFF
--- a/changelogs/fragments/11927-selective-log-path.yml
+++ b/changelogs/fragments/11927-selective-log-path.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - selective callback plugin - route all output through ``self._display.display()``
+    instead of bare ``print()`` calls, fixing missing output when ``ANSIBLE_LOG_PATH``
+    is set (https://github.com/ansible-collections/community.general/issues/4850,
+    https://github.com/ansible-collections/community.general/pull/11927).

--- a/plugins/callback/selective.py
+++ b/plugins/callback/selective.py
@@ -101,10 +101,10 @@ class CallbackModule(CallbackBase):
             self.printed_last_task = True
             line_length = 120
             if self.last_skipped:
-                print()
+                self._display.display("")
             line = f"# {task_name} "
             msg = colorize(f"{line}{'*' * (line_length - len(line))}", "bold")
-            print(msg)
+            self._display.display(msg)
 
     def _indent_text(self, text, indent_level):
         lines = text.splitlines()
@@ -128,7 +128,7 @@ class CallbackModule(CallbackBase):
                 diff = dict_diff(diff["before"], diff["after"])
         if diff:
             diff = colorize(str(diff), "changed")
-            print(self._indent_text(diff, indent_level + 4))
+            self._display.display(self._indent_text(diff, indent_level + 4))
 
     def _print_host_or_item(self, host_or_item, changed, msg, diff, is_host, error, stdout, stderr):
         if is_host:
@@ -156,19 +156,19 @@ class CallbackModule(CallbackBase):
 
         if len(msg) < 50:
             line += f" -- {msg}"
-            print(f"{line} {'-' * (line_length - len(line))}---------")
+            self._display.display(f"{line} {'-' * (line_length - len(line))}---------")
         else:
-            print(f"{line} {'-' * (line_length - len(line))}")
-            print(self._indent_text(msg, indent_level + 4))
+            self._display.display(f"{line} {'-' * (line_length - len(line))}")
+            self._display.display(self._indent_text(msg, indent_level + 4))
 
         if diff:
             self._print_diff(diff, indent_level)
         if stdout:
             stdout = colorize(stdout, "failed")
-            print(self._indent_text(stdout, indent_level + 4))
+            self._display.display(self._indent_text(stdout, indent_level + 4))
         if stderr:
             stderr = colorize(stderr, "failed")
-            print(self._indent_text(stderr, indent_level + 4))
+            self._display.display(self._indent_text(stderr, indent_level + 4))
 
     def v2_playbook_on_play_start(self, play):
         """Run on start of the play."""
@@ -223,7 +223,7 @@ class CallbackModule(CallbackBase):
 
     def v2_playbook_on_stats(self, stats):
         """Display info about playbook statistics."""
-        print()
+        self._display.display("")
         self.printed_last_task = False
         self._print_task("STATS")
 
@@ -242,7 +242,7 @@ class CallbackModule(CallbackBase):
                 f"{host}    : ok={s['ok']}\tchanged={s['changed']}\tfailed={s['failures']}\tunreachable="
                 f"{s['unreachable']}\trescued={s['rescued']}\tignored={s['ignored']}"
             )
-            print(colorize(msg, color))
+            self._display.display(colorize(msg, color))
 
     def v2_runner_on_skipped(self, result, **kwargs):
         """Run when a task is skipped."""
@@ -258,11 +258,11 @@ class CallbackModule(CallbackBase):
             reason = result._result.get("skipped_reason", "") or result._result.get("skip_reason", "")
             if len(reason) < 50:
                 line += f" -- {reason}"
-                print(f"{line} {'-' * (line_length - len(line))}---------")
+                self._display.display(f"{line} {'-' * (line_length - len(line))}---------")
             else:
-                print(f"{line} {'-' * (line_length - len(line))}")
-                print(self._indent_text(reason, 8))
-                print(reason)
+                self._display.display(f"{line} {'-' * (line_length - len(line))}")
+                self._display.display(self._indent_text(reason, 8))
+                self._display.display(reason)
 
     def v2_runner_on_ok(self, result, **kwargs):
         self._print_task_result(result, error=False, **kwargs)


### PR DESCRIPTION
##### SUMMARY

The `selective` callback was using bare `print()` calls for all output. Ansible's log file integration (`ANSIBLE_LOG_PATH`) is wired through `Display.display()` — any plugin that bypasses it produces no log file output at all.

This fix replaces all meaningful `print()` calls with `self._display.display()`. The only exception is the `print(".", end="")` dot for silently-skipped tasks, which intentionally stays as a bare `print()` since dots are a stdout-only progress indicator and are not useful in a log file.

Fixes #4850

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
selective

##### ADDITIONAL INFORMATION

Before this fix: running with `ANSIBLE_LOG_PATH` set and `stdout_callback=community.general.selective` produced an empty log file — no task output, no stats.

After this fix: all task headers, host/item result lines, diffs, stdout/stderr, and stats are written to both the console and the log file.