### PR TITLE
keycloak_realm - add ``max_secondary_auth_failures`` parameter to configure brute force detection for secondary authentication mechanisms.

### DIFF
--- a/changelogs/fragments/12087-keycloak-realm-max-secondary-auth-failures.yml
+++ b/changelogs/fragments/12087-keycloak-realm-max-secondary-auth-failures.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak_realm - add ``max_secondary_auth_failures`` parameter to configure brute force detection for secondary authentication mechanisms. (https://github.com/ansible-collections/community.general/pull/12087)

--- a/changelogs/fragments/12087-keycloak-realm-max-secondary-auth-failures.yml
+++ b/changelogs/fragments/12087-keycloak-realm-max-secondary-auth-failures.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - keycloak_realm - add ``max_secondary_auth_failures`` parameter to configure brute force detection for secondary authentication mechanisms. (https://github.com/ansible-collections/community.general/pull/12087)
+  - keycloak_realm - add ``max_secondary_auth_failures`` parameter to configure brute force detection for secondary authentication mechanisms (https://github.com/ansible-collections/community.general/pull/12087).

--- a/plugins/modules/keycloak_realm.py
+++ b/plugins/modules/keycloak_realm.py
@@ -329,6 +329,13 @@ options:
     aliases:
       - maxFailureWaitSeconds
     type: int
+  max_secondary_auth_failures:
+    description:
+      - The realm max secondary authentication failures (used with brute force detection for secondary auth mechanisms).
+    aliases:
+      - maxSecondaryAuthFailures
+    type: int
+    version_added: 13.1.0
   max_temporary_lockouts:
     description:
       - The realm max temporary lockouts.
@@ -937,6 +944,7 @@ def main():
         login_with_email_allowed=dict(type="bool", aliases=["loginWithEmailAllowed"]),
         max_delta_time_seconds=dict(type="int", aliases=["maxDeltaTimeSeconds"]),
         max_failure_wait_seconds=dict(type="int", aliases=["maxFailureWaitSeconds"]),
+        max_secondary_auth_failures=dict(type="int", aliases=["maxSecondaryAuthFailures"]),
         max_temporary_lockouts=dict(type="int", aliases=["maxTemporaryLockouts"]),
         minimum_quick_login_wait_seconds=dict(type="int", aliases=["minimumQuickLoginWaitSeconds"]),
         not_before=dict(type="int", aliases=["notBefore"]),


### PR DESCRIPTION
  - keycloak_realm - add ``max_secondary_auth_failures`` parameter to configure brute force detection for secondary authentication mechanisms.

##### SUMMARY
Fix for: Unsupported parameters for (community.general.keycloak_realm) module: maxSecondaryAuthFailures.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
keycloak_realm

##### ADDITIONAL INFORMATION

Without this fix/feature it is not possible to configure the value "Maximum Secondary Authentication Failures" in Realm Settings -> Security defenses -> Brute force detection