### PR TITLE
composer: warn when running as root

### DIFF
--- a/changelogs/fragments/12090-composer-warn-root.yml
+++ b/changelogs/fragments/12090-composer-warn-root.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - composer - emit a warning when running as root, pointing to ``COMPOSER_ALLOW_SUPERUSER``
+    (https://github.com/ansible-collections/community.general/issues/2388,
+    https://github.com/ansible-collections/community.general/pull/12090).

--- a/plugins/modules/composer.py
+++ b/plugins/modules/composer.py
@@ -119,6 +119,8 @@ notes:
     if available.
   - We received reports about issues on macOS if composer was installed by Homebrew. Please use the official install method
     to avoid issues.
+  - Running composer as root is strongly discouraged by the composer project. If you must do it, set the environment
+    variable E(COMPOSER_ALLOW_SUPERUSER=1) to suppress the upstream warning.
 """
 
 EXAMPLES = r"""
@@ -228,6 +230,12 @@ def main():
         supports_check_mode=True,
     )
     module.run_command_environ_update = {"LANGUAGE": "C", "LC_ALL": "C"}
+
+    if os.getuid() == 0:
+        module.warn(
+            "Running composer as root is strongly discouraged by the composer project. "
+            "Set COMPOSER_ALLOW_SUPERUSER=1 to suppress the upstream warning."
+        )
 
     # Get composer command with fallback to default
     command = module.params["command"]

--- a/tests/unit/plugins/modules/test_composer.py
+++ b/tests/unit/plugins/modules/test_composer.py
@@ -22,4 +22,15 @@ class OsPathExistsMock(TestCaseMock):
         pass
 
 
-UTHelper.from_module(composer, __name__, mocks=[RunCommandMock, OsPathExistsMock])
+class OsGetuidMock(TestCaseMock):
+    name = "os_getuid"
+
+    def setup(self, mocker):
+        mocker.patch("os.getuid", return_value=self.mock_specs.get("return_value", 1000))
+
+    def check(self, test_case, results):
+        if self.mock_specs.get("return_value", 1000) == 0:
+            assert "COMPOSER_ALLOW_SUPERUSER" in str(results.get("warnings", []))
+
+
+UTHelper.from_module(composer, __name__, mocks=[RunCommandMock, OsPathExistsMock, OsGetuidMock])

--- a/tests/unit/plugins/modules/test_composer.yaml
+++ b/tests/unit/plugins/modules/test_composer.yaml
@@ -64,6 +64,22 @@ test_cases:
       run_command:
         - *help_create_project
 
+  - id: composer_as_root
+    input:
+      command: install
+      working_dir: "/var/www/foo"
+    output:
+      changed: true
+    mocks:
+      os_getuid:
+        return_value: 0
+      run_command:
+        - *help_install
+        - command: ["/testbin/php", "/testbin/composer", "install", "--working-dir", "/var/www/foo"]
+          rc: 0
+          out: ''
+          err: ''
+
   - id: create_project_force
     input:
       command: create-project


### PR DESCRIPTION
##### SUMMARY
When the `community.general.composer` module runs as root, composer itself emits a security warning that is currently silently swallowed. This PR adds a `module.warn()` call when the effective UID is 0, so operators are made aware of the issue. The `COMPOSER_ALLOW_SUPERUSER` environment variable is documented in the module notes as the upstream escape hatch.

Fixes #2388

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
composer

##### ADDITIONAL INFORMATION

N/A

```paste below

```