### PR TITLE
[WIP] timezone: use `/run/systemd/system` to detect systemd presence

### DIFF
--- a/changelogs/fragments/11999-timezone-systemd-detection.yml
+++ b/changelogs/fragments/11999-timezone-systemd-detection.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - "timezone - detect systemd via ``/run/systemd/system`` instead of probing ``timedatectl``,
+    fixing incorrect backend selection on containerized systems
+    (https://github.com/ansible-collections/community.general/issues/10135,
+    https://github.com/ansible-collections/community.general/pull/11999)."

--- a/plugins/modules/timezone.py
+++ b/plugins/modules/timezone.py
@@ -97,13 +97,10 @@ class Timezone:
         """
         if platform.system() == "Linux":
             timedatectl = module.get_bin_path("timedatectl")
-            if timedatectl is not None:
-                rc, stdout, stderr = module.run_command(timedatectl)
-                if rc == 0:
-                    return super(Timezone, SystemdTimezone).__new__(SystemdTimezone)
-                else:
-                    module.debug(f"timedatectl command was found but not usable: {stderr}. using other method.")
-                    return super(Timezone, NosystemdTimezone).__new__(NosystemdTimezone)
+            # /run/systemd/system is only present when systemd is actually running
+            # as PID 1 — absent in containers where timedatectl exists but fails.
+            if timedatectl is not None and os.path.isdir("/run/systemd/system"):
+                return super(Timezone, SystemdTimezone).__new__(SystemdTimezone)
             else:
                 return super(Timezone, NosystemdTimezone).__new__(NosystemdTimezone)
         elif re.match("^joyent_.*Z", platform.version()):

--- a/plugins/modules/timezone.py
+++ b/plugins/modules/timezone.py
@@ -97,10 +97,17 @@ class Timezone:
         """
         if platform.system() == "Linux":
             timedatectl = module.get_bin_path("timedatectl")
-            # /run/systemd/system is only present when systemd is actually running
-            # as PID 1 — absent in containers where timedatectl exists but fails.
+            # /run/systemd/system exists only when systemd is running as PID 1.
+            # Check it first (no subprocess) to exclude containers that have the
+            # timedatectl binary installed but no live systemd, then probe to
+            # confirm D-Bus is reachable before committing to SystemdTimezone.
             if timedatectl is not None and os.path.isdir("/run/systemd/system"):
-                return super(Timezone, SystemdTimezone).__new__(SystemdTimezone)
+                rc, stdout, stderr = module.run_command(timedatectl)
+                if rc == 0:
+                    return super(Timezone, SystemdTimezone).__new__(SystemdTimezone)
+                else:
+                    module.debug(f"timedatectl found but not usable: {stderr}. Using other method.")
+                    return super(Timezone, NosystemdTimezone).__new__(NosystemdTimezone)
             else:
                 return super(Timezone, NosystemdTimezone).__new__(NosystemdTimezone)
         elif re.match("^joyent_.*Z", platform.version()):

--- a/tests/integration/targets/timezone/tasks/test.yml
+++ b/tests/integration/targets/timezone/tasks/test.yml
@@ -290,9 +290,23 @@
   register: timedatectl_test
   ignore_errors: true
 
-- name:
+- name: check if /run/systemd/system exists (systemd actually running as init)
+  stat:
+    path: /run/systemd/system
+  register: systemd_dir_stat
+
+- name: determine which backend the timezone module will use
   set_fact:
-    hwclock_supported: '{{ hwclock_test is successful or (timedatectl_test is successful and "RTC time: n/a" not in timedatectl_test.stdout) }}'
+    using_systemd_backend: '{{ systemd_dir_stat.stat.exists and timedatectl_test.rc == 0 }}'
+
+- name: determine if hwclock can be reliably set in this environment
+  set_fact:
+    hwclock_supported: >-
+      {{
+        (using_systemd_backend and "RTC time: n/a" not in timedatectl_test.stdout)
+        or
+        (not using_systemd_backend and hwclock_test is successful)
+      }}
 ##
 ## test set hwclock, idempotency and checkmode
 ##
@@ -301,6 +315,18 @@
     - name: set hwclock to local
       timezone:
         hwclock: local
+
+    - name: verify hwclock is local via timedatectl (systemd backend)
+      command: timedatectl show --property=LocalRTC --value
+      register: timedatectl_localrtc_local
+      changed_when: false
+      when: using_systemd_backend
+
+    - name: ensure timedatectl reports hwclock as local
+      assert:
+        that: timedatectl_localrtc_local.stdout | trim == 'yes'
+        msg: "Expected timedatectl LocalRTC=yes (local) but got: {{ timedatectl_localrtc_local.stdout }}"
+      when: using_systemd_backend
 
     - name: set hwclock to UTC (checkmode)
       timezone:
@@ -344,6 +370,18 @@
         - name: ensure that hwclock is updated in the config file
           command: grep ^UTC=yes {{ hwclock_config_file }}
       when: ansible_facts.service_mgr != 'systemd'
+
+    - name: verify hwclock is UTC via timedatectl (systemd backend)
+      command: timedatectl show --property=LocalRTC --value
+      register: timedatectl_localrtc_utc
+      changed_when: false
+      when: using_systemd_backend
+
+    - name: ensure timedatectl reports hwclock as UTC
+      assert:
+        that: timedatectl_localrtc_utc.stdout | trim == 'no'
+        msg: "Expected timedatectl LocalRTC=no (UTC) but got: {{ timedatectl_localrtc_utc.stdout }}"
+      when: using_systemd_backend
 
     - name: set hwclock to RTC again
       timezone:

--- a/tests/integration/targets/timezone/tasks/test.yml
+++ b/tests/integration/targets/timezone/tasks/test.yml
@@ -297,7 +297,7 @@
 
 - name: determine which backend the timezone module will use
   set_fact:
-    using_systemd_backend: '{{ systemd_dir_stat.stat.exists and timedatectl_test.rc == 0 }}'
+    using_systemd_backend: '{{ ansible_facts.service_mgr == "systemd" }}'
 
 - name: determine if hwclock can be reliably set in this environment
   set_fact:


### PR DESCRIPTION
##### SUMMARY

On Linux, the module selected the systemd backend by running `timedatectl` and
checking its exit code. In containers where systemd is installed but not
running as PID 1 (e.g. D-Bus is absent), `timedatectl` fails and the module
fell back to `NosystemdTimezone`, which writes to `/etc/sysconfig/clock` and
calls `hwclock`. On modern Fedora those operations are silently ignored,
causing a state-mismatch failure.

The fix checks `/run/systemd/system` instead. Systemd creates that directory
at boot, so its presence reliably indicates systemd is the init; no probe
execution is needed.

The integration tests are also extended to mirror this detection logic:
`hwclock_supported` is now derived from which backend will actually be used,
and timedatectl-based verification tasks are added for the systemd backend
path (previously unasserted).

Fixes #10135

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
timezone