### PR TITLE
ssh_config: Add AddressFamily

### DIFF
--- a/changelogs/fragments/11968-ssh_config_add_addressfamily.yml
+++ b/changelogs/fragments/11968-ssh_config_add_addressfamily.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "ssh_config: added support for the ``AddressFamily`` option, allowing users to specify the address family (IPv4, IPv6, or any) for SSH connections (https://github.com/ansible-collections/community.general/pull/11968)."

--- a/changelogs/fragments/11968-ssh_config_add_addressfamily.yml
+++ b/changelogs/fragments/11968-ssh_config_add_addressfamily.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "ssh_config: added support for the ``AddressFamily`` option, allowing users to specify the address family (IPv4, IPv6, or any) for SSH connections (https://github.com/ansible-collections/community.general/pull/11968)."
+  - "ssh_config: add support for the ``AddressFamily`` option, allowing users to specify the address family (IPv4, IPv6, or any) for SSH connections (https://github.com/ansible-collections/community.general/pull/11968)."

--- a/changelogs/fragments/11968-ssh_config_add_addressfamily.yml
+++ b/changelogs/fragments/11968-ssh_config_add_addressfamily.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "ssh_config: add support for the ``AddressFamily`` option, allowing users to specify the address family (IPv4, IPv6, or any) for SSH connections (https://github.com/ansible-collections/community.general/pull/11968)."
+  - "ssh_config - add support for the ``AddressFamily`` option, allowing users to specify the address family (IPv4, IPv6, or any) for SSH connections (https://github.com/ansible-collections/community.general/pull/11968)."

--- a/changelogs/fragments/11968-ssh_config_add_addressfamily.yml
+++ b/changelogs/fragments/11968-ssh_config_add_addressfamily.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "ssh_config - add support for the ``AddressFamily`` option, allowing users to specify the address family (IPv4, IPv6, or any) for SSH connections (https://github.com/ansible-collections/community.general/pull/11968)."
+  - "ssh_config - add support for the ``AddressFamily`` option (https://github.com/ansible-collections/community.general/pull/11968)."

--- a/changelogs/fragments/ssh_config_add_addressfamily.yml
+++ b/changelogs/fragments/ssh_config_add_addressfamily.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - "ssh_config: added support for the ``AddressFamily`` option, allowing users to specify the address family (IPv4, IPv6, or any) for SSH connections (https://github.com/ansible-collections/community.general/pull/XXXX)."

--- a/changelogs/fragments/ssh_config_add_addressfamily.yml
+++ b/changelogs/fragments/ssh_config_add_addressfamily.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ssh_config: Added support for the `AddressFamily` option, allowing users to specify the address family (IPv4, IPv6, or any) for SSH connections.
+  - ssh_config: added support for the `AddressFamily` option, allowing users to specify the address family (IPv4, IPv6, or any) for SSH connections (https://github.com/ansible-collections/community.general/pull/XXXX).

--- a/changelogs/fragments/ssh_config_add_addressfamily.yml
+++ b/changelogs/fragments/ssh_config_add_addressfamily.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ssh_config: Added support for the `AddressFamily` option, allowing users to specify the address family (IPv4, IPv6, or any) for SSH connections.

--- a/changelogs/fragments/ssh_config_add_addressfamily.yml
+++ b/changelogs/fragments/ssh_config_add_addressfamily.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ssh_config: added support for the `AddressFamily` option, allowing users to specify the address family (IPv4, IPv6, or any) for SSH connections (https://github.com/ansible-collections/community.general/pull/XXXX).
+  - "ssh_config: added support for the ``AddressFamily`` option, allowing users to specify the address family (IPv4, IPv6, or any) for SSH connections (https://github.com/ansible-collections/community.general/pull/XXXX)."

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -301,7 +301,7 @@ class SSHConfig:
             controlpath=self.params.get("controlpath"),
             controlpersist=fix_bool_str(self.params.get("controlpersist")),
             dynamicforward=self.params.get("dynamicforward"),
-            address_family=self.params.get('address_family'),
+            address_family=self.params.get("address_family"),
         )
         if self.params.get("other_options"):
             for key, value in self.params.get("other_options").items():
@@ -421,7 +421,7 @@ def main():
             dynamicforward=dict(type="str"),
             user=dict(type="str"),
             user_known_hosts_file=dict(type="str"),
-            address_family=dict(type='str', default=None),
+            address_family=dict(type="str", default=None),
         ),
         supports_check_mode=True,
         mutually_exclusive=[

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -147,7 +147,7 @@ options:
     description:
       - Sets the C(AddressFamily) option.
     type: str
-    version_added: 10.4.0
+    version_added: 13.0.0
 requirements:
   - paramiko
 """
@@ -421,7 +421,7 @@ def main():
             dynamicforward=dict(type="str"),
             user=dict(type="str"),
             user_known_hosts_file=dict(type="str"),
-            address_family=dict(type="str", default=None),
+            address_family=dict(type="str"),
         ),
         supports_check_mode=True,
         mutually_exclusive=[

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -143,6 +143,11 @@ options:
       - The values must be strings. Other values are rejected.
     type: dict
     version_added: 10.4.0
+  address_family:
+    description:
+      - Sets the C(AddressFamily) option.
+    type: str
+    version_added: 10.4.0
 requirements:
   - paramiko
 """
@@ -296,6 +301,7 @@ class SSHConfig:
             controlpath=self.params.get("controlpath"),
             controlpersist=fix_bool_str(self.params.get("controlpersist")),
             dynamicforward=self.params.get("dynamicforward"),
+            address_family=self.params.get('address_family'),
         )
         if self.params.get("other_options"):
             for key, value in self.params.get("other_options").items():
