### PR TITLE
Allow hourly logrotate

### DIFF
--- a/changelogs/fragments/11939-logrotate-hourly.yml
+++ b/changelogs/fragments/11939-logrotate-hourly.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Allow hourly logrotate

--- a/changelogs/fragments/11939-logrotate-hourly.yml
+++ b/changelogs/fragments/11939-logrotate-hourly.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Allow hourly logrotate
+  - logrotate - allow hourly logrotate

--- a/changelogs/fragments/11939-logrotate-hourly.yml
+++ b/changelogs/fragments/11939-logrotate-hourly.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - logrotate - allow hourly logrotate
+  - logrotate - allow hourly logrotate (https://github.com/ansible-collections/community.general/pull/11939).

--- a/plugins/modules/logrotate.py
+++ b/plugins/modules/logrotate.py
@@ -55,7 +55,7 @@ options:
       - If not specified when modifying an existing configuration, the existing value is preserved.
       - When creating a new configuration, this option is only included if specified.
     type: str
-    choices: [daily, weekly, monthly, yearly]
+    choices: [hourly, daily, weekly, monthly, yearly]
   rotate_count:
     description:
       - Number of rotated log files to keep.
@@ -567,7 +567,7 @@ class LogrotateConfig:
                     ):
                         if not any(
                             keyword in line
-                            for keyword in [" ", "\t", "daily", "weekly", "monthly", "yearly", "rotate", "compress"]
+                            for keyword in [" ", "\t", "hourly", "daily", "weekly", "monthly", "yearly", "rotate", "compress"]
                         ):
                             paths.append(line)
 
@@ -885,7 +885,7 @@ def main() -> None:
             paths=dict(type="list", elements="path"),
             rotation_period=dict(
                 type="str",
-                choices=["daily", "weekly", "monthly", "yearly"],
+                choices=["hourly", "daily", "weekly", "monthly", "yearly"],
             ),
             rotate_count=dict(type="int"),
             compress=dict(type="bool"),

--- a/plugins/modules/logrotate.py
+++ b/plugins/modules/logrotate.py
@@ -54,6 +54,7 @@ options:
       - How often to rotate the logs.
       - If not specified when modifying an existing configuration, the existing value is preserved.
       - When creating a new configuration, this option is only included if specified.
+      - Choice V(hourly) was added in community.general 13.0.0.
     type: str
     choices: [hourly, daily, weekly, monthly, yearly]
   rotate_count:

--- a/plugins/modules/logrotate.py
+++ b/plugins/modules/logrotate.py
@@ -567,7 +567,17 @@ class LogrotateConfig:
                     ):
                         if not any(
                             keyword in line
-                            for keyword in [" ", "\t", "hourly", "daily", "weekly", "monthly", "yearly", "rotate", "compress"]
+                            for keyword in [
+                                " ",
+                                "\t",
+                                "hourly",
+                                "daily",
+                                "weekly",
+                                "monthly",
+                                "yearly",
+                                "rotate",
+                                "compress",
+                            ]
                         ):
                             paths.append(line)
 


### PR DESCRIPTION
##### SUMMARY

logrotate 3.8.5 supports hourly:

https://github.com/logrotate/logrotate/blob/main/ChangeLog.md#385---2013-06-10

This pull requests allows to set it.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible.community.logrotate
