### PR TITLE
nomad modules: extract common connection logic into `_nomad` module utils

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -403,6 +403,8 @@ files:
   $module_utils/_module_helper.py:
     labels: module_helper
     maintainers: russoz
+  $module_utils/_nomad.py:
+    maintainers: russoz
   $module_utils/_pritunl_api.py:
     maintainers: Lowess
   $module_utils/_pacemaker.py:

--- a/changelogs/fragments/11957-nomad-module-utils.yml
+++ b/changelogs/fragments/11957-nomad-module-utils.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "nomad_job - use ``_nomad`` module utils for common Nomad connection logic (https://github.com/ansible-collections/community.general/issues/7688, https://github.com/ansible-collections/community.general/pull/11957)."
+  - "nomad_job_info - use ``_nomad`` module utils for common Nomad connection logic (https://github.com/ansible-collections/community.general/issues/7688, https://github.com/ansible-collections/community.general/pull/11957)."
+  - "nomad_token - use ``_nomad`` module utils for common Nomad connection logic (https://github.com/ansible-collections/community.general/issues/7688, https://github.com/ansible-collections/community.general/pull/11957)."

--- a/plugins/module_utils/_nomad.py
+++ b/plugins/module_utils/_nomad.py
@@ -11,9 +11,9 @@ import typing as t
 
 from ansible_collections.community.general.plugins.module_utils import _deps as deps
 
-nomad = None
+nomad: t.Any = None
 with deps.declare("python-nomad"):
-    import nomad  # type: ignore[assignment]
+    import nomad  # type: ignore[no-redef]
 
 if t.TYPE_CHECKING:
     from ansible.module_utils.basic import AnsibleModule

