### PR TITLE
consul_kv: add `empty_value` option for null Consul values

### DIFF
--- a/changelogs/fragments/12120-consul-kv-empty-value.yml
+++ b/changelogs/fragments/12120-consul-kv-empty-value.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - consul_kv lookup plugin - add ``empty_value`` option to control what is returned for null Consul values (https://github.com/ansible-collections/community.general/issues/11039, https://github.com/ansible-collections/community.general/pull/12120).

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -96,10 +96,13 @@ options:
         key: url
   empty_value:
     description:
-      - Value to return when a key exists in Consul but has a null/empty value.
-      - Set to V('') to return an empty string instead.
+      - Controls what is returned when a Consul value is null.
+      - V(textual_none) returns the string V(None), which is the legacy behavior.
+      - V(python_none) returns a Python V(null)/V(None) value.
+      - V(empty_string) returns an empty string.
     type: str
-    default: 'None'
+    default: 'textual_none'
+    choices: ['textual_none', 'python_none', 'empty_string']
     version_added: 13.1.0
 """
 
@@ -143,6 +146,13 @@ except ImportError:
     HAS_CONSUL = False
 
 
+_EMPTY_VALUE_MAP = {
+    "textual_none": "None",
+    "python_none": None,
+    "empty_string": "",
+}
+
+
 class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
         if not HAS_CONSUL:
@@ -172,7 +182,7 @@ class LookupModule(LookupBase):
 
         verify = (ca_path or validate_certs) if validate_certs else False
 
-        empty_value = self.get_option("empty_value")
+        empty_value = _EMPTY_VALUE_MAP[self.get_option("empty_value")]
         values = []
         try:
             for term in terms:

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -94,6 +94,13 @@ options:
     ini:
       - section: lookup_consul
         key: url
+  empty_value:
+    description:
+      - Value to return when a key exists in Consul but has a null/empty value.
+      - Set to V('') to return an empty string instead.
+    type: str
+    default: 'None'
+    version_added: 13.1.0
 """
 
 EXAMPLES = r"""
@@ -165,6 +172,7 @@ class LookupModule(LookupBase):
 
         verify = (ca_path or validate_certs) if validate_certs else False
 
+        empty_value = self.get_option("empty_value")
         values = []
         try:
             for term in terms:
@@ -182,9 +190,11 @@ class LookupModule(LookupBase):
                     # responds with a single or list of result maps
                     if isinstance(results[1], list):
                         for r in results[1]:
-                            values.append(to_text(r["Value"]))
+                            v = r["Value"]
+                            values.append(to_text(v) if v is not None else empty_value)
                     else:
-                        values.append(to_text(results[1]["Value"]))
+                        v = results[1]["Value"]
+                        values.append(to_text(v) if v is not None else empty_value)
         except Exception as e:
             raise AnsibleError(f"Error locating '{term}' in kv store. Error was {e}") from e
 

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -97,12 +97,12 @@ options:
   empty_value:
     description:
       - Controls what is returned when a Consul value is null.
-      - V(textual_none) returns the string V(None), which is the legacy behavior.
-      - V(python_none) returns a Python V(null)/V(None) value.
-      - V(empty_string) returns an empty string.
     type: str
     default: 'textual_none'
-    choices: ['textual_none', 'python_none', 'empty_string']
+    choices:
+      textual_none: Return the string V(None). This is the legacy behavior.
+      python_none: Return a Python V(null)/V(None) value.
+      empty_string: Return an empty string.
     version_added: 13.1.0
 """
 


### PR DESCRIPTION
##### SUMMARY

Add an ``empty_value`` option to the ``consul_kv`` lookup plugin that controls what is returned when a key exists in Consul but has a null/empty value. Defaults to ``'None'`` to preserve existing behaviour; users can set it to ``''`` to get an empty string instead.

Fixes #11039

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
consul_kv

##### ADDITIONAL INFORMATION

When a Consul key is stored with an empty string value, the py-consul library returns ``None`` for the ``Value`` field. The lookup was calling ``to_text(None)`` which produces the string ``"None"`` rather than an empty string — surprising and hard to work around in playbooks.

```paste below

```