### PR TITLE
to_ini filter plugin: add no_extra_spaces parameter (#8576)

### DIFF
--- a/changelogs/fragments/12059-to_ini_filter_add_no_extra_spaces_parameter.yml
+++ b/changelogs/fragments/12059-to_ini_filter_add_no_extra_spaces_parameter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - to_ini filter plugin - add ``no_extra_spaces`` parameter (https://github.com/ansible-collections/community.general/issues/8576).
+  - to_ini filter plugin - add ``no_extra_spaces`` parameter (https://github.com/ansible-collections/community.general/issues/8576, https://github.com/ansible-collections/community.general/pull/12059).

--- a/changelogs/fragments/12059-to_ini_filter_add_no_extra_spaces_parameter.yml
+++ b/changelogs/fragments/12059-to_ini_filter_add_no_extra_spaces_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - to_ini filter plugin - add ``no_extra_spaces`` parameter (https://github.com/ansible-collections/community.general/issues/8576).

--- a/plugins/filter/to_ini.py
+++ b/plugins/filter/to_ini.py
@@ -79,6 +79,8 @@ def to_ini(obj, no_extra_spaces=False):
 
     if not isinstance(obj, Mapping):
         raise AnsibleFilterError(f"to_ini requires a dict, got {type(obj)}")
+    if not isinstance(no_extra_spaces, bool):
+        raise AnsibleFilterError(f"no_extra_spaces must be a boolean, got {type(no_extra_spaces)}")
 
     ini_parser = IniParser()
 

--- a/plugins/filter/to_ini.py
+++ b/plugins/filter/to_ini.py
@@ -21,6 +21,7 @@ options:
       - Do not insert spaces before and after '=' symbol.
     type: bool
     default: false
+    version_added: 13.0.0
 seealso:
   - plugin: ansible.builtin.ini
     plugin_type: lookup

--- a/plugins/filter/to_ini.py
+++ b/plugins/filter/to_ini.py
@@ -16,6 +16,11 @@ options:
     description: The dictionary that should be converted to the INI format.
     type: dictionary
     required: true
+  no_extra_spaces:
+    description:
+      - Do not insert spaces before and after '=' symbol.
+    type: bool
+    default: false
 seealso:
   - plugin: ansible.builtin.ini
     plugin_type: lookup
@@ -68,7 +73,7 @@ class IniParser(ConfigParser):
         self.optionxform = str
 
 
-def to_ini(obj):
+def to_ini(obj, no_extra_spaces=False):
     """Read the given dict and return an INI formatted string"""
 
     if not isinstance(obj, Mapping):
@@ -86,7 +91,7 @@ def to_ini(obj):
         raise AnsibleFilterError("to_ini received an empty dict. An empty dict cannot be converted.")
 
     config = StringIO()
-    ini_parser.write(config)
+    ini_parser.write(config, space_around_delimiters=not no_extra_spaces)
 
     # config.getvalue() returns two \n at the end
     # with the below insanity, we remove the very last character of

--- a/plugins/filter/to_ini.py
+++ b/plugins/filter/to_ini.py
@@ -74,7 +74,7 @@ class IniParser(ConfigParser):
         self.optionxform = str
 
 
-def to_ini(obj, no_extra_spaces=False):
+def to_ini(obj, *, no_extra_spaces=False):
     """Read the given dict and return an INI formatted string"""
 
     if not isinstance(obj, Mapping):

--- a/plugins/filter/to_ini.py
+++ b/plugins/filter/to_ini.py
@@ -18,7 +18,7 @@ options:
     required: true
   no_extra_spaces:
     description:
-      - Do not insert spaces before and after '=' symbol.
+      - Do not insert spaces before and after V(=) symbol.
     type: bool
     default: false
     version_added: 13.0.0


### PR DESCRIPTION
##### SUMMARY
Adds a `no_extra_spaces` parameter (analogous to the [ini_file module](https://docs.ansible.com/projects/ansible/latest/collections/community/general/ini_file_module.html#parameter-no_extra_spaces))  to the `to_ini` filter.

Fixes #8576

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
to_ini filter plugin

##### ADDITIONAL INFORMATION
n/a