--- a/plugins/module_utils/_nomad.py
+++ b/plugins/module_utils/_nomad.py
@@ -34,15 +34,15 @@ argument_spec = dict(
 def setup_nomad_client(module: AnsibleModule) -> nomad.Nomad:
     deps.validate(module)
 
-    certificate_ssl = (module.params.get("client_cert"), module.params.get("client_key"))
+    certificate_ssl = (module.params["client_cert"], module.params["client_key"])
 
     return nomad.Nomad(
-        host=module.params.get("host"),
-        port=module.params.get("port"),
-        secure=module.params.get("use_ssl"),
-        timeout=module.params.get("timeout"),
-        verify=module.params.get("validate_certs"),
+        host=module.params["host"],
+        port=module.params["port"],
+        secure=module.params["use_ssl"],
+        timeout=module.params["timeout"],
+        verify=module.params["validate_certs"],
         cert=certificate_ssl,
-        namespace=module.params.get("namespace"),
-        token=module.params.get("token"),
+        namespace=module.params["namespace"],
+        token=module.params["token"],
     )

--- a/plugins/module_utils/_nomad.py
+++ b/plugins/module_utils/_nomad.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Note that this module util is **PRIVATE** to the collection. It can have breaking changes at any time.
+# Do not use this from other collections or standalone plugins/modules!
+
+from __future__ import annotations
+
+import typing as t
+
+from ansible_collections.community.general.plugins.module_utils import _deps as deps
+
+nomad = None
+with deps.declare("python-nomad"):
+    import nomad  # type: ignore[assignment]
+
+if t.TYPE_CHECKING:
+    from ansible.module_utils.basic import AnsibleModule
+
+argument_spec = dict(
+    host=dict(required=True, type="str"),
+    port=dict(type="int", default=4646),
+    use_ssl=dict(type="bool", default=True),
+    timeout=dict(type="int", default=5),
+    validate_certs=dict(type="bool", default=True),
+    client_cert=dict(type="path"),
+    client_key=dict(type="path"),
+    namespace=dict(type="str"),
+    token=dict(type="str", no_log=True),
+)
+
+
+def setup_nomad_client(module: AnsibleModule) -> nomad.Nomad:
+    deps.validate(module)
+
+    certificate_ssl = (module.params.get("client_cert"), module.params.get("client_key"))
+
+    return nomad.Nomad(
+        host=module.params.get("host"),
+        port=module.params.get("port"),
+        secure=module.params.get("use_ssl"),
+        timeout=module.params.get("timeout"),
+        verify=module.params.get("validate_certs"),
+        cert=certificate_ssl,
+        namespace=module.params.get("namespace"),
+        token=module.params.get("token"),
+    )

--- a/plugins/modules/nomad_job.py
+++ b/plugins/modules/nomad_job.py
@@ -93,56 +93,29 @@ EXAMPLES = r"""
 
 import json
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-import_nomad = None
-try:
-    import nomad
-
-    import_nomad = True
-except ImportError:
-    import_nomad = False
+from ansible_collections.community.general.plugins.module_utils._nomad import argument_spec as nomad_argument_spec
+from ansible_collections.community.general.plugins.module_utils._nomad import nomad, setup_nomad_client
 
 
 def run():
     module = AnsibleModule(
-        argument_spec=dict(
-            host=dict(required=True, type="str"),
-            port=dict(type="int", default=4646),
-            state=dict(required=True, choices=["present", "absent"]),
-            use_ssl=dict(type="bool", default=True),
-            timeout=dict(type="int", default=5),
-            validate_certs=dict(type="bool", default=True),
-            client_cert=dict(type="path"),
-            client_key=dict(type="path"),
-            namespace=dict(type="str"),
-            name=dict(type="str"),
-            content_format=dict(choices=["hcl", "json"], default="hcl"),
-            content=dict(type="str"),
-            force_start=dict(type="bool", default=False),
-            token=dict(type="str", no_log=True),
-        ),
+        argument_spec={
+            **nomad_argument_spec,
+            "state": dict(required=True, choices=["present", "absent"]),
+            "name": dict(type="str"),
+            "content_format": dict(choices=["hcl", "json"], default="hcl"),
+            "content": dict(type="str"),
+            "force_start": dict(type="bool", default=False),
+        },
         supports_check_mode=True,
         mutually_exclusive=[["name", "content"]],
         required_one_of=[["name", "content"]],
     )
 
-    if not import_nomad:
-        module.fail_json(msg=missing_required_lib("python-nomad"))
-
-    certificate_ssl = (module.params.get("client_cert"), module.params.get("client_key"))
-
-    nomad_client = nomad.Nomad(
-        host=module.params.get("host"),
-        port=module.params.get("port"),
-        secure=module.params.get("use_ssl"),
-        timeout=module.params.get("timeout"),
-        verify=module.params.get("validate_certs"),
-        cert=certificate_ssl,
-        namespace=module.params.get("namespace"),
-        token=module.params.get("token"),
-    )
+    nomad_client = setup_nomad_client(module)
 
     if module.params.get("state") == "present":
         if module.params.get("name") and not module.params.get("force_start"):

--- a/plugins/modules/nomad_job.py
+++ b/plugins/modules/nomad_job.py
@@ -117,20 +117,19 @@ def run():
 
     nomad_client = setup_nomad_client(module)
 
-    if module.params.get("state") == "present":
-        if module.params.get("name") and not module.params.get("force_start"):
+    if module.params["state"] == "present":
+        if module.params["name"] and not module.params["force_start"]:
             module.fail_json(msg="For start job with name, force_start is needed")
 
         changed = False
-        if module.params.get("content"):
-            if module.params.get("content_format") == "json":
-                job_json = module.params.get("content")
+        if module.params["content"]:
+            if module.params["content_format"] == "json":
+                job_json = module.params["content"]
                 try:
                     job_json = json.loads(job_json)
                 except ValueError as e:
                     module.fail_json(msg=f"{e}")
-                job = dict()
-                job["job"] = job_json
+                job = {"job": job_json}
                 try:
                     job_id = job_json.get("ID")
                     if job_id is None:
@@ -147,12 +146,11 @@ def run():
                 except Exception as e:
                     module.fail_json(msg=f"{e}")
 
-            if module.params.get("content_format") == "hcl":
+            if module.params["content_format"] == "hcl":
                 try:
-                    job_hcl = module.params.get("content")
+                    job_hcl = module.params["content"]
                     job_json = nomad_client.jobs.parse(job_hcl)
-                    job = dict()
-                    job["job"] = job_json
+                    job = {"job": job_json}
                 except nomad.api.exceptions.BadRequestNomadException as err:
                     module.fail_json(msg=f"{err.nomad_resp.reason} {err.nomad_resp.text}")
                 try:
@@ -169,11 +167,10 @@ def run():
                 except Exception as e:
                     module.fail_json(msg=f"{e}")
 
-        if module.params.get("force_start"):
+        if module.params["force_start"]:
             try:
-                job = dict()
-                if module.params.get("name"):
-                    job_name = module.params.get("name")
+                if module.params["name"]:
+                    job_name = module.params["name"]
                 else:
                     job_name = job_json["Name"]
                 job_json = nomad_client.job.get_job(job_name)
@@ -182,7 +179,7 @@ def run():
                 else:
                     job_json["Status"] = "running"
                     job_json["Stop"] = False
-                    job["job"] = job_json
+                    job = {"job": job_json}
                     if not module.check_mode:
                         result = nomad_client.jobs.register_job(job)
                     else:
@@ -194,16 +191,16 @@ def run():
             except Exception as e:
                 module.fail_json(msg=f"{e}")
 
-    if module.params.get("state") == "absent":
+    if module.params["state"] == "absent":
         try:
-            if module.params.get("name") is not None:
-                job_name = module.params.get("name")
+            if module.params["name"] is not None:
+                job_name = module.params["name"]
             else:
-                if module.params.get("content_format") == "hcl":
-                    job_json = nomad_client.jobs.parse(module.params.get("content"))
+                if module.params["content_format"] == "hcl":
+                    job_json = nomad_client.jobs.parse(module.params["content"])
                     job_name = job_json["Name"]
-                if module.params.get("content_format") == "json":
-                    job_json = module.params.get("content")
+                if module.params["content_format"] == "json":
+                    job_json = module.params["content"]
                     job_name = job_json["Name"]
             job = nomad_client.job.get_job(job_name)
             if job["Status"] == "dead":

--- a/plugins/modules/nomad_job_info.py
+++ b/plugins/modules/nomad_job_info.py
@@ -262,49 +262,22 @@ result:
     ]
 """
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
 
-import_nomad = None
-try:
-    import nomad
-
-    import_nomad = True
-except ImportError:
-    import_nomad = False
+from ansible_collections.community.general.plugins.module_utils._nomad import argument_spec as nomad_argument_spec
+from ansible_collections.community.general.plugins.module_utils._nomad import setup_nomad_client
 
 
 def run():
     module = AnsibleModule(
-        argument_spec=dict(
-            host=dict(required=True, type="str"),
-            port=dict(type="int", default=4646),
-            use_ssl=dict(type="bool", default=True),
-            timeout=dict(type="int", default=5),
-            validate_certs=dict(type="bool", default=True),
-            client_cert=dict(type="path"),
-            client_key=dict(type="path"),
-            namespace=dict(type="str"),
-            name=dict(type="str"),
-            token=dict(type="str", no_log=True),
-        ),
+        argument_spec={
+            **nomad_argument_spec,
+            "name": dict(type="str"),
+        },
         supports_check_mode=True,
     )
 
-    if not import_nomad:
-        module.fail_json(msg=missing_required_lib("python-nomad"))
-
-    certificate_ssl = (module.params.get("client_cert"), module.params.get("client_key"))
-
-    nomad_client = nomad.Nomad(
-        host=module.params.get("host"),
-        port=module.params.get("port"),
-        secure=module.params.get("use_ssl"),
-        timeout=module.params.get("timeout"),
-        verify=module.params.get("validate_certs"),
-        cert=certificate_ssl,
-        namespace=module.params.get("namespace"),
-        token=module.params.get("token"),
-    )
+    nomad_client = setup_nomad_client(module)
 
     changed = False
     result = list()

--- a/plugins/modules/nomad_job_info.py
+++ b/plugins/modules/nomad_job_info.py
@@ -288,11 +288,11 @@ def run():
     except Exception as e:
         module.fail_json(msg=f"{e}")
 
-    if module.params.get("name"):
+    if module.params["name"]:
         filter = list()
         try:
             for job in result:
-                if job.get("ID") == module.params.get("name"):
+                if job.get("ID") == module.params["name"]:
                     filter.append(job)
                     result = filter
             if not filter:

--- a/plugins/modules/nomad_token.py
+++ b/plugins/modules/nomad_token.py
@@ -118,16 +118,10 @@ result:
     }
 """
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
 
-import_nomad = None
-
-try:
-    import nomad
-
-    import_nomad = True
-except ImportError:
-    import_nomad = False
+from ansible_collections.community.general.plugins.module_utils._nomad import argument_spec as nomad_argument_spec
+from ansible_collections.community.general.plugins.module_utils._nomad import nomad, setup_nomad_client
 
 
 def get_token(name, nomad_client):
@@ -156,22 +150,14 @@ def transform_response(nomad_response):
     return transformed_response
 
 
-argument_spec = dict(
-    host=dict(required=True, type="str"),
-    port=dict(type="int", default=4646),
-    state=dict(required=True, choices=["present", "absent"]),
-    use_ssl=dict(type="bool", default=True),
-    timeout=dict(type="int", default=5),
-    validate_certs=dict(type="bool", default=True),
-    client_cert=dict(type="path"),
-    client_key=dict(type="path"),
-    namespace=dict(type="str"),
-    token=dict(type="str", no_log=True),
-    name=dict(type="str"),
-    token_type=dict(choices=["client", "management", "bootstrap"], default="client"),
-    policies=dict(type="list", elements="str", default=[]),
-    global_replicated=dict(type="bool", default=False),
-)
+argument_spec = {
+    **nomad_argument_spec,
+    "state": dict(required=True, choices=["present", "absent"]),
+    "name": dict(type="str"),
+    "token_type": dict(choices=["client", "management", "bootstrap"], default="client"),
+    "policies": dict(type="list", elements="str", default=[]),
+    "global_replicated": dict(type="bool", default=False),
+}
 
 
 def setup_module_object():
@@ -185,26 +171,6 @@ def setup_module_object():
         ],
     )
     return module
-
-
-def setup_nomad_client(module):
-    if not import_nomad:
-        module.fail_json(msg=missing_required_lib("python-nomad"))
-
-    certificate_ssl = (module.params.get("client_cert"), module.params.get("client_key"))
-
-    nomad_client = nomad.Nomad(
-        host=module.params.get("host"),
-        port=module.params.get("port"),
-        secure=module.params.get("use_ssl"),
-        timeout=module.params.get("timeout"),
-        verify=module.params.get("validate_certs"),
-        cert=certificate_ssl,
-        namespace=module.params.get("namespace"),
-        token=module.params.get("token"),
-    )
-
-    return nomad_client
 
 
 def run(module):

--- a/plugins/modules/nomad_token.py
+++ b/plugins/modules/nomad_token.py
@@ -179,8 +179,8 @@ def run(module):
     msg = ""
     result = {}
     changed = False
-    if module.params.get("state") == "present":
-        if module.params.get("token_type") == "bootstrap":
+    if module.params["state"] == "present":
+        if module.params["token_type"] == "bootstrap":
             try:
                 current_token = get_token("Bootstrap Token", nomad_client)
                 if current_token:
@@ -203,10 +203,10 @@ def run(module):
         else:
             try:
                 token_info = {
-                    "Name": module.params.get("name"),
-                    "Type": module.params.get("token_type"),
-                    "Policies": module.params.get("policies"),
-                    "Global": module.params.get("global_replicated"),
+                    "Name": module.params["name"],
+                    "Type": module.params["token_type"],
+                    "Policies": module.params["policies"],
+                    "Global": module.params["global_replicated"],
                 }
 
                 current_token = get_token(token_info["Name"], nomad_client)
@@ -227,15 +227,15 @@ def run(module):
             except Exception as e:
                 module.fail_json(msg=f"{e}")
 
-    if module.params.get("state") == "absent":
-        if not module.params.get("name"):
+    if module.params["state"] == "absent":
+        if not module.params["name"]:
             module.fail_json(msg="name is needed to delete token.")
 
-        if module.params.get("token_type") == "bootstrap" or module.params.get("name") == "Bootstrap Token":
+        if module.params["token_type"] == "bootstrap" or module.params["name"] == "Bootstrap Token":
             module.fail_json(msg="Delete ACL bootstrap token is not allowed.")
 
         try:
-            token = get_token(module.params.get("name"), nomad_client)
+            token = get_token(module.params["name"], nomad_client)
             if token:
                 nomad_client.acl.delete_token(token.get("AccessorID"))
                 msg = "ACL token deleted."


### PR DESCRIPTION
##### SUMMARY
Extracts the duplicated Nomad client connection logic (argument spec, `python-nomad` import guard, and `nomad.Nomad(...)` construction) into a new private module util `plugins/module_utils/_nomad.py`, shared by all three Nomad modules.

Uses `_deps` for the `python-nomad` import guard instead of the old ad-hoc `try/except` pattern.

Fixes #7688

##### ISSUE TYPE
- Refactoring Pull Request

##### COMPONENT NAME
nomad_job
nomad_job_info
nomad_token

##### ADDITIONAL INFORMATION

```paste below

```