### PR TITLE
nmcli: preserve existing bond mode when omitted on existing connections

### DIFF
--- a/changelogs/fragments/9201-nmcli-preserve-bond-mode.yml
+++ b/changelogs/fragments/9201-nmcli-preserve-bond-mode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nmcli - preserve the existing bond mode when `mode` is omitted on an existing connection, avoiding unintended changes to `balance-rr` and preventing broken bond configurations (https://github.com/ansible-collections/community.general/issues/9201)

--- a/changelogs/fragments/9201-nmcli-preserve-bond-mode.yml
+++ b/changelogs/fragments/9201-nmcli-preserve-bond-mode.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - nmcli - preserve the existing bond mode when ``mode`` is omitted on an existing connection, avoiding unintended changes to ``balance-rr`` and preventing broken bond configurations (https://github.com/ansible-collections/community.general/issues/9201).
+  - nmcli - add ``bond_mode_behavior`` to control whether omitted ``mode`` preserves the existing bond mode or uses the legacy ``balance-rr`` default on existing connections (https://github.com/ansible-collections/community.general/issues/9201).

--- a/changelogs/fragments/9201-nmcli-preserve-bond-mode.yml
+++ b/changelogs/fragments/9201-nmcli-preserve-bond-mode.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - nmcli - preserve the existing bond mode when `mode` is omitted on an existing connection, avoiding unintended changes to `balance-rr` and preventing broken bond configurations (https://github.com/ansible-collections/community.general/issues/9201)
+  - nmcli - preserve the existing bond mode when ``mode`` is omitted on an existing connection, avoiding unintended changes to ``balance-rr`` and preventing broken bond configurations (https://github.com/ansible-collections/community.general/issues/9201).

--- a/changelogs/fragments/9201-nmcli-preserve-bond-mode.yml
+++ b/changelogs/fragments/9201-nmcli-preserve-bond-mode.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - nmcli - add ``bond_mode_behavior`` to control whether omitted ``mode`` preserves the existing bond mode or uses the legacy ``balance-rr`` default on existing connections (https://github.com/ansible-collections/community.general/issues/9201).
+  - nmcli - add ``bond_mode_behavior`` to control whether omitted ``mode`` preserves the existing bond mode or uses the legacy ``balance-rr`` default on existing connections (https://github.com/ansible-collections/community.general/issues/9201, https://github.com/ansible-collections/community.general/pull/12114).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -120,10 +120,12 @@ options:
       - loopback
   mode:
     description:
-      - This is the type of device or network connection that you wish to create for a bond or bridge.
+      - Bond mode to use for a bond connection.
+      - When creating a new bond, NetworkManager's default mode V(balance-rr) is used if this option is not provided.
+      - When omitted for an existing bond connection, the module preserves the current bond mode.
+      - This option only applies when C(type) is set to C(bond).
     type: str
     choices: [802.3ad, active-backup, balance-alb, balance-rr, balance-tlb, balance-xor, broadcast]
-    default: balance-rr
   transport_mode:
     description:
       - This option sets the connection type of Infiniband IPoIB devices.
@@ -2818,7 +2820,6 @@ def create_module() -> AnsibleModule:
             # Bond Specific vars
             mode=dict(
                 type="str",
-                default="balance-rr",
                 choices=[
                     "802.3ad",
                     "active-backup",

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -122,8 +122,8 @@ options:
     description:
       - This is the type of device or network connection that you wish to create for a bond or bridge.
       - When creating a new bond, NetworkManager's default mode V(balance-rr) is used if this option is not provided.
-      - When omitted for an existing bond connection, the module preserves the current bond mode by default.
-      - This option only applies when C(type) is set to C(bond).
+      - When omitted for an existing bond connection, the module uses the behavior selected by O(bond_mode_behavior).
+      - This option only applies when O(type=bond).
     type: str
     choices: [802.3ad, active-backup, balance-alb, balance-rr, balance-tlb, balance-xor, broadcast]
   bond_mode_behavior:
@@ -131,7 +131,7 @@ options:
       - Controls how the module behaves when O(mode) is omitted on an existing bond connection.
       - When set to V(preserve), the module leaves the current bond mode unchanged.
       - When set to V(reset), the module uses the legacy default V(balance-rr).
-      - This option only applies when C(type) is set to C(bond).
+      - This option only applies when O(type=bond).
     type: str
     choices: [preserve, reset]
     default: reset

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -122,10 +122,20 @@ options:
     description:
       - This is the type of device or network connection that you wish to create for a bond or bridge.
       - When creating a new bond, NetworkManager's default mode V(balance-rr) is used if this option is not provided.
-      - When omitted for an existing bond connection, the module preserves the current bond mode.
+      - When omitted for an existing bond connection, the module preserves the current bond mode by default.
       - This option only applies when C(type) is set to C(bond).
     type: str
     choices: [802.3ad, active-backup, balance-alb, balance-rr, balance-tlb, balance-xor, broadcast]
+  bond_mode_behavior:
+    description:
+      - Controls how the module behaves when O(mode) is omitted on an existing bond connection.
+      - When set to V(preserve), the module leaves the current bond mode unchanged.
+      - When set to V(reset), the module uses the legacy default V(balance-rr).
+      - This option only applies when C(type) is set to C(bond).
+    type: str
+    choices: [preserve, reset]
+    default: reset
+    version_added: 13.3.0
   transport_mode:
     description:
       - This option sets the connection type of Infiniband IPoIB devices.
@@ -1786,6 +1796,7 @@ class Nmcli:
         self.stp = module.params["stp"]
         self.priority = module.params["priority"]
         self.mode = module.params["mode"]
+        self.bond_mode_behavior = module.params["bond_mode_behavior"]
         self.miimon = module.params["miimon"]
         self.primary = module.params["primary"]
         self.downdelay = module.params["downdelay"]
@@ -1941,19 +1952,21 @@ class Nmcli:
 
         # Options specific to a connection type.
         if self.type == "bond":
-            options.update(
-                {
-                    "arp_interval": self.arp_interval,
-                    "arp_ip_target": self.arp_ip_target,
-                    "downdelay": self.downdelay,
-                    "miimon": self.miimon,
-                    "mode": self.mode,
-                    "primary": self.primary,
-                    "updelay": self.updelay,
-                    "xmit_hash_policy": self.xmit_hash_policy,
-                    "fail_over_mac": self.fail_over_mac,
-                }
-            )
+            bond_options = {
+                "arp_interval": self.arp_interval,
+                "arp_ip_target": self.arp_ip_target,
+                "downdelay": self.downdelay,
+                "miimon": self.miimon,
+                "primary": self.primary,
+                "updelay": self.updelay,
+                "xmit_hash_policy": self.xmit_hash_policy,
+                "fail_over_mac": self.fail_over_mac,
+            }
+            if self.mode is not None:
+                bond_options["mode"] = self.mode
+            elif self.bond_mode_behavior == "reset":
+                bond_options["mode"] = "balance-rr"
+            options.update(bond_options)
         elif self.type == "bond-slave":
             if self.slave_type and self.slave_type != "bond":
                 self.module.fail_json(
@@ -2830,6 +2843,7 @@ def create_module() -> AnsibleModule:
                     "broadcast",
                 ],
             ),
+            bond_mode_behavior=dict(type="str", choices=["preserve", "reset"], default="reset"),
             miimon=dict(type="int"),
             downdelay=dict(type="int"),
             updelay=dict(type="int"),

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -120,7 +120,7 @@ options:
       - loopback
   mode:
     description:
-      - Bond mode to use for a bond connection.
+      - This is the type of device or network connection that you wish to create for a bond or bridge.
       - When creating a new bond, NetworkManager's default mode V(balance-rr) is used if this option is not provided.
       - When omitted for an existing bond connection, the module preserves the current bond mode.
       - This option only applies when C(type) is set to C(bond).

--- a/tests/unit/plugins/modules/test_nmcli.py
+++ b/tests/unit/plugins/modules/test_nmcli.py
@@ -621,6 +621,34 @@ ipv6.ignore-auto-routes:                no
 bond.options:                           mode=active-backup,primary=non_existent_primary,xmit_hash_policy=layer3+4
 """
 
+TESTCASE_BOND_MODE_UNSET = [
+    {
+        "type": "bond",
+        "conn_name": "non_existent_nw_device",
+        "ifname": "bond_non_existant",
+        "dns4_search": ["example1.com", "example2.com"],
+        "state": "present",
+        "_ansible_check_mode": False,
+    }
+]
+
+TESTCASE_BOND_MODE_UNSET_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              bond_non_existant
+connection.autoconnect:                 yes
+ipv4.method:                            manual
+ipv4.dns-search:                        example1.com,example2.com
+ipv4.ignore-auto-dns:                   no
+ipv4.ignore-auto-routes:                no
+ipv4.never-default:                     no
+ipv4.may-fail:                          yes
+ipv6.method:                            auto
+ipv6.ignore-auto-dns:                   no
+ipv6.ignore-auto-routes:                no
+802-3-ethernet.mtu:                     auto
+bond.options:                           mode=802.3ad
+"""
+
 TESTCASE_BOND_ARP = [
     {
         "type": "bond",
@@ -1818,6 +1846,11 @@ def mocked_bond_connection_unchanged(mocker):
 
 
 @pytest.fixture
+def mocked_bond_mode_unset_connection_unchanged(mocker):
+    mocker_set(mocker, connection_exists=True, execute_return=(0, TESTCASE_BOND_MODE_UNSET_OUTPUT, ""))
+
+
+@pytest.fixture
 def mocked_bond_arp_connection_unchanged(mocker):
     mocker_set(mocker, connection_exists=True, execute_return=(0, TESTCASE_BOND_ARP_SHOW_OUTPUT, ""))
 
@@ -2275,6 +2308,22 @@ def test_bond_connection_unchanged(mocked_bond_connection_unchanged, capfd):
     results = json.loads(out)
     assert not results.get("failed")
     assert not results["changed"]
+
+
+@pytest.mark.parametrize("patch_ansible_module", TESTCASE_BOND_MODE_UNSET, indirect=["patch_ansible_module"])
+def test_bond_mode_omitted_does_not_change_existing_connection(mocked_bond_mode_unset_connection_unchanged):
+    """
+    Regression test for unspecified bond mode on existing connections.
+    """
+    module = nmcli.create_module()
+    nmcli_module = nmcli.Nmcli(module)
+
+    changed, diff = nmcli_module.is_connection_changed()
+    assert not changed
+    assert "mode" not in diff["before"]
+    assert "mode" not in diff["after"]
+    assert diff["before"]["ipv4.dns-search"] == ["example1.com", "example2.com"]
+    assert diff["after"]["ipv4.dns-search"] == ["example1.com", "example2.com"]
 
 
 @pytest.mark.parametrize("patch_ansible_module", TESTCASE_BOND_ARP, indirect=["patch_ansible_module"])

--- a/tests/unit/plugins/modules/test_nmcli.py
+++ b/tests/unit/plugins/modules/test_nmcli.py
@@ -621,13 +621,26 @@ ipv6.ignore-auto-routes:                no
 bond.options:                           mode=active-backup,primary=non_existent_primary,xmit_hash_policy=layer3+4
 """
 
-TESTCASE_BOND_MODE_UNSET = [
+TESTCASE_BOND_MODE_UNSET_PRESERVE = [
     {
         "type": "bond",
         "conn_name": "non_existent_nw_device",
         "ifname": "bond_non_existant",
         "dns4_search": ["example1.com", "example2.com"],
         "state": "present",
+        "bond_mode_behavior": "preserve",
+        "_ansible_check_mode": False,
+    }
+]
+
+TESTCASE_BOND_MODE_UNSET_RESET = [
+    {
+        "type": "bond",
+        "conn_name": "non_existent_nw_device",
+        "ifname": "bond_non_existant",
+        "dns4_search": ["example1.com", "example2.com"],
+        "state": "present",
+        "bond_mode_behavior": "reset",
         "_ansible_check_mode": False,
     }
 ]
@@ -648,6 +661,18 @@ ipv6.ignore-auto-routes:                no
 802-3-ethernet.mtu:                     auto
 bond.options:                           mode=802.3ad
 """
+
+TESTCASE_BOND_MODE_EXPLICIT = [
+    {
+        "type": "bond",
+        "conn_name": "non_existent_nw_device",
+        "ifname": "bond_non_existant",
+        "mode": "active-backup",
+        "state": "present",
+        "bond_mode_behavior": "preserve",
+        "_ansible_check_mode": False,
+    }
+]
 
 TESTCASE_BOND_ARP = [
     {
@@ -2310,8 +2335,8 @@ def test_bond_connection_unchanged(mocked_bond_connection_unchanged, capfd):
     assert not results["changed"]
 
 
-@pytest.mark.parametrize("patch_ansible_module", TESTCASE_BOND_MODE_UNSET, indirect=["patch_ansible_module"])
-def test_bond_mode_omitted_does_not_change_existing_connection(mocked_bond_mode_unset_connection_unchanged):
+@pytest.mark.parametrize("patch_ansible_module", TESTCASE_BOND_MODE_UNSET_PRESERVE, indirect=["patch_ansible_module"])
+def test_bond_mode_omitted_preserves_existing_connection(mocked_bond_mode_unset_connection_unchanged):
     """
     Regression test for unspecified bond mode on existing connections.
     """
@@ -2324,6 +2349,30 @@ def test_bond_mode_omitted_does_not_change_existing_connection(mocked_bond_mode_
     assert "mode" not in diff["after"]
     assert diff["before"]["ipv4.dns-search"] == ["example1.com", "example2.com"]
     assert diff["after"]["ipv4.dns-search"] == ["example1.com", "example2.com"]
+
+
+@pytest.mark.parametrize("patch_ansible_module", TESTCASE_BOND_MODE_UNSET_RESET, indirect=["patch_ansible_module"])
+def test_bond_mode_omitted_uses_legacy_reset_behavior(mocked_bond_mode_unset_connection_unchanged):
+    """
+    Regression test for the legacy reset behavior when bond mode is omitted.
+    """
+    module = nmcli.create_module()
+    nmcli_module = nmcli.Nmcli(module)
+
+    options = nmcli_module.connection_options()
+    assert options["mode"] == "balance-rr"
+
+
+@pytest.mark.parametrize("patch_ansible_module", TESTCASE_BOND_MODE_EXPLICIT, indirect=["patch_ansible_module"])
+def test_bond_mode_explicit_value_takes_precedence_over_behavior(mocked_bond_mode_unset_connection_unchanged):
+    """
+    An explicitly provided mode should take precedence over the behavior setting.
+    """
+    module = nmcli.create_module()
+    nmcli_module = nmcli.Nmcli(module)
+
+    options = nmcli_module.connection_options()
+    assert options["mode"] == "active-backup"
 
 
 @pytest.mark.parametrize("patch_ansible_module", TESTCASE_BOND_ARP, indirect=["patch_ansible_module"])


### PR DESCRIPTION
Remove hardcoded bond mode default from nmcli module and preserve the existing bond mode during updates when mode is not explicitly supplied.

Include regression coverage and a changelog fragment for issue #9201.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #9201
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
nmcli

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The `balanced-rr` default value for `bond` mode is the default one use by `nmcli` at creation. So it didn't seem necessary to force the value in this module.

<!--- Paste verbatim command output below, e.g. before and after your change
```paste below

``` -->