### PR TITLE
ipa_group: fix idempotency when `external: false` on existing non-external group

### DIFF
--- a/changelogs/fragments/11933-ipa-group-external-no-fix.yml
+++ b/changelogs/fragments/11933-ipa-group-external-no-fix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ipa_group - fix idempotency when ``external: false`` on an existing non-external group (https://github.com/ansible-collections/community.general/issues/5061, https://github.com/ansible-collections/community.general/pull/11933).
+  - "ipa_group - fix idempotency when ``external: false`` on an existing non-external group (https://github.com/ansible-collections/community.general/issues/5061, https://github.com/ansible-collections/community.general/pull/11933)."

--- a/changelogs/fragments/11933-ipa-group-external-no-fix.yml
+++ b/changelogs/fragments/11933-ipa-group-external-no-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ipa_group - fix idempotency when ``external: false`` on an existing non-external group (https://github.com/ansible-collections/community.general/issues/5061, https://github.com/ansible-collections/community.general/pull/11933).

--- a/plugins/modules/ipa_group.py
+++ b/plugins/modules/ipa_group.py
@@ -238,7 +238,8 @@ def get_group_diff(client, ipa_group, module_group):
         del module_group["nonposix"]
 
     if "external" in module_group:
-        if module_group["external"] and "ipaexternalgroup" in ipa_group.get("objectclass"):
+        is_external_in_ipa = "ipaexternalgroup" in ipa_group.get("objectclass", [])
+        if module_group["external"] == is_external_in_ipa:
             del module_group["external"]
 
     return client.get_diff(ipa_data=ipa_group, module_data=module_group)


### PR DESCRIPTION
##### SUMMARY

When `external: false` (or omitted, since it defaults to false) is set on a group that already exists as a non-external group, the module incorrectly included the `external` flag in the diff and called `group_mod` with `{external: false}`. FreeIPA rejected this with `"no modifications to be performed"`, causing the task to fail before ever reaching the user/group membership logic.

The fix in `get_group_diff()` removes `external` from the diff whenever the requested value already matches the current IPA state — in either direction (true→already external, or false→already non-external).

Fixes #5061

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ipa_group

##### ADDITIONAL INFORMATION

Root cause: the original condition only stripped `external` from the diff when `external=True` and the group already had `ipaexternalgroup` in its objectclass. The `external=False` case was never handled.