### PR TITLE
supervisorctl: use parallel bulk commands when `name=all`

### DIFF
--- a/changelogs/fragments/11953-supervisorctl-parallel-all.yml
+++ b/changelogs/fragments/11953-supervisorctl-parallel-all.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - supervisorctl - when ``name=all``, dispatch a single ``supervisorctl start/stop/restart all``
+    command (https://github.com/ansible-collections/community.general/issues/8159,
+    https://github.com/ansible-collections/community.general/pull/11953).

--- a/plugins/modules/supervisorctl.py
+++ b/plugins/modules/supervisorctl.py
@@ -117,6 +117,22 @@ import os
 from ansible.module_utils.basic import AnsibleModule, is_executable
 
 
+def _is_active(status):
+    return status in ("RUNNING", "STARTING")
+
+
+def _is_not_active(status):
+    return not _is_active(status)
+
+
+def _is_strictly_running(status):
+    return status in ("RUNNING",)
+
+
+def _always(_status):
+    return True
+
+
 def main():
     arg_spec = dict(
         name=dict(type="str", required=True),
@@ -231,13 +247,31 @@ def main():
         if exit_module:
             module.exit_json(changed=True, name=name, state=state, affected=to_take_action_on)
 
+    if name == "all" and state in ("started", "stopped", "restarted"):
+        if state == "restarted":
+            run_supervisorctl("update", check_rc=True)
+        processes = get_matched_processes()
+        status_filters = {
+            "started": _is_not_active,
+            "stopped": _is_active,
+            "restarted": _always,
+        }
+        to_act_on = [p for p, s in processes if status_filters[state](s)]
+        if not to_act_on:
+            module.exit_json(changed=False, name=name, state=state)
+        if module.check_mode:
+            module.exit_json(changed=True)
+        actions = {"started": "start", "stopped": "stop", "restarted": "restart"}
+        run_supervisorctl(actions[state], "all", check_rc=True)
+        module.exit_json(changed=True, name=name, state=state, affected=to_act_on)
+
     if state == "restarted":
         rc, out, err = run_supervisorctl("update", check_rc=True)
         processes = get_matched_processes()
         if len(processes) == 0:
             module.fail_json(name=name, msg="ERROR (no such process)")
 
-        take_action_on_processes(processes, lambda s: True, "restart", "started")
+        take_action_on_processes(processes, _always, "restart", "started")
 
     processes = get_matched_processes()
 
@@ -246,9 +280,7 @@ def main():
             module.exit_json(changed=False, name=name, state=state)
 
         if stop_before_removing:
-            take_action_on_processes(
-                processes, lambda s: s in ("RUNNING", "STARTING"), "stop", "stopped", exit_module=False
-            )
+            take_action_on_processes(processes, _is_active, "stop", "stopped", exit_module=False)
 
         if module.check_mode:
             module.exit_json(changed=True)
@@ -277,13 +309,13 @@ def main():
         module.fail_json(name=name, msg="ERROR (no such process)")
 
     if state == "started":
-        take_action_on_processes(processes, lambda s: s not in ("RUNNING", "STARTING"), "start", "started")
+        take_action_on_processes(processes, _is_not_active, "start", "started")
 
     if state == "stopped":
-        take_action_on_processes(processes, lambda s: s in ("RUNNING", "STARTING"), "stop", "stopped")
+        take_action_on_processes(processes, _is_active, "stop", "stopped")
 
     if state == "signalled":
-        take_action_on_processes(processes, lambda s: s in ("RUNNING",), f"signal {signal}", "signalled")
+        take_action_on_processes(processes, _is_strictly_running, f"signal {signal}", "signalled")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### SUMMARY

When `name=all`, the module was iterating over each process individually and stopping/starting them one at a time. The `supervisorctl stop all` CLI command stops processes in parallel, so with many slow-stopping processes the module could take many times longer than the equivalent CLI invocation.

This PR dispatches a single `supervisorctl start/stop/restart all` command when `name=all` for the `started`, `stopped`, and `restarted` states, matching the CLI's parallel behaviour.

`get_matched_processes()` is still called first to preserve accurate `check_mode` support and idempotency (no-op when all processes are already in the desired state).

Also extracts the inline status-filter lambdas into named module-level functions (`_is_active`, `_is_not_active`, `_is_strictly_running`, `_always`) to avoid duplication and improve readability.

Fixes #8159

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
supervisorctl