### PR TITLE
cobbler_system: fix `KeyError` when adding new interface to existing system

### DIFF
--- a/changelogs/fragments/11995-cobbler-system-interface-keyerror.yml
+++ b/changelogs/fragments/11995-cobbler-system-interface-keyerror.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - cobbler_system - fix ``KeyError`` when adding a new interface to an existing system that does not yet have it defined
+    (https://github.com/ansible-collections/community.general/issues/7007,
+    https://github.com/ansible-collections/community.general/pull/11995).

--- a/plugins/modules/cobbler_system.py
+++ b/plugins/modules/cobbler_system.py
@@ -298,7 +298,8 @@ def main():
                         continue
                     if key not in IFPROPS_MAPPING:
                         module.warn(f"Property '{key}' is not a valid system property.")
-                    if not system or system["interfaces"][device][IFPROPS_MAPPING[key]] != value:
+                        continue
+                    if not system or system["interfaces"].get(device, {}).get(IFPROPS_MAPPING[key]) != value:
                         result["changed"] = True
                     interface_properties[f"{key}-{device}"] = value
 


### PR DESCRIPTION
##### SUMMARY

When adding a new interface to a Cobbler system that already exists but does not yet have that interface defined, the module raised a `KeyError` on `system["interfaces"][device]`.

Two fixes applied:
- Use `.get(device, {}).get(IFPROPS_MAPPING[key])` so a missing device is treated as having no existing properties, correctly triggering `changed=True`.
- Add `continue` after the unknown-property `warn()` call to prevent a secondary `KeyError` on `IFPROPS_MAPPING[key]` for invalid keys.

Fixes #7007

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cobbler_system

##### ADDITIONAL INFORMATION

```paste below

```