### PR TITLE
multiple: mark integration tests that run `pip install` as destructive

### DIFF
--- a/tests/integration/targets/django_command/aliases
+++ b/tests/integration/targets/django_command/aliases
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
+destructive
 skip/freebsd
 skip/macos
 skip/rhel9.3

--- a/tests/integration/targets/django_manage/aliases
+++ b/tests/integration/targets/django_manage/aliases
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
+destructive
 skip/freebsd
 skip/macos
 skip/rhel9.3

--- a/tests/integration/targets/filter_hashids/aliases
+++ b/tests/integration/targets/filter_hashids/aliases
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
+destructive

--- a/tests/integration/targets/filter_jc/aliases
+++ b/tests/integration/targets/filter_jc/aliases
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
+destructive

--- a/tests/integration/targets/filter_json_patch/aliases
+++ b/tests/integration/targets/filter_json_patch/aliases
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
+destructive

--- a/tests/integration/targets/filter_json_query/aliases
+++ b/tests/integration/targets/filter_json_query/aliases
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
+destructive

--- a/tests/integration/targets/filter_to_prettytable/aliases
+++ b/tests/integration/targets/filter_to_prettytable/aliases
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
+destructive

--- a/tests/integration/targets/filter_to_toml/aliases
+++ b/tests/integration/targets/filter_to_toml/aliases
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/3
+destructive

--- a/tests/integration/targets/gitlab_branch/aliases
+++ b/tests/integration/targets/gitlab_branch/aliases
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
+destructive
 disabled

--- a/tests/integration/targets/gitlab_deploy_key/aliases
+++ b/tests/integration/targets/gitlab_deploy_key/aliases
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
+destructive
 gitlab/ci
 disabled

--- a/tests/integration/targets/gitlab_group/aliases
+++ b/tests/integration/targets/gitlab_group/aliases
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
+destructive
 gitlab/ci
 disabled

--- a/tests/integration/targets/gitlab_group_access_token/aliases
+++ b/tests/integration/targets/gitlab_group_access_token/aliases
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
+destructive
 gitlab/ci
 disabled

--- a/tests/integration/targets/gitlab_hook/aliases
+++ b/tests/integration/targets/gitlab_hook/aliases
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
+destructive
 gitlab/ci
 disabled

--- a/tests/integration/targets/gitlab_issue/aliases
+++ b/tests/integration/targets/gitlab_issue/aliases
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 gitlab/ci
+destructive
 disabled

--- a/tests/integration/targets/gitlab_label/aliases
+++ b/tests/integration/targets/gitlab_label/aliases
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 gitlab/ci
+destructive
 disabled

--- a/tests/integration/targets/gitlab_merge_request/aliases
+++ b/tests/integration/targets/gitlab_merge_request/aliases
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 gitlab/ci
+destructive
 disabled

--- a/tests/integration/targets/gitlab_milestone/aliases
+++ b/tests/integration/targets/gitlab_milestone/aliases
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 gitlab/ci
+destructive
 disabled

--- a/tests/integration/targets/gitlab_project/aliases
+++ b/tests/integration/targets/gitlab_project/aliases
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
+destructive
 gitlab/ci
 disabled

--- a/tests/integration/targets/gitlab_project_access_token/aliases
+++ b/tests/integration/targets/gitlab_project_access_token/aliases
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
+destructive
 gitlab/ci
 disabled

--- a/tests/integration/targets/gitlab_project_badge/aliases
+++ b/tests/integration/targets/gitlab_project_badge/aliases
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 gitlab/ci
+destructive
 disabled

--- a/tests/integration/targets/gitlab_runner/aliases
+++ b/tests/integration/targets/gitlab_runner/aliases
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
+destructive
 gitlab/ci
 disabled

--- a/tests/integration/targets/gitlab_user/aliases
+++ b/tests/integration/targets/gitlab_user/aliases
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
+destructive
 gitlab/ci
 disabled

--- a/tests/integration/targets/lookup_dig/aliases
+++ b/tests/integration/targets/lookup_dig/aliases
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
+destructive

--- a/tests/integration/targets/lookup_random_pet/aliases
+++ b/tests/integration/targets/lookup_random_pet/aliases
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
+destructive

--- a/tests/integration/targets/lookup_random_words/aliases
+++ b/tests/integration/targets/lookup_random_words/aliases
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
+destructive

--- a/tests/integration/targets/mail/aliases
+++ b/tests/integration/targets/mail/aliases
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
+destructive

--- a/tests/integration/targets/mqtt/aliases
+++ b/tests/integration/targets/mqtt/aliases
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
+destructive
 skip/macos
 skip/freebsd
 skip/rhel

--- a/tests/integration/targets/pids/aliases
+++ b/tests/integration/targets/pids/aliases
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/3
+destructive

--- a/tests/integration/targets/python_requirements_info/aliases
+++ b/tests/integration/targets/python_requirements_info/aliases
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
+destructive

--- a/tests/integration/targets/python_runner/aliases
+++ b/tests/integration/targets/python_runner/aliases
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
+destructive

--- a/tests/integration/targets/test_fqdn_valid/aliases
+++ b/tests/integration/targets/test_fqdn_valid/aliases
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
+destructive


### PR DESCRIPTION
##### SUMMARY
Integration tests that run `pip install` (either as a shell command or via the `pip` module) can modify the system Python environment and should be marked as `destructive`.

This PR adds the `destructive` keyword to the `aliases` file of 31 such tests that were missing it.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
tests/integration/targets/django_command
tests/integration/targets/django_manage
tests/integration/targets/filter_hashids
tests/integration/targets/filter_jc
tests/integration/targets/filter_json_patch
tests/integration/targets/filter_json_query
tests/integration/targets/filter_to_prettytable
tests/integration/targets/filter_to_toml
tests/integration/targets/gitlab_branch
tests/integration/targets/gitlab_deploy_key
tests/integration/targets/gitlab_group
tests/integration/targets/gitlab_group_access_token
tests/integration/targets/gitlab_hook
tests/integration/targets/gitlab_issue
tests/integration/targets/gitlab_label
tests/integration/targets/gitlab_merge_request
tests/integration/targets/gitlab_milestone
tests/integration/targets/gitlab_project
tests/integration/targets/gitlab_project_access_token
tests/integration/targets/gitlab_project_badge
tests/integration/targets/gitlab_runner
tests/integration/targets/gitlab_user
tests/integration/targets/lookup_dig
tests/integration/targets/lookup_random_pet
tests/integration/targets/lookup_random_words
tests/integration/targets/mail
tests/integration/targets/mqtt
tests/integration/targets/pids
tests/integration/targets/python_requirements_info
tests/integration/targets/python_runner
tests/integration/targets/test_fqdn_valid

##### ADDITIONAL INFORMATION

```paste below

```