### PR TITLE
telegram: add ability to specify a custom URL for the API

### DIFF
--- a/changelogs/fragments/12040-telegram-api_host.yaml
+++ b/changelogs/fragments/12040-telegram-api_host.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "telegram - added the ``api_host`` parameter to fix connectivity with self-hosted proxies and custom API endpoints (https://github.com/ansible-collections/community.general/pull/12040)."

--- a/plugins/modules/telegram.py
+++ b/plugins/modules/telegram.py
@@ -37,6 +37,7 @@ options:
     description:
       - Custom telegram api host.
     required: false
+    default: api.telegram.org
   api_method:
     type: str
     description:

--- a/plugins/modules/telegram.py
+++ b/plugins/modules/telegram.py
@@ -35,7 +35,7 @@ options:
   api_host:
     type: str
     description:
-      - Custom telegram api host. Default: api.telegram.org
+      - Custom telegram api host.
     required: false
   api_method:
     type: str
@@ -102,7 +102,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             token=dict(type="str", required=True, no_log=True),
-            api_host=dict(type="str", required=False, no_log=True),
+            api_host=dict(type="str", default="api.telegram.org"),
             api_args=dict(type="dict"),
             api_method=dict(type="str", default="SendMessage"),
         ),
@@ -110,7 +110,7 @@ def main():
     )
 
     token = quote(module.params.get("token"))
-    api_host = quote(module.params.get("api_host") or "api.telegram.org")
+    api_host = quote(module.params.get("api_host"))
     api_args = module.params.get("api_args") or {}
     api_method = module.params.get("api_method")
     # filling backward compatibility args

--- a/plugins/modules/telegram.py
+++ b/plugins/modules/telegram.py
@@ -119,10 +119,10 @@ def main():
         supports_check_mode=True,
     )
 
-    token = quote(module.params.get("token"))
-    api_host = module.params.get("api_host")
-    api_args = module.params.get("api_args") or {}
-    api_method = module.params.get("api_method")
+    token = quote(module.params["token"])
+    api_host = module.params["api_host"]
+    api_args = module.params["api_args"] or {}
+    api_method = module.params["api_method"]
     # filling backward compatibility args
     api_args["chat_id"] = api_args.get("chat_id")
     api_args["parse_mode"] = api_args.get("parse_mode")

--- a/plugins/modules/telegram.py
+++ b/plugins/modules/telegram.py
@@ -35,9 +35,9 @@ options:
   api_host:
     type: str
     description:
-      - Custom telegram api host.
-    required: false
+      - Custom telegram API host.
     default: api.telegram.org
+    version_added: 13.0.0
   api_method:
     type: str
     description:
@@ -57,7 +57,6 @@ EXAMPLES = r"""
 - name: Send notify to Telegram
   community.general.telegram:
     token: '9999999:XXXXXXXXXXXXXXXXXXXXXXX'
-    api_host: "api.telegram.org"
     api_args:
       chat_id: "000000"
       parse_mode: "markdown"
@@ -68,13 +67,23 @@ EXAMPLES = r"""
 - name: Forward message to someone
   community.general.telegram:
     token: '9999999:XXXXXXXXXXXXXXXXXXXXXXX'
-    api_host: "api.telegram.org"
     api_method: forwardMessage
     api_args:
       chat_id: "000000"
       from_chat_id: 111111
       disable_notification: true
       message_id: '{{ saved_msg_id }}'
+
+- name: Send notify to custom telegram API host
+  community.general.telegram:
+    token: '9999999:XXXXXXXXXXXXXXXXXXXXXXX'
+    api_host: "telegram.example.com"
+    api_args:
+      chat_id: "000000"
+      parse_mode: "markdown"
+      text: "Your precious application has been deployed: https://example.com"
+      disable_web_page_preview: true
+      disable_notification: true
 """
 
 RETURN = r"""
@@ -111,7 +120,7 @@ def main():
     )
 
     token = quote(module.params.get("token"))
-    api_host = quote(module.params.get("api_host"))
+    api_host = module.params.get("api_host")
     api_args = module.params.get("api_args") or {}
     api_method = module.params.get("api_method")
     # filling backward compatibility args

--- a/plugins/modules/telegram.py
+++ b/plugins/modules/telegram.py
@@ -32,6 +32,11 @@ options:
     description:
       - Token identifying your telegram bot.
     required: true
+  api_host:
+    type: str
+    description:
+      - Custom telegram api host. Default: api.telegram.org
+    required: false
   api_method:
     type: str
     description:
@@ -51,6 +56,7 @@ EXAMPLES = r"""
 - name: Send notify to Telegram
   community.general.telegram:
     token: '9999999:XXXXXXXXXXXXXXXXXXXXXXX'
+    api_host: "api.telegram.org"
     api_args:
       chat_id: "000000"
       parse_mode: "markdown"
@@ -61,6 +67,7 @@ EXAMPLES = r"""
 - name: Forward message to someone
   community.general.telegram:
     token: '9999999:XXXXXXXXXXXXXXXXXXXXXXX'
+    api_host: "api.telegram.org"
     api_method: forwardMessage
     api_args:
       chat_id: "000000"
@@ -95,6 +102,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             token=dict(type="str", required=True, no_log=True),
+            api_host=dict(type="str", required=False, no_log=True),
             api_args=dict(type="dict"),
             api_method=dict(type="str", default="SendMessage"),
         ),
@@ -102,6 +110,7 @@ def main():
     )
 
     token = quote(module.params.get("token"))
+    api_host = quote(module.params.get("api_host") or "api.telegram.org")
     api_args = module.params.get("api_args") or {}
     api_method = module.params.get("api_method")
     # filling backward compatibility args
@@ -112,7 +121,7 @@ def main():
     if api_args["parse_mode"] == "plain":
         del api_args["parse_mode"]
 
-    url = f"https://api.telegram.org/bot{token}/{api_method}"
+    url = f"https://{api_host}/bot{token}/{api_method}"
 
     if module.check_mode:
         module.exit_json(changed=False)


### PR DESCRIPTION
##### SUMMARY
Ability to specify a custom URL for the API telegram

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
telegram

##### ADDITIONAL INFORMATION
Add `api_host` argument for custom telegram api host
