### PR TITLE
Add ansible-lint to CI

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,36 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+skip_list:
+  # Ignore rules that make no sense:
+  - galaxy[tags]
+  - galaxy[version-incorrect]
+  - meta-runtime[unsupported-version]
+  - no-changed-when
+  - sanity[cannot-ignore]  # some of the rules you cannot ignore actually MUST be ignored, like yamllint:unparsable-with-libyaml
+  - yaml  # we're using yamllint ourselves
+  - var-naming[no-role-prefix]
+
+  # To be checked and maybe fixed:
+  - args
+  - avoid-implicit
+  - command-instead-of-module
+  - command-instead-of-shell
+  - complexity
+  - fqcn
+  - galaxy
+  - ignore-errors
+  - jinja
+  - key-order
+  - latest
+  - literal-compare
+  - name
+  - no-free-form
+  - no-handler
+  - package-latest
+  - risky-file-permissions
+  - risky-shell-pipe
+  - schema
+  - var-naming

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -34,3 +34,15 @@ skip_list:
   - risky-shell-pipe
   - schema
   - var-naming
+
+exclude_paths:
+  # Ansible-lint uses "ansible-playbook --syntax-check" as its "syntax check",
+  # which bails out on roles it cannot find. The following playbooks are 100% valid,
+  # but we need to skip them due to ansible-lint's syntax check's deficiencies...
+  - tests/integration/targets/filter_hashids/runme.yml
+  - tests/integration/targets/filter_jc/runme.yml
+  - tests/integration/targets/filter_json_patch/runme.yml
+  - tests/integration/targets/filter_json_query/runme.yml
+  - tests/integration/targets/lookup_etcd3/dependencies.yml
+  - tests/integration/targets/lookup_etcd3/test_lookup_etcd3.yml
+  - tests/integration/targets/test_fqdn_valid/runme.yml

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -115,6 +115,8 @@ doc_fragment = "community.general._scaleway.actiongroup_scaleway"
 [sessions.build_import_check]
 run_galaxy_importer = true
 
+[sessions.ansible_lint]
+
 [sessions.ansible_test_sanity]
 include_devel = true
 

--- a/tests/integration/targets/connection/test_connection.yml
+++ b/tests/integration/targets/connection/test_connection.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- hosts: "{{ target_hosts }}"
+- hosts: "{{ target_hosts | default('you need to specify target_hosts!') }}"
   gather_facts: false
   serial: 1
   tasks:
@@ -22,7 +22,8 @@
     ### copy local file with unicode filename and content
 
     - name: create local file with unicode filename and content
-      local_action: lineinfile dest={{ local_tmp }}-汉语/汉语.txt create=true line=汉语
+      lineinfile: dest={{ local_tmp }}-汉语/汉语.txt create=true line=汉语
+      delegate_to: localhost
     - name: remove remote file with unicode filename and content
       action: "{{ action_prefix }}file path={{ remote_tmp }}-汉语/汉语.txt state=absent"
     - name: create remote directory with unicode name
@@ -33,14 +34,16 @@
     ### fetch remote file with unicode filename and content
 
     - name: remove local file with unicode filename and content
-      local_action: file path={{ local_tmp }}-汉语/汉语.txt state=absent
+      file: path={{ local_tmp }}-汉语/汉语.txt state=absent
+      delegate_to: localhost
     - name: fetch remote file with unicode filename and content
       fetch: src={{ remote_tmp }}-汉语/汉语.txt dest={{ local_tmp }}-汉语/汉语.txt fail_on_missing=true validate_checksum=true flat=true
 
     ### remove local and remote temp files
 
     - name: remove local temp file
-      local_action: file path={{ local_tmp }}-汉语 state=absent
+      file: path={{ local_tmp }}-汉语 state=absent
+      delegate_to: localhost
     - name: remove remote temp file
       action: "{{ action_prefix }}file path={{ remote_tmp }}-汉语 state=absent"
 

--- a/tests/integration/targets/connection_wsl/plugin-specific-tests.yml
+++ b/tests/integration/targets/connection_wsl/plugin-specific-tests.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- hosts: "{{ target_hosts }}"
+- hosts: "{{ target_hosts | default('you need to specify target_hosts!') }}"
   gather_facts: false
   tasks:
     - name: create file without content


### PR DESCRIPTION
##### SUMMARY
Add ansible-lint to CI.

Doesn't yet work because `syntax-check` reports non-syntax errors as syntax errors and isn't skipable, and because of https://github.com/ansible/ansible-lint/issues/5037.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
