### PR TITLE
Fix flatpak id check

### DIFF
--- a/changelogs/fragments/12063-flatpak-id-check.yml
+++ b/changelogs/fragments/12063-flatpak-id-check.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - flatpak - fix reporting ``changed`` on already present flatpaks with a dash in the last part of the id (https://github.com/ansible-collections/community.general/issues/12062).

--- a/changelogs/fragments/12063-flatpak-id-check.yml
+++ b/changelogs/fragments/12063-flatpak-id-check.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - flatpak - fix reporting ``changed`` on already present flatpaks with a dash in the last part of the id (https://github.com/ansible-collections/community.general/issues/12062).
+  - flatpak - fix reporting ``changed`` on already present flatpaks with a dash in the last part of the ID (https://github.com/ansible-collections/community.general/issues/12062, https://github.com/ansible-collections/community.general/pull/12063).

--- a/plugins/modules/flatpak.py
+++ b/plugins/modules/flatpak.py
@@ -185,7 +185,6 @@ command:
 """
 
 from re import match
-
 from urllib.parse import urlparse
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/flatpak.py
+++ b/plugins/modules/flatpak.py
@@ -184,6 +184,8 @@ command:
   sample: "/usr/bin/flatpak install --user --nontinteractive flathub org.gnome.Calculator"
 """
 
+from re import match
+
 from urllib.parse import urlparse
 
 from ansible.module_utils.basic import AnsibleModule
@@ -324,15 +326,7 @@ def _is_flatpak_id(part):
     # https://docs.flatpak.org/en/latest/conventions.html#application-ids
     # Flathub:
     # https://docs.flathub.org/docs/for-app-authors/requirements#application-id
-    if "." not in part:
-        return False
-    sections = part.split(".")
-    if len(sections) < 2:
-        return False
-    domain = sections[0]
-    if not domain.islower():
-        return False
-    return all(section.isalnum() for section in sections[1:])
+    return match(r"^[a-z]{2,}(\.\w+)+\.[\w-]+$", part)
 
 
 def _parse_flatpak_name(name):


### PR DESCRIPTION
##### SUMMARY
This PR fixes the flatpak ID check by allowing the last component of the ID to contain dashes. The regular expression will match the flatpak ID according to the flatpak specification. It matches all 4600+ IDs currently present in flathub.

Fixes #12062

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
flatpak
##### ADDITIONAL INFORMATION
Fllatpaks with a dash in the name (e.g. org.freedesktop.Sdk.Extension.rust-stable) would install correctly but subsequent ansible runs would keep reporting 'changed' on this flatpak as if it was installed for the first time. This was due to a flawed flatpak id check which didn't account for dashes in the name. This is allowed by the [specification](https://docs.flatpak.org/en/latest/conventions.html#application-ids) but only in the last part.