### PR TITLE
datadog_downtime: handle uuid.UUID type in API response

### DIFF
--- a/changelogs/fragments/12019-datadog-downtime-uuid.yml
+++ b/changelogs/fragments/12019-datadog-downtime-uuid.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "datadog_downtime - fix ``TypeError`` when returning API response with ``datadog-api-client`` >= 2.28.0
+    (https://github.com/ansible-collections/community.general/issues/9079,
+    https://github.com/ansible-collections/community.general/pull/12019)."

--- a/plugins/modules/datadog_downtime.py
+++ b/plugins/modules/datadog_downtime.py
@@ -247,13 +247,20 @@ def build_downtime(module):
     return downtime
 
 
+def _resp_to_dict(resp):
+    d = resp.to_dict()
+    if "uuid" in d:
+        d["uuid"] = str(d["uuid"])
+    return d
+
+
 def _post_downtime(module, api_client):
     api = DowntimesApi(api_client)
     downtime = build_downtime(module)
     try:
         resp = api.create_downtime(downtime)
         module.params["id"] = resp.id
-        module.exit_json(changed=True, downtime=resp.to_dict())
+        module.exit_json(changed=True, downtime=_resp_to_dict(resp))
     except ApiException as e:
         module.fail_json(msg=f"Failed to create downtime: {e}")
 
@@ -273,9 +280,9 @@ def _update_downtime(module, current_downtime, api_client):
         else:
             resp = api.update_downtime(module.params["id"], downtime)
         if _equal_dicts(resp.to_dict(), current_downtime.to_dict(), ["active", "creator_id", "updater_id"]):
-            module.exit_json(changed=False, downtime=resp.to_dict())
+            module.exit_json(changed=False, downtime=_resp_to_dict(resp))
         else:
-            module.exit_json(changed=True, downtime=resp.to_dict())
+            module.exit_json(changed=True, downtime=_resp_to_dict(resp))
     except ApiException as e:
         module.fail_json(msg=f"Failed to update downtime: {e}")
 


### PR DESCRIPTION
##### SUMMARY

Starting with `datadog-api-client==2.28.0`, the `uuid` field in the downtime API response is returned as a `uuid.UUID` object instead of a plain string. Ansible's `exit_json` serialization cannot handle `uuid.UUID`, causing a `TypeError` even though the operation itself succeeded on Datadog's side.

Adds a small helper `_resp_to_dict()` that calls `str()` on the `uuid` field when present, which is safe on older client versions (already a string) and fixes the error on newer ones.

Fixes #9079

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
datadog_downtime

##### ADDITIONAL INFORMATION

```paste below

```