### PR TITLE
bundler: replace deprecated CLI flags with `BUNDLE_*` env vars

### DIFF
--- a/changelogs/fragments/12024-bundler-deprecated-flags.yml
+++ b/changelogs/fragments/12024-bundler-deprecated-flags.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - "bundler - replace deprecated ``--deployment``, ``--without``, ``--path``,
+    ``--clean``, and ``--binstubs`` flags with ``BUNDLE_*`` environment variables,
+    fixing compatibility with Bundler 4 (https://github.com/ansible-collections/community.general/issues/4583,
+    https://github.com/ansible-collections/community.general/issues/11380,
+    https://github.com/ansible-collections/community.general/pull/12024)."

--- a/plugins/modules/bundler.py
+++ b/plugins/modules/bundler.py
@@ -165,24 +165,25 @@ def main():
 
         module.exit_json(changed=rc != 0, state=state, stdout=out, stderr=err)
 
+    bundle_env = {}
     if state == "present":
         cmd.append("install")
         if exclude_groups:
-            cmd.extend(["--without", ":".join(exclude_groups)])
+            bundle_env["BUNDLE_WITHOUT"] = ":".join(exclude_groups)
         if clean:
-            cmd.append("--clean")
+            bundle_env["BUNDLE_CLEAN"] = "true"
         if gemfile:
             cmd.extend(["--gemfile", gemfile])
         if local:
             cmd.append("--local")
         if deployment_mode:
-            cmd.append("--deployment")
+            bundle_env["BUNDLE_DEPLOYMENT"] = "true"
         if not user_install:
             cmd.append("--system")
         if gem_path:
-            cmd.extend(["--path", gem_path])
+            bundle_env["BUNDLE_PATH"] = gem_path
         if binstub_directory:
-            cmd.extend(["--binstubs", binstub_directory])
+            bundle_env["BUNDLE_BIN"] = binstub_directory
     else:
         cmd.append("update")
         if local:
@@ -191,7 +192,7 @@ def main():
     if extra_args:
         cmd.extend(extra_args.split(" "))
 
-    rc, out, err = module.run_command(cmd, cwd=chdir, check_rc=True)
+    rc, out, err = module.run_command(cmd, cwd=chdir, check_rc=True, environ_update=bundle_env)
 
     module.exit_json(changed="Installing" in out, state=state, stdout=out, stderr=err)
 


### PR DESCRIPTION
##### SUMMARY

Bundler 2.1 deprecated the `--deployment`, `--without`, `--path`, `--clean`, and `--binstubs` flags because they relied on persistent remembered state. Bundler 4 has gone further and **removed** `--clean` entirely, causing a hard failure.

This replaces all five flags with their `BUNDLE_*` environment variable equivalents, which have been supported since Bundler 1.0.0 (2010) and are process-scoped — no persistent `.bundle/config` is written.

Fixes #4583
Fixes #11380

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
bundler

##### ADDITIONAL INFORMATION

Mapping applied:

| Parameter | Old flag (broken in Bundler 4) | Replacement |
|---|---|---|
| `deployment_mode: true` | `--deployment` | `BUNDLE_DEPLOYMENT=true` |
| `exclude_groups: [...]` | `--without g1:g2` | `BUNDLE_WITHOUT=g1:g2` |
| `gem_path: /path` | `--path /path` | `BUNDLE_PATH=/path` |
| `clean: true` | `--clean` | `BUNDLE_CLEAN=true` |
| `binstub_directory: /dir` | `--binstubs /dir` | `BUNDLE_BIN=/dir` |

Non-remembered flags (`--gemfile`, `--local`, `--system`) are unchanged.

```paste below

```