### PR TITLE
iso_create: sanitize ISO9660 path components to avoid invalid character errors

### DIFF
--- a/changelogs/fragments/12028-iso-create-sanitize.yml
+++ b/changelogs/fragments/12028-iso-create-sanitize.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - iso_create - fix failure with non-conforming ISO9660 path characters
+    (https://github.com/ansible-collections/community.general/issues/5103,
+    https://github.com/ansible-collections/community.general/pull/12028).

--- a/plugins/modules/iso_create.py
+++ b/plugins/modules/iso_create.py
@@ -225,6 +225,17 @@ import os
 import re
 import traceback
 
+PYCDLIB_IMP_ERR = None
+try:
+    import pycdlib
+
+    HAS_PYCDLIB = True
+except ImportError:
+    PYCDLIB_IMP_ERR = traceback.format_exc()
+    HAS_PYCDLIB = False
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+
 PLATFORM_ID_MAP = {
     "x86": b"\x00",
     "efi": b"\xef",
@@ -247,18 +258,6 @@ def _sanitize_iso_path(path, is_file=False):
         else:
             result.append(_ISO9660_INVALID.sub("_", part.upper()))
     return "/".join(result)
-
-
-PYCDLIB_IMP_ERR = None
-try:
-    import pycdlib
-
-    HAS_PYCDLIB = True
-except ImportError:
-    PYCDLIB_IMP_ERR = traceback.format_exc()
-    HAS_PYCDLIB = False
-
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 
 def add_file(module, iso_file=None, src_file=None, file_path=None, rock_ridge=None, use_joliet=None, use_udf=None):

--- a/plugins/modules/iso_create.py
+++ b/plugins/modules/iso_create.py
@@ -222,6 +222,7 @@ boot_options:
 """
 
 import os
+import re
 import traceback
 
 PLATFORM_ID_MAP = {
@@ -229,6 +230,24 @@ PLATFORM_ID_MAP = {
     "efi": b"\xef",
     "mac": b"\x02",
 }
+
+_ISO9660_INVALID = re.compile(r"[^A-Z0-9_]")
+
+
+def _sanitize_iso_path(path, is_file=False):
+    parts = path.split("/")
+    result = []
+    for i, part in enumerate(parts):
+        if not part:
+            result.append(part)
+            continue
+        if is_file and i == len(parts) - 1 and "." in part:
+            name, ext = part.upper().rsplit(".", 1)
+            result.append(_ISO9660_INVALID.sub("_", name) + "." + _ISO9660_INVALID.sub("_", ext))
+        else:
+            result.append(_ISO9660_INVALID.sub("_", part.upper()))
+    return "/".join(result)
+
 
 PYCDLIB_IMP_ERR = None
 try:
@@ -249,10 +268,11 @@ def add_file(module, iso_file=None, src_file=None, file_path=None, rock_ridge=No
     # In standard ISO interchange level 1, file names have a maximum of 8 characters, followed by a required dot,
     # followed by a maximum 3 character extension, followed by a semicolon and a version
     file_name = os.path.basename(file_path)
+    sanitized_path = _sanitize_iso_path(file_path, is_file=True)
     if "." not in file_name:
-        file_in_iso_path = f"{file_path.upper()}.;1"
+        file_in_iso_path = f"{sanitized_path}.;1"
     else:
-        file_in_iso_path = f"{file_path.upper()};1"
+        file_in_iso_path = f"{sanitized_path};1"
     if rock_ridge:
         rr_name = file_name
     if use_joliet:
@@ -271,7 +291,7 @@ def add_directory(module, iso_file=None, dir_path=None, rock_ridge=None, use_jol
     rr_name = None
     joliet_path = None
     udf_path = None
-    iso_dir_path = dir_path.upper()
+    iso_dir_path = _sanitize_iso_path(dir_path)
     if rock_ridge:
         rr_name = os.path.basename(dir_path)
     if use_joliet:
@@ -419,10 +439,11 @@ def main():
         if boot_options:
             boot_file = boot_options["boot_file"]
             boot_file_basename = os.path.basename(boot_file)
+            sanitized_boot_path = _sanitize_iso_path(f"/{boot_file_basename}", is_file=True)
             if "." not in boot_file_basename:
-                boot_iso_path = f"/{boot_file_basename.upper()}.;1"
+                boot_iso_path = f"{sanitized_boot_path}.;1"
             else:
-                boot_iso_path = f"/{boot_file_basename.upper()};1"
+                boot_iso_path = f"{sanitized_boot_path};1"
             add_file(
                 module,
                 iso_file=iso_file,


### PR DESCRIPTION
##### SUMMARY

When a source directory or file has a name containing characters outside `[A-Z0-9_]` (e.g. `en-us` with a hyphen), the module passed the raw uppercased path directly to pycdlib, which rejected it with:

> ISO9660 filenames must consist of characters A-Z, 0-9, and _

The fix adds a `_sanitize_iso_path()` helper that replaces any invalid character with `_` in the ISO9660 path, while leaving Rock Ridge (`rr_name`), Joliet (`joliet_path`), and UDF (`udf_path`) extension paths untouched so the original names are preserved when those extensions are used.

Applied consistently in `add_directory()`, `add_file()`, and the `boot_options` block in `main()`.

Fixes #5103

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
iso_create

##### ADDITIONAL INFORMATION

Example that previously failed:
```yaml
- community.general.iso_create:
    src_files:
      - /sources/support/logging/en-us
    dest_iso: /tmp/test.iso
```

With this fix, `en-us` maps to `EN_US` in the ISO9660 namespace. When Rock Ridge or Joliet is also enabled, the original `en-us` name is preserved in those extension paths.