### PR TITLE
pamd: handle non-PAM lines in authselect profile files

### DIFF
--- a/changelogs/fragments/12137-pamd-authselect.yml
+++ b/changelogs/fragments/12137-pamd-authselect.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "pamd - handle non-PAM lines such as authselect template directives without crashing
+    (https://github.com/ansible-collections/community.general/issues/5850,
+    https://github.com/ansible-collections/community.general/pull/12137)."

--- a/plugins/modules/pamd.py
+++ b/plugins/modules/pamd.py
@@ -348,6 +348,8 @@ class PamdRule(PamdLine):
     @classmethod
     def rule_from_string(cls, line):
         rule_match = RULE_REGEX.search(line)
+        if rule_match is None:
+            return None
         rule_args = parse_module_arguments(rule_match.group("args"))
         return cls(rule_match.group("rule_type"), rule_match.group("control"), rule_match.group("path"), rule_args)
 
@@ -432,7 +434,7 @@ class PamdService:
             elif line.strip() == "":
                 pamd_line = PamdEmptyLine(line)
             else:
-                pamd_line = PamdRule.rule_from_string(line)
+                pamd_line = PamdRule.rule_from_string(line) or PamdLine(line)
 
             self.append(pamd_line)
 

--- a/tests/unit/plugins/modules/test_pamd.py
+++ b/tests/unit/plugins/modules/test_pamd.py
@@ -144,6 +144,13 @@ auth       requisite pam_succeed_if.so uid
 auth       required pam_deny.so
 """
 
+        self.authselect_system_auth_string = """{imply "with-smartcard" if "with-smartcard-required"}
+auth        required                                     pam_env.so
+auth        required                                     pam_faildelay.so delay=2000000
+password    sufficient                                   pam_unix.so yescrypt shadow use_authtok
+password    required                                     pam_deny.so
+"""
+
         self.pamd = PamdService(self.system_auth_string)
 
     def test_properly_parsed(self):
@@ -157,6 +164,11 @@ auth       required pam_deny.so
 
     def test_doesnt_have_rule(self):
         self.assertFalse(self.pamd.has_rule("account", "requisite", "pam_permit.so"))
+
+    def test_authselect_directive_line_does_not_crash(self):
+        pamd = PamdService(self.authselect_system_auth_string)
+        self.assertTrue(pamd.has_rule("password", "sufficient", "pam_unix.so"))
+        self.assertIn('{imply "with-smartcard" if "with-smartcard-required"}', str(pamd))
 
     # Test Update
     def test_update_rule_type(self):


### PR DESCRIPTION
##### SUMMARY

`community.general.pamd` crashes with `AttributeError: 'NoneType' object has no attribute 'group'` when processing authselect profile files that contain template directive lines such as `{imply "with-smartcard" if "with-smartcard-required"}`.

These lines don't match the PAM rule regex, causing `PamdRule.rule_from_string()` to call `.group()` on a `None` match object.

The fix makes `rule_from_string` return `None` when the line doesn't match, and falls back to a plain `PamdLine` in `PamdService.__init__`, preserving the directive line in the output unchanged.

Fixes #5850

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pamd

##### ADDITIONAL INFORMATION

Authselect profile files (e.g. `/etc/authselect/custom/test/system-auth`) can have template directive lines at the top that are not standard PAM rules. The module now preserves these lines as-is instead of crashing.