### PR TITLE
multiple: replace `namedtuple` with dataclass

### DIFF
--- a/changelogs/fragments/12094-namedtuple-to-dataclass.yml
+++ b/changelogs/fragments/12094-namedtuple-to-dataclass.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - homebrew_services - replace ``NamedTuple`` with dataclass (https://github.com/ansible-collections/community.general/pull/12094).
+  - one_service - replace function-local ``namedtuple`` with module-level dataclass (https://github.com/ansible-collections/community.general/pull/12094).
+  - one_vm - replace function-local ``namedtuple`` with module-level dataclass (https://github.com/ansible-collections/community.general/pull/12094).
+  - opennebula inventory plugin - replace function-local ``namedtuple`` with module-level dataclass (https://github.com/ansible-collections/community.general/pull/12094).
+  - pacman - replace ``namedtuple`` with dataclass for ``VersionTuple`` (https://github.com/ansible-collections/community.general/pull/12094).

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -90,12 +90,19 @@ except ImportError:
     HAS_PYONE = False
 
 import os
-from collections import namedtuple
+from dataclasses import dataclass
 
 from ansible.errors import AnsibleError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 
 from ansible_collections.community.general.plugins.plugin_utils._unsafe import make_unsafe
+
+
+@dataclass
+class AuthParams:
+    url: str
+    username: str
+    password: str
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable):
@@ -126,9 +133,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             except Exception as e:
                 raise AnsibleError(f"Error occurs when reading ONE_AUTH file at '{authfile}'") from e
 
-        auth_params = namedtuple("auth", ("url", "username", "password"))
-
-        return auth_params(url=url, username=username, password=password)
+        return AuthParams(url=url, username=username, password=password)
 
     def _get_vm_ipv4(self, vm):
         nic = vm.TEMPLATE.get("NIC")

--- a/plugins/modules/homebrew_services.py
+++ b/plugins/modules/homebrew_services.py
@@ -88,6 +88,7 @@ running:
 
 import json
 import typing as t
+from dataclasses import dataclass
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -97,16 +98,15 @@ from ansible_collections.community.general.plugins.module_utils._homebrew import
 )
 
 
-# Stores validated arguments for an instance of an action.
-# See DOCUMENTATION string for argument-specific information.
-class HomebrewServiceArgs(t.NamedTuple):
+@dataclass
+class HomebrewServiceArgs:
     name: str
     state: str
     brew_path: str
 
 
-# Stores the state of a Homebrew service.
-class HomebrewServiceState(t.NamedTuple):
+@dataclass
+class HomebrewServiceState:
     running: bool
     pid: int | None
 

--- a/plugins/modules/one_service.py
+++ b/plugins/modules/one_service.py
@@ -232,10 +232,18 @@ roles:
 
 import os
 import time
-from collections import namedtuple
+from dataclasses import dataclass
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import open_url
+
+
+@dataclass
+class AuthParams:
+    url: str
+    user: str
+    password: str
+
 
 STATES = (
     "PENDING",
@@ -728,9 +736,7 @@ def get_connection_info(module):
         module.fail_json(
             msg="One or more connection parameters (api_url, api_username, api_password) were not specified"
         )
-    auth_params = namedtuple("auth", ("url", "user", "password"))
-
-    return auth_params(url=url, user=username, password=password)
+    return AuthParams(url=url, user=username, password=password)
 
 
 def main():

--- a/plugins/modules/one_vm.py
+++ b/plugins/modules/one_vm.py
@@ -688,12 +688,20 @@ import copy
 import os
 import re
 import time
-from collections import namedtuple
+from dataclasses import dataclass
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.dict_transformations import dict_merge
 
 from ansible_collections.community.general.plugins.module_utils._opennebula import flatten, render
+
+
+@dataclass
+class AuthParams:
+    url: str
+    username: str
+    password: str
+
 
 # Updateconf attributes documentation: https://docs.opennebula.io/6.10/integration_and_development/system_interfaces/api.html#one-vm-updateconf
 UPDATECONF_ATTRIBUTES = {
@@ -1632,9 +1640,7 @@ def get_connection_info(module):
     if not url:
         module.fail_json(msg="Opennebula API url (api_url) is not specified")
 
-    auth_params = namedtuple("auth", ("url", "username", "password"))
-
-    return auth_params(url=url, username=username, password=password)
+    return AuthParams(url=url, username=username, password=password)
 
 
 def main():

--- a/plugins/modules/pacman.py
+++ b/plugins/modules/pacman.py
@@ -721,7 +721,7 @@ class Pacman:
             "installed_groups": {groupname: set(pkgnames)},
             "available_pkgs": {pkgname: version},
             "available_groups": {groupname: set(pkgnames)},
-            "upgradable_pkgs": {pkgname: (current_version,latest_version)},
+            "upgradable_pkgs": {pkgname: VersionTuple},
             "pkg_reasons": {pkgname: reason},
         }
 

--- a/plugins/modules/pacman.py
+++ b/plugins/modules/pacman.py
@@ -275,7 +275,8 @@ EXAMPLES = r"""
 
 import re
 import shlex
-from collections import defaultdict, namedtuple
+from collections import defaultdict
+from dataclasses import dataclass
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -296,7 +297,10 @@ class Package:
         return f'Package("{self.name}", "{self.source}", {self.source_is_URL})'
 
 
-VersionTuple = namedtuple("VersionTuple", ["current", "latest"])
+@dataclass
+class VersionTuple:
+    current: str
+    latest: str
 
 
 class Pacman:


### PR DESCRIPTION
##### SUMMARY
Replace uses of `collections.namedtuple` and `typing.NamedTuple` with `@dataclass` across five plugins. No functional changes — pure refactoring.

Files changed:
- `plugins/modules/homebrew_services.py` — `HomebrewServiceArgs`, `HomebrewServiceState`
- `plugins/modules/pacman.py` — `VersionTuple`
- `plugins/modules/one_service.py` — `AuthParams` (was a function-local namedtuple)
- `plugins/modules/one_vm.py` — `AuthParams` (was a function-local namedtuple)
- `plugins/inventory/opennebula.py` — `AuthParams` (was a function-local namedtuple)

##### ISSUE TYPE
- Refactoring Pull Request

##### COMPONENT NAME
homebrew_services
one_service
one_vm
pacman
plugins/inventory/opennebula.py

##### ADDITIONAL INFORMATION

```paste below

```