### PR TITLE
pkgng: remove constraints for FreeBSD 12.x from pkgng test

### DIFF
--- a/tests/integration/targets/pkgng/tasks/freebsd.yml
+++ b/tests/integration/targets/pkgng/tasks/freebsd.yml
@@ -498,16 +498,6 @@
 ## pkgng - example - Install single package in jail
 ##
 - name: Test within jail
-  #
-  # NOTE: FreeBSD 12.0 test runner receives a "connection reset by peer" after ~20% downloaded so we are
-  #       only running this on 12.1 or higher
-  #
-  # NOTE: FreeBSD 12.3 fails with some kernel mismatch for packages
-  #       (someone with FreeBSD knowledge has to take a look)
-  #
-  # NOTE: FreeBSD 12.4 fails to update repositories because it cannot load certificates from /usr/share/keys/pkg/trusted
-  #       (someone with FreeBSD knowledge has to take a look)
-  #
   # NOTE: FreeBSD 13.0 fails to update the package catalogue for unknown reasons (someone with FreeBSD
   #       knowledge has to take a look)
   #
@@ -539,8 +529,7 @@
   # See also
   # https://github.com/ansible-collections/community.general/issues/5795
   when: >-
-    (ansible_facts.distribution_version is version('12.01', '>=') and ansible_facts.distribution_version is version('12.3', '<'))
-    or (ansible_facts.distribution_version is version('13.6', '>=') and ansible_facts.distribution_version is version('14.0', '<'))
+    (ansible_facts.distribution_version is version('13.6', '>=') and ansible_facts.distribution_version is version('14.0', '<'))
     or ansible_facts.distribution_version is version('14.4', '>=')
   block:
     - name: Setup testjail


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Test has constraints for FreeBSD 12.x but the proejct no longer runs integration tests against those versions.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
pkgng