### PR TITLE
ldap_attrs: fix case-insensitive attribute lookup in `state=exact`

### DIFF
--- a/changelogs/fragments/11990-ldap-attrs-case-insensitive-attr-lookup.yml
+++ b/changelogs/fragments/11990-ldap-attrs-case-insensitive-attr-lookup.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ldap_attrs - fix ``state=exact`` incorrectly issuing ``MOD_ADD`` instead of ``MOD_REPLACE`` for attributes returned by the server with different casing (https://github.com/ansible-collections/community.general/issues/1624, https://github.com/ansible-collections/community.general/pull/11990).

--- a/plugins/modules/ldap_attrs.py
+++ b/plugins/modules/ldap_attrs.py
@@ -347,7 +347,8 @@ class LdapAttrs(LdapGeneric):
                 results = self.connection.search_s(self.dn, ldap.SCOPE_BASE, attrlist=[name])
             except ldap.LDAPError as e:
                 self.fail(f"Cannot search for attribute {name}", e)
-            self._cached_values[lc_name] = results[0][1].get(name, [])
+            attrs = results[0][1]
+            self._cached_values[lc_name] = next((v for k, v in attrs.items() if k.lower() == lc_name), [])
         return self._cached_values[lc_name]
 
     def _is_value_absent(self, name, value):


### PR DESCRIPTION
##### SUMMARY

LDAP attribute names are case-insensitive (RFC 4512), but `_get_all_values_of` used a case-sensitive dict lookup on the LDAP server's response. When the server returns an attribute name with different casing than requested, the lookup silently returns `[]`. In `state=exact`, an empty `current` list causes the code to issue `MOD_ADD` instead of `MOD_REPLACE`, which fails with "cannot add a value to single valued attribute" on any single-valued attribute that already has a value.

Fix: replace the case-sensitive `.get(name, [])` with a case-insensitive scan over the result dict keys.

Fixes #1624

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ldap_attrs