### PR TITLE
Docs: ohai examples are not YAML

### DIFF
--- a/plugins/modules/ohai.py
+++ b/plugins/modules/ohai.py
@@ -28,6 +28,8 @@ author:
 """
 
 EXAMPLES = r"""
+# fmt: console
+
 ansible webservers -m ohai --tree=/tmp/ohaidata
 ...
 """


### PR DESCRIPTION
##### SUMMARY
The correct way to declare non-YAML `EXAMPLES` is using `# fmt: xxx`.

Ref: https://github.com/ansible/ansible-lint/issues/5037
Ref: https://github.com/ansible/ansible/pull/71184

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ohai
