### PR TITLE
udm_dns_record: fix idempotency with shortened IPv6 addresses

### DIFF
--- a/changelogs/fragments/12149-udm-dns-record-ipv6-idempotency.yml
+++ b/changelogs/fragments/12149-udm-dns-record-ipv6-idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "udm_dns_record - normalize IPv6 addresses in ``data`` to expanded form to fix idempotency (https://github.com/ansible-collections/community.general/issues/317, https://github.com/ansible-collections/community.general/pull/12149)."

--- a/plugins/modules/udm_dns_record.py
+++ b/plugins/modules/udm_dns_record.py
@@ -125,7 +125,7 @@ def _normalize_ip(value: str) -> str:
 
 
 def _normalize_data_ips(data: dict) -> dict:
-    result = {}
+    result: dict = {}
     for key, value in data.items():
         if isinstance(value, list):
             result[key] = [_normalize_ip(v) if isinstance(v, str) else v for v in value]

--- a/plugins/modules/udm_dns_record.py
+++ b/plugins/modules/udm_dns_record.py
@@ -114,6 +114,28 @@ with deps.declare("ipaddress"):
     import ipaddress
 
 
+def _normalize_ip(value: str) -> str:
+    try:
+        addr = ipaddress.ip_address(value)
+        if isinstance(addr, ipaddress.IPv6Address):
+            return addr.exploded
+    except ValueError:
+        pass
+    return value
+
+
+def _normalize_data_ips(data: dict) -> dict:
+    result = {}
+    for key, value in data.items():
+        if isinstance(value, list):
+            result[key] = [_normalize_ip(v) if isinstance(v, str) else v for v in value]
+        elif isinstance(value, str):
+            result[key] = _normalize_ip(value)
+        else:
+            result[key] = value
+    return result
+
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -185,7 +207,7 @@ def main():
             else:
                 obj["name"] = name
 
-            obj.update(data)
+            obj.update(_normalize_data_ips(data))
             diff = obj.diff()
             changed = obj.diff() != []
             if not module.check_mode:


### PR DESCRIPTION
##### SUMMARY

UCS (Univention Corporate Server) stores IPv6 addresses in fully expanded form. When a user provides a shortened address (e.g. `2001:0db8::42`), the Univention library's `obj.diff()` detects a string mismatch against the stored `2001:0db8:0000:0000:0000:0000:0000:0042` and always reports `changed=True`.

Two helper functions are added to normalize IPv6 addresses in the `data` dict to exploded form before passing to `obj.update()`. IPv4 addresses and non-IP strings are left unchanged.

Fixes #317

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
udm_dns_record

##### ADDITIONAL INFORMATION

The `ipaddress` module (stdlib since Python 3.3) was already imported in this file, so no new dependency is introduced.