### PR TITLE
odbc: add Arch Linux support via AUR psqlodbc

### DIFF
--- a/tests/integration/targets/odbc/handlers/main.yml
+++ b/tests/integration/targets/odbc/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Remove user odbcbuilder
+  ansible.builtin.user:
+    name: odbcbuilder
+    state: absent
+    remove: true
+
+- name: Remove odbcbuilder sudoers
+  community.general.sudoers:
+    name: odbcbuilder
+    state: absent

--- a/tests/integration/targets/odbc/meta/main.yml
+++ b/tests/integration/targets/odbc/meta/main.yml
@@ -5,4 +5,5 @@
 
 dependencies:
   - setup_pkg_mgr
+  - setup_remote_tmp_dir
   - setup_postgresql_db

--- a/tests/integration/targets/odbc/tasks/install_arch_odbc.yml
+++ b/tests/integration/targets/odbc/tasks/install_arch_odbc.yml
@@ -1,0 +1,56 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# psqlodbc is only available in the AUR on Arch Linux, so we must build it.
+# makepkg cannot run as root, so we create a temporary build user with sudo.
+
+- name: Create AUR build user
+  ansible.builtin.user:
+    name: odbcbuilder
+    state: present
+  notify: Remove user odbcbuilder
+
+- name: Grant sudo powers to build user
+  community.general.sudoers:
+    name: odbcbuilder
+    user: odbcbuilder
+    commands: ALL
+    nopassword: true
+  notify: Remove odbcbuilder sudoers
+
+- name: Install AUR build dependencies
+  ansible.builtin.package:
+    name:
+      - base-devel
+      - git
+      - postgresql-libs
+    state: present
+
+- name: Allow build user to write to remote_tmp_dir
+  ansible.builtin.file:
+    path: "{{ remote_tmp_dir }}"
+    mode: "0777"
+
+- name: Create build directory for psqlodbc
+  ansible.builtin.file:
+    path: "{{ remote_tmp_dir }}/odbcbuilder/psqlodbc"
+    owner: odbcbuilder
+    state: directory
+    mode: "0755"
+
+- name: Clone psqlodbc from AUR
+  become: true
+  become_user: odbcbuilder
+  ansible.builtin.git:
+    repo: https://aur.archlinux.org/psqlodbc.git
+    dest: "{{ remote_tmp_dir }}/odbcbuilder/psqlodbc"
+    depth: 1
+
+- name: Build and install psqlodbc
+  become: true
+  become_user: odbcbuilder
+  ansible.builtin.command:
+    chdir: "{{ remote_tmp_dir }}/odbcbuilder/psqlodbc"
+    cmd: makepkg -si --noconfirm

--- a/tests/integration/targets/odbc/tasks/main.yml
+++ b/tests/integration/targets/odbc/tasks/main.yml
@@ -12,7 +12,6 @@
     msg: "{{ ansible_facts.os_family }} / {{ ansible_facts.distribution }} / {{ ansible_facts.distribution_major_version }}"
 
 - when:
-    - ansible_facts.os_family != 'Archlinux'  # TODO install driver from AUR: https://aur.archlinux.org/packages/psqlodbc
     - ansible_facts.distribution != 'Debian' or ansible_facts.distribution_major_version != '13'  # TODO fix tests for Debian 13 (Trixie)!
   block:
 
@@ -22,6 +21,12 @@
     # Some of the docker images already have pyodbc installed on it
     - include_tasks: no_pyodbc.yml
       when: ansible_facts.os_family != 'FreeBSD' and ansible_facts.os_family != 'Suse' and ansible_facts.os_family != 'Debian'
+
+    #
+    # Install PostgreSQL ODBC driver from AUR on Arch Linux
+    #
+    - include_tasks: install_arch_odbc.yml
+      when: ansible_facts.os_family == 'Archlinux'
 
     #
     # Get pyodbc installed
@@ -50,6 +55,11 @@
       set_fact:
         dsn: "DRIVER={PostgreSQL Unicode};Server=localhost;Port=5432;Database=postgres;Uid={{ my_user }};Pwd={{ my_pass_decrypted }};UseUnicode=True"
       when: ansible_facts.os_family == 'Debian'
+
+    - name: Changing DSN for Arch Linux
+      set_fact:
+        dsn: "DRIVER={/usr/lib/psqlodbcw.so};Server=localhost;Port=5432;Database=postgres;Uid={{ my_user }};Pwd={{ my_pass_decrypted }};UseUnicode=True"
+      when: ansible_facts.os_family == 'Archlinux'
 
     #
     # Name setup database

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -100,6 +100,8 @@
 
 - name: Initialize postgres (Archlinux)
   command: su - postgres -c "initdb --locale en_US.UTF-8 -D '/var/lib/postgres/data'"
+  args:
+    creates: /var/lib/postgres/data/PG_VERSION
   when: ansible_facts.os_family == "Archlinux"
 
 - name: Initialize postgres (Alpine)


### PR DESCRIPTION
##### SUMMARY

The `odbc` integration tests have been skipping Arch Linux since the driver (`psqlodbc`) is not available in the official Arch repositories — only in the AUR.

This PR installs `psqlodbc` from the AUR by:
- Creating a temporary non-root build user (required by `makepkg`)
- Granting it passwordless sudo
- Cloning the AUR `psqlodbc` PKGBUILD and running `makepkg -si --noconfirm`

The DSN for Arch uses the direct `.so` path (`/usr/lib/psqlodbcw.so`), consistent with the Alpine approach.

Fixes #4267

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
odbc

##### ADDITIONAL INFORMATION

The pattern for building AUR packages as a non-root user with sudo is already established in the `pacman` integration test target (`tests/integration/targets/pacman/tasks/yay-become.yml`).