### PR TITLE
filetree lookup: document RETURN value `state`

### DIFF
--- a/plugins/lookup/filetree.py
+++ b/plugins/lookup/filetree.py
@@ -88,8 +88,12 @@ _raw:
       description: The permissions the resulting file or directory.
       type: str
     state:
-      description: TODO.
+      description:
+        - Entry type of the path relative to the tree root.
+        - V(directory) for a directory, V(file) for a regular file, V(link) for a symbolic link.
+        - Other file types are skipped and not returned.
       type: str
+      choices: [directory, file, link]
     owner:
       description: Name of the user that owns the file/directory.
       type: raw

--- a/plugins/lookup/filetree.py
+++ b/plugins/lookup/filetree.py
@@ -89,7 +89,7 @@ _raw:
       type: str
     state:
       description:
-        - Entry type of the path relative to the tree root.
+        - Type of the resulting file or directory.
         - V(directory) for a directory, V(file) for a regular file, V(link) for a symbolic link.
         - Other file types are skipped and not returned.
       type: str


### PR DESCRIPTION
##### SUMMARY
Complete the `RETURN` documentation for the `community.general.filetree` lookup by replacing the `state` field placeholder and listing the possible values.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
filetree

##### ADDITIONAL INFORMATION
Docs-only change; no functional code changes.
