### PR TITLE
selective callback plugin: align host names in stats output

### DIFF
--- a/changelogs/fragments/12065-selective-callback-stats-alignment.yml
+++ b/changelogs/fragments/12065-selective-callback-stats-alignment.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - selective callback plugin - align host names in stats output by padding to the longest name (https://github.com/ansible-collections/community.general/issues/8797, https://github.com/ansible-collections/community.general/pull/12065).

--- a/plugins/callback/selective.py
+++ b/plugins/callback/selective.py
@@ -228,6 +228,7 @@ class CallbackModule(CallbackBase):
         self._print_task("STATS")
 
         hosts = sorted(stats.processed.keys())
+        max_len = max((len(h) for h in hosts), default=0)
         for host in hosts:
             s = stats.summarize(host)
 
@@ -239,8 +240,8 @@ class CallbackModule(CallbackBase):
                 color = "ok"
 
             msg = (
-                f"{host}    : ok={s['ok']}\tchanged={s['changed']}\tfailed={s['failures']}\tunreachable="
-                f"{s['unreachable']}\trescued={s['rescued']}\tignored={s['ignored']}"
+                f"{host.ljust(max_len)} : ok={s['ok']}\tchanged={s['changed']}\tfailed={s['failures']}\t"
+                f"unreachable={s['unreachable']}\trescued={s['rescued']}\tignored={s['ignored']}"
             )
             self._display.display(colorize(msg, color))
 


### PR DESCRIPTION
##### SUMMARY

The stats block at the end of a playbook run had misaligned host names because the separator between the hostname and `:` was a hardcoded 4-space string. Host names of different lengths caused the colon to appear at different columns.

Fixed by computing the longest hostname width and using `ljust()` to pad all names to the same width.

Fixes #8797

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
selective

##### ADDITIONAL INFORMATION

Before:
```
Kali    : ok=0	changed=0	...
bullseye-virtiofs    : ok=0	changed=0	...
```

After:
```
Kali              : ok=0	changed=0	...
bullseye-virtiofs : ok=0	changed=0	...
```