### PR TITLE
gandi_livedns: implement diff mode support

### DIFF
--- a/changelogs/fragments/11934-gandi-livedns-diff-mode.yml
+++ b/changelogs/fragments/11934-gandi-livedns-diff-mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - gandi_livedns - add support for diff mode, showing before and after state of DNS records (https://github.com/ansible-collections/community.general/issues/4927, https://github.com/ansible-collections/community.general/pull/11934).

--- a/plugins/module_utils/_gandi_livedns_api.py
+++ b/plugins/module_utils/_gandi_livedns_api.py
@@ -168,6 +168,7 @@ class GandiLiveDNSAPI:
 
         if records:
             cur_record = records[0]
+            before = cur_record
 
             self.changed = True
 
@@ -177,14 +178,14 @@ class GandiLiveDNSAPI:
                     # Removing one or more values from a record, we update the record with the remaining values
                     self.update_record(record, type, list(new_values), cur_record["rrset_ttl"], domain)
                     records = self.get_records(record, type, domain)
-                    return records[0], self.changed
+                    return before, records[0], self.changed
 
             if not self.module.check_mode:
                 self.delete_record(record, type, domain)
         else:
-            cur_record = None
+            before = None
 
-        return None, self.changed
+        return before, None, self.changed
 
     def ensure_dns_record(self, record, type, ttl, values, domain):
         if record == "":
@@ -194,6 +195,7 @@ class GandiLiveDNSAPI:
 
         if records:
             cur_record = records[0]
+            before = cur_record
 
             do_update = False
             if ttl is not None and cur_record["rrset_ttl"] != ttl:
@@ -210,10 +212,11 @@ class GandiLiveDNSAPI:
                     records = self.get_records(record, type, domain)
                     result = records[0]
                 self.changed = True
-                return result, self.changed
+                return before, result, self.changed
             else:
-                return cur_record, self.changed
+                return before, cur_record, self.changed
 
+        before = None
         if self.module.check_mode:
             new_record = dict(rrset_type=type, rrset_name=record, rrset_values=values, rrset_ttl=ttl)
             result = new_record
@@ -221,4 +224,4 @@ class GandiLiveDNSAPI:
             result = self.create_record(record, type, values, ttl, domain)
 
         self.changed = True
-        return result, self.changed
+        return before, result, self.changed

--- a/plugins/modules/gandi_livedns.py
+++ b/plugins/modules/gandi_livedns.py
@@ -20,7 +20,7 @@ attributes:
   check_mode:
     support: full
   diff_mode:
-    support: none
+    support: full
 options:
   personal_access_token:
     description:
@@ -189,24 +189,32 @@ def main():
 
     gandi_api = GandiLiveDNSAPI(module)
 
+    domain = module.params["domain"]
+
     if module.params["state"] == "present":
-        ret, changed = gandi_api.ensure_dns_record(
+        before, ret, changed = gandi_api.ensure_dns_record(
             module.params["record"],
             module.params["type"],
             module.params["ttl"],
             module.params["values"],
-            module.params["domain"],
+            domain,
         )
     else:
-        ret, changed = gandi_api.delete_dns_record(
-            module.params["record"], module.params["type"], module.params["values"], module.params["domain"]
+        before, ret, changed = gandi_api.delete_dns_record(
+            module.params["record"], module.params["type"], module.params["values"], domain
         )
 
     result = dict(
         changed=changed,
     )
     if ret:
-        result["record"] = gandi_api.build_result(ret, module.params["domain"])
+        result["record"] = gandi_api.build_result(ret, domain)
+
+    if module._diff:
+        result["diff"] = {
+            "before": gandi_api.build_result(before, domain) or {},
+            "after": result.get("record") or {},
+        }
 
     module.exit_json(**result)
 

--- a/plugins/modules/gandi_livedns.py
+++ b/plugins/modules/gandi_livedns.py
@@ -21,6 +21,7 @@ attributes:
     support: full
   diff_mode:
     support: full
+    version_added: 13.0.0
 options:
   personal_access_token:
     description:


### PR DESCRIPTION
##### SUMMARY

Implements diff mode support for the ``community.general.gandi_livedns`` module.

When running with ``--diff``, the module now shows the before and after state of the DNS record (TTL, values, type, etc.), making it easier to audit and verify changes.

Fixes #4927

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
gandi_livedns