### PR TITLE
apt_rpm: handle `update-kernel` rc=1 when no new kernel is available

### DIFF
--- a/changelogs/fragments/11949-apt-rpm-update-kernel-no-new-kernel.yml
+++ b/changelogs/fragments/11949-apt-rpm-update-kernel-no-new-kernel.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "apt_rpm - do not fail when ``update_kernel`` finds no new kernel available (https://github.com/ansible-collections/community.general/issues/10055, https://github.com/ansible-collections/community.general/pull/11949)."

--- a/plugins/modules/apt_rpm.py
+++ b/plugins/modules/apt_rpm.py
@@ -144,6 +144,7 @@ APT_PATH = "/usr/bin/apt-get"
 RPM_PATH = "/usr/bin/rpm"
 APT_GET_ZERO = "\n0 upgraded, 0 newly installed"
 UPDATE_KERNEL_ZERO = "\nTry to install new kernel "
+UPDATE_KERNEL_NO_NEW = "There are no available kernels"
 
 
 def local_rpm_package_name(path):
@@ -233,8 +234,12 @@ def dist_upgrade(module):
 
 def update_kernel(module):
     rc, out, err = module.run_command(
-        ["/usr/sbin/update-kernel", "-y"], check_rc=True, environ_update={"LANGUAGE": "C", "LC_ALL": "C"}
+        ["/usr/sbin/update-kernel", "-y"], environ_update={"LANGUAGE": "C", "LC_ALL": "C"}
     )
+    if rc != 0:
+        if UPDATE_KERNEL_NO_NEW in err:
+            return (False, out)
+        module.fail_json(msg=err or out, rc=rc, stdout=out, stderr=err)
     return (UPDATE_KERNEL_ZERO not in out, out)
 
 

--- a/plugins/modules/apt_rpm.py
+++ b/plugins/modules/apt_rpm.py
@@ -239,7 +239,7 @@ def update_kernel(module):
     if rc != 0:
         if UPDATE_KERNEL_NO_NEW in err:
             return (False, out)
-        module.fail_json(msg=err or out, rc=rc, stdout=out, stderr=err)
+        module.fail_json(msg=f"Error while updating kernel: {err or out}", rc=rc, stdout=out, stderr=err)
     return (UPDATE_KERNEL_ZERO not in out, out)
 
 


### PR DESCRIPTION
##### SUMMARY

When `update_kernel: true` is used and the running kernel is already at the latest version, `update-kernel -y` exits with `rc=1` and prints `"There are no available kernels with kernel flavour ..."` to stderr. The module was calling it with `check_rc=True`, causing an unconditional failure in this normal situation.

Fix: drop `check_rc=True`, detect the specific "no available kernels" stderr message on `rc != 0`, and return `changed=False` instead of failing. Any other non-zero exit is still treated as an error.

Fixes #10055

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apt_rpm

##### ADDITIONAL INFORMATION

Before the fix, running with `update_kernel: true` on an already-current kernel would fail with:
```
fatal: [host]: FAILED! => {"rc": 1, "msg": "update-kernel: There are no available kernels with kernel flavour un-def", ...}
```

After the fix it returns `changed=false` and succeeds.