### PR TITLE
uptimerobot: deprecate module

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1090,6 +1090,10 @@ plugin_routing:
       tombstone:
         removal_version: 13.0.0
         warning_text: The typetalk service will be discontinued on Dec 2025.
+    uptimerobot:
+      deprecation:
+        removal_version: 15.0.0
+        warning_text: The module uses the Uptime Robot API v1, which was retired and is no longer available. Use the Uptime Robot API v3 directly with the ansible.builtin.uri module.
     vertica_facts:
       tombstone:
         removal_version: 3.0.0

--- a/plugins/modules/uptimerobot.py
+++ b/plugins/modules/uptimerobot.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 DOCUMENTATION = r"""
 module: uptimerobot
 short_description: Pause and start Uptime Robot monitoring
+deprecated:
+  removed_in: 15.0.0
+  why: The module uses the Uptime Robot API v1, which was retired and is no longer available.
+  alternative: Use the Uptime Robot API v3 directly with the M(ansible.builtin.uri) module.
 description:
   - This module lets you start and pause Uptime Robot Monitoring.
 author: "Nate Kingsley (@nate-kingsley)"


### PR DESCRIPTION
##### SUMMARY
Deprecates the `community.general.uptimerobot` module because it uses the Uptime Robot API v1, which was retired and is no longer available. The API endpoint now responds with a message directing users to API v3.

Fixes #7190

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
uptimerobot

##### ADDITIONAL INFORMATION
The module hardcodes `https://api.uptimerobot.com/` as the base URL, which now returns:
```
{"message":"Please use API v3 (https://uptimerobot.com/api/)"}
```
The v1 API was retired in 2017 and the endpoint was fully removed, causing the `AttributeError: 'NoneType' object has no attribute 'read'` reported in the issue. The module is deprecated with removal planned for 15.0.0.