### PR TITLE
logstash_plugin: fix proxy support and improve error reporting

### DIFF
--- a/changelogs/fragments/11951-logstash-plugin-proxy-env-vars.yml
+++ b/changelogs/fragments/11951-logstash-plugin-proxy-env-vars.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "logstash_plugin - use ``http_proxy``/``https_proxy`` environment variables for proxy support instead of broken JVM flags; expose ``stderr`` on failure (https://github.com/ansible-collections/community.general/issues/8650, https://github.com/ansible-collections/community.general/pull/11951)."

--- a/plugins/modules/logstash_plugin.py
+++ b/plugins/modules/logstash_plugin.py
@@ -39,6 +39,10 @@ options:
     type: str
     description:
       - Proxy host to use during plugin installation.
+      - Can be specified as a hostname (for example, V(myproxy.example.com)) or as a URL (for example, V(http://myproxy.example.com)).
+        When specified without a scheme, V(http://) is assumed.
+      - Sets the O(proxy_host):O(proxy_port) combination as the E(http_proxy) and E(https_proxy) environment variables
+        when running the C(logstash-plugin) command.
   proxy_port:
     type: str
     description:
@@ -99,21 +103,24 @@ def install_plugin(module, plugin_bin, plugin_name, version, proxy_host, proxy_p
     if version:
         cmd_args.extend(["--version", version])
 
-    if proxy_host and proxy_port:
-        cmd_args.extend([f"-DproxyHost={proxy_host}", f"-DproxyPort={proxy_port}"])
-
     cmd_args.append(plugin_name)
+
+    environ_update = {}
+    if proxy_host and proxy_port:
+        scheme = proxy_host if "://" in proxy_host else f"http://{proxy_host}"
+        proxy_url = f"{scheme}:{proxy_port}"
+        environ_update = {"http_proxy": proxy_url, "https_proxy": proxy_url}
 
     cmd = " ".join(cmd_args)
 
     if module.check_mode:
         rc, out, err = 0, "check mode", ""
     else:
-        rc, out, err = module.run_command(cmd_args)
+        rc, out, err = module.run_command(cmd_args, environ_update=environ_update)
 
     if rc != 0:
         reason = parse_error(out)
-        module.fail_json(msg=reason)
+        module.fail_json(msg=reason, stderr=err)
 
     return True, cmd, out, err
 
@@ -130,7 +137,7 @@ def remove_plugin(module, plugin_bin, plugin_name):
 
     if rc != 0:
         reason = parse_error(out)
-        module.fail_json(msg=reason)
+        module.fail_json(msg=reason, stderr=err)
 
     return True, cmd, out, err
 


### PR DESCRIPTION
##### SUMMARY

Modern Logstash bundles its own JDK and no longer honours `-DproxyHost`/`-DproxyPort` JVM flags passed as CLI arguments. This PR switches the proxy implementation to set `http_proxy` and `https_proxy` environment variables when calling `logstash-plugin`, which works with all Logstash versions.

Additionally, `fail_json` previously discarded `stderr`, making it impossible to diagnose installation failures. Both `install` and `remove` paths now expose `stderr` in the failure output.

Fixes #8650

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
logstash_plugin

##### ADDITIONAL INFORMATION

`proxy_host` continues to accept both a bare hostname (e.g. `myproxy.example.com`) and a URL with scheme (e.g. `http://myproxy.example.com`); the module adds `http://` when no scheme is present.

```paste below

```