### PR TITLE
docs(nagios): clarify the module runs on the Nagios server and show delegate_to (#9870)

### DIFF
--- a/changelogs/fragments/9870-nagios-delegate-to-docs.yml
+++ b/changelogs/fragments/9870-nagios-delegate-to-docs.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nagios - clarify in the documentation that the module must run on the Nagios server, and add an example using ``delegate_to`` for the common case where the managed host is not itself the Nagios server (https://github.com/ansible-collections/community.general/issues/9870).

--- a/plugins/modules/nagios.py
+++ b/plugins/modules/nagios.py
@@ -21,6 +21,10 @@ description:
     variable to refer to the host the playbook is currently running on.
   - The module executes commands and needs to be run directly on the Nagios server
     with a user that has appropriate access rights. It does not use Nagios' HTTP API.
+  - The O(host) argument identifies the host that Nagios should act on, not where the module runs.
+    When the managed host is not itself the Nagios server (for example, when it runs an NRPE daemon
+    instead), use C(delegate_to) to run the module against the Nagios server while keeping O(host)
+    pointed at the managed host. See the examples below.
   - Searches for a I(nagios.cfg) in I(/etc/nagios), I(/etc/nagios2), I(/etc/nagios3), I(/usr/local/etc/nagios),
     I(/usr/local/groundwork/nagios/etc), I(/omd/sites/oppy/tmp/nagios), I(/usr/local/nagios/etc),
     I(/usr/local/nagios), I(/opt/nagios/etc), and I(/opt/nagios),
@@ -119,6 +123,14 @@ EXAMPLES = r"""
     minutes: 30
     service: httpd
     host: '{{ inventory_hostname }}'
+
+- name: Schedule an hour of downtime for a host that is not itself the Nagios server
+  community.general.nagios:
+    action: downtime
+    minutes: 60
+    service: all
+    host: '{{ inventory_hostname }}'
+  delegate_to: nagios.example.com
 
 - name: Schedule an hour of HOST downtime
   community.general.nagios:


### PR DESCRIPTION
Fixes #9870.

The nagios module's existing description mentions it must run on the Nagios server, but every example uses `host: '{{ inventory_hostname }}'`, which makes the requirement easy to miss when the managed host is a different machine (for example one running an NRPE daemon).

Per @miniwark's report and @russoz's invitation to PR:

- Added a description bullet pointing out that O(host) identifies the Nagios target, not where the module runs, and directing readers to `delegate_to`.
- Added an example using `delegate_to: nagios.example.com` so the pattern is copy-paste discoverable, mirroring the reporter's own use case.

Changelog fragment included per project convention.