### PR TITLE
apk: document non-interactive mode requirement

### DIFF
--- a/plugins/modules/apk.py
+++ b/plugins/modules/apk.py
@@ -79,7 +79,7 @@ notes:
   - When used with a C(loop:) each package is processed individually, it is much more efficient to pass the list directly
     to the O(name) option.
   - This module expects C(apk) to run in non-interactive mode. On Chimera Linux, C(apk) runs interactively by default,
-    which will cause this module to hang. Interactive mode can be configured in E(/etc/apk/config). Even though not
+    which will cause this module to hang. Interactive mode can be configured in C(/etc/apk/config). Even though not
     officially supported, other systems using C(apk) should be able to use this module, as long as C(apk) is running
     in non-interactive mode by default.
 """

--- a/plugins/modules/apk.py
+++ b/plugins/modules/apk.py
@@ -78,6 +78,10 @@ notes:
   - O(name) and O(upgrade) are mutually exclusive.
   - When used with a C(loop:) each package is processed individually, it is much more efficient to pass the list directly
     to the O(name) option.
+  - This module expects C(apk) to run in non-interactive mode. On Chimera Linux, C(apk) runs interactively by default,
+    which will cause this module to hang. Interactive mode can be configured in E(/etc/apk/config). Even though not
+    officially supported, other systems using C(apk) should be able to use this module, as long as C(apk) is running
+    in non-interactive mode by default.
 """
 
 EXAMPLES = r"""


### PR DESCRIPTION
## Summary

Adds a note to the `apk` module documentation clarifying that the module expects `apk` to run in non-interactive mode.

On Chimera Linux, `apk` runs interactively by default, which causes the module to hang waiting for user input. This PR documents the expected behavior and points users to the configuration file where interactive mode can be disabled.

Fixes #10521

## Issue Type

Docs Pull Request

## Component Name

`apk`

## Additional Information

The sanity test failures present in CI are pre-existing and unrelated to this change, as confirmed by running the tests against the unmodified file.