### PR TITLE
zpool: reduce disk usage in integration tests by using sparse files

### DIFF
--- a/changelogs/fragments/12054-zpool-tests-disk-space.yml
+++ b/changelogs/fragments/12054-zpool-tests-disk-space.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "zpool integration tests - use sparse files instead of zero-filled disk images to reduce disk space usage (https://github.com/ansible-collections/community.general/issues/12054)."

--- a/changelogs/fragments/12054-zpool-tests-disk-space.yml
+++ b/changelogs/fragments/12054-zpool-tests-disk-space.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "zpool integration tests - use sparse files instead of zero-filled disk images to reduce disk space usage (https://github.com/ansible-collections/community.general/issues/12054)."
+  - "zpool integration tests - use sparse files instead of zero-filled disk images to reduce disk space usage (https://github.com/ansible-collections/community.general/issues/12054, https://github.com/ansible-collections/community.general/pull/12128)."

--- a/changelogs/fragments/12054-zpool-tests-disk-space.yml
+++ b/changelogs/fragments/12054-zpool-tests-disk-space.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - "zpool integration tests - use sparse files instead of zero-filled disk images to reduce disk space usage (https://github.com/ansible-collections/community.general/issues/12054, https://github.com/ansible-collections/community.general/pull/12128)."

--- a/tests/integration/targets/zpool/aliases
+++ b/tests/integration/targets/zpool/aliases
@@ -11,4 +11,3 @@ skip/macos
 skip/rhel
 skip/docker
 skip/alpine  # TODO: figure out what goes wrong
-skip/ubuntu26.04  # TODO: VM seems to have less disk space than required

--- a/tests/integration/targets/zpool/tasks/main.yml
+++ b/tests/integration/targets/zpool/tasks/main.yml
@@ -8,7 +8,7 @@
   block:
     - name: Ensure disk files exists
       ansible.builtin.command:
-        cmd: "dd if=/dev/zero of={{ item }} bs=1M count=256 conv=fsync"
+        cmd: "truncate -s 256M {{ item }}"
         creates: "{{ item }}"
       loop: "{{ zpool_disk_configs }}"
 


### PR DESCRIPTION
##### SUMMARY

The zpool integration tests currently create 11 disk images using `dd if=/dev/zero`, with each image sized at 256MB. This results in roughly 2.8GB of actual disk usage and causes the tests to run out of space on the Ubuntu 26.04 test environment.

Replace `dd` with `truncate -s 256M` so the test images are created as sparse files. The files still appear as 256MB to ZFS, but consume almost no disk space until data is written to them.

Since the tests no longer exhaust the available disk space, remove the `skip/ubuntu26.04` workaround that was added in #12052.

Fixes #12054

##### ISSUE TYPE

- Test Pull Request

##### COMPONENT NAME

zpool

##### ADDITIONAL INFORMATION

- Use `truncate -s 256M` instead of `dd if=/dev/zero` when creating test disk images
- Reduce disk usage during the integration tests while keeping the same file size visible to ZFS
- Remove the `skip/ubuntu26.04` workaround
- Sparse file compatibility with ZFS will be validated by CI

```paste below
# Before (dd, zero-filled):
$ du -sh /tmp/test_dd.img
256M

# After (truncate, sparse):
$ du -sh /tmp/test_sparse.img
0

$ ls -lh /tmp/test_sparse.img
-rw-r--r-- 1 user user 256M Jan 1 00:00 /tmp/test_sparse.img
```