### PR TITLE
lxc_container: Fix create_script in plugins/module_utils/_lxc.py

### DIFF
--- a/changelogs/fragments/12106-fix-lxc-create_script.yml
+++ b/changelogs/fragments/12106-fix-lxc-create_script.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - lxc_container - fix ``create_script`` in ``module_utils/_lxc.py`` to accept a single tuple argument, resolving a ``TypeError`` that silently prevented ``container_command`` from being executed (https://github.com/ansible-collections/community.general/pull/12106).
+  - lxc_container - fix ``create_script`` to accept a single tuple argument, resolving a ``TypeError`` that silently prevented ``container_command`` from being executed (https://github.com/ansible-collections/community.general/issues/11360, https://github.com/ansible-collections/community.general/pull/12106).

--- a/changelogs/fragments/12106-fix-lxc-create_script.yml
+++ b/changelogs/fragments/12106-fix-lxc-create_script.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lxc_container - fix ``create_script`` in ``module_utils/_lxc.py`` to accept a single tuple argument, resolving a ``TypeError`` that silently prevented ``container_command`` from being executed (https://github.com/ansible-collections/community.general/pull/12106).

--- a/plugins/module_utils/_lxc.py
+++ b/plugins/module_utils/_lxc.py
@@ -39,7 +39,7 @@ def create_script(arg_tuple: tuple[str, AnsibleModule]) -> None:
     This method should be backward compatible with Python when executing
     from within the container.
 
-    :param args: a tuple of (command, module) where command is the command
+    :param arg_tuple: a tuple of (command, module) where command is the command
                  to run (this can be a script and can use spacing with
                  newlines as separation) and module is the AnsibleModule
                  to run commands with.

--- a/plugins/module_utils/_lxc.py
+++ b/plugins/module_utils/_lxc.py
@@ -33,16 +33,21 @@ popd
 """
 
 
-def create_script(command: str, module: AnsibleModule) -> None:
+def create_script(arg_tuple: tuple) -> None:
     """Write out a script onto a target.
 
     This method should be backward compatible with Python when executing
     from within the container.
 
-    :param command: command to run, this can be a script and can use spacing
-                    with newlines as separation.
-    :param module: AnsibleModule to run commands with.
+    :param args: a tuple of (command, module) where command is the command
+                 to run (this can be a script and can use spacing with
+                 newlines as separation) and module is the AnsibleModule
+                 to run commands with.
     """
+
+    command: str
+    module: AnsibleModule
+    command, module = arg_tuple
 
     script_file = ""
     try:

--- a/plugins/module_utils/_lxc.py
+++ b/plugins/module_utils/_lxc.py
@@ -40,9 +40,9 @@ def create_script(arg_tuple: tuple[str, AnsibleModule]) -> None:
     from within the container.
 
     :param arg_tuple: a tuple of (command, module) where command is the command
-                 to run (this can be a script and can use spacing with
-                 newlines as separation) and module is the AnsibleModule
-                 to run commands with.
+                      to run (this can be a script and can use spacing with
+                      newlines as separation) and module is the AnsibleModule
+                      to run commands with.
     """
 
     command, module = arg_tuple

--- a/plugins/module_utils/_lxc.py
+++ b/plugins/module_utils/_lxc.py
@@ -33,7 +33,7 @@ popd
 """
 
 
-def create_script(arg_tuple: tuple) -> None:
+def create_script(arg_tuple: tuple[str, AnsibleModule]) -> None:
     """Write out a script onto a target.
 
     This method should be backward compatible with Python when executing
@@ -45,8 +45,6 @@ def create_script(arg_tuple: tuple) -> None:
                  to run commands with.
     """
 
-    command: str
-    module: AnsibleModule
     command, module = arg_tuple
 
     script_file = ""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The library `attach_wait` method on the `Container` class from python3-lxc only [takes a single function and an optional parameter for that function as parameters](https://github.com/lxc/python3-lxc/blob/main/lxc.c#L744).

`create_script` is passed to `attach_wait` in [the lxc_containers module](https://github.com/ansible-collections/community.general/blob/cbc6f6eed3dd6725f9618a8b9682616dc9dd7c3d/plugins/modules/lxc_container.py#L816).

python3-lxc causes `create_script` to be called with only a single argument. Which results in a TypeError that is only visible with `-vvvv` logging in ansible:

```
`(0, b'\r\n\x1b[1;35mTypeError\x1b[0m: \x1b[35mcreate_script() missing 1 required positional argument: \'module\'\x1b[0m\r\n\r\n{"changed": true, "lxc_container": {"interfaces": ["eth0", "lo"], "ips": ["10.102.101.2", "2 001:41d0:f00:2d04::2"], "state": "running", "init_pid": 3506504, "name": "forgejo-runner"}, "invocation": {"module_args": {"container_command": "touch /root/standalone-command-test\\n", "name": "forgejo-runner", "state": "started", "tem plate": "ubuntu", "backing_store": "dir", "vg_name": "lxc", "fs_type": "ext4", "fs_size": "5G", "container_log": false, "container_log_level": "INFO", "clone_snapshot": false, "archive": false, "archive_compression": "gzip", "template_o ptions": null, "config": null, "thinpool": null, "directory": null, "zfs_root": null, "lv_name": "forgejo-runner", "lxc_path": null, "container_config": null, "clone_name": null, "archive_path": null}}}\r\n', b'Shared connection to 217. 182.199.35 closed.\r\n')
```

This pull request does minimal changes so that `create_script` is compatible for passing to `attach_wait`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #11360
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
lxc
