### PR TITLE
cargo: fix version parsing when `state=latest`

### DIFF
--- a/changelogs/fragments/12064-cargo-latest-version-regex.yml
+++ b/changelogs/fragments/12064-cargo-latest-version-regex.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "cargo - fix ``state=latest`` always reporting ``changed`` due to greedy regex capturing description text instead of version string
+    (https://github.com/ansible-collections/community.general/issues/8949,
+    https://github.com/ansible-collections/community.general/pull/12064)."

--- a/plugins/modules/cargo.py
+++ b/plugins/modules/cargo.py
@@ -196,7 +196,7 @@ class Cargo:
         cmd = ["search", name, "--limit", "1"]
         data, dummy = self._exec(cmd, True, False, False)
 
-        match = re.search(r'"(.+)"', data)
+        match = re.search(r"^" + re.escape(name) + r'\s*=\s*"([^"]+)"', data, re.MULTILINE)
         if not match:
             self.module.fail_json(msg=f"No published version for package {name} found")
         return match.group(1)


### PR DESCRIPTION
##### SUMMARY

When `state=latest`, `is_outdated()` calls `get_latest_published_version()` which ran `cargo search <name> --limit 1` and parsed the output with the greedy regex `r'"(.+)"'`. Because `cargo search` includes a crate description on the same line, a description containing quoted text could cause the regex to capture far beyond the version string, returning garbage that never matched the installed version — making the task always report `changed`.

Two problems addressed:
- **Greedy capture**: changed `"(.+)"` to `[^"]+` so the match stops at the first closing quote.
- **Fuzzy name match**: `cargo search` is a fuzzy search; the first result may not be for the requested package. The regex now anchors on `^<name>\s*=\s*"..."` (multiline) to require an exact name match.

Fixes #8949

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cargo

##### ADDITIONAL INFORMATION

`cargo search` output format:
```
ludusavi = "0.21.0"    # A tool for backing up your "game" save data
```

Before the fix, `r'"(.+)"'` would match from the opening quote of the version all the way to the last `"` in the description, producing `0.21.0"    # A tool for backing up your "game` as the "version".