### PR TITLE
nmap inventory plugin: add `skip_host_discovery` option

### DIFF
--- a/changelogs/fragments/11955-nmap-skip-host-discovery.yml
+++ b/changelogs/fragments/11955-nmap-skip-host-discovery.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - nmap inventory plugin - add ``skip_host_discovery`` option to skip nmap host discovery phase (``-Pn``)
+    (https://github.com/ansible-collections/community.general/issues/7893,
+    https://github.com/ansible-collections/community.general/pull/11955).

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -95,6 +95,16 @@ options:
     type: boolean
     default: true
     version_added: 7.4.0
+  skip_host_discovery:
+    description:
+      - Skip nmap host discovery phase and treat all hosts as online (C(-Pn)).
+      - Useful when scanning remote hosts over VPN or through firewalls where nmap's default discovery probes
+        (TCP SYN to ports 80/443) are blocked but the target port is open.
+      - When V(false) (default), nmap performs host discovery before port scanning, which may send packets
+        to ports 80 and 443 regardless of the O(port) setting.
+    type: boolean
+    default: false
+    version_added: 13.0.0
   set_name_variable:
     description:
       - Set the C(name) variable for each host.
@@ -263,6 +273,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             if not self.get_option("use_arp_ping"):
                 cmd.append("--disable-arp-ping")
+
+            if self.get_option("skip_host_discovery"):
+                cmd.append("-Pn")
 
             cmd.append(self.get_option("address"))
             try:


### PR DESCRIPTION
##### SUMMARY

Adds a `skip_host_discovery` option to the `nmap` inventory plugin, which passes `-Pn` to nmap to skip the host discovery phase.

By default, nmap probes hosts for liveness before scanning ports (using TCP SYN to ports 80 and 443, among others). When scanning remote hosts over VPN or through firewalls where those ports are blocked, nmap marks the host as down and never reaches the target port — even if `port` is explicitly set. This option allows users to treat all hosts as online and skip that phase entirely.

Fixes #7893
Closes #11763

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
nmap

##### ADDITIONAL INFORMATION

Without this option, a config like:

```yaml
plugin: community.general.nmap
address: 192.168.88.194
port: 5986
```

causes nmap to send TCP SYN probes to ports 80 and 443 (host discovery), not just port 5986. The host is declared down and nothing is discovered.

With `skip_host_discovery: true`, the command becomes `nmap -p 5986 -Pn 192.168.88.194`, which scans only the specified port.

```paste below

```