### PR TITLE
filetree lookup: handle invalid exclude regex with AnsibleError

### DIFF
--- a/changelogs/fragments/12140-filetree-exclude-regex-error.yml
+++ b/changelogs/fragments/12140-filetree-exclude-regex-error.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - filetree lookup - raise ``AnsibleError`` when the ``exclude`` option contains an invalid regular expression instead of an uncaught ``re.error`` (https://github.com/ansible-collections/community.general/pull/12140).
+  - filetree lookup - raise `AnsibleError` when the `exclude` option contains an invalid regular expression instead of an uncaught `re.error` (https://github.com/ansible-collections/community.general/pull/12140).

--- a/changelogs/fragments/12140-filetree-exclude-regex-error.yml
+++ b/changelogs/fragments/12140-filetree-exclude-regex-error.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - filetree lookup - raise ``AnsibleError`` when the `exclude` option contains an invalid regular expression instead of an uncaught ``re.error`` (https://github.com/ansible-collections/community.general/pull/12140).
+  - filetree lookup - raise ``AnsibleLookupError`` when the `exclude` option contains an invalid regular expression instead of an uncaught ``re.error`` (https://github.com/ansible-collections/community.general/pull/12140).

--- a/changelogs/fragments/12140-filetree-exclude-regex-error.yml
+++ b/changelogs/fragments/12140-filetree-exclude-regex-error.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - filetree lookup - raise ``AnsibleLookupError`` when the `exclude` option contains an invalid regular expression instead of an uncaught ``re.error`` (https://github.com/ansible-collections/community.general/pull/12140).
+  - filetree lookup plugin - raise ``AnsibleLookupError`` when the ``exclude`` option contains an invalid regular expression instead of an uncaught ``re.error`` (https://github.com/ansible-collections/community.general/pull/12140).

--- a/changelogs/fragments/12140-filetree-exclude-regex-error.yml
+++ b/changelogs/fragments/12140-filetree-exclude-regex-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - filetree lookup - raise ``AnsibleError`` when the ``exclude`` option contains an invalid regular expression instead of an uncaught ``re.error`` (https://github.com/ansible-collections/community.general/pull/12140).

--- a/changelogs/fragments/12140-filetree-exclude-regex-error.yml
+++ b/changelogs/fragments/12140-filetree-exclude-regex-error.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - filetree lookup - raise `AnsibleError` when the `exclude` option contains an invalid regular expression instead of an uncaught `re.error` (https://github.com/ansible-collections/community.general/pull/12140).
+  - filetree lookup - raise ``AnsibleError`` when the `exclude` option contains an invalid regular expression instead of an uncaught ``re.error`` (https://github.com/ansible-collections/community.general/pull/12140).

--- a/plugins/lookup/filetree.py
+++ b/plugins/lookup/filetree.py
@@ -143,6 +143,7 @@ try:
 except ImportError:
     pass
 
+from ansible.errors import AnsibleError
 from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.display import Display
@@ -227,7 +228,13 @@ class LookupModule(LookupBase):
 
         # Regular expression for exclude
         exclude = self.get_option("exclude")
-        exclude_pattern = re.compile(exclude) if exclude else None
+        if exclude:
+            try:
+                exclude_pattern = re.compile(exclude)
+            except re.error as e:
+                raise AnsibleError(f"Invalid exclude regular expression {exclude!r}: {e}") from e
+        else:
+            exclude_pattern = None
 
         ret = []
         for term in terms:

--- a/plugins/lookup/filetree.py
+++ b/plugins/lookup/filetree.py
@@ -143,7 +143,7 @@ try:
 except ImportError:
     pass
 
-from ansible.errors import AnsibleError
+from ansible.errors import AnsibleLookupError
 from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.display import Display
@@ -232,7 +232,7 @@ class LookupModule(LookupBase):
             try:
                 exclude_pattern = re.compile(exclude)
             except re.error as e:
-                raise AnsibleError(f"Invalid exclude regular expression {exclude!r}: {e}") from e
+                raise AnsibleLookupError(f"Invalid exclude regular expression {exclude!r}: {e}") from e
         else:
             exclude_pattern = None
 


### PR DESCRIPTION
… re.compile() for the exclude option so invalid regular expressions produce a clear AnsibleError instead of an uncaught re.error traceback.

##### SUMMARY
- Wrap `re.compile()` for the `exclude` option in the `filetree` lookup plugin with error handling.
- Raise a clear `AnsibleError` when `exclude` contains an invalid regular expression, instead of an uncaught Python `re.error` traceback.
- No change to filtering behavior when a valid regex is provided.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
- filetree lookup

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**Steps to reproduce:**
```paste below
- ansible.builtin.debug:
    msg: "{{ lookup('community.general.filetree', 'files/', exclude='temp[1') }}"
```
Output before:
```paste below
re.error: unterminated character set at position 4
```
Output after:
```paste below
AnsibleError: Invalid exclude regular expression 'temp[1': unterminated character set at position 4
```