### PR TITLE
odbc: fetch rows before commit to fix HY010 function sequence error

### DIFF
--- a/changelogs/fragments/11972-odbc-fix-commit-fetch-order.yml
+++ b/changelogs/fragments/11972-odbc-fix-commit-fetch-order.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - odbc - fetch rows before committing to fix ``HY010`` function sequence error (https://github.com/ansible-collections/community.general/issues/5395, https://github.com/ansible-collections/community.general/pull/11972).

--- a/plugins/modules/odbc.py
+++ b/plugins/modules/odbc.py
@@ -132,8 +132,6 @@ def main():
             cursor.execute(query, params)
         else:
             cursor.execute(query)
-        if commit:
-            cursor.commit()
         try:
             # Get the rows out into an 2d array
             for row in cursor.fetchall():
@@ -158,6 +156,8 @@ def main():
         except Exception as e:
             module.fail_json(msg=f"Exception while reading rows: {e}")
 
+        if commit:
+            cursor.commit()
         cursor.close()
     except Exception as e:
         module.fail_json(msg=f"Failed to execute query: {e}")


### PR DESCRIPTION
##### SUMMARY

When a query returns a result set (e.g. `INSERT INTO ... OUTPUT ... VALUES ...`), the module was calling `cursor.commit()` before `cursor.fetchall()`. This invalidates the cursor state, causing pyodbc to raise `HY010 Function sequence error`.

Fix: move `cursor.commit()` to after the fetch block, so rows are read while the cursor is still in a valid state.

Fixes #5395

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
odbc

##### ADDITIONAL INFORMATION

```paste below

```