### PR TITLE
Mark nomad tests as unstable

### DIFF
--- a/tests/integration/targets/nomad/aliases
+++ b/tests/integration/targets/nomad/aliases
@@ -6,3 +6,4 @@ azp/posix/2
 nomad_job_info
 destructive
 skip/freebsd
+unstable  # TODO


### PR DESCRIPTION
##### SUMMARY
They currently fail a lot. Marking them as unstable still runs them in CI, but won't make a CI run fail if no files related to nomad are modified.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
nomad
