### PR TITLE
redfish_config: fix `KeyError: 'ret'` when `SetManagerNic` cannot find a matching NIC

### DIFF
--- a/changelogs/fragments/12124-redfish-setmanagernic-keyerror.yml
+++ b/changelogs/fragments/12124-redfish-setmanagernic-keyerror.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "redfish_config - fix ``KeyError: 'ret'`` when ``SetManagerNic`` cannot find a matching NIC
+    (https://github.com/ansible-collections/community.general/issues/5892,
+    https://github.com/ansible-collections/community.general/pull/12124)."

--- a/plugins/module_utils/_redfish_utils.py
+++ b/plugins/module_utils/_redfish_utils.py
@@ -3688,7 +3688,7 @@ class RedfishUtils:
         nic_info["ethernet_setting"] = target_ethernet_current_setting
 
         if target_ethernet_uri is None:
-            return {}
+            return {"ret": False, "msg": f"Manager NIC with address '{nic_addr}' not found"}
         else:
             return nic_info
 


### PR DESCRIPTION
##### SUMMARY

`get_manager_ethernet_uri()` returned an empty dict `{}` when no matching NIC was found (e.g. when the manager hostname in `baseuri` doesn't match any entry in the EthernetInterfaces data). This caused a `KeyError: 'ret'` in `main()` when the result was inspected.

The fix makes this error path return `{"ret": False, "msg": ...}`, consistent with all other error returns in the same function.

Fixes #5892

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redfish_config