@@ -415,6 +421,7 @@ def main():
             dynamicforward=dict(type="str"),
             user=dict(type="str"),
             user_known_hosts_file=dict(type="str"),
+            address_family=dict(type='str', default=None),
         ),
         supports_check_mode=True,
         mutually_exclusive=[

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -146,6 +146,7 @@ options:
   address_family:
     description:
       - Sets the C(AddressFamily) option.
+    choices: ['any', 'inet', 'inet6']
     type: str
     version_added: 13.0.0
 requirements:
@@ -421,7 +422,7 @@ def main():
             dynamicforward=dict(type="str"),
             user=dict(type="str"),
             user_known_hosts_file=dict(type="str"),
-            address_family=dict(type="str"),
+            address_family=dict(type="str", choices=["any", "inet", "inet6"]),
         ),
         supports_check_mode=True,
         mutually_exclusive=[

--- a/tests/integration/targets/ssh_config/tasks/options.yml
+++ b/tests/integration/targets/ssh_config/tasks/options.yml
@@ -24,6 +24,7 @@
     dynamicforward: '10080'
     other_options:
       serveraliveinterval: '30'
+    address_family: "inet"
     state: present
   register: options_add
   check_mode: true
@@ -61,6 +62,7 @@
     dynamicforward: '10080'
     other_options:
       serveraliveinterval: '30'
+    address_family: "inet"
     state: present
   register: options_add
 
@@ -87,6 +89,7 @@
     dynamicforward: '10080'
     other_options:
       serveraliveinterval: '30'
+    address_family: "inet"
     state: present
   register: options_add_again
 
@@ -116,6 +119,7 @@
       - "'controlpersist yes' in slurp_ssh_config['content'] | b64decode"
       - "'dynamicforward 10080' in slurp_ssh_config['content'] | b64decode"
       - "'serveraliveinterval 30' in slurp_ssh_config['content'] | b64decode"
+      - "'addressfamily inet' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Update host
   community.general.ssh_config:
@@ -132,6 +136,7 @@
     dynamicforward: '11080'
     other_options:
       serveraliveinterval: '30'
+    address_family: "inet6"
     state: present
   register: options_update
 
@@ -160,6 +165,7 @@
     dynamicforward: '11080'
     other_options:
       serveraliveinterval: '30'
+    address_family: "inet6"
     state: present
   register: options_update
 
@@ -190,6 +196,7 @@
       - "'controlpersist 600' in slurp_ssh_config['content'] | b64decode"
       - "'dynamicforward 11080' in slurp_ssh_config['content'] | b64decode"
       - "'serveraliveinterval 30' in slurp_ssh_config['content'] | b64decode"
+      - "'addressfamily inet6' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Ensure no update in case option exist in ssh_config file but wasn't defined in playbook
   community.general.ssh_config:
@@ -225,6 +232,7 @@
       - "'controlpersist 600' in slurp_ssh_config['content'] | b64decode"
       - "'dynamicforward 11080' in slurp_ssh_config['content'] | b64decode"
       - "'serveraliveinterval 30' in slurp_ssh_config['content'] | b64decode"
+      - "'addressfamily inet6' in slurp_ssh_config['content'] | b64decode"
 
 - name: Debug
   debug:
@@ -278,6 +286,7 @@
       - "'controlpersist yes' not in slurp_ssh_config['content'] | b64decode"
       - "'dynamicforward 10080' not in slurp_ssh_config['content'] | b64decode"
       - "'serveraliveinterval 30' not in slurp_ssh_config['content'] | b64decode"
+      - "'addressfamily inet' not in slurp_ssh_config['content'] | b64decode"
 
 # Proxycommand and ProxyJump are mutually exclusive.
 # Reset ssh_config before testing options with proxyjump
@@ -302,6 +311,7 @@
     dynamicforward: '10080'
     other_options:
       serveraliveinterval: '30'
+    address_family: "inet"
     state: present
   register: options_add
   check_mode: true
@@ -339,6 +349,7 @@
     dynamicforward: '10080'
     other_options:
       serveraliveinterval: '30'
+    address_family: "inet"
     state: present
   register: options_add
 
@@ -365,6 +376,7 @@
     dynamicforward: '10080'
     other_options:
       serveraliveinterval: '30'
+    address_family: "inet"
     state: present
   register: options_add_again
 
@@ -394,6 +406,7 @@
       - "'controlpersist yes' in slurp_ssh_config['content'] | b64decode"
       - "'dynamicforward 10080' in slurp_ssh_config['content'] | b64decode"
       - "'serveraliveinterval 30' in slurp_ssh_config['content'] | b64decode"
+      - "'addressfamily inet' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Update host
   community.general.ssh_config:
@@ -410,6 +423,7 @@
     dynamicforward: '11080'
     other_options:
       serveraliveinterval: '30'
+    address_family: "inet6"
     state: present
   register: options_update
 
@@ -438,6 +452,7 @@
     dynamicforward: '11080'
     other_options:
       serveraliveinterval: '30'
+    address_family: "inet6"
     state: present
   register: options_update
 
@@ -468,6 +483,7 @@
       - "'controlpersist 600' in slurp_ssh_config['content'] | b64decode"
       - "'dynamicforward 11080' in slurp_ssh_config['content'] | b64decode"
       - "'serveraliveinterval 30' in slurp_ssh_config['content'] | b64decode"
+      - "'addressfamily inet6' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Ensure no update in case option exist in ssh_config file but wasn't defined in playbook
   community.general.ssh_config:
@@ -503,6 +519,7 @@
       - "'controlpersist 600' in slurp_ssh_config['content'] | b64decode"
       - "'dynamicforward 11080' in slurp_ssh_config['content'] | b64decode"
       - "'serveraliveinterval 30' in slurp_ssh_config['content'] | b64decode"
+      - "'addressfamily inet6' in slurp_ssh_config['content'] | b64decode"
 
 - name: Debug
   debug:
@@ -556,3 +573,4 @@
       - "'controlpersist yes' not in slurp_ssh_config['content'] | b64decode"
       - "'dynamicforward 10080' not in slurp_ssh_config['content'] | b64decode"
       - "'serveraliveinterval 30' not in slurp_ssh_config['content'] | b64decode"
+      - "'addressfamily inet' not in slurp_ssh_config['content'] | b64decode"


### PR DESCRIPTION
##### SUMMARY
This pull request adds support for the `AddressFamily` option in `ssh_config`, allowing users to specify the address family (IPv4, IPv6, or any) for the given SSH host.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ssh_config

##### ADDITIONAL INFORMATION
This change introduces a new feature to enhance SSH configuration. The `AddressFamily` option is used to specify the IP address family to be used for connecting the the specified host.

Example:
```yaml
    - name: SSH configuration
      community.general.ssh_config:
        user: alice
        host: "example.com"
        hostname: "example.com"
        address_family: inet6
        state: present
```
