### PR TITLE
xenserver_guest_info: add VDI uuid and vdi_type to disk info

### DIFF
--- a/changelogs/fragments/11998-xenserver-disk-uuid-vdi-type.yml
+++ b/changelogs/fragments/11998-xenserver-disk-uuid-vdi-type.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - xenserver_guest_info - add VDI ``uuid`` and ``vdi_type`` (VHD/QCOW2) fields to disk info output (https://github.com/ansible-collections/community.general/issues/11998).
+  - xenserver_guest_info - add VDI ``uuid`` and ``vdi_type`` (VHD/QCOW2) fields to disk info output (https://github.com/ansible-collections/community.general/issues/11998, https://github.com/ansible-collections/community.general/pull/12119).

--- a/changelogs/fragments/11998-xenserver-disk-uuid-vdi-type.yml
+++ b/changelogs/fragments/11998-xenserver-disk-uuid-vdi-type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - xenserver_guest_info - add VDI ``uuid`` and ``vdi_type`` (VHD/QCOW2) fields to disk info output (https://github.com/ansible-collections/community.general/issues/11998).

--- a/plugins/module_utils/_xenserver.py
+++ b/plugins/module_utils/_xenserver.py
@@ -454,7 +454,9 @@ def gather_vm_facts(module: AnsibleModule, vm_params):
                 "sr": vm_disk_sr_params["name_label"],
                 "sr_uuid": vm_disk_sr_params["uuid"],
                 "os_device": vm_vbd_params["device"],
+                "uuid": vm_vbd_params["VDI"]["uuid"],
                 "vbd_userdevice": vm_vbd_params["userdevice"],
+                "vdi_type": vm_vbd_params["VDI"].get("sm_config", {}).get("vdi_type", ""),
             }
 
             vm_facts["disks"].append(vm_disk_params)

--- a/plugins/modules/xenserver_guest_info.py
+++ b/plugins/modules/xenserver_guest_info.py
@@ -76,7 +76,9 @@ instance:
           "size": 42949672960,
           "sr": "Local storage",
           "sr_uuid": "0af1245e-bdb0-ba33-1446-57a962ec4075",
-          "vbd_userdevice": "0"
+          "uuid": "3f98b388-b2c0-4355-9a01-15c0e61b5a76",
+          "vbd_userdevice": "0",
+          "vdi_type": "vhd"
         },
         {
           "name": "testvm_11-1",
@@ -85,7 +87,9 @@ instance:
           "size": 42949672960,
           "sr": "Local storage",
           "sr_uuid": "0af1245e-bdb0-ba33-1446-57a962ec4075",
-          "vbd_userdevice": "1"
+          "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "vbd_userdevice": "1",
+          "vdi_type": "vhd"
         }
       ],
       "domid": "56",

--- a/tests/unit/plugins/module_utils/_xenserver/fixtures/ansible-test-vm-1-facts.json
+++ b/tests/unit/plugins/module_utils/_xenserver/fixtures/ansible-test-vm-1-facts.json
@@ -11,7 +11,9 @@
             "size": 42949672960,
             "sr": "Ansible Test Storage 1",
             "sr_uuid": "767b30e4-f8db-a83d-8ba7-f5e6e732e06f",
-            "vbd_userdevice": "0"
+            "uuid": "b807f67b-3f37-4a6e-ad6c-033f812ab093",
+            "vbd_userdevice": "0",
+            "vdi_type": "vhd"
         }
     ],
     "domid": "143",

--- a/tests/unit/plugins/module_utils/_xenserver/fixtures/ansible-test-vm-2-facts.json
+++ b/tests/unit/plugins/module_utils/_xenserver/fixtures/ansible-test-vm-2-facts.json
@@ -11,7 +11,9 @@
             "size": 10737418240,
             "sr": "Ansible Test Storage 1",
             "sr_uuid": "767b30e4-f8db-a83d-8ba7-f5e6e732e06f",
-            "vbd_userdevice": "0"
+            "uuid": "fa1202b8-326f-4235-802e-fafbed66b26b",
+            "vbd_userdevice": "0",
+            "vdi_type": "vhd"
         },
         {
             "name": "ansible-test-vm-2-mysql",
@@ -20,7 +22,9 @@
             "size": 1073741824,
             "sr": "Ansible Test Storage 1",
             "sr_uuid": "767b30e4-f8db-a83d-8ba7-f5e6e732e06f",
-            "vbd_userdevice": "1"
+            "uuid": "ab3a4d72-f498-4687-86ce-ca937046db76",
+            "vbd_userdevice": "1",
+            "vdi_type": "vhd"
         }
     ],
     "domid": "140",

--- a/tests/unit/plugins/module_utils/_xenserver/fixtures/ansible-test-vm-3-facts.json
+++ b/tests/unit/plugins/module_utils/_xenserver/fixtures/ansible-test-vm-3-facts.json
@@ -11,7 +11,9 @@
             "size": 8589934592,
             "sr": "Ansible Test Storage 1",
             "sr_uuid": "767b30e4-f8db-a83d-8ba7-f5e6e732e06f",
-            "vbd_userdevice": "0"
+            "uuid": "bdd0baeb-5447-4963-9e71-a5ff6e85fa59",
+            "vbd_userdevice": "0",
+            "vdi_type": "qcow2"
         }
     ],
     "domid": "-1",

--- a/tests/unit/plugins/module_utils/_xenserver/fixtures/ansible-test-vm-3-params.json
+++ b/tests/unit/plugins/module_utils/_xenserver/fixtures/ansible-test-vm-3-params.json
@@ -138,7 +138,8 @@
             "read_only": false,
             "sharable": false,
             "sm_config": {
-                "vdi_type": "vhd"
+                "image-format": "qcow2",
+                "vdi_type": "qcow2"
             },
             "snapshot_of": "OpaqueRef:NULL",
             "snapshot_time": "19700101T00:00:00Z",


### PR DESCRIPTION
##### SUMMARY

Added two new fields to the disk info returned by `xenserver_guest_info`:

- `uuid` - the VDI UUID for each disk
- `vdi_type` - the disk image format (`vhd` or `qcow2`)

Fixes #11998

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

xenserver_guest_info

##### ADDITIONAL INFORMATION

- Added `uuid` and `vdi_type` to disk information in `gather_vm_facts()`
- Read `vdi_type` from VDI `sm_config`
- Updated `RETURN` example output with the new fields
- Updated unit test fixtures with expected values
- Added test coverage for both VHD and QCOW2 disk formats
- Added changelog fragment

```paste below
# Example disk entry in output:
{
  "name": "testvm_11-0",
  "name_desc": "",
  "os_device": "xvda",
  "size": 42949672960,
  "sr": "Local storage",
  "sr_uuid": "0af1245e-bdb0-ba33-1446-57a962ec4075",
  "uuid": "3f98b388-b2c0-4355-9a01-15c0e61b5a76",
  "vbd_userdevice": "0",
  "vdi_type": "vhd"
}
```