### PR TITLE
new module: apache2_site manage Apache2 virtual host sites

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -478,6 +478,8 @@ files:
   $modules/apache2_module.py:
     ignore: robinro
     maintainers: berendt n0trax
+  $modules/apache2_site.py:
+    maintainers: Francisco-Xiq
   $modules/apk.py:
     ignore: kbrebanov
     labels: apk

--- a/changelogs/fragments/9209-apache2-site.yml
+++ b/changelogs/fragments/9209-apache2-site.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - apache2_site - new module to enable/disable Apache2 sites using ``a2ensite`` and ``a2dissite`` (https://github.com/ansible-collections/community.general/issues/9209).

--- a/changelogs/fragments/9209-apache2-site.yml
+++ b/changelogs/fragments/9209-apache2-site.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - apache2_site - new module to enable/disable Apache2 sites using ``a2ensite`` and ``a2dissite`` (https://github.com/ansible-collections/community.general/issues/9209).

--- a/plugins/modules/apache2_site.py
+++ b/plugins/modules/apache2_site.py
@@ -60,6 +60,7 @@ name:
 """
 
 import os
+
 from ansible.module_utils.basic import AnsibleModule
 
 
@@ -89,10 +90,7 @@ def main():
             a2ensite = module.get_bin_path("a2ensite", required=True)
             rc, stdout, stderr = module.run_command([a2ensite, name])
             if rc != 0:
-                module.fail_json(
-                    msg=f"Failed to enable site {name}: {stderr}",
-                    rc=rc, stdout=stdout, stderr=stderr
-                )
+                module.fail_json(msg=f"Failed to enable site {name}: {stderr}", rc=rc, stdout=stdout, stderr=stderr)
 
     elif not want_enabled and is_enabled:
         changed = True
@@ -100,10 +98,7 @@ def main():
             a2dissite = module.get_bin_path("a2dissite", required=True)
             rc, stdout, stderr = module.run_command([a2dissite, name])
             if rc != 0:
-                module.fail_json(
-                    msg=f"Failed to disable site {name}: {stderr}",
-                    rc=rc, stdout=stdout, stderr=stderr
-                )
+                module.fail_json(msg=f"Failed to disable site {name}: {stderr}", rc=rc, stdout=stdout, stderr=stderr)
 
     module.exit_json(changed=changed, name=name)
 

--- a/plugins/modules/apache2_site.py
+++ b/plugins/modules/apache2_site.py
@@ -16,7 +16,7 @@ description:
   - Uses C(a2ensite) and C(a2dissite) under the hood.
 version_added: 13.1.0
 notes:
-  - This module is only available on Debian/Ubuntu-based systems,
+  - This module is only supported on Debian/Ubuntu-based systems,
     as it depends on C(a2ensite) and C(a2dissite).
 extends_documentation_fragment:
   - community.general._attributes

--- a/plugins/modules/apache2_site.py
+++ b/plugins/modules/apache2_site.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2025, Francisco Pereira (@Francisco-Xiq)
+# Copyright (c) 2026, Francisco Pereira (@Francisco-Xiq)
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -88,17 +88,13 @@ def main():
         changed = True
         if not module.check_mode:
             a2ensite = module.get_bin_path("a2ensite", required=True)
-            rc, stdout, stderr = module.run_command([a2ensite, name])
-            if rc != 0:
-                module.fail_json(msg=f"Failed to enable site {name}: {stderr}", rc=rc, stdout=stdout, stderr=stderr)
+            module.run_command([a2ensite, name], check_rc=True)
 
     elif not want_enabled and is_enabled:
         changed = True
         if not module.check_mode:
             a2dissite = module.get_bin_path("a2dissite", required=True)
-            rc, stdout, stderr = module.run_command([a2dissite, name])
-            if rc != 0:
-                module.fail_json(msg=f"Failed to disable site {name}: {stderr}", rc=rc, stdout=stdout, stderr=stderr)
+            module.run_command([a2dissite, name], check_rc=True)
 
     module.exit_json(changed=changed, name=name)
 

--- a/plugins/modules/apache2_site.py
+++ b/plugins/modules/apache2_site.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python
+
+# Copyright (c) 2025, Francisco Pereira (@Francisco-Xiq)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+DOCUMENTATION = r"""
+module: apache2_site
+author:
+  - Francisco Pereira (@Francisco-Xiq)
+short_description: Enables/disables a site of the Apache2 webserver
+description:
+  - Enables or disables a specified site of the Apache2 webserver.
+  - Uses C(a2ensite) and C(a2dissite) under the hood.
+notes:
+  - This module is only available on Debian/Ubuntu-based systems,
+    as it depends on C(a2ensite) and C(a2dissite).
+extends_documentation_fragment:
+  - community.general._attributes
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
+options:
+  name:
+    type: str
+    description:
+      - Name of the site to enable/disable as given to C(a2ensite)/C(a2dissite).
+      - The name should not include the C(.conf) extension.
+    required: true
+  state:
+    type: str
+    description:
+      - Desired state of the site.
+    choices: [present, absent]
+    required: true
+"""
+
+EXAMPLES = r"""
+- name: Enable my_cool_site
+  community.general.apache2_site:
+    state: present
+    name: my_cool_site
+
+- name: Disable old site
+  community.general.apache2_site:
+    state: absent
+    name: very_old_site
+"""
+
+RETURN = r"""
+name:
+  description: Name of the site.
+  returned: success
+  type: str
+  sample: my_cool_site
+"""
+
+import os
+from ansible.module_utils.basic import AnsibleModule
+
+
+def site_is_enabled(name):
+    return os.path.islink(f"/etc/apache2/sites-enabled/{name}.conf")
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(type="str", required=True),
+            state=dict(type="str", required=True, choices=["present", "absent"]),
+        ),
+        supports_check_mode=True,
+    )
+
+    name = module.params["name"]
+    state = module.params["state"]
+    want_enabled = state == "present"
+    is_enabled = site_is_enabled(name)
+
+    changed = False
+
+    if want_enabled and not is_enabled:
+        changed = True
+        if not module.check_mode:
+            a2ensite = module.get_bin_path("a2ensite", required=True)
+            rc, stdout, stderr = module.run_command([a2ensite, name])
+            if rc != 0:
+                module.fail_json(
+                    msg=f"Failed to enable site {name}: {stderr}",
+                    rc=rc, stdout=stdout, stderr=stderr
+                )
+
+    elif not want_enabled and is_enabled:
+        changed = True
+        if not module.check_mode:
+            a2dissite = module.get_bin_path("a2dissite", required=True)
+            rc, stdout, stderr = module.run_command([a2dissite, name])
+            if rc != 0:
+                module.fail_json(
+                    msg=f"Failed to disable site {name}: {stderr}",
+                    rc=rc, stdout=stdout, stderr=stderr
+                )
+
+    module.exit_json(changed=changed, name=name)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/apache2_site.py
+++ b/plugins/modules/apache2_site.py
@@ -14,6 +14,7 @@ short_description: Enables/disables a site of the Apache2 webserver
 description:
   - Enables or disables a specified site of the Apache2 webserver.
   - Uses C(a2ensite) and C(a2dissite) under the hood.
+version_added: 13.0.0
 notes:
   - This module is only available on Debian/Ubuntu-based systems,
     as it depends on C(a2ensite) and C(a2dissite).

--- a/plugins/modules/apache2_site.py
+++ b/plugins/modules/apache2_site.py
@@ -14,7 +14,7 @@ short_description: Enables/disables a site of the Apache2 webserver
 description:
   - Enables or disables a specified site of the Apache2 webserver.
   - Uses C(a2ensite) and C(a2dissite) under the hood.
-version_added: 13.0.0
+version_added: 13.1.0
 notes:
   - This module is only available on Debian/Ubuntu-based systems,
     as it depends on C(a2ensite) and C(a2dissite).

--- a/tests/integration/targets/apache2_site/aliases
+++ b/tests/integration/targets/apache2_site/aliases
@@ -1,0 +1,6 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+azp/posix/3
+destructive

--- a/tests/integration/targets/apache2_site/aliases
+++ b/tests/integration/targets/apache2_site/aliases
@@ -4,3 +4,8 @@
 
 azp/posix/3
 destructive
+
+skip/rhel
+skip/freebsd
+skip/macos
+skip/alpine

--- a/tests/integration/targets/apache2_site/meta/main.yml
+++ b/tests/integration/targets/apache2_site/meta/main.yml
@@ -1,0 +1,7 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependencies:
+  - setup_apache2

--- a/tests/integration/targets/apache2_site/tasks/actualtest.yml
+++ b/tests/integration/targets/apache2_site/tasks/actualtest.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: create test site config
+- name: Create test site config
   ansible.builtin.copy:
     dest: /etc/apache2/sites-available/ansible_test_site.conf
     content: |
@@ -12,73 +12,73 @@
           DocumentRoot /var/www/html
       </VirtualHost>
 
-- name: enable test site
+- name: Enable test site
   community.general.apache2_site:
     name: ansible_test_site
     state: present
   register: enable_first
 
-- name: ensure changed on first enable
+- name: Ensure changed on first enable
   ansible.builtin.assert:
     that:
       - enable_first is changed
 
-- name: enable test site again (idempotency check)
+- name: Enable test site again (idempotency check)
   community.general.apache2_site:
     name: ansible_test_site
     state: present
   register: enable_second
 
-- name: ensure idempotency on enable
+- name: Ensure idempotency on enable
   ansible.builtin.assert:
     that:
       - enable_second is not changed
 
-- name: disable test site
+- name: Disable test site
   community.general.apache2_site:
     name: ansible_test_site
     state: absent
   register: disable_first
 
-- name: ensure changed on first disable
+- name: Ensure changed on first disable
   ansible.builtin.assert:
     that:
       - disable_first is changed
 
-- name: disable test site again (idempotency check)
+- name: Disable test site again (idempotency check)
   community.general.apache2_site:
     name: ansible_test_site
     state: absent
   register: disable_second
 
-- name: ensure idempotency on disable
+- name: Ensure idempotency on disable
   ansible.builtin.assert:
     that:
       - disable_second is not changed
 
-- name: enable test site in check_mode
+- name: Enable test site in check_mode
   community.general.apache2_site:
     name: ansible_test_site
     state: present
   check_mode: true
   register: check_mode_result
 
-- name: ensure check_mode reports changed
+- name: Ensure check_mode reports changed
   ansible.builtin.assert:
     that:
       - check_mode_result is changed
 
-- name: ensure check_mode did not actually enable the site
+- name: Ensure check_mode did not actually enable the site
   ansible.builtin.stat:
     path: /etc/apache2/sites-enabled/ansible_test_site.conf
   register: site_stat
 
-- name: assert symlink was not created in check_mode
+- name: Assert symlink was not created in check_mode
   ansible.builtin.assert:
     that:
       - not site_stat.stat.exists
 
-- name: remove test site config
+- name: Remove test site config
   ansible.builtin.file:
     path: /etc/apache2/sites-available/ansible_test_site.conf
     state: absent

--- a/tests/integration/targets/apache2_site/tasks/actualtest.yml
+++ b/tests/integration/targets/apache2_site/tasks/actualtest.yml
@@ -3,7 +3,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# Setup: create a minimal site config for testing
 - name: create test site config
   ansible.builtin.copy:
     dest: /etc/apache2/sites-available/ansible_test_site.conf
@@ -13,9 +12,6 @@
           DocumentRoot /var/www/html
       </VirtualHost>
 
-# ------------------------------------------------------------------
-# Test: enable a site
-# ------------------------------------------------------------------
 - name: enable test site
   community.general.apache2_site:
     name: ansible_test_site
@@ -27,9 +23,6 @@
     that:
       - enable_first is changed
 
-# ------------------------------------------------------------------
-# Test: idempotency on enable
-# ------------------------------------------------------------------
 - name: enable test site again (idempotency check)
   community.general.apache2_site:
     name: ansible_test_site
@@ -41,9 +34,6 @@
     that:
       - enable_second is not changed
 
-# ------------------------------------------------------------------
-# Test: disable a site
-# ------------------------------------------------------------------
 - name: disable test site
   community.general.apache2_site:
     name: ansible_test_site
@@ -55,9 +45,6 @@
     that:
       - disable_first is changed
 
-# ------------------------------------------------------------------
-# Test: idempotency on disable
-# ------------------------------------------------------------------
 - name: disable test site again (idempotency check)
   community.general.apache2_site:
     name: ansible_test_site
@@ -69,9 +56,6 @@
     that:
       - disable_second is not changed
 
-# ------------------------------------------------------------------
-# Test: check_mode does not make changes
-# ------------------------------------------------------------------
 - name: enable test site in check_mode
   community.general.apache2_site:
     name: ansible_test_site
@@ -94,9 +78,6 @@
     that:
       - not site_stat.stat.exists
 
-# ------------------------------------------------------------------
-# Cleanup: remove test site config
-# ------------------------------------------------------------------
 - name: remove test site config
   ansible.builtin.file:
     path: /etc/apache2/sites-available/ansible_test_site.conf

--- a/tests/integration/targets/apache2_site/tasks/actualtest.yml
+++ b/tests/integration/targets/apache2_site/tasks/actualtest.yml
@@ -1,0 +1,103 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Setup: create a minimal site config for testing
+- name: create test site config
+  ansible.builtin.copy:
+    dest: /etc/apache2/sites-available/ansible_test_site.conf
+    content: |
+      <VirtualHost *:80>
+          ServerName ansible-test.local
+          DocumentRoot /var/www/html
+      </VirtualHost>
+
+# ------------------------------------------------------------------
+# Test: enable a site
+# ------------------------------------------------------------------
+- name: enable test site
+  community.general.apache2_site:
+    name: ansible_test_site
+    state: present
+  register: enable_first
+
+- name: ensure changed on first enable
+  ansible.builtin.assert:
+    that:
+      - enable_first is changed
+
+# ------------------------------------------------------------------
+# Test: idempotency on enable
+# ------------------------------------------------------------------
+- name: enable test site again (idempotency check)
+  community.general.apache2_site:
+    name: ansible_test_site
+    state: present
+  register: enable_second
+
+- name: ensure idempotency on enable
+  ansible.builtin.assert:
+    that:
+      - enable_second is not changed
+
+# ------------------------------------------------------------------
+# Test: disable a site
+# ------------------------------------------------------------------
+- name: disable test site
+  community.general.apache2_site:
+    name: ansible_test_site
+    state: absent
+  register: disable_first
+
+- name: ensure changed on first disable
+  ansible.builtin.assert:
+    that:
+      - disable_first is changed
+
+# ------------------------------------------------------------------
+# Test: idempotency on disable
+# ------------------------------------------------------------------
+- name: disable test site again (idempotency check)
+  community.general.apache2_site:
+    name: ansible_test_site
+    state: absent
+  register: disable_second
+
+- name: ensure idempotency on disable
+  ansible.builtin.assert:
+    that:
+      - disable_second is not changed
+
+# ------------------------------------------------------------------
+# Test: check_mode does not make changes
+# ------------------------------------------------------------------
+- name: enable test site in check_mode
+  community.general.apache2_site:
+    name: ansible_test_site
+    state: present
+  check_mode: true
+  register: check_mode_result
+
+- name: ensure check_mode reports changed
+  ansible.builtin.assert:
+    that:
+      - check_mode_result is changed
+
+- name: ensure check_mode did not actually enable the site
+  ansible.builtin.stat:
+    path: /etc/apache2/sites-enabled/ansible_test_site.conf
+  register: site_stat
+
+- name: assert symlink was not created in check_mode
+  ansible.builtin.assert:
+    that:
+      - not site_stat.stat.exists
+
+# ------------------------------------------------------------------
+# Cleanup: remove test site config
+# ------------------------------------------------------------------
+- name: remove test site config
+  ansible.builtin.file:
+    path: /etc/apache2/sites-available/ansible_test_site.conf
+    state: absent

--- a/tests/integration/targets/apache2_site/tasks/main.yml
+++ b/tests/integration/targets/apache2_site/tasks/main.yml
@@ -37,4 +37,3 @@
     - name: ensure that all test sites are disabled again
       ansible.builtin.assert:
         that: sites_before.stdout == sites_after.stdout
-

--- a/tests/integration/targets/apache2_site/tasks/main.yml
+++ b/tests/integration/targets/apache2_site/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: test apache2_site
 
   when: ansible_facts.os_family == 'Debian'
-  
+
   block:
     - name: get list of enabled sites before tests
       ansible.builtin.command: ls /etc/apache2/sites-enabled/

--- a/tests/integration/targets/apache2_site/tasks/main.yml
+++ b/tests/integration/targets/apache2_site/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: test apache2_site
+  block:
+    - name: get list of enabled sites before tests
+      ansible.builtin.command: ls /etc/apache2/sites-enabled/
+      register: sites_before
+      changed_when: false
+
+    - name: include actual tests
+      include_tasks: actualtest.yml
+
+  always:
+    - name: get list of enabled sites after tests
+      ansible.builtin.command: ls /etc/apache2/sites-enabled/
+      register: sites_after
+      changed_when: false
+
+    - name: sites before tests
+      ansible.builtin.debug:
+        var: sites_before.stdout_lines
+
+    - name: sites after tests
+      ansible.builtin.debug:
+        var: sites_after.stdout_lines
+
+    - name: ensure that all test sites are disabled again
+      ansible.builtin.assert:
+        that: sites_before.stdout == sites_after.stdout
+
+  when: ansible_facts.os_family == 'Debian'
+  # a2ensite/a2dissite are Debian/Ubuntu specific tools

--- a/tests/integration/targets/apache2_site/tasks/main.yml
+++ b/tests/integration/targets/apache2_site/tasks/main.yml
@@ -9,6 +9,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: test apache2_site
+
+  when: ansible_facts.os_family == 'Debian'
+  
   block:
     - name: get list of enabled sites before tests
       ansible.builtin.command: ls /etc/apache2/sites-enabled/
@@ -16,9 +19,8 @@
       changed_when: false
 
     - name: include actual tests
-      include_tasks: actualtest.yml
+      ansible.builtin.include_tasks: actualtest.yml
 
-  always:
     - name: get list of enabled sites after tests
       ansible.builtin.command: ls /etc/apache2/sites-enabled/
       register: sites_after
@@ -36,5 +38,3 @@
       ansible.builtin.assert:
         that: sites_before.stdout == sites_after.stdout
 
-  when: ansible_facts.os_family == 'Debian'
-  # a2ensite/a2dissite are Debian/Ubuntu specific tools


### PR DESCRIPTION
##### SUMMARY
Adds a new module `apache2_site` to enable/disable Apache2 virtual host sites
using `a2ensite` and `a2dissite`.

Fixes #9209


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- New Module/Plugin Pull Request


##### COMPONENT NAME
`apache2_site`

##### ADDITIONAL INFORMATION
This module manages Apache2 sites on Debian/Ubuntu-based systems by enabling
or disabling them via `a2ensite` and `a2dissite`. It supports `check_mode`.

### TESTS
Integration tests included in `tests/integration/targets/apache2_site/`.
Tested locally with `ansible-test integration apache2_site --docker default --python 3.11`.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible-test sanity plugins/modules/apache2_site.py --docker default -v
Configured locale: C.UTF-8
Run command: docker -v
Detected "docker" container runtime version: Docker version 29.5.0, build 98f1464
Run command: docker info --format '{{ json . }}'
Run command: docker version --format '{{ json . }}'
Container runtime: docker client=29.5.0 server=29.5.0 cgroup=v2
Assuming Docker is available on localhost.
Run command: docker image inspect quay.io/ansible/default-test-container:v2.20-4
Run command: docker image inspect quay.io/ansible/ansible-test-utility-container:3.4.0
Run command: docker run --volume /sys/fs/cgroup:/probe:ro --name ansible-test-probe-PR8gaerR --rm quay.io/ansible/ansible-test-utility-container:3.4.0 sh -c 'audit-status && cat /proc/sys ...
Container host audit status: EPERM (-1)
Container host max open files: 524288
Container loginuid: 4294967295 (not set)
Starting new "ansible-test-controller-PR8gaerR" container.
Run command: docker run --tmpfs /tmp:exec --tmpfs /run:exec --tmpfs /run/lock --volume /var/run/docker.sock:/var/run/docker.sock --cgroupns private -dt --ulimit nofile=10240 --name ansibl ...
Adding "ansible-test-controller-PR8gaerR" to container database.
Run command: docker container inspect ansible-test-controller-PR8gaerR
Run command: docker run --pid host --privileged --name ansible-test-init-controller-PR8gaerR --rm quay.io/ansible/ansible-test-utility-container:3.4.0 nsenter -t 22532 -m -p sh -c 'mount  ...
Stream command with data: docker exec -i ansible-test-controller-PR8gaerR /bin/sh
Bootstrapping Python 3.14 at: /usr/bin/python3.14
Loaded configuration: tests/config.yml
Scanning collection root: /home/chico/opensource/ansible_collections
Including collection: community.general (3601 files)
Creating a payload archive containing 4634 files...
Created a 4233534 byte payload archive containing 4634 files in 0 seconds.
Run command with stdin: docker exec -i ansible-test-controller-PR8gaerR tar oxzf - -C /root
Creating container database.
Stream command: docker exec ansible-test-controller-PR8gaerR /usr/bin/env ANSIBLE_TEST_CONTENT_ROOT=/root/ansible_collections/community/general LC_ALL=en_US.UTF-8 /usr/bin/python3.14 /roo ...
Configured locale: en_US.UTF-8
Parsing container database.
Read 9 sanity test ignore line(s) for Ansible 2.20 from: tests/sanity/ignore-2.20.txt
Running sanity test "action-plugin-docs"
Initializing "/tmp/ansible-test-f8v0hjnf-injector" as the temporary injector directory.
Run command with data: /root/.ansible/test/venv/sanity/3.14/4f53cda1/bin/python /root/ansible/test/lib/ansible_test/_util/controller/sanity/code-smell/action-plugin-docs.py
Running sanity test "ansible-doc"
Run command: ansible-doc -t module community.general.apache2_site
Run command: ansible-doc -t module --json community.general.apache2_site
Running sanity test "changelog"
No tests applicable.
Running sanity test "compile" on Python 3.9
Run command with data: /usr/bin/python3.9 /root/ansible/test/lib/ansible_test/_util/target/sanity/compile/compile.py
Running sanity test "compile" on Python 3.10
Run command with data: /usr/bin/python3.10 /root/ansible/test/lib/ansible_test/_util/target/sanity/compile/compile.py
Running sanity test "compile" on Python 3.11
Run command with data: /usr/bin/python3.11 /root/ansible/test/lib/ansible_test/_util/target/sanity/compile/compile.py
Running sanity test "compile" on Python 3.12
Run command with data: /usr/bin/python3.12 /root/ansible/test/lib/ansible_test/_util/target/sanity/compile/compile.py
Running sanity test "compile" on Python 3.13
Run command with data: /usr/bin/python3.13 /root/ansible/test/lib/ansible_test/_util/target/sanity/compile/compile.py
Running sanity test "compile" on Python 3.14
Run command with data: /usr/bin/python3.14 /root/ansible/test/lib/ansible_test/_util/target/sanity/compile/compile.py
Running sanity test "empty-init"
No tests applicable.
Running sanity test "ignores"
Running sanity test "import" on Python 3.9
Run command with data: importer.py
Running sanity test "import" on Python 3.10
Run command with data: importer.py
Running sanity test "import" on Python 3.11
Run command with data: importer.py
Running sanity test "import" on Python 3.12
Run command with data: importer.py
Running sanity test "import" on Python 3.13
Run command with data: importer.py
Running sanity test "import" on Python 3.14
Run command with data: importer.py
Running sanity test "line-endings"
Run command with data: /root/.ansible/test/venv/sanity/3.14/4f53cda1/bin/python /root/ansible/test/lib/ansible_test/_util/controller/sanity/code-smell/line-endings.py
Running sanity test "no-assert"
Run command with data: /root/.ansible/test/venv/sanity/3.14/4f53cda1/bin/python /root/ansible/test/lib/ansible_test/_util/controller/sanity/code-smell/no-assert.py
Running sanity test "no-get-exception"
Run command with data: /root/.ansible/test/venv/sanity/3.14/4f53cda1/bin/python /root/ansible/test/lib/ansible_test/_util/controller/sanity/code-smell/no-get-exception.py
Running sanity test "no-illegal-filenames"
Run command with data: /root/.ansible/test/venv/sanity/3.14/4f53cda1/bin/python /root/ansible/test/lib/ansible_test/_util/controller/sanity/code-smell/no-illegal-filenames.py
Running sanity test "no-smart-quotes"
Run command with data: /root/.ansible/test/venv/sanity/3.14/4f53cda1/bin/python /root/ansible/test/lib/ansible_test/_util/controller/sanity/code-smell/no-smart-quotes.py
Running sanity test "pep8"
Run command: /root/.ansible/test/venv/sanity.pep8/3.14/84e10cff/bin/python -m pycodestyle --max-line-length 160 --config /dev/null --ignore E203,E402,E701,E704,E741,W503,W504 plugins/modu ...
Running sanity test "pslint"
No tests applicable.
Running sanity test "pylint"
Run command: /root/.ansible/test/venv/sanity.pylint/3.14/ff3a769b/bin/python /root/ansible/test/lib/ansible_test/_util/controller/tools/collection_detail.py /root/ansible_collections/comm ...
Checking 1 file(s) in context 'modules' (target) with config: /root/ansible/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
Run command: /root/.ansible/test/venv/sanity.pylint/3.14/ff3a769b/bin/python -m pylint --py-version 3.9 --load-plugins deprecated_calls,deprecated_comment,hide_unraisable,string_format,un ...
Running sanity test "replace-urlopen"
Run command with data: /root/.ansible/test/venv/sanity/3.14/4f53cda1/bin/python /root/ansible/test/lib/ansible_test/_util/controller/sanity/code-smell/replace-urlopen.py
Running sanity test "runtime-metadata"
No tests applicable.
Running sanity test "shebang"
Run command with data: /root/.ansible/test/venv/sanity/3.14/4f53cda1/bin/python /root/ansible/test/lib/ansible_test/_util/controller/sanity/code-smell/shebang.py
Running sanity test "shellcheck"
No tests applicable.
Running sanity test "symlinks"
Run command with data: /root/.ansible/test/venv/sanity/3.14/4f53cda1/bin/python /root/ansible/test/lib/ansible_test/_util/controller/sanity/code-smell/symlinks.py
Running sanity test "use-argspec-type-path"
Run command with data: /root/.ansible/test/venv/sanity/3.14/4f53cda1/bin/python /root/ansible/test/lib/ansible_test/_util/controller/sanity/code-smell/use-argspec-type-path.py
Running sanity test "use-compat-six"
Run command with data: /root/.ansible/test/venv/sanity/3.14/4f53cda1/bin/python /root/ansible/test/lib/ansible_test/_util/controller/sanity/code-smell/use-compat-six.py
Running sanity test "validate-modules"
Run command: /root/.ansible/test/venv/sanity.validate-modules/3.14/8088ee77/bin/python /root/ansible/test/lib/ansible_test/_util/controller/tools/collection_detail.py /root/ansible_collec ...
Run command: /root/.ansible/test/venv/sanity.validate-modules/3.14/8088ee77/bin/python /root/ansible/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate.py --format js ...
Running sanity test "yamllint"
Run command with data: /root/.ansible/test/venv/sanity.yamllint/3.14/a8582752/bin/python /root/ansible/test/lib/ansible_test/_util/controller/sanity/yamllint/yamllinter.py
Run command with stdout: docker exec -i ansible-test-controller-PR8gaerR sh -c 'tar cf - -C /root/ansible_collections/community/general/tests --exclude .tmp output | gzip'
Run command with stdin: tar oxzf - -C /home/chico/opensource/ansible_collections/community/general/tests
Run command: docker stop -t 0 ansible-test-controller-PR8gaerR
Run command: docker rm ansible-test-controller-PR8gaerR
 ```
