### PR TITLE
onepassword: add support for secret references

### DIFF
--- a/changelogs/fragments/11958-support-op-secret-references.yml
+++ b/changelogs/fragments/11958-support-op-secret-references.yml
@@ -1,2 +1,2 @@
 minor_changes:
-    - onepassword - add support for `op://` secret references in the OnePassword lookup plugin (https://github.com/ansible-collections/community.general/pull/11958).
+    - onepassword - add support for ``op://`` secret references in the OnePassword lookup plugin (https://github.com/ansible-collections/community.general/issues/7586, https://github.com/ansible-collections/community.general/pull/11958).

--- a/changelogs/fragments/11958-support-op-secret-references.yml
+++ b/changelogs/fragments/11958-support-op-secret-references.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - onepassword - add support for `op://` secret references in the OnePassword lookup plugin (https://github.com/ansible-collections/community.general/pull/11958).

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -19,8 +19,9 @@ requirements:
   - C(op) 1Password command line utility
 options:
   _terms:
-      - description: Identifier(s) (case-insensitive UUID or name or secret reference) of item(s) to retrieve.
-      - description: Secret references start with V(op://) and are supported since community.general 13.0.0.
+    description:
+      - Identifier(s) (case-insensitive UUID or name or secret reference) of item(s) to retrieve.
+      - Secret references start with V(op://) and are supported since community.general 13.0.0.
     required: true
     type: list
     elements: string
@@ -29,8 +30,9 @@ options:
   domain:
     version_added: 3.2.0
   field:
-    - description: Field to return from each matching item (case-insensitive).
-    - description: Ignored when using a secret reference, as the field is included in the secret reference.
+    description:
+      - Field to return from each matching item (case-insensitive).
+      - Ignored when using a secret reference, as the field is included in the secret reference.
     default: 'password'
     type: str
   service_account_token:

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -348,6 +348,11 @@ class OnePassCLIv1(OnePassCLIBase):
 
         return self._run(args, command_input=to_bytes(self.master_password))
 
+    def get_secret_reference(self, reference):
+        raise AnsibleLookupError(
+            "Secret references are not supported in op v1. Upgrade to op v2 or use item names/UUIDs"
+        )
+
 
 class OnePassCLIv2(OnePassCLIBase):
     """
@@ -580,6 +585,10 @@ class OnePassCLIv2(OnePassCLIBase):
         args = ["item", "get", item_id, "--format", "json"]
         return self._add_parameters_and_run(args, vault=vault, token=token)
 
+    def get_secret_reference(self, reference, token=None):
+        args = ["read", reference]
+        return self._add_parameters_and_run(args, token=token)
+
     def signin(self):
         self._check_required_params(["master_password"])
 
@@ -700,6 +709,20 @@ class OnePass:
 
         return ""
 
+    def get_secret_reference(self, reference):
+        path = reference[5:]
+        if not path:
+            raise AnsibleLookupError("Secret references must have a path")
+        # Split into parts, to check length in a second
+        path_parts = [part for part in path.split("/") if part]
+
+        # Must be 3 parts (vault,item,field) or 4(vault,item,section,field)
+        if len(path_parts) not in [3, 4]:
+            raise AnsibleLookupError("Not a valid secret reference")
+
+        rc, out, err = self._cli.get_secret_reference(reference, self.token)
+        return out.strip()
+
 
 class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
@@ -733,6 +756,9 @@ class LookupModule(LookupBase):
 
         values = []
         for term in terms:
-            values.append(op.get_field(term, field, section, vault))
+            if term.startswith("op://"):
+                values.append(op.get_secret_reference(term))
+            else:
+                values.append(op.get_field(term, field, section, vault))
 
         return values

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -19,7 +19,8 @@ requirements:
   - C(op) 1Password command line utility
 options:
   _terms:
-    description: Identifier(s) (case-insensitive UUID or name) of item(s) to retrieve.
+      - description: Identifier(s) (case-insensitive UUID or name or secret reference) of item(s) to retrieve.
+      - description: Secret references start with V(op://) and are supported since community.general 13.0.0.
     required: true
     type: list
     elements: string
@@ -28,7 +29,8 @@ options:
   domain:
     version_added: 3.2.0
   field:
-    description: Field to return from each matching item (case-insensitive).
+    - description: Field to return from each matching item (case-insensitive).
+    - description: Ignored when using a secret reference, as the field is included in the secret reference.
     default: 'password'
     type: str
   service_account_token:
@@ -716,8 +718,8 @@ class OnePass:
         # Split into parts, to check length in a second
         path_parts = [part for part in path.split("/") if part]
 
-        # Must be 3 parts (vault,item,field) or 4(vault,item,section,field)
-        if len(path_parts) not in [3, 4]:
+        # Must be 3 parts (vault,item,field) or 4 (vault,item,section,field)
+        if len(path_parts) not in (3, 4):
             raise AnsibleLookupError("Not a valid secret reference")
 
         rc, out, err = self._cli.get_secret_reference(reference, self.token)


### PR DESCRIPTION
Disclaimer: I'm a 1Password employee, this was done on my own time. 

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support for 1Password secret references. Fixes #7586

Changelog fragment to come. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

onepassword

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Some other thoughts: 

1Password CLI version 1 is [completely deprecated](https://developer.1password.com/docs/cli/upgrade/#about-1password-cli-2), and will always return a "No longer supported". It may be worth removing the v1 code paths here. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
PLAY [Test secret reference] ****************************************************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************************************************************
ok: [localhost]

TASK [Secret reference] *********************************************************************************************************************************************************
ok: [localhost] => {
    "lookup('community.general.onepassword', 'op://Secrets/Demo Ansible/credential')": "hunter2"
}

TASK [name / vault] *************************************************************************************************************************************************************
ok: [localhost] => {
    "lookup('community.general.onepassword', 'Demo Ansible', vault='Secrets', field='credential')": "hunter2"
}

PLAY RECAP **********************************************************************************************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
