### PR TITLE
composer: config file hash to evaluate whether a change occurred

### DIFF
--- a/changelogs/fragments/composer-working-dir-and-config-sha256.yaml
+++ b/changelogs/fragments/composer-working-dir-and-config-sha256.yaml
@@ -5,8 +5,8 @@ bugfixes:
   - composer - the ``--working-dir`` option is now always placed first on the command line, before the
     subcommand, to ensure consistent behavior across all composer commands
     (https://github.com/ansible-collections/community.general/pull/12084).
-  - composer - use file sha256 hashing to determine ``changed`` status when ``command=config``,
-    instead of relying on the command return output. The module now compares sha256 checksums of
+  - composer - use file checksum to determine ``changed`` status when ``command=config``,
+    instead of relying on the command return output. The module now compares SHA256 checksums of
     relevant configuration files (``composer.json``, ``auth.json``, or their global equivalents)
     before and after running the command
     (https://github.com/ansible-collections/community.general/pull/12084).

--- a/changelogs/fragments/composer-working-dir-and-config-sha256.yaml
+++ b/changelogs/fragments/composer-working-dir-and-config-sha256.yaml
@@ -1,0 +1,12 @@
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+minor_changes:
+  - composer - the ``--working-dir`` option is now always placed first on the command line, before the
+    subcommand, to ensure consistent behavior across all composer commands
+    (https://github.com/ansible-collections/community.general/pull/12084).
+  - composer - use file sha256 hashing to determine ``changed`` status when ``command=config``,
+    instead of relying on the command return output. The module now compares sha256 checksums of
+    relevant configuration files (``composer.json``, ``auth.json``, or their global equivalents)
+    before and after running the command
+    (https://github.com/ansible-collections/community.general/pull/12084).

--- a/changelogs/fragments/composer-working-dir-and-config-sha256.yaml
+++ b/changelogs/fragments/composer-working-dir-and-config-sha256.yaml
@@ -4,7 +4,7 @@
 bugfixes:
   - composer - the ``--working-dir`` option is now always placed first on the command line, before the
     subcommand, to ensure consistent behavior across all composer commands
-    (https://github.com/ansible-collections/community.general/pull/12084).
+    (https://github.com/ansible-collections/community.general/issues/5204, https://github.com/ansible-collections/community.general/pull/12084).
   - composer - use file checksum to determine ``changed`` status when ``command=config``,
     instead of relying on the command return output. The module now compares SHA256 checksums of
     relevant configuration files (``composer.json``, ``auth.json``, or their global equivalents)

--- a/changelogs/fragments/composer-working-dir-and-config-sha256.yaml
+++ b/changelogs/fragments/composer-working-dir-and-config-sha256.yaml
@@ -1,7 +1,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-minor_changes:
+bugfixes:
   - composer - the ``--working-dir`` option is now always placed first on the command line, before the
     subcommand, to ensure consistent behavior across all composer commands
     (https://github.com/ansible-collections/community.general/pull/12084).

--- a/plugins/modules/composer.py
+++ b/plugins/modules/composer.py
@@ -186,9 +186,10 @@ def composer_command(module, command, arguments=None, options=None):
 
     if global_command:
         global_arg = ["global"]
+        working_dir_option = []
     else:
         global_arg = []
-        options.extend(["--working-dir", module.params["working_dir"]])
+        working_dir_option = ["--working-dir", module.params["working_dir"]]
 
     if module.params["executable"] is None:
         php_path = module.get_bin_path("php", True, ["/usr/local/bin"])
@@ -200,8 +201,57 @@ def composer_command(module, command, arguments=None, options=None):
     else:
         composer_path = module.params["composer_executable"]
 
-    cmd = [php_path, composer_path] + global_arg + command + options + arguments
+    cmd = [php_path, composer_path] + working_dir_option + global_arg + command + options + arguments
     return module.run_command(cmd)
+
+
+def get_composer_home(module):
+    """Get the composer home directory by running 'composer config --global home'."""
+    if module.params["executable"] is None:
+        php_path = module.get_bin_path("php", True, ["/usr/local/bin"])
+    else:
+        php_path = module.params["executable"]
+
+    if module.params["composer_executable"] is None:
+        composer_path = module.get_bin_path("composer", True, ["/usr/local/bin"])
+    else:
+        composer_path = module.params["composer_executable"]
+
+    cmd = [php_path, composer_path, "config", "--global", "--no-interaction", "home"]
+    rc, out, err = module.run_command(cmd)
+    if rc == 0:
+        return out.strip()
+    return None
+
+
+def get_config_files(module):
+    """Get list of config files that might be changed by 'composer config'."""
+    files = []
+    global_command = module.params["global_command"]
+    working_dir = module.params["working_dir"]
+
+    if global_command:
+        composer_home = get_composer_home(module)
+        if composer_home:
+            for f in ("config.json", "auth.json"):
+                files.append(os.path.join(composer_home, f))
+    else:
+        if working_dir:
+            for f in ("composer.json", "auth.json"):
+                files.append(os.path.join(working_dir, f))
+
+    return files
+
+
+def hash_config_files(module, files):
+    """Return a dict mapping file path to its sha256 hash (or None if the file does not exist)."""
+    hashes = {}
+    for f in files:
+        if os.path.isfile(f):
+            hashes[f] = module.sha256(f)
+        else:
+            hashes[f] = None
+    return hashes
 
 
 def main():
@@ -280,6 +330,12 @@ def main():
         else:
             module.exit_json(skipped=True, msg=f"command '{command}' does not support check mode, skipping")
 
+    # For 'config' command in non-check mode, use sha256 hashing to detect changes
+    use_hash_detection = (command == "config" and not module.check_mode)
+    if use_hash_detection:
+        config_files = get_config_files(module)
+        hashes_before = hash_config_files(module, config_files)
+
     rc, out, err = composer_command(module, [command], arguments, options)
 
     if rc != 0:
@@ -288,7 +344,12 @@ def main():
     else:
         # Composer version > 1.0.0-alpha9 now use stderr for standard notification messages
         output = parse_out(out + err)
-        module.exit_json(changed=has_changed(output), msg=output, stdout=out + err)
+        if use_hash_detection:
+            hashes_after = hash_config_files(module, config_files)
+            changed = hashes_before != hashes_after
+        else:
+            changed = has_changed(output)
+        module.exit_json(changed=changed, msg=output, stdout=out + err)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/composer.py
+++ b/plugins/modules/composer.py
@@ -246,9 +246,9 @@ def get_config_files(module):
 def hash_config_files(module, files):
     """Return a dict mapping file path to its sha256 hash (or None if the file does not exist)."""
     return {
-        f: (module.sha256(f) if os.path.isfile(f) else None) 
+        f: (module.sha256(f) if os.path.isfile(f) else None)
         for f in files
-    } 
+    }
 
 
 def main():

--- a/plugins/modules/composer.py
+++ b/plugins/modules/composer.py
@@ -245,13 +245,10 @@ def get_config_files(module):
 
 def hash_config_files(module, files):
     """Return a dict mapping file path to its sha256 hash (or None if the file does not exist)."""
-    hashes = {}
-    for f in files:
-        if os.path.isfile(f):
-            hashes[f] = module.sha256(f)
-        else:
-            hashes[f] = None
-    return hashes
+    return {
+        f: (module.sha256(f) if os.path.isfile(f) else None) 
+        for f in files
+    } 
 
 
 def main():

--- a/plugins/modules/composer.py
+++ b/plugins/modules/composer.py
@@ -226,19 +226,16 @@ def get_composer_home(module):
 
 def get_config_files(module):
     """Get list of config files that might be changed by 'composer config'."""
-    files = []
+    files = ["composer.json", "auth.json"]
     global_command = module.params["global_command"]
     working_dir = module.params["working_dir"]
 
     if global_command:
         composer_home = get_composer_home(module)
         if composer_home:
-            for f in ("config.json", "auth.json"):
-                files.append(os.path.join(composer_home, f))
-    else:
-        if working_dir:
-            for f in ("composer.json", "auth.json"):
-                files.append(os.path.join(working_dir, f))
+            files = [os.path.join(composer_home, f) for f in files]
+    elif working_dir:
+        files = [os.path.join(working_dir, f) for f in files]
 
     return files
 

--- a/plugins/modules/composer.py
+++ b/plugins/modules/composer.py
@@ -242,10 +242,7 @@ def get_config_files(module):
 
 def hash_config_files(module, files):
     """Return a dict mapping file path to its sha256 hash (or None if the file does not exist)."""
-    return {
-        f: (module.sha256(f) if os.path.isfile(f) else None)
-        for f in files
-    }
+    return {f: (module.sha256(f) if os.path.isfile(f) else None) for f in files}
 
 
 def main():
@@ -325,7 +322,7 @@ def main():
             module.exit_json(skipped=True, msg=f"command '{command}' does not support check mode, skipping")
 
     # For 'config' command in non-check mode, use sha256 hashing to detect changes
-    use_hash_detection = (command == "config" and not module.check_mode)
+    use_hash_detection = command == "config" and not module.check_mode
     if use_hash_detection:
         config_files = get_config_files(module)
         hashes_before = hash_config_files(module, config_files)

--- a/tests/unit/plugins/modules/test_composer.py
+++ b/tests/unit/plugins/modules/test_composer.py
@@ -22,4 +22,31 @@ class OsPathExistsMock(TestCaseMock):
         pass
 
 
-UTHelper.from_module(composer, __name__, mocks=[RunCommandMock, OsPathExistsMock])
+class OsPathIsfileMock(TestCaseMock):
+    name = "os_path_isfile"
+
+    def setup(self, mocker):
+        mocker.patch("os.path.isfile", return_value=self.mock_specs.get("return_value", False))
+
+    def check(self, test_case, results):
+        pass
+
+
+class Sha256Mock(TestCaseMock):
+    name = "sha256"
+
+    def setup(self, mocker):
+        values = list(self.mock_specs.get("return_values", []))
+
+        def _sha256_side_effect(path):
+            if values:
+                return values.pop(0)
+            return "default_hash"
+
+        mocker.patch("ansible.module_utils.basic.AnsibleModule.sha256", side_effect=_sha256_side_effect)
+
+    def check(self, test_case, results):
+        pass
+
+
+UTHelper.from_module(composer, __name__, mocks=[RunCommandMock, OsPathExistsMock, OsPathIsfileMock, Sha256Mock])

--- a/tests/unit/plugins/modules/test_composer.yaml
+++ b/tests/unit/plugins/modules/test_composer.yaml
@@ -5,21 +5,27 @@
 ---
 anchors:
   help_install: &help_install
-    command: ["/testbin/php", "/testbin/composer", "help", "install", "--working-dir", "/var/www/foo", "--no-interaction", "--format=json"]
+    command: ["/testbin/php", "/testbin/composer", "--working-dir", "/var/www/foo", "help", "install", "--no-interaction", "--format=json"]
     rc: 0
     out: |
       {"definition": {"options": ["a", "b", "c"]}}
     err: ''
   help_create_project: &help_create_project
-    command: ["/testbin/php", "/testbin/composer", "help", "create-project", "--working-dir", "/var/www/foo", "--no-interaction", "--format=json"]
+    command: ["/testbin/php", "/testbin/composer", "--working-dir", "/var/www/foo", "help", "create-project", "--no-interaction", "--format=json"]
     rc: 0
     out: |
       {"definition": {"options": ["a", "b", "c"]}}
     err: ''
   run_create_project: &run_create_project
-    command: ["/testbin/php", "/testbin/composer", "create-project", "--working-dir", "/var/www/foo", "vendor/package"]
+    command: ["/testbin/php", "/testbin/composer", "--working-dir", "/var/www/foo", "create-project", "vendor/package"]
     rc: 0
     out: ''
+    err: ''
+  help_config: &help_config
+    command: ["/testbin/php", "/testbin/composer", "--working-dir", "/var/www/foo", "help", "config", "--no-interaction", "--format=json"]
+    rc: 0
+    out: |
+      {"definition": {"options": ["a", "b", "c"]}}
     err: ''
 
 test_cases:
@@ -32,7 +38,7 @@ test_cases:
     mocks:
       run_command:
         - *help_install
-        - command: ["/testbin/php", "/testbin/composer", "install", "--working-dir", "/var/www/foo"]
+        - command: ["/testbin/php", "/testbin/composer", "--working-dir", "/var/www/foo", "install"]
           rc: 0
           out: ''
           err: ''
@@ -78,3 +84,41 @@ test_cases:
       run_command:
         - *help_create_project
         - *run_create_project
+
+  - id: config_no_change
+    input:
+      command: config
+      arguments: "setting-key setting-value"
+      working_dir: "/var/www/foo"
+    output:
+      changed: false
+    mocks:
+      os_path_isfile:
+        return_value: true
+      sha256:
+        return_values: ["hash1", "hash2", "hash1", "hash2"]
+      run_command:
+        - *help_config
+        - command: ["/testbin/php", "/testbin/composer", "--working-dir", "/var/www/foo", "config", "setting-key", "setting-value"]
+          rc: 0
+          out: ''
+          err: ''
+
+  - id: config_changed
+    input:
+      command: config
+      arguments: "setting-key setting-value"
+      working_dir: "/var/www/foo"
+    output:
+      changed: true
+    mocks:
+      os_path_isfile:
+        return_value: true
+      sha256:
+        return_values: ["hash1", "hash2", "hash1_changed", "hash2"]
+      run_command:
+        - *help_config
+        - command: ["/testbin/php", "/testbin/composer", "--working-dir", "/var/www/foo", "config", "setting-key", "setting-value"]
+          rc: 0
+          out: ''
+          err: ''


### PR DESCRIPTION
##### SUMMARY
composer: Use config file hash to evaluate whether a change occurred (instead of unreliable output). Ensure `--working-dir` option consistently comes first (sudo-friendly)

Fixes #5204

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
composer
