### PR TITLE
snap: add `devmode` parameter to support `--devmode` flag

### DIFF
--- a/changelogs/fragments/11952-snap-devmode.yml
+++ b/changelogs/fragments/11952-snap-devmode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - snap - add ``devmode`` option to support installing snaps in developer mode (https://github.com/ansible-collections/community.general/pull/11952, https://github.com/ansible-collections/community.general/issues/8155).

--- a/plugins/module_utils/_snap.py
+++ b/plugins/module_utils/_snap.py
@@ -47,6 +47,7 @@ def snap_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
             options=cmd_runner_fmt.as_list(),
             info=cmd_runner_fmt.as_fixed("info"),
             dangerous=cmd_runner_fmt.as_bool("--dangerous"),
+            devmode=cmd_runner_fmt.as_bool("--devmode"),
             version=cmd_runner_fmt.as_fixed("version"),
             _connect=cmd_runner_fmt.as_func(lambda v: ["connect", v]),
             _disconnect=cmd_runner_fmt.as_func(lambda v: ["disconnect", v]),

--- a/plugins/modules/snap.py
+++ b/plugins/modules/snap.py
@@ -77,6 +77,13 @@ options:
     type: bool
     default: false
     version_added: 7.2.0
+  devmode:
+    description:
+      - Install the snap in developer mode, granting the snap full system access and disabling security confinement.
+      - See U(https://snapcraft.io/docs/install-modes) for more details about installation modes.
+    type: bool
+    default: false
+    version_added: 13.0.0
 notes:
   - Privileged operations, such as installing and configuring snaps, require root priviledges. This is only the case if the
     user has not logged in to the Snap Store.
@@ -194,6 +201,7 @@ class Snap(StateModuleHelper):
             "channel": dict(type="str"),
             "options": dict(type="list", elements="str"),
             "dangerous": dict(type="bool", default=False),
+            "devmode": dict(type="bool", default=False),
         },
         supports_check_mode=True,
     )
@@ -390,7 +398,7 @@ class Snap(StateModuleHelper):
         if self.check_mode:
             return
 
-        params = ["state", "classic", "channel", "dangerous"]  # get base cmd parts
+        params = ["state", "classic", "channel", "dangerous", "devmode"]  # get base cmd parts
         has_one_pkg_params = bool(self.vars.classic) or self.vars.channel != "stable"
         has_multiple_snaps = len(actionable_snaps) > 1
 


### PR DESCRIPTION
##### SUMMARY
Adds a `devmode` boolean parameter to the `community.general.snap` module, enabling installation of snaps in developer mode (`--devmode`). This grants the snap full system access and disables security confinement.

Fixes #8155

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
snap

##### ADDITIONAL INFORMATION
The new parameter follows the same pattern as the existing `dangerous` parameter (added in 7.2.0). The `--devmode` flag is passed to `snap install` and `snap refresh` commands when `devmode: true` is set.

Example usage:
```yaml
- name: Install microstack in devmode
  community.general.snap:
    name: microstack
    devmode: true
```