### PR TITLE
puppet: fix `TypeError` when writing facts data

### DIFF
--- a/changelogs/fragments/11954-puppet-facts-write-error.yml
+++ b/changelogs/fragments/11954-puppet-facts-write-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - puppet - fix ``TypeError`` when writing facts data (https://github.com/ansible-collections/community.general/issues/7932, https://github.com/ansible-collections/community.general/pull/11954).

--- a/plugins/modules/puppet.py
+++ b/plugins/modules/puppet.py
@@ -204,7 +204,7 @@ def _write_structured_data(basedir, basename, data):
     # open the file with only u+rw set. Also, we use the stat constants
     # because ansible still supports python 2.4 and the octal syntax changed
     out_file = os.fdopen(os.open(file_path, os.O_CREAT | os.O_WRONLY, stat.S_IRUSR | stat.S_IWUSR), "w")
-    out_file.write(json.dumps(data).encode("utf8"))
+    out_file.write(json.dumps(data))
     out_file.close()
 
 


### PR DESCRIPTION
##### SUMMARY

`_write_structured_data()` opens the output file in text mode (`"w"`) but then called `.encode("utf8")` on the JSON string, producing `bytes` — which Python 3 rejects with `TypeError: write() argument must be str, not bytes`. This is a Python 2 → 3 migration artifact.

Fix: drop the `.encode("utf8")` call.

Fixes #7932

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
puppet

##### ADDITIONAL INFORMATION

Reproduction: pass any dict to the `facts` parameter of `community.general.puppet`. The error occurs immediately when the module tries to write the facts JSON to disk.