### PR TITLE
pam_limits: only create backup file when content actually changes

### DIFF
--- a/changelogs/fragments/12014-pam_limits-backup.yml
+++ b/changelogs/fragments/12014-pam_limits-backup.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "pam_limits - only create backup file when the target file is actually modified (https://github.com/ansible-collections/community.general/issues/12011, https://github.com/ansible-collections/community.general/pull/12014)."

--- a/plugins/modules/pam_limits.py
+++ b/plugins/modules/pam_limits.py
@@ -235,10 +235,7 @@ def main():
 
     _assert_is_valid_value(module, limit_item, value)
 
-    # Backup
-    if backup:
-        backup_file = module.backup_local(limits_conf)
-
+    backup_file = None
     space_pattern = re.compile(r"\s+")
 
     if does_not_exist:
@@ -356,6 +353,9 @@ def main():
             with open(limits_conf, "a"):
                 pass
 
+        if backup and changed and not does_not_exist:
+            backup_file = module.backup_local(limits_conf)
+
         # Move tempfile to newfile
         module.atomic_move(os.path.abspath(nf.name), os.path.abspath(limits_conf))
 
@@ -370,7 +370,7 @@ def main():
         diff=dict(before=b"".join(lines), after=content_new),
     )
 
-    if backup:
+    if backup_file:
         res_args["backup_file"] = backup_file
 
     module.exit_json(**res_args)


### PR DESCRIPTION
##### SUMMARY

Backup files were being created on every run with `backup=yes`, even when the target file was already in the desired state and no change was made. This caused backup files to accumulate indefinitely.

The fix moves the `backup_local()` call to just before the atomic write, guarded by `changed and not does_not_exist`, so a backup is only taken when the file is actually about to be modified.

As a side effect, this also corrects two related issues:
- No backup is created when the target file does not yet exist (nothing to back up).
- No backup is created in check mode (backups mutate state and should not occur in dry-run).

Fixes #12011

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pam_limits

##### ADDITIONAL INFORMATION

```paste below

```