### PR TITLE
bundler: handle removal of --clean flag in Bundler 4

### DIFF
--- a/changelogs/fragments/11380-bundler-clean-flag-bundler4.yaml
+++ b/changelogs/fragments/11380-bundler-clean-flag-bundler4.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - bundler - handle removal of the ``--clean`` flag in Bundler 4 by running ``bundle config set clean true`` instead (https://github.com/ansible-collections/community.general/issues/11380).

--- a/plugins/modules/bundler.py
+++ b/plugins/modules/bundler.py
@@ -114,6 +114,8 @@ EXAMPLES = r"""
     chdir: ~/rails_project
 """
 
+import re
+
 from ansible.module_utils.basic import AnsibleModule
 
 
@@ -123,6 +125,15 @@ def get_bundler_executable(module):
     else:
         result = [module.get_bin_path("bundle", True)]
     return result
+
+
+def get_bundler_major_version(module, bundler_cmd, chdir):
+    rc, out, _err = module.run_command(bundler_cmd + ["--version"], cwd=chdir, check_rc=False)
+    if rc == 0:
+        match = re.search(r"Bundler version (\d+)\.", out)
+        if match:
+            return int(match.group(1))
+    return 0
 
 
 def main():
@@ -170,7 +181,12 @@ def main():
         if exclude_groups:
             cmd.extend(["--without", ":".join(exclude_groups)])
         if clean:
-            cmd.append("--clean")
+            bundler_major = get_bundler_major_version(module, get_bundler_executable(module), chdir)
+            if bundler_major >= 4:
+                config_cmd = get_bundler_executable(module) + ["config", "set", "clean", "true"]
+                module.run_command(config_cmd, cwd=chdir, check_rc=True)
+            else:
+                cmd.append("--clean")
         if gemfile:
             cmd.extend(["--gemfile", gemfile])
         if local:

--- a/tests/unit/plugins/modules/test_bundler.py
+++ b/tests/unit/plugins/modules/test_bundler.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, Prayas Vadlakonda
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+import pytest
+from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
+    AnsibleExitJson,
+    ModuleTestCase,
+    set_module_args,
+)
+
+from ansible_collections.community.general.plugins.modules import bundler
+
+
+def get_run_command_calls(run_command_mock):
+    return [" ".join(call[0][0]) for call in run_command_mock.call_args_list]
+
+
+class TestBundler(ModuleTestCase):
+    def setUp(self):
+        super().setUp()
+        self.mocker.patch(
+            "ansible.module_utils.basic.AnsibleModule.get_bin_path",
+            return_value="/usr/bin/bundle",
+        )
+
+    @pytest.fixture(autouse=True)
+    def _mocker(self, mocker):
+        self.mocker = mocker
+
+    def patch_run_command(self, version_output="Bundler version 2.5.0"):
+        target = "ansible.module_utils.basic.AnsibleModule.run_command"
+        mock = self.mocker.patch(target)
+        mock.side_effect = [
+            (0, version_output, ""),  # bundle --version
+            (0, "Installing gems\n", ""),  # bundle install
+        ]
+        return mock
+
+    def test_clean_uses_flag_on_bundler_3(self):
+        run_command = self.patch_run_command("Bundler version 3.5.0")
+        with set_module_args({"state": "present", "clean": True}):
+            with pytest.raises(AnsibleExitJson):
+                bundler.main()
+
+        calls = get_run_command_calls(run_command)
+        assert any("--clean" in c for c in calls)
+        assert not any("config set clean" in c for c in calls)
+
+    def test_clean_uses_config_set_on_bundler_4(self):
+        target = "ansible.module_utils.basic.AnsibleModule.run_command"
+        mock = self.mocker.patch(target)
+        mock.side_effect = [
+            (0, "Bundler version 4.0.0", ""),  # bundle --version
+            (0, "", ""),  # bundle config set clean true
+            (0, "Installing gems\n", ""),  # bundle install
+        ]
+        with set_module_args({"state": "present", "clean": True}):
+            with pytest.raises(AnsibleExitJson):
+                bundler.main()
+
+        calls = get_run_command_calls(mock)
+        assert any("config set clean true" in c for c in calls)
+        assert not any("--clean" in c for c in calls)
+
+    def test_clean_false_skips_version_check(self):
+        target = "ansible.module_utils.basic.AnsibleModule.run_command"
+        mock = self.mocker.patch(target)
+        mock.return_value = (0, "Installing gems\n", "")
+        with set_module_args({"state": "present", "clean": False}):
+            with pytest.raises(AnsibleExitJson):
+                bundler.main()
+
+        calls = get_run_command_calls(mock)
+        assert not any("--version" in c for c in calls)
+        assert not any("--clean" in c for c in calls)
+        assert not any("config set clean" in c for c in calls)
+
+    def test_basic_install(self):
+        target = "ansible.module_utils.basic.AnsibleModule.run_command"
+        mock = self.mocker.patch(target)
+        mock.return_value = (0, "Installing gems\n", "")
+        with set_module_args({"state": "present"}):
+            with pytest.raises(AnsibleExitJson) as exc:
+                bundler.main()
+
+        result = exc.value.args[0]
+        assert result["changed"] is True
+        calls = get_run_command_calls(mock)
+        assert any("bundle install" in c for c in calls)


### PR DESCRIPTION
## Summary

Fixes #11380

In Bundler 4, the `--clean` flag was removed from `bundle install`. When users set `clean: true` in the `bundler` module, the task now fails with:

```
The `--clean` flag has been removed because it relied on being remembered across
bundler invocations, which bundler no longer does. Instead please use
`bundle config set clean true`, and stop using this flag
```

### Changes

- `plugins/modules/bundler.py` — added `get_bundler_major_version()` helper that parses `bundle --version` output; updated the `clean` handling to run `bundle config set clean true` on Bundler 4+ and keep the existing `--clean` flag for older versions
- `tests/unit/plugins/modules/test_bundler.py` — new unit tests covering Bundler 3 (flag path), Bundler 4 (config set path), `clean: false` (no version check), and basic install
- `changelogs/fragments/11380-bundler-clean-flag-bundler4.yaml` — changelog entry

### Behaviour

| Bundler version | `clean: true` behaviour |
|---|---|
| < 4 | `bundle install --clean` (unchanged) |
| >= 4 | `bundle config set clean true` then `bundle install` |

## Testing

Unit tests added covering both code paths.