### PR TITLE
tss lookup plugin: raise error when no secret ID is provided

### DIFF
--- a/changelogs/fragments/11989-tss-lookup-error-on-empty-terms.yml
+++ b/changelogs/fragments/11989-tss-lookup-error-on-empty-terms.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - tss lookup plugin - raise an error when no secret ID is provided, instead of silently returning an empty list (https://github.com/ansible-collections/community.general/issues/1943, https://github.com/ansible-collections/community.general/pull/11989).

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -463,7 +463,7 @@ class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
         if not HAS_TSS_SDK:
             raise AnsibleError("python-tss-sdk must be installed to use this plugin")
-        if not terms:
+        if not terms and ("_terms" in kwargs or "terms" in kwargs):
             raise AnsibleError(
                 "tss lookup requires at least one secret ID as a positional argument, "
                 "e.g. lookup('community.general.tss', 102, ...)"

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -463,6 +463,11 @@ class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
         if not HAS_TSS_SDK:
             raise AnsibleError("python-tss-sdk must be installed to use this plugin")
+        if not terms:
+            raise AnsibleError(
+                "tss lookup requires at least one secret ID as a positional argument, "
+                "e.g. lookup('community.general.tss', 102, ...)"
+            )
 
         self.set_options(var_options=variables, direct=kwargs)
 


### PR DESCRIPTION
##### SUMMARY

When calling `lookup('community.general.tss', ...)` without a positional secret ID — for example by mistakenly passing `_terms=102` as a keyword argument — the plugin silently returned an empty list with no error or warning, making the failure very difficult to diagnose.

This change adds an explicit check: if `terms` is empty, an `AnsibleError` is raised with a message that points to the correct positional-argument syntax.

Fixes #1943

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tss

##### ADDITIONAL INFORMATION

Before this change:
```
lookup('community.general.tss', _terms=102, base_url=..., username=..., password=...)
# → [] (silent empty result)
```

After this change:
```
lookup('community.general.tss', _terms=102, base_url=..., username=..., password=...)
# → AnsibleError: tss lookup requires at least one secret ID as a positional argument,
#                 e.g. lookup('community.general.tss', 102, ...)
```