### PR TITLE
launchd: fix `restarted` and `reloaded` always reporting `changed=False`

### DIFF
--- a/changelogs/fragments/12122-launchd-restarted-always-changed.yml
+++ b/changelogs/fragments/12122-launchd-restarted-always-changed.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "launchd - fix ``restarted`` and ``reloaded`` states always reporting ``changed=False``
+    (https://github.com/ansible-collections/community.general/issues/6199,
+    https://github.com/ansible-collections/community.general/pull/12122)."

--- a/plugins/modules/launchd.py
+++ b/plugins/modules/launchd.py
@@ -501,6 +501,9 @@ def main():
     # Run the requested task
     if not module.check_mode:
         state, pid, status_code, err = tasks[action].run()
+        # restarted and reloaded always perform commands unconditionally, so they always change state
+        if action in ("restarted", "reloaded"):
+            result["changed"] = True
 
     result["status"]["current_state"] = ServiceState.to_string(state)
     result["status"]["current_pid"] = pid

--- a/plugins/modules/launchd.py
+++ b/plugins/modules/launchd.py
@@ -508,10 +508,9 @@ def main():
     result["status"]["error"] = err
 
     # restarted and reloaded always perform commands unconditionally, so they always change state
-    if action in ("restarted", "reloaded"):
-        result["changed"] = True
-    elif (
-        result["status"]["current_state"] != result["status"]["previous_state"]
+    if (
+        action in ("restarted", "reloaded")
+        or result["status"]["current_state"] != result["status"]["previous_state"]
         or result["status"]["current_pid"] != result["status"]["previous_pid"]
     ):
         result["changed"] = True

--- a/plugins/modules/launchd.py
+++ b/plugins/modules/launchd.py
@@ -501,23 +501,22 @@ def main():
     # Run the requested task
     if not module.check_mode:
         state, pid, status_code, err = tasks[action].run()
-        # restarted and reloaded always perform commands unconditionally, so they always change state
-        if action in ("restarted", "reloaded"):
-            result["changed"] = True
 
     result["status"]["current_state"] = ServiceState.to_string(state)
     result["status"]["current_pid"] = pid
     result["status"]["status_code"] = status_code
     result["status"]["error"] = err
 
-    if (
+    # restarted and reloaded always perform commands unconditionally, so they always change state
+    if action in ("restarted", "reloaded"):
+        result["changed"] = True
+    elif (
         result["status"]["current_state"] != result["status"]["previous_state"]
         or result["status"]["current_pid"] != result["status"]["previous_pid"]
     ):
         result["changed"] = True
-    if module.check_mode:
-        if result["status"]["current_state"] != action:
-            result["changed"] = True
+    elif module.check_mode and result["status"]["current_state"] != action:
+        result["changed"] = True
     module.exit_json(**result)
 
 


### PR DESCRIPTION
##### SUMMARY

`restarted` and `reloaded` always execute commands unconditionally (unload → load → start / unload → load), so they should always report `changed=True` in non-check mode. The previous implementation relied solely on PID/state comparison, which could produce `changed=False` if the PID was unchanged after the restart (e.g., when `launchctl unload` succeeds with rc=0 but the service process is not actually terminated, as can happen with SIP-protected services on newer macOS).

Fixes #6199

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
launchd