### PR TITLE
Setup pip path generic

### DIFF
--- a/tests/integration/targets/setup_pip_path/tasks/main.yml
+++ b/tests/integration/targets/setup_pip_path/tasks/main.yml
@@ -20,6 +20,9 @@
   changed_when: false
 
 - name: Build pip_path from env PATH and Python scripts dir
-  ansible.builtin.set_fact:
-    pip_path: >
+  vars:
+    pip_path_list: >
       {{ [_pip_scripts_path.stdout.strip()] + ansible_facts.env.PATH.split(":") }}
+  ansible.builtin.set_fact:
+    pip_path: >-
+      {{ pip_path_list | join(":") }}

--- a/tests/integration/targets/setup_pip_path/tasks/main.yml
+++ b/tests/integration/targets/setup_pip_path/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Get pip scripts path from current Python interpreter
   ansible.builtin.command:
     argv:
-      - "{{ ansible_facts.python_interpreter }}"
+      - "{{ ansible_python_interpreter }}"
       - -c
       - |
         import sys

--- a/tests/integration/targets/setup_pip_path/tasks/main.yml
+++ b/tests/integration/targets/setup_pip_path/tasks/main.yml
@@ -12,10 +12,21 @@
   setup:
   when: ansible_facts == {}
 
+# pip._internal.locations.get_scheme() reflects pip's actual install scheme (e.g. RHEL root → /usr/local/bin),
+# which can differ from sysconfig.get_path('scripts') (e.g. RHEL → /usr/bin).
 - name: Get pip scripts path from current Python interpreter
-  ansible.builtin.command: >
-    {{ ansible_python_interpreter | default('/usr/bin/python3') }} -c
-    "import sysconfig; print(sysconfig.get_path('scripts'))"
+  ansible.builtin.command:
+    argv:
+      - "{{ ansible_facts.python_interpreter }}"
+      - -c
+      - |
+        import sys
+        try:
+            from pip._internal.locations import get_scheme
+            print(get_scheme('pip').scripts)
+        except Exception:
+            import sysconfig
+            print(sysconfig.get_path('scripts'))
   register: _pip_scripts_path
   changed_when: false
 

--- a/tests/integration/targets/setup_pip_path/tasks/main.yml
+++ b/tests/integration/targets/setup_pip_path/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Get facts
+  setup:
+  when: ansible_facts == {}
+
+- name: Get pip scripts path from current Python interpreter
+  ansible.builtin.command: >
+    {{ ansible_python_interpreter | default('/usr/bin/python3') }} -c
+    "import sysconfig; print(sysconfig.get_path('scripts'))"
+  register: _pip_scripts_path
+  changed_when: false
+
+- name: Build pip_path from env PATH and Python scripts dir
+  ansible.builtin.set_fact:
+    pip_path: >
+      {{ [_pip_scripts_path.stdout.strip()] + ansible_facts.env.PATH.split(":") }}

--- a/tests/integration/targets/setup_pip_scripts_path/tasks/main.yml
+++ b/tests/integration/targets/setup_pip_scripts_path/tasks/main.yml
@@ -35,5 +35,5 @@
     pip_path_list: >
       {{ [_pip_scripts_path.stdout.strip()] + ansible_facts.env.PATH.split(":") }}
   ansible.builtin.set_fact:
-    pip_path: >-
+    pip_scripts_path: >-
       {{ pip_path_list | join(":") }}

--- a/tests/integration/targets/supervisorctl/aliases
+++ b/tests/integration/targets/supervisorctl/aliases
@@ -4,5 +4,5 @@
 
 azp/posix/2
 destructive
-skip/rhel  # TODO executables are installed in /usr/local/bin, which isn't part of $PATH
-skip/macos  # TODO executables are installed in /Library/Frameworks/Python.framework/Versions/3.11/bin, which isn't part of $PATH
+#skip/rhel  # TODO executables are installed in /usr/local/bin, which isn't part of $PATH
+#skip/macos  # TODO executables are installed in /Library/Frameworks/Python.framework/Versions/3.11/bin, which isn't part of $PATH

--- a/tests/integration/targets/supervisorctl/aliases
+++ b/tests/integration/targets/supervisorctl/aliases
@@ -4,5 +4,3 @@
 
 azp/posix/2
 destructive
-#skip/rhel  # TODO executables are installed in /usr/local/bin, which isn't part of $PATH
-#skip/macos  # TODO executables are installed in /Library/Frameworks/Python.framework/Versions/3.11/bin, which isn't part of $PATH

--- a/tests/integration/targets/supervisorctl/meta/main.yml
+++ b/tests/integration/targets/supervisorctl/meta/main.yml
@@ -6,4 +6,4 @@
 dependencies:
   - setup_pkg_mgr
   - setup_remote_tmp_dir
-  - setup_pip_path
+  - setup_pip_scripts_path

--- a/tests/integration/targets/supervisorctl/meta/main.yml
+++ b/tests/integration/targets/supervisorctl/meta/main.yml
@@ -6,3 +6,4 @@
 dependencies:
   - setup_pkg_mgr
   - setup_remote_tmp_dir
+  - setup_pip_path

--- a/tests/integration/targets/supervisorctl/tasks/main.yml
+++ b/tests/integration/targets/supervisorctl/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Install/Uninstall supervisorctl block
   environment:
-    PATH: "{{ pip_path }}"
+    PATH: "{{ pip_scripts_path }}"
   block:
     - tempfile:
         state: directory

--- a/tests/integration/targets/supervisorctl/tasks/main.yml
+++ b/tests/integration/targets/supervisorctl/tasks/main.yml
@@ -8,7 +8,10 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- block:
+- name: Install/Uninstall supervisorctl block
+  environment:
+    PATH: "{{ pip_path }}"
+  block:
     - tempfile:
         state: directory
         suffix: supervisorctl-tests
@@ -34,8 +37,6 @@
             - 'install_{{ ansible_facts.system }}.yml'       # Linux
 
     - include_tasks: test.yml
-      environment:
-        PATH: "{{ pip_path }}"
       with_items:
         - { username: '', password: '' }
         - { username: 'testétest', password: 'passéword' } # non-ASCII credentials

--- a/tests/integration/targets/supervisorctl/tasks/main.yml
+++ b/tests/integration/targets/supervisorctl/tasks/main.yml
@@ -34,6 +34,8 @@
             - 'install_{{ ansible_facts.system }}.yml'       # Linux
 
     - include_tasks: test.yml
+      environment:
+        PATH: "{{ pip_path }}"
       with_items:
         - { username: '', password: '' }
         - { username: 'testétest', password: 'passéword' } # non-ASCII credentials


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Calculate a variable with the pip installation path prepended to PATH.

Trying to use that to enable supervisorctl tests in MacOS and RHEL

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
