### PR TITLE
xml: fix predicated xpath no-match incorrectly creating nodes

### DIFF
--- a/changelogs/fragments/12031-xml-predicate-xpath-nomatch.yml
+++ b/changelogs/fragments/12031-xml-predicate-xpath-nomatch.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - "xml - fix predicated ``xpath`` (e.g. ``element[text()='old']``) incorrectly
+    creating nodes when the predicate finds no match instead of being a no-op
+    (https://github.com/ansible-collections/community.general/issues/8730,
+    https://github.com/ansible-collections/community.general/pull/12031)."

--- a/changelogs/fragments/12031-xml-predicate-xpath-nomatch.yml
+++ b/changelogs/fragments/12031-xml-predicate-xpath-nomatch.yml
@@ -1,5 +1,5 @@
-bugfixes:
-  - "xml - fix predicated ``xpath`` (e.g. ``element[text()='old']``) incorrectly
-    creating nodes when the predicate finds no match instead of being a no-op
+minor_changes:
+  - xml - add ``create_if_missing`` option to control whether a node is created when
+    ``value`` is set and ``xpath`` finds no match
     (https://github.com/ansible-collections/community.general/issues/8730,
-    https://github.com/ansible-collections/community.general/pull/12031)."
+    https://github.com/ansible-collections/community.general/pull/12031).

--- a/plugins/modules/xml.py
+++ b/plugins/modules/xml.py
@@ -678,6 +678,12 @@ def set_target_inner(module, tree, xpath, namespaces, attribute, value):
 
     try:
         if not is_node(tree, xpath, namespaces):
+            # If the xpath ends with a [predicate] and the base path exists,
+            # the no-match is due to the predicate not being satisfied —
+            # treat as no-op rather than incorrectly creating new nodes.
+            m = _RE_SPLITSUBLAST.match(xpath)
+            if m and m.group(1) and is_node(tree, m.group(1), namespaces):
+                return changed
             changed = check_or_make_target(module, tree, xpath, namespaces)
     except Exception as e:
         missing_namespace = ""

--- a/plugins/modules/xml.py
+++ b/plugins/modules/xml.py
@@ -144,6 +144,13 @@ options:
       - This parameter requires O(xpath) to be set.
     type: bool
     default: false
+  create_if_missing:
+    description:
+      - When using O(value) and the O(xpath) matches no nodes, create the node.
+      - When set to V(false), a no-match is silently ignored instead of creating a new node.
+    type: bool
+    default: true
+    version_added: "13.0.0"
 requirements:
   - lxml >= 2.3.0
 notes:
@@ -673,16 +680,12 @@ def ensure_xpath_exists(module, tree, xpath, namespaces):
     finish(module, tree, xpath, namespaces, changed)
 
 
-def set_target_inner(module, tree, xpath, namespaces, attribute, value):
+def set_target_inner(module, tree, xpath, namespaces, attribute, value, create_if_missing=True):
     changed = False
 
     try:
         if not is_node(tree, xpath, namespaces):
-            # If the xpath ends with a [predicate] and the base path exists,
-            # the no-match is due to the predicate not being satisfied —
-            # treat as no-op rather than incorrectly creating new nodes.
-            m = _RE_SPLITSUBLAST.match(xpath)
-            if m and m.group(1) and is_node(tree, m.group(1), namespaces):
+            if not create_if_missing:
                 return changed
             changed = check_or_make_target(module, tree, xpath, namespaces)
     except Exception as e:
@@ -728,8 +731,8 @@ def set_target_inner(module, tree, xpath, namespaces, attribute, value):
     return changed
 
 
-def set_target(module, tree, xpath, namespaces, attribute, value):
-    changed = set_target_inner(module, tree, xpath, namespaces, attribute, value)
+def set_target(module, tree, xpath, namespaces, attribute, value, create_if_missing):
+    changed = set_target_inner(module, tree, xpath, namespaces, attribute, value, create_if_missing)
     finish(module, tree, xpath, namespaces, changed)
 
 
@@ -901,6 +904,7 @@ def main():
             huge_tree=dict(type="bool", default=False),
             insertbefore=dict(type="bool", default=False),
             insertafter=dict(type="bool", default=False),
+            create_if_missing=dict(type="bool", default=True),
         ),
         supports_check_mode=True,
         required_by=dict(
@@ -945,6 +949,7 @@ def main():
     huge_tree = module.params["huge_tree"]
     insertbefore = module.params["insertbefore"]
     insertafter = module.params["insertafter"]
+    create_if_missing = module.params["create_if_missing"]
 
     # Check if we have lxml 2.3.0 or newer installed
     if not HAS_LXML:
@@ -1020,7 +1025,7 @@ def main():
 
     # Is the xpath target an attribute selector?
     if value is not None:
-        set_target(module, doc, xpath, namespaces, attribute, value)
+        set_target(module, doc, xpath, namespaces, attribute, value, create_if_missing)
 
     # If an xpath was provided, we need to do something with the data
     if xpath is not None:

--- a/tests/integration/targets/xml/fixtures/ansible-xml-items.xml
+++ b/tests/integration/targets/xml/fixtures/ansible-xml-items.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business>
+  <items>
+    <item>value_a</item>
+    <item>value_a</item>
+    <item>value_b</item>
+  </items>
+</business>

--- a/tests/integration/targets/xml/fixtures/ansible-xml-items.xml.license
+++ b/tests/integration/targets/xml/fixtures/ansible-xml-items.xml.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/integration/targets/xml/results/test-set-element-value-predicate.xml
+++ b/tests/integration/targets/xml/results/test-set-element-value-predicate.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business>
+  <items>
+    <item>value_c</item>
+    <item>value_c</item>
+    <item>value_b</item>
+  </items>
+</business>

--- a/tests/integration/targets/xml/results/test-set-element-value-predicate.xml.license
+++ b/tests/integration/targets/xml/results/test-set-element-value-predicate.xml.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/integration/targets/xml/tasks/main.yml
+++ b/tests/integration/targets/xml/tasks/main.yml
@@ -67,7 +67,6 @@
     - include_tasks: test-set-element-value.yml
     - include_tasks: test-set-element-value-empty.yml
     - include_tasks: test-set-element-value-predicate.yml
-    - include_tasks: test-unset-element-value.yml
     - include_tasks: test-pretty-print.yml
     - include_tasks: test-pretty-print-only.yml
     - include_tasks: test-add-namespaced-children-elements.yml

--- a/tests/integration/targets/xml/tasks/main.yml
+++ b/tests/integration/targets/xml/tasks/main.yml
@@ -66,6 +66,8 @@
     - include_tasks: test-set-children-elements-value.yml
     - include_tasks: test-set-element-value.yml
     - include_tasks: test-set-element-value-empty.yml
+    - include_tasks: test-set-element-value-predicate.yml
+    - include_tasks: test-unset-element-value.yml
     - include_tasks: test-pretty-print.yml
     - include_tasks: test-pretty-print-only.yml
     - include_tasks: test-add-namespaced-children-elements.yml

--- a/tests/integration/targets/xml/tasks/test-set-element-value-predicate.yml
+++ b/tests/integration/targets/xml/tasks/test-set-element-value-predicate.yml
@@ -1,0 +1,46 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Test for https://github.com/ansible-collections/community.general/issues/8730
+# When using a predicated xpath like element[text()='old'] with value=new, a second
+# run with the same search predicate (which no longer matches) must be a no-op and
+# must NOT create spurious new elements.
+
+- name: Setup test fixture
+  copy:
+    src: fixtures/ansible-xml-items.xml
+    dest: /tmp/ansible-xml-items.xml
+
+- name: Set items matching predicate - first run (should change two items)
+  xml:
+    path: /tmp/ansible-xml-items.xml
+    xpath: /business/items/item[text()='value_a']
+    value: value_c
+  register: set_predicate_first_run
+
+- name: Set items matching predicate - second run (predicate no longer matches, should be no-op)
+  xml:
+    path: /tmp/ansible-xml-items.xml
+    xpath: /business/items/item[text()='value_a']
+    value: value_c
+  register: set_predicate_second_run
+
+- name: Add trailing newline
+  shell: echo "" >> /tmp/ansible-xml-items.xml
+
+- name: Compare to expected result
+  copy:
+    src: results/test-set-element-value-predicate.xml
+    dest: /tmp/ansible-xml-items.xml
+  check_mode: true
+  diff: true
+  register: comparison
+
+- name: Test expected result
+  assert:
+    that:
+      - set_predicate_first_run is changed
+      - set_predicate_second_run is not changed
+      - comparison is not changed  # identical - no spurious elements created

--- a/tests/integration/targets/xml/tasks/test-set-element-value-predicate.yml
+++ b/tests/integration/targets/xml/tasks/test-set-element-value-predicate.yml
@@ -3,28 +3,29 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# Test for https://github.com/ansible-collections/community.general/issues/8730
-# When using a predicated xpath like element[text()='old'] with value=new, a second
-# run with the same search predicate (which no longer matches) must be a no-op and
-# must NOT create spurious new elements.
+# Tests for https://github.com/ansible-collections/community.general/issues/8730
+
+# --- create_if_missing=false: predicate no-match must be a silent no-op ---
 
 - name: Setup test fixture
   copy:
     src: fixtures/ansible-xml-items.xml
     dest: /tmp/ansible-xml-items.xml
 
-- name: Set items matching predicate - first run (should change two items)
+- name: Update items via predicate (create_if_missing=false, first run - matches)
   xml:
     path: /tmp/ansible-xml-items.xml
     xpath: /business/items/item[text()='value_a']
     value: value_c
+    create_if_missing: false
   register: set_predicate_first_run
 
-- name: Set items matching predicate - second run (predicate no longer matches, should be no-op)
+- name: Update items via predicate (create_if_missing=false, second run - predicate no longer matches)
   xml:
     path: /tmp/ansible-xml-items.xml
     xpath: /business/items/item[text()='value_a']
     value: value_c
+    create_if_missing: false
   register: set_predicate_second_run
 
 - name: Add trailing newline
@@ -38,9 +39,58 @@
   diff: true
   register: comparison
 
-- name: Test expected result
+- name: Assert create_if_missing=false with predicate no-match is a no-op
   assert:
     that:
       - set_predicate_first_run is changed
       - set_predicate_second_run is not changed
-      - comparison is not changed  # identical - no spurious elements created
+      - comparison is not changed  # no spurious elements created
+
+# --- create_if_missing=false: non-existent simple path must also be a no-op ---
+
+- name: Setup test fixture
+  copy:
+    src: fixtures/ansible-xml-items.xml
+    dest: /tmp/ansible-xml-items.xml
+
+- name: Set value on non-existent element (create_if_missing=false)
+  xml:
+    path: /tmp/ansible-xml-items.xml
+    xpath: /business/items/nonexistent
+    value: something
+    create_if_missing: false
+  register: set_nonexistent
+
+- name: Assert create_if_missing=false with missing simple path is a no-op
+  assert:
+    that:
+      - set_nonexistent is not changed
+
+# --- create_if_missing=true (default): no-match must create the node ---
+
+- name: Setup test fixture
+  copy:
+    src: fixtures/ansible-xml-items.xml
+    dest: /tmp/ansible-xml-items.xml
+
+- name: Set value on non-existent element (create_if_missing=true, should create)
+  xml:
+    path: /tmp/ansible-xml-items.xml
+    xpath: /business/items/item[text()='value_z']
+    value: value_z
+    create_if_missing: true
+  register: set_predicate_create
+
+- name: Set same value again (create_if_missing=true, should be idempotent)
+  xml:
+    path: /tmp/ansible-xml-items.xml
+    xpath: /business/items/item[text()='value_z']
+    value: value_z
+    create_if_missing: true
+  register: set_predicate_create_again
+
+- name: Assert create_if_missing=true creates the node and is then idempotent
+  assert:
+    that:
+      - set_predicate_create is changed
+      - set_predicate_create_again is not changed


### PR DESCRIPTION
##### SUMMARY

When using a predicated xpath like `element[text()='old_value']` with `value: new_value`, if the predicate finds no matching nodes (e.g. because a loop iteration already changed the value), the module incorrectly fell through to node creation. It would strip the predicate, find all parent nodes, and append spurious new child elements — corrupting the XML document.

The fix detects when a no-match is predicate-based (the base path exists but the predicate is not satisfied) and returns `changed=false` as a no-op instead.

Fixes #8730

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
xml

##### ADDITIONAL INFORMATION

Root cause is in `set_target_inner`: when `is_node()` returns False, `check_or_make_target` is called unconditionally. For xpaths ending with `[predicate]` where the parent path already exists, the no-match is due to the predicate not being satisfied — node creation is wrong in this case.

```paste below

```