### PR TITLE
snap: support `system` as a configuration target

### DIFF
--- a/changelogs/fragments/12025-snap-system.yml
+++ b/changelogs/fragments/12025-snap-system.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - snap - add support for ``system`` as a special configuration target, allowing
+    ``snap set system`` to be used via the ``options`` parameter
+    (https://github.com/ansible-collections/community.general/issues/11266,
+    https://github.com/ansible-collections/community.general/pull/12025).

--- a/plugins/modules/snap.py
+++ b/plugins/modules/snap.py
@@ -29,6 +29,9 @@ options:
       - Name of the snaps to be installed.
       - Any named snap accepted by the C(snap) command is valid.
       - O(dangerous=true) may be necessary when installing C(.snap) files. See O(dangerous) for more details.
+      - The special name V(system) refers to the snapd system-wide configuration namespace.
+        When used with O(options), it runs C(snap set system <key=value>).
+        It is always considered present and only V(state=present) and O(options) are meaningful for it.
     required: true
     type: list
     elements: str
@@ -155,6 +158,14 @@ EXAMPLES = r"""
     name: helm
     classic: true
     revision: 481
+
+# Set snap system-wide configuration
+- name: Configure snapd proxy
+  community.general.snap:
+    name: system
+    options:
+      - proxy.http=http://proxy.example.com:3128/
+      - proxy.https=http://proxy.example.com:3128/
 """
 
 RETURN = r"""
@@ -200,6 +211,8 @@ import numbers
 import re
 
 from ansible.module_utils.common.text.converters import to_native
+
+_VIRTUAL_SNAPS = frozenset({"system"})
 
 from ansible_collections.community.general.plugins.module_utils._module_helper import StateModuleHelper
 from ansible_collections.community.general.plugins.module_utils._snap import get_version, snap_runner
@@ -345,6 +358,11 @@ class Snap(StateModuleHelper):
             )
 
     def names_from_snaps(self, snaps):
+        real_snaps = [s for s in snaps if s not in _VIRTUAL_SNAPS]
+
+        if not real_snaps:
+            return list(snaps)
+
         def process_one(rc, out, err):
             res = [line for line in out.split("\n") if line.startswith("name:")]
             name = res[0].split()[1]
@@ -361,7 +379,7 @@ class Snap(StateModuleHelper):
             return res
 
         def process(rc, out, err):
-            if len(snaps) == 1:
+            if len(real_snaps) == 1:
                 check_error = err
                 process_ = process_one
             else:
@@ -373,17 +391,20 @@ class Snap(StateModuleHelper):
                 self.do_raise(f"Snaps not found: {snaps_not_found}.")
             return process_(rc, out, err)
 
-        names = []
-        if snaps:
-            with self.runner("info name", output_process=process) as ctx:
-                try:
-                    names = ctx.run(name=snaps)
-                finally:
-                    self.vars.snapinfo_run_info.append(ctx.run_info)
-        return names
+        real_names = []
+        with self.runner("info name", output_process=process) as ctx:
+            try:
+                real_names = ctx.run(name=real_snaps)
+            finally:
+                self.vars.snapinfo_run_info.append(ctx.run_info)
+
+        real_name_iter = iter(real_names)
+        return [s if s in _VIRTUAL_SNAPS else next(real_name_iter) for s in snaps]
 
     def snap_status(self, snap_name, channel, revision=None):
         def _status_check(name, channel, revision, installed):
+            if name in _VIRTUAL_SNAPS:
+                return Snap.INSTALLED
             match = [(r, c) for n, r, c in installed if n == name]
             if not match:
                 return Snap.NOT_INSTALLED

--- a/plugins/modules/snap.py
+++ b/plugins/modules/snap.py
@@ -32,6 +32,7 @@ options:
       - The special name V(system) refers to the snapd system-wide configuration namespace.
         When used with O(options), it runs C(snap set system <key=value>).
         It is always considered present and only V(state=present) and O(options) are meaningful for it.
+        Support for V(system) was added in community.general 13.0.0.
     required: true
     type: list
     elements: str

--- a/tests/unit/plugins/modules/test_snap.py
+++ b/tests/unit/plugins/modules/test_snap.py
@@ -439,6 +439,90 @@ TEST_SPEC = dict(
             ),
         ),
         dict(
+            id="set_system_option",
+            input={"name": ["system"], "options": ["proxy.http=http://proxy.example.com:3128/"]},
+            output=dict(changed=True, options_changed=["system:proxy.http=http://proxy.example.com:3128/"]),
+            flags={},
+            mocks=dict(
+                run_command=[
+                    dict(
+                        command=["/testbin/snap", "version"],
+                        environ=default_env,
+                        rc=0,
+                        out=default_version_out,
+                        err="",
+                    ),
+                    # No "snap info system" — virtual snap bypasses names_from_snaps
+                    dict(
+                        command=["/testbin/snap", "list"],
+                        environ=default_env,
+                        rc=0,
+                        out="",
+                        err="",
+                    ),
+                    dict(
+                        command=["/testbin/snap", "get", "-d", "system"],
+                        environ=default_env,
+                        rc=0,
+                        out="{}",
+                        err="",
+                    ),
+                    dict(
+                        command=["/testbin/snap", "set", "system", "proxy.http=http://proxy.example.com:3128/"],
+                        environ=default_env,
+                        rc=0,
+                        out="",
+                        err="",
+                    ),
+                    dict(
+                        command=["/testbin/snap", "list"],
+                        environ=default_env,
+                        rc=0,
+                        out="",
+                        err="",
+                    ),
+                ],
+            ),
+        ),
+        dict(
+            id="set_system_option_idempotent",
+            input={"name": ["system"], "options": ["proxy.http=http://proxy.example.com:3128/"]},
+            output=dict(changed=False),
+            flags={},
+            mocks=dict(
+                run_command=[
+                    dict(
+                        command=["/testbin/snap", "version"],
+                        environ=default_env,
+                        rc=0,
+                        out=default_version_out,
+                        err="",
+                    ),
+                    dict(
+                        command=["/testbin/snap", "list"],
+                        environ=default_env,
+                        rc=0,
+                        out="",
+                        err="",
+                    ),
+                    dict(
+                        command=["/testbin/snap", "get", "-d", "system"],
+                        environ=default_env,
+                        rc=0,
+                        out='{"proxy": {"http": "http://proxy.example.com:3128/"}}',
+                        err="",
+                    ),
+                    dict(
+                        command=["/testbin/snap", "list"],
+                        environ=default_env,
+                        rc=0,
+                        out="",
+                        err="",
+                    ),
+                ],
+            ),
+        ),
+        dict(
             id="issue_6803",
             input={"name": ["microk8s", "kubectl"], "classic": True},
             output=dict(changed=True, snaps_installed=["microk8s", "kubectl"]),


### PR DESCRIPTION
##### SUMMARY

Adds support for `name: system` in the `community.general.snap` module, allowing users to manage snapd system-wide configuration via the `options` parameter.

The `system` name is a reserved snapd target — not a real snap package — used to set daemon-level configuration such as proxy settings. Previously, using `name: system` would attempt `snap install system`, which fails.

The fix treats `system` (and any future entries in `_VIRTUAL_SNAPS`) as always present: it bypasses `snap info` lookup and install/refresh logic, while still invoking `snap get`/`snap set` for idempotent option management.

Fixes #11266

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
snap

##### ADDITIONAL INFORMATION

Example usage now supported:

```yaml
- name: Configure snapd proxy
  community.general.snap:
    name: system
    options:
      - proxy.http=http://proxy.example.com:3128/
      - proxy.https=http://proxy.example.com:3128/
```