### PR TITLE
nsupdate: add configurable `timeout` parameter

### DIFF
--- a/changelogs/fragments/12012-nsupdate-timeout.yml
+++ b/changelogs/fragments/12012-nsupdate-timeout.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "nsupdate - add ``timeout`` parameter to control the DNS query timeout (https://github.com/ansible-collections/community.general/issues/9906, https://github.com/ansible-collections/community.general/pull/12012)."

--- a/plugins/modules/nsupdate.py
+++ b/plugins/modules/nsupdate.py
@@ -99,7 +99,7 @@ options:
     description:
       - Timeout in seconds for each DNS query sent to O(server).
     default: 10
-    type: int
+    type: float
     version_added: 13.0.0
 """
 
@@ -612,7 +612,7 @@ def main():
             ttl=dict(default=3600, type="int"),
             value=dict(type="list", elements="str"),
             protocol=dict(default="tcp", choices=["tcp", "udp"], type="str"),
-            timeout=dict(default=10, type="int"),
+            timeout=dict(default=10, type="float"),
         ),
         supports_check_mode=True,
     )

--- a/plugins/modules/nsupdate.py
+++ b/plugins/modules/nsupdate.py
@@ -95,6 +95,12 @@ options:
     default: 'tcp'
     choices: ['tcp', 'udp']
     type: str
+  timeout:
+    description:
+      - Timeout in seconds for each DNS query sent to O(server).
+    default: 10
+    type: int
+    version_added: 13.0.0
 """
 
 EXAMPLES = r"""
@@ -308,8 +314,9 @@ class RecordManager:
         except dns.exception.DNSException as e:
             self.module.fail_json(msg=f"DNS resolution error for server '{server}': {e}")
 
-    def query(self, query, timeout=10):
+    def query(self, query):
         last_exception = None
+        timeout = self.module.params["timeout"]
         for server_ip in self.server_ips:
             try:
                 if self.module.params["protocol"] == "tcp":
@@ -605,6 +612,7 @@ def main():
             ttl=dict(default=3600, type="int"),
             value=dict(type="list", elements="str"),
             protocol=dict(default="tcp", choices=["tcp", "udp"], type="str"),
+            timeout=dict(default=10, type="int"),
         ),
         supports_check_mode=True,
     )


### PR DESCRIPTION
##### SUMMARY

The DNS query timeout in the `nsupdate` module was hardcoded to 10 seconds with no way to override it. On high-latency connections (e.g. mobile hotspots) this causes spurious `DNS operation timed out` failures even when the server is reachable.

This adds a `timeout` parameter (default: `10`, preserving existing behavior) that controls how long each DNS query waits before timing out.

Fixes #9906

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
nsupdate