### PR TITLE
xml_info: add module to query XML files

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -142,6 +142,9 @@ files:
     maintainers: chris93111 apecnascimento
   $doc_fragments/_pipx.py:
     maintainers: russoz
+  $doc_fragments/_xml.py:
+    labels: xml
+    maintainers: shrbhosa dagwieers magnus919 tbielawa
   $doc_fragments/_xenserver.py:
     labels: xenserver
     maintainers: bvitnik
@@ -455,6 +458,9 @@ files:
   $module_utils/_xfconf.py:
     labels: xfconf
     maintainers: russoz
+  $module_utils/_xml.py:
+    labels: xml
+    maintainers: shrbhosa dagwieers magnus919 tbielawa
   $modules/aerospike_migrations.py:
     maintainers: Alb0t
   $modules/airbrake_deployment.py:
@@ -1485,6 +1491,9 @@ files:
     ignore: magnus919
     labels: m:xml xml
     maintainers: dagwieers magnus919 tbielawa cmprescott sm4rk0
+  $modules/xml_info.py:
+    labels: m:xml_info xml
+    maintainers: shrbhosa Shreyashxredhat dagwieers magnus919 tbielawa cmprescott sm4rk0
   $modules/yarn.py:
     ignore: chrishoffman verkaufer
   $modules/yum_versionlock.py:

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -144,7 +144,7 @@ files:
     maintainers: russoz
   $doc_fragments/_xml.py:
     labels: xml
-    maintainers: shrbhosa dagwieers magnus919 tbielawa
+    maintainers: Shreyashxredhat dagwieers magnus919 tbielawa
   $doc_fragments/_xenserver.py:
     labels: xenserver
     maintainers: bvitnik
@@ -460,7 +460,7 @@ files:
     maintainers: russoz
   $module_utils/_xml.py:
     labels: xml
-    maintainers: shrbhosa dagwieers magnus919 tbielawa
+    maintainers: Shreyashxredhat dagwieers magnus919 tbielawa
   $modules/aerospike_migrations.py:
     maintainers: Alb0t
   $modules/airbrake_deployment.py:
@@ -1493,7 +1493,7 @@ files:
     maintainers: dagwieers magnus919 tbielawa cmprescott sm4rk0
   $modules/xml_info.py:
     labels: m:xml_info xml
-    maintainers: shrbhosa Shreyashxredhat dagwieers magnus919 tbielawa cmprescott sm4rk0
+    maintainers: Shreyashxredhat dagwieers magnus919 tbielawa cmprescott sm4rk0
   $modules/yarn.py:
     ignore: chrishoffman verkaufer
   $modules/yum_versionlock.py:

--- a/changelogs/fragments/12029-xml-info.yml
+++ b/changelogs/fragments/12029-xml-info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - xml_info - new module to query XML files or strings using XPath expressions (https://github.com/ansible-collections/community.general/pull/12150).

--- a/changelogs/fragments/12029-xml-info.yml
+++ b/changelogs/fragments/12029-xml-info.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - xml_info - new module to query XML files or strings using XPath expressions (https://github.com/ansible-collections/community.general/pull/12150).

--- a/plugins/doc_fragments/_xml.py
+++ b/plugins/doc_fragments/_xml.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2014, Red Hat, Inc.
+# Copyright (c) 2014, Tim Bielawa <tbielawa@redhat.com>
+# Copyright (c) 2014, Magnus Hedemark <mhedemar@redhat.com>
+# Copyright (c) 2017, Dag Wieers <dag@wieers.com>
+# Copyright (c) 2026, Shreyash Bhosale <shreyashpb16@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Note that this doc fragment is **PRIVATE** to the collection. It can have breaking changes at any time.
+# Do not use this from other collections or standalone plugins/modules!
+
+from __future__ import annotations
+
+
+class ModuleDocFragment:
+    DOCUMENTATION = r"""
+options:
+  path:
+    description:
+      - Path to the file to operate on.
+      - This file must exist ahead of time.
+      - This parameter is required, unless O(xmlstring) is given.
+    type: path
+    aliases: [dest, file]
+  xmlstring:
+    description:
+      - A string containing XML on which to operate.
+      - This parameter is required, unless O(path) is given.
+    type: str
+  xpath:
+    description:
+      - A valid XPath expression describing the item(s) you want to operate on.
+      - Operates on the document root, V(/), by default.
+    type: str
+  namespaces:
+    description:
+      - The namespace C(prefix:uri) mapping for the XPath expression.
+      - Needs to be a C(dict), not a C(list) of items.
+    type: dict
+    default: {}
+  count:
+    description:
+      - Search for a given O(xpath) and provide the count of any matches.
+      - This parameter requires O(xpath) to be set.
+    type: bool
+    default: false
+  print_match:
+    description:
+      - Search for a given O(xpath) and return the XPath paths of any matches.
+      - This parameter requires O(xpath) to be set.
+    type: bool
+    default: false
+  content:
+    description:
+      - Search for a given O(xpath) and get content.
+      - If V(attribute), return the attributes of matched elements.
+      - If V(text), return the text content of matched elements.
+    type: str
+    choices: [attribute, text]
+  strip_cdata_tags:
+    description:
+      - Remove CDATA tags surrounding text values.
+      - Note that this might break your XML file if text values contain characters that could be interpreted as XML.
+    type: bool
+    default: false
+  huge_tree:
+    description:
+      - Disable libxml2 security restrictions on XML node size or document depth, allowing processing of very large XML files.
+      - This option should only be activated when needed, as it disables internal safety limits.
+    type: bool
+    default: false
+requirements:
+  - lxml >= 2.3.0
+notes:
+  - This module does not handle complicated xpath expressions, so limit xpath selectors to simple expressions.
+  - Beware that in case your XML elements are namespaced, you need to use the O(namespaces) parameter, see the examples.
+  - Namespaces prefix should be used for all children of an element where namespace is defined, unless another namespace is
+    defined for them.
+"""

--- a/plugins/doc_fragments/_xml.py
+++ b/plugins/doc_fragments/_xml.py
@@ -38,25 +38,6 @@ options:
       - Needs to be a C(dict), not a C(list) of items.
     type: dict
     default: {}
-  count:
-    description:
-      - Search for a given O(xpath) and provide the count of any matches.
-      - This parameter requires O(xpath) to be set.
-    type: bool
-    default: false
-  print_match:
-    description:
-      - Search for a given O(xpath) and return the XPath paths of any matches.
-      - This parameter requires O(xpath) to be set.
-    type: bool
-    default: false
-  content:
-    description:
-      - Search for a given O(xpath) and get content.
-      - If V(attribute), return the attributes of matched elements.
-      - If V(text), return the text content of matched elements.
-    type: str
-    choices: [attribute, text]
   strip_cdata_tags:
     description:
       - Remove CDATA tags surrounding text values.

--- a/plugins/module_utils/_xml.py
+++ b/plugins/module_utils/_xml.py
@@ -79,7 +79,7 @@ def parse_xml_doc(
                 module.fail_json(msg=f"The target XML source '{xml_file}' is not readable.")
             infile = open(xml_file, "rb")  # noqa: SIM115
         else:
-            module.fail_json(msg=f"The target XML source '{xml_file}' does not exist.")
+            module.fail_json(msg="No XML source provided; specify 'path' or 'xmlstring'.")
 
         parser = etree.XMLParser(
             remove_blank_text=remove_blank_text,
@@ -106,11 +106,8 @@ def xpath_matches(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> bool:
 
 def is_node(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> bool:
     """Test if a given xpath matches anything and if that match is a node."""
-    if xpath_matches(tree, xpath, namespaces):
-        match = tree.xpath(xpath, namespaces=namespaces)
-        if isinstance(match[0], etree._Element):
-            return True
-    return False
+    match = tree.xpath(xpath, namespaces=namespaces)
+    return bool(match) and isinstance(match[0], etree._Element)
 
 
 def get_matches(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> tuple[list[str], str]:
@@ -122,24 +119,33 @@ def get_matches(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> tuple[li
     return match_xpaths, msg
 
 
-def count_matches(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> tuple[int, str]:
-    """Return the count of nodes matching the xpath as (count, message)."""
-    hits = len(tree.xpath(xpath, namespaces=namespaces))
+def count_matches(tree: t.Any, xpath: str, namespaces: dict[str, str], *, count_mode: str = "match") -> tuple[int, str]:
+    """Return the count of nodes matching the xpath as (count, message).
+
+    When count_mode is "xpath", uses the XPath count() function for better memory efficiency.
+    When count_mode is "match" (default), evaluates the expression and counts with len().
+    """
+    if count_mode == "xpath":
+        hits = int(tree.xpath(f"count({xpath})", namespaces=namespaces))
+    else:
+        hits = len(tree.xpath(xpath, namespaces=namespaces))
     msg = f"found {hits} nodes"
     return hits, msg
 
 
 def collect_element_text(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> list[tuple[str, str | None]] | None:
     """Get text content of matched elements as (tag, text) tuples. Returns None if xpath does not match a node."""
-    if not is_node(tree, xpath, namespaces):
+    match = tree.xpath(xpath, namespaces=namespaces)
+    if not match or not isinstance(match[0], etree._Element):
         return None
-    return [(element.tag, element.text) for element in tree.xpath(xpath, namespaces=namespaces)]
+    return [(element.tag, element.text) for element in match]
 
 
 def collect_element_attr(
     tree: t.Any, xpath: str, namespaces: dict[str, str]
 ) -> list[tuple[str, dict[str, str]]] | None:
     """Get attributes of matched elements as (tag, attributes) tuples. Returns None if xpath does not match a node."""
-    if not is_node(tree, xpath, namespaces):
+    match = tree.xpath(xpath, namespaces=namespaces)
+    if not match or not isinstance(match[0], etree._Element):
         return None
-    return [(element.tag, dict(element.attrib)) for element in tree.xpath(xpath, namespaces=namespaces)]
+    return [(element.tag, dict(element.attrib)) for element in match]

--- a/plugins/module_utils/_xml.py
+++ b/plugins/module_utils/_xml.py
@@ -108,34 +108,33 @@ def is_node(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> bool:
     return False
 
 
-def get_matches(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> dict[str, t.Any]:
-    """Return matched XPath paths."""
+def get_matches(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> tuple[list[str], str]:
+    """Return matched XPath paths as (match_xpaths, message)."""
     match = tree.xpath(xpath, namespaces=namespaces)
     match_xpaths: list[str] = [tree.getpath(m) for m in match]
     match_str = json.dumps(match_xpaths)
     msg = f"selector '{xpath}' match: {match_str}"
-    return {"msg": msg, "matches": match_xpaths}
+    return match_xpaths, msg
 
 
-def count_matches(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> dict[str, t.Any]:
-    """Return the count of nodes matching the xpath."""
+def count_matches(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> tuple[int, str]:
+    """Return the count of nodes matching the xpath as (count, message)."""
     hits = len(tree.xpath(xpath, namespaces=namespaces))
     msg = f"found {hits} nodes"
-    return {"msg": msg, "count": hits}
+    return hits, msg
 
 
-def collect_element_text(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> list[dict[str, t.Any]] | None:
-    """Get text content of matched elements. Returns None if xpath does not match a node."""
+def collect_element_text(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> list[tuple[str, str | None]] | None:
+    """Get text content of matched elements as (tag, text) tuples. Returns None if xpath does not match a node."""
     if not is_node(tree, xpath, namespaces):
         return None
-    return [{element.tag: element.text} for element in tree.xpath(xpath, namespaces=namespaces)]
+    return [(element.tag, element.text) for element in tree.xpath(xpath, namespaces=namespaces)]
 
 
-def collect_element_attr(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> list[dict[str, t.Any]] | None:
-    """Get attributes of matched elements. Returns None if xpath does not match a node."""
+def collect_element_attr(
+    tree: t.Any, xpath: str, namespaces: dict[str, str]
+) -> list[tuple[str, dict[str, str]]] | None:
+    """Get attributes of matched elements as (tag, attributes) tuples. Returns None if xpath does not match a node."""
     if not is_node(tree, xpath, namespaces):
         return None
-    elements: list[dict[str, t.Any]] = []
-    for element in tree.xpath(xpath, namespaces=namespaces):
-        elements.append({element.tag: dict(element.attrib)})
-    return elements
+    return [(element.tag, dict(element.attrib)) for element in tree.xpath(xpath, namespaces=namespaces)]

--- a/plugins/module_utils/_xml.py
+++ b/plugins/module_utils/_xml.py
@@ -29,7 +29,7 @@ with deps.declare("lxml"):
     from lxml import etree  # type: ignore[no-redef]
 
 
-def get_common_argument_spec(*, xpath_required: bool = False) -> dict[str, t.Any]:
+def get_common_argument_spec(*, xpath_required: bool = False) -> dict[str, dict[str, t.Any]]:
     """Return the argument spec shared by xml and xml_info modules."""
     return dict(
         path=dict(type="path", aliases=["dest", "file"]),
@@ -72,21 +72,26 @@ def parse_xml_doc(
     try:
         if xml_string:
             infile = BytesIO(to_bytes(xml_string, errors="surrogate_or_strict"))
-        elif xml_file and os.path.isfile(xml_file):
+        elif xml_file:
+            if not os.path.isfile(xml_file):
+                module.fail_json(msg=f"The target XML source '{xml_file}' does not exist.")
+            if not os.access(xml_file, os.R_OK):
+                module.fail_json(msg=f"The target XML source '{xml_file}' is not readable.")
             infile = open(xml_file, "rb")  # noqa: SIM115
         else:
             module.fail_json(msg=f"The target XML source '{xml_file}' does not exist.")
 
-        try:
-            parser = etree.XMLParser(
-                remove_blank_text=remove_blank_text,
-                strip_cdata=strip_cdata_tags,
-                huge_tree=huge_tree,
-                resolve_entities=resolve_entities,
-            )
-            doc = etree.parse(infile, parser)
-        except etree.XMLSyntaxError as e:
-            module.fail_json(msg=f"Error while parsing document: {xml_file or 'xml_string'} ({e})")
+        parser = etree.XMLParser(
+            remove_blank_text=remove_blank_text,
+            strip_cdata=strip_cdata_tags,
+            huge_tree=huge_tree,
+            resolve_entities=resolve_entities,
+        )
+        doc = etree.parse(infile, parser)
+    except etree.XMLSyntaxError as e:
+        module.fail_json(msg=f"Error while parsing document: {xml_file or 'xml_string'} ({e})")
+    except OSError as e:
+        module.fail_json(msg=f"Error reading XML source: {xml_file or 'xml_string'} ({e})")
     finally:
         if infile:
             infile.close()

--- a/plugins/module_utils/_xml.py
+++ b/plugins/module_utils/_xml.py
@@ -29,6 +29,18 @@ with deps.declare("lxml"):
     from lxml import etree  # type: ignore[no-redef]
 
 
+def get_common_argument_spec(*, xpath_required: bool = False) -> dict[str, t.Any]:
+    """Return the argument spec shared by xml and xml_info modules."""
+    return dict(
+        path=dict(type="path", aliases=["dest", "file"]),
+        xmlstring=dict(type="str"),
+        xpath=dict(type="str", required=xpath_required),
+        namespaces=dict(type="dict", default={}),
+        strip_cdata_tags=dict(type="bool", default=False),
+        huge_tree=dict(type="bool", default=False),
+    )
+
+
 def check_lxml(module: AnsibleModule) -> None:
     deps.validate(module, "lxml")
     version_str = ".".join(str(f) for f in etree.LXML_VERSION)
@@ -82,12 +94,12 @@ def parse_xml_doc(
     return doc
 
 
-def xpath_matches(tree: t.Any, xpath: str, namespaces: dict) -> bool:
+def xpath_matches(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> bool:
     """Test if a node exists."""
     return bool(tree.xpath(xpath, namespaces=namespaces))
 
 
-def is_node(tree: t.Any, xpath: str, namespaces: dict) -> bool:
+def is_node(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> bool:
     """Test if a given xpath matches anything and if that match is a node."""
     if xpath_matches(tree, xpath, namespaces):
         match = tree.xpath(xpath, namespaces=namespaces)
@@ -96,34 +108,34 @@ def is_node(tree: t.Any, xpath: str, namespaces: dict) -> bool:
     return False
 
 
-def get_matches(tree: t.Any, xpath: str, namespaces: dict) -> dict:
+def get_matches(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> dict[str, t.Any]:
     """Return matched XPath paths."""
     match = tree.xpath(xpath, namespaces=namespaces)
-    match_xpaths = [tree.getpath(m) for m in match]
+    match_xpaths: list[str] = [tree.getpath(m) for m in match]
     match_str = json.dumps(match_xpaths)
     msg = f"selector '{xpath}' match: {match_str}"
     return {"msg": msg, "matches": match_xpaths}
 
 
-def count_matches(tree: t.Any, xpath: str, namespaces: dict) -> dict:
+def count_matches(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> dict[str, t.Any]:
     """Return the count of nodes matching the xpath."""
     hits = len(tree.xpath(xpath, namespaces=namespaces))
     msg = f"found {hits} nodes"
     return {"msg": msg, "count": hits}
 
 
-def collect_element_text(tree: t.Any, xpath: str, namespaces: dict) -> list | None:
+def collect_element_text(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> list[dict[str, t.Any]] | None:
     """Get text content of matched elements. Returns None if xpath does not match a node."""
     if not is_node(tree, xpath, namespaces):
         return None
     return [{element.tag: element.text} for element in tree.xpath(xpath, namespaces=namespaces)]
 
 
-def collect_element_attr(tree: t.Any, xpath: str, namespaces: dict) -> list | None:
+def collect_element_attr(tree: t.Any, xpath: str, namespaces: dict[str, str]) -> list[dict[str, t.Any]] | None:
     """Get attributes of matched elements. Returns None if xpath does not match a node."""
     if not is_node(tree, xpath, namespaces):
         return None
-    elements = []
+    elements: list[dict[str, t.Any]] = []
     for element in tree.xpath(xpath, namespaces=namespaces):
         elements.append({element.tag: dict(element.attrib)})
     return elements

--- a/plugins/module_utils/_xml.py
+++ b/plugins/module_utils/_xml.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2014, Red Hat, Inc.
+# Copyright (c) 2014, Tim Bielawa <tbielawa@redhat.com>
+# Copyright (c) 2014, Magnus Hedemark <mhedemar@redhat.com>
+# Copyright (c) 2017, Dag Wieers <dag@wieers.com>
+# Copyright (c) 2026, Shreyash Bhosale <shreyashpb16@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Note that this module util is **PRIVATE** to the collection. It can have breaking changes at any time.
+# Do not use this from other collections or standalone plugins/modules!
+
+from __future__ import annotations
+
+import json
+import os
+import typing as t
+from io import BytesIO
+
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.community.general.plugins.module_utils import _deps as deps
+from ansible_collections.community.general.plugins.module_utils._version import LooseVersion
+
+if t.TYPE_CHECKING:
+    from ansible.module_utils.basic import AnsibleModule
+
+etree: t.Any = None
+with deps.declare("lxml"):
+    from lxml import etree  # type: ignore[no-redef]
+
+
+def check_lxml(module: AnsibleModule) -> None:
+    deps.validate(module, "lxml")
+    version_str = ".".join(str(f) for f in etree.LXML_VERSION)
+    if LooseVersion(version_str) < LooseVersion("2.3.0"):
+        module.fail_json(msg="The xml ansible module requires lxml 2.3.0 or newer installed on the managed machine")
+    elif LooseVersion(version_str) < LooseVersion("3.0.0"):
+        module.warn("Using lxml version lower than 3.0.0 does not guarantee predictable element attribute order.")
+
+
+def validate_xpath(module: AnsibleModule, xpath: str) -> None:
+    try:
+        etree.XPath(xpath)
+    except etree.XPathSyntaxError as e:
+        module.fail_json(msg=f"Syntax error in xpath expression: {xpath} ({e})")
+    except etree.XPathEvalError as e:
+        module.fail_json(msg=f"Evaluation error in xpath expression: {xpath} ({e})")
+
+
+def parse_xml_doc(
+    module: AnsibleModule,
+    xml_file: str | None = None,
+    xml_string: str | None = None,
+    strip_cdata_tags: bool = False,
+    huge_tree: bool = False,
+    remove_blank_text: bool = False,
+    resolve_entities: bool = True,
+) -> t.Any:
+    infile: t.IO[bytes] | None = None
+    try:
+        if xml_string:
+            infile = BytesIO(to_bytes(xml_string, errors="surrogate_or_strict"))
+        elif xml_file and os.path.isfile(xml_file):
+            infile = open(xml_file, "rb")  # noqa: SIM115
+        else:
+            module.fail_json(msg=f"The target XML source '{xml_file}' does not exist.")
+
+        try:
+            parser = etree.XMLParser(
+                remove_blank_text=remove_blank_text,
+                strip_cdata=strip_cdata_tags,
+                huge_tree=huge_tree,
+                resolve_entities=resolve_entities,
+            )
+            doc = etree.parse(infile, parser)
+        except etree.XMLSyntaxError as e:
+            module.fail_json(msg=f"Error while parsing document: {xml_file or 'xml_string'} ({e})")
+    finally:
+        if infile:
+            infile.close()
+
+    return doc
+
+
+def xpath_matches(tree: t.Any, xpath: str, namespaces: dict) -> bool:
+    """Test if a node exists."""
+    return bool(tree.xpath(xpath, namespaces=namespaces))
+
+
+def is_node(tree: t.Any, xpath: str, namespaces: dict) -> bool:
+    """Test if a given xpath matches anything and if that match is a node."""
+    if xpath_matches(tree, xpath, namespaces):
+        match = tree.xpath(xpath, namespaces=namespaces)
+        if isinstance(match[0], etree._Element):
+            return True
+    return False
+
+
+def get_matches(tree: t.Any, xpath: str, namespaces: dict) -> dict:
+    """Return matched XPath paths."""
+    match = tree.xpath(xpath, namespaces=namespaces)
+    match_xpaths = [tree.getpath(m) for m in match]
+    match_str = json.dumps(match_xpaths)
+    msg = f"selector '{xpath}' match: {match_str}"
+    return {"msg": msg, "matches": match_xpaths}
+
+
+def count_matches(tree: t.Any, xpath: str, namespaces: dict) -> dict:
+    """Return the count of nodes matching the xpath."""
+    hits = len(tree.xpath(xpath, namespaces=namespaces))
+    msg = f"found {hits} nodes"
+    return {"msg": msg, "count": hits}
+
+
+def collect_element_text(tree: t.Any, xpath: str, namespaces: dict) -> list | None:
+    """Get text content of matched elements. Returns None if xpath does not match a node."""
+    if not is_node(tree, xpath, namespaces):
+        return None
+    return [{element.tag: element.text} for element in tree.xpath(xpath, namespaces=namespaces)]
+
+
+def collect_element_attr(tree: t.Any, xpath: str, namespaces: dict) -> list | None:
+    """Get attributes of matched elements. Returns None if xpath does not match a node."""
+    if not is_node(tree, xpath, namespaces):
+        return None
+    elements = []
+    for element in tree.xpath(xpath, namespaces=namespaces):
+        elements.append({element.tag: dict(element.attrib)})
+    return elements

--- a/plugins/module_utils/_xml.py
+++ b/plugins/module_utils/_xml.py
@@ -23,10 +23,11 @@ from ansible_collections.community.general.plugins.module_utils._version import 
 
 if t.TYPE_CHECKING:
     from ansible.module_utils.basic import AnsibleModule
-
-etree = None
-with deps.declare("lxml"):
-    from lxml import etree  # type: ignore[no-redef]
+    from lxml import etree
+else:
+    etree = None
+    with deps.declare("lxml"):
+        from lxml import etree
 
 
 def get_common_argument_spec(*, xpath_required: bool = False) -> dict[str, dict[str, t.Any]]:

--- a/plugins/module_utils/_xml.py
+++ b/plugins/module_utils/_xml.py
@@ -24,7 +24,7 @@ from ansible_collections.community.general.plugins.module_utils._version import 
 if t.TYPE_CHECKING:
     from ansible.module_utils.basic import AnsibleModule
 
-etree: t.Any = None
+etree = None
 with deps.declare("lxml"):
     from lxml import etree  # type: ignore[no-redef]
 

--- a/plugins/module_utils/_xml.py
+++ b/plugins/module_utils/_xml.py
@@ -68,7 +68,7 @@ def parse_xml_doc(
     huge_tree: bool = False,
     remove_blank_text: bool = False,
     resolve_entities: bool = True,
-) -> t.Any:
+) -> etree._ElementTree:
     infile: t.IO[bytes] | None = None
     try:
         if xml_string:

--- a/plugins/module_utils/_xml.py
+++ b/plugins/module_utils/_xml.py
@@ -23,11 +23,9 @@ from ansible_collections.community.general.plugins.module_utils._version import 
 
 if t.TYPE_CHECKING:
     from ansible.module_utils.basic import AnsibleModule
+
+with deps.declare("lxml"):
     from lxml import etree
-else:
-    etree = None
-    with deps.declare("lxml"):
-        from lxml import etree
 
 
 def get_common_argument_spec(*, xpath_required: bool = False) -> dict[str, dict[str, t.Any]]:

--- a/plugins/modules/xml.py
+++ b/plugins/modules/xml.py
@@ -16,35 +16,13 @@ description:
   - A CRUD-like interface to managing bits of XML files.
 extends_documentation_fragment:
   - community.general._attributes
+  - community.general._xml
 attributes:
   check_mode:
     support: full
   diff_mode:
     support: full
 options:
-  path:
-    description:
-      - Path to the file to operate on.
-      - This file must exist ahead of time.
-      - This parameter is required, unless O(xmlstring) is given.
-    type: path
-    aliases: [dest, file]
-  xmlstring:
-    description:
-      - A string containing XML on which to operate.
-      - This parameter is required, unless O(path) is given.
-    type: str
-  xpath:
-    description:
-      - A valid XPath expression describing the item(s) you want to manipulate.
-      - Operates on the document root, V(/), by default.
-    type: str
-  namespaces:
-    description:
-      - The namespace C(prefix:uri) mapping for the XPath expression.
-      - Needs to be a C(dict), not a C(list) of items.
-    type: dict
-    default: {}
   state:
     description:
       - Set or remove an xpath selection (node(s), attribute(s)).
@@ -80,29 +58,11 @@ options:
       - This parameter requires O(xpath) to be set.
     type: list
     elements: raw
-  count:
-    description:
-      - Search for a given O(xpath) and provide the count of any matches.
-      - This parameter requires O(xpath) to be set.
-    type: bool
-    default: false
-  print_match:
-    description:
-      - Search for a given O(xpath) and print out any matches.
-      - This parameter requires O(xpath) to be set.
-    type: bool
-    default: false
   pretty_print:
     description:
       - Pretty print XML output.
     type: bool
     default: false
-  content:
-    description:
-      - Search for a given O(xpath) and get content.
-      - This parameter requires O(xpath) to be set.
-    type: str
-    choices: [attribute, text]
   input_type:
     description:
       - Type of input for O(add_children) and O(set_children).
@@ -115,18 +75,7 @@ options:
         it incorrectly.
     type: bool
     default: false
-  strip_cdata_tags:
-    description:
-      - Remove CDATA tags surrounding text values.
-      - Note that this might break your XML file if text values contain characters that could be interpreted as XML.
-    type: bool
-    default: false
   huge_tree:
-    description:
-      - Disable libxml2 security restrictions on XML node size or document depth, allowing processing of very large XML files.
-      - This option should only be activated when needed, as it disables internal safety limits.
-    type: bool
-    default: false
     version_added: "13.0.0"
   insertbefore:
     description:
@@ -151,15 +100,9 @@ options:
     type: bool
     default: true
     version_added: "13.0.0"
-requirements:
-  - lxml >= 2.3.0
 notes:
   - Use the C(--check) and C(--diff) options when testing your expressions.
   - The diff output is automatically pretty-printed, so may not reflect the actual file content, only the file structure.
-  - This module does not handle complicated xpath expressions, so limit xpath selectors to simple expressions.
-  - Beware that in case your XML elements are namespaced, you need to use the O(namespaces) parameter, see the examples.
-  - Namespaces prefix should be used for all children of an element where namespace is defined, unless another namespace is
-    defined for them.
 seealso:
   - name: XML module development community wiki (archived)
     description: More information related to the development of this xml module.
@@ -370,27 +313,33 @@ xmlstring:
 """
 
 import copy
-import json
-import os
 import re
 import traceback
+import typing as t
 from collections.abc import MutableMapping
 from io import BytesIO
 
-from ansible_collections.community.general.plugins.module_utils._version import LooseVersion
-
-LXML_IMP_ERR = None
-try:
-    from lxml import etree, objectify
-
-    LXML_VERSION_STR = ".".join(str(f) for f in etree.LXML_VERSION)
-    HAS_LXML = True
-except ImportError:
-    LXML_IMP_ERR = traceback.format_exc()
-    HAS_LXML = False
-
-from ansible.module_utils.basic import AnsibleModule, json_dict_bytes_to_unicode, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule, json_dict_bytes_to_unicode
 from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.community.general.plugins.module_utils._xml import (
+    check_lxml,
+    collect_element_attr,
+    collect_element_text,
+    count_matches,
+    etree,
+    get_matches,
+    is_node,
+    parse_xml_doc,
+    validate_xpath,
+    xpath_matches,
+)
+
+objectify: t.Any = None
+try:
+    from lxml import objectify  # type: ignore[no-redef]
+except ImportError:
+    pass
 
 _IDENT = r"[a-zA-Z-][a-zA-Z0-9_\-\.]*"
 _NSIDENT = f"{_IDENT}|{_IDENT}:{_IDENT}"
@@ -413,33 +362,14 @@ def has_changed(doc):
 
 
 def do_print_match(module, tree, xpath, namespaces):
-    match = tree.xpath(xpath, namespaces=namespaces)
-    match_xpaths = []
-    for m in match:
-        match_xpaths.append(tree.getpath(m))
-    match_str = json.dumps(match_xpaths)
-    msg = f"selector '{xpath}' match: {match_str}"
-    finish(module, tree, xpath, namespaces, changed=False, msg=msg, matches=match_xpaths)
+    result = get_matches(tree, xpath, namespaces)
+    finish(module, tree, xpath, namespaces, changed=False, msg=result["msg"], matches=result["matches"])
 
 
 def count_nodes(module, tree, xpath, namespaces):
     """Return the count of nodes matching the xpath"""
-    hits = tree.xpath(f"count(/{xpath})", namespaces=namespaces)
-    msg = f"found {hits} nodes"
-    finish(module, tree, xpath, namespaces, changed=False, msg=msg, hitcount=int(hits))
-
-
-def is_node(tree, xpath, namespaces):
-    """Test if a given xpath matches anything and if that match is a node.
-
-    For now we just assume you're only searching for one specific thing."""
-    if xpath_matches(tree, xpath, namespaces):
-        # OK, it found something
-        match = tree.xpath(xpath, namespaces=namespaces)
-        if isinstance(match[0], etree._Element):
-            return True
-
-    return False
+    result = count_matches(tree, xpath, namespaces)
+    finish(module, tree, xpath, namespaces, changed=False, msg=result["msg"], hitcount=result["count"])
 
 
 def is_attribute(tree, xpath, namespaces):
@@ -455,14 +385,9 @@ def is_attribute(tree, xpath, namespaces):
         match = tree.xpath(xpath, namespaces=namespaces)
         if isinstance(match[0], etree._ElementUnicodeResult):
             return True
-        elif ElementStringResult is not None and isinstance(match[0], ElementStringResult):
+        elif ElementStringResult is not None and isinstance(match[0], ElementStringResult):  # pylint: disable=isinstance-second-argument-not-valid-type
             return True
     return False
-
-
-def xpath_matches(tree, xpath, namespaces):
-    """Test if a node exists"""
-    return bool(tree.xpath(xpath, namespaces=namespaces))
 
 
 def delete_xpath_target(module, tree, xpath, namespaces):
@@ -737,28 +662,16 @@ def set_target(module, tree, xpath, namespaces, attribute, value, create_if_miss
 
 
 def get_element_text(module, tree, xpath, namespaces):
-    if not is_node(tree, xpath, namespaces):
+    elements = collect_element_text(tree, xpath, namespaces)
+    if elements is None:
         module.fail_json(msg=f"Xpath {xpath} does not reference a node!")
-
-    elements = []
-    for element in tree.xpath(xpath, namespaces=namespaces):
-        elements.append({element.tag: element.text})
-
     finish(module, tree, xpath, namespaces, changed=False, msg=len(elements), hitcount=len(elements), matches=elements)
 
 
 def get_element_attr(module, tree, xpath, namespaces):
-    if not is_node(tree, xpath, namespaces):
+    elements = collect_element_attr(tree, xpath, namespaces)
+    if elements is None:
         module.fail_json(msg=f"Xpath {xpath} does not reference a node!")
-
-    elements = []
-    for element in tree.xpath(xpath, namespaces=namespaces):
-        child = {}
-        for key in element.keys():
-            value = element.get(key)
-            child.update({key: value})
-        elements.append({element.tag: child})
-
     finish(module, tree, xpath, namespaces, changed=False, msg=len(elements), hitcount=len(elements), matches=elements)
 
 
@@ -951,42 +864,19 @@ def main():
     insertafter = module.params["insertafter"]
     create_if_missing = module.params["create_if_missing"]
 
-    # Check if we have lxml 2.3.0 or newer installed
-    if not HAS_LXML:
-        module.fail_json(msg=missing_required_lib("lxml"), exception=LXML_IMP_ERR)
-    elif LooseVersion(LXML_VERSION_STR) < LooseVersion("2.3.0"):
-        module.fail_json(msg="The xml ansible module requires lxml 2.3.0 or newer installed on the managed machine")
-    elif LooseVersion(LXML_VERSION_STR) < LooseVersion("3.0.0"):
-        module.warn("Using lxml version lower than 3.0.0 does not guarantee predictable element attribute order.")
+    check_lxml(module)
 
-    infile = None
-    try:
-        # Check if the file exists
-        if xml_string:
-            infile = BytesIO(to_bytes(xml_string, errors="surrogate_or_strict"))
-        elif os.path.isfile(xml_file):
-            infile = open(xml_file, "rb")
-        else:
-            module.fail_json(msg=f"The target XML source '{xml_file}' does not exist.")
+    if xpath is not None:
+        validate_xpath(module, xpath)
 
-        # Parse and evaluate xpath expression
-        if xpath is not None:
-            try:
-                etree.XPath(xpath)
-            except etree.XPathSyntaxError as e:
-                module.fail_json(msg=f"Syntax error in xpath expression: {xpath} ({e})")
-            except etree.XPathEvalError as e:
-                module.fail_json(msg=f"Evaluation error in xpath expression: {xpath} ({e})")
-
-        # Try to parse in the target XML file
-        try:
-            parser = etree.XMLParser(remove_blank_text=pretty_print, strip_cdata=strip_cdata_tags, huge_tree=huge_tree)
-            doc = etree.parse(infile, parser)
-        except etree.XMLSyntaxError as e:
-            module.fail_json(msg=f"Error while parsing document: {xml_file or 'xml_string'} ({e})")
-    finally:
-        if infile:
-            infile.close()
+    doc = parse_xml_doc(
+        module,
+        xml_file=xml_file,
+        xml_string=xml_string,
+        strip_cdata_tags=strip_cdata_tags,
+        huge_tree=huge_tree,
+        remove_blank_text=pretty_print,
+    )
 
     # Ensure we have the original copy to compare
     global orig_doc

--- a/plugins/modules/xml.py
+++ b/plugins/modules/xml.py
@@ -93,6 +93,25 @@ options:
       - This parameter requires O(xpath) to be set.
     type: bool
     default: false
+  count:
+    description:
+      - Search for a given O(xpath) and provide the count of any matches.
+      - This parameter requires O(xpath) to be set.
+    type: bool
+    default: false
+  print_match:
+    description:
+      - Search for a given O(xpath) and return the XPath paths of any matches.
+      - This parameter requires O(xpath) to be set.
+    type: bool
+    default: false
+  content:
+    description:
+      - Search for a given O(xpath) and get content.
+      - If V(attribute), return the attributes of matched elements.
+      - If V(text), return the text content of matched elements.
+    type: str
+    choices: [attribute, text]
   create_if_missing:
     description:
       - When using O(value) and the O(xpath) matches no nodes, create the node.
@@ -328,6 +347,7 @@ from ansible_collections.community.general.plugins.module_utils._xml import (
     collect_element_text,
     count_matches,
     etree,
+    get_common_argument_spec,
     get_matches,
     is_node,
     parse_xml_doc,
@@ -796,29 +816,25 @@ def finish(module, tree, xpath, namespaces, changed=False, msg="", hitcount=0, m
 
 
 def main():
+    argument_spec = get_common_argument_spec()
+    argument_spec.update(
+        count=dict(type="bool", default=False),
+        print_match=dict(type="bool", default=False),
+        content=dict(type="str", choices=["attribute", "text"]),
+        state=dict(type="str", default="present", choices=["absent", "present"], aliases=["ensure"]),
+        value=dict(type="raw"),
+        attribute=dict(type="raw"),
+        add_children=dict(type="list", elements="raw"),
+        set_children=dict(type="list", elements="raw"),
+        pretty_print=dict(type="bool", default=False),
+        input_type=dict(type="str", default="yaml", choices=["xml", "yaml"]),
+        backup=dict(type="bool", default=False),
+        insertbefore=dict(type="bool", default=False),
+        insertafter=dict(type="bool", default=False),
+        create_if_missing=dict(type="bool", default=True),
+    )
     module = AnsibleModule(
-        argument_spec=dict(
-            path=dict(type="path", aliases=["dest", "file"]),
-            xmlstring=dict(type="str"),
-            xpath=dict(type="str"),
-            namespaces=dict(type="dict", default={}),
-            state=dict(type="str", default="present", choices=["absent", "present"], aliases=["ensure"]),
-            value=dict(type="raw"),
-            attribute=dict(type="raw"),
-            add_children=dict(type="list", elements="raw"),
-            set_children=dict(type="list", elements="raw"),
-            count=dict(type="bool", default=False),
-            print_match=dict(type="bool", default=False),
-            pretty_print=dict(type="bool", default=False),
-            content=dict(type="str", choices=["attribute", "text"]),
-            input_type=dict(type="str", default="yaml", choices=["xml", "yaml"]),
-            backup=dict(type="bool", default=False),
-            strip_cdata_tags=dict(type="bool", default=False),
-            huge_tree=dict(type="bool", default=False),
-            insertbefore=dict(type="bool", default=False),
-            insertafter=dict(type="bool", default=False),
-            create_if_missing=dict(type="bool", default=True),
-        ),
+        argument_spec=argument_spec,
         supports_check_mode=True,
         required_by=dict(
             add_children=["xpath"],

--- a/plugins/modules/xml.py
+++ b/plugins/modules/xml.py
@@ -58,11 +58,29 @@ options:
       - This parameter requires O(xpath) to be set.
     type: list
     elements: raw
+  count:
+    description:
+      - Search for a given O(xpath) and provide the count of any matches.
+      - This parameter requires O(xpath) to be set.
+    type: bool
+    default: false
+  print_match:
+    description:
+      - Search for a given O(xpath) and print out any matches.
+      - This parameter requires O(xpath) to be set.
+    type: bool
+    default: false
   pretty_print:
     description:
       - Pretty print XML output.
     type: bool
     default: false
+  content:
+    description:
+      - Search for a given O(xpath) and get content.
+      - This parameter requires O(xpath) to be set.
+    type: str
+    choices: [attribute, text]
   input_type:
     description:
       - Type of input for O(add_children) and O(set_children).
@@ -93,25 +111,6 @@ options:
       - This parameter requires O(xpath) to be set.
     type: bool
     default: false
-  count:
-    description:
-      - Search for a given O(xpath) and provide the count of any matches.
-      - This parameter requires O(xpath) to be set.
-    type: bool
-    default: false
-  print_match:
-    description:
-      - Search for a given O(xpath) and return the XPath paths of any matches.
-      - This parameter requires O(xpath) to be set.
-    type: bool
-    default: false
-  content:
-    description:
-      - Search for a given O(xpath) and get content.
-      - If V(attribute), return the attributes of matched elements.
-      - If V(text), return the text content of matched elements.
-    type: str
-    choices: [attribute, text]
   create_if_missing:
     description:
       - When using O(value) and the O(xpath) matches no nodes, create the node.
@@ -382,14 +381,14 @@ def has_changed(doc):
 
 
 def do_print_match(module, tree, xpath, namespaces):
-    result = get_matches(tree, xpath, namespaces)
-    finish(module, tree, xpath, namespaces, changed=False, msg=result["msg"], matches=result["matches"])
+    match_xpaths, msg = get_matches(tree, xpath, namespaces)
+    finish(module, tree, xpath, namespaces, changed=False, msg=msg, matches=match_xpaths)
 
 
 def count_nodes(module, tree, xpath, namespaces):
     """Return the count of nodes matching the xpath"""
-    result = count_matches(tree, xpath, namespaces)
-    finish(module, tree, xpath, namespaces, changed=False, msg=result["msg"], hitcount=result["count"])
+    hits, msg = count_matches(tree, xpath, namespaces)
+    finish(module, tree, xpath, namespaces, changed=False, msg=msg, hitcount=hits)
 
 
 def is_attribute(tree, xpath, namespaces):
@@ -682,16 +681,18 @@ def set_target(module, tree, xpath, namespaces, attribute, value, create_if_miss
 
 
 def get_element_text(module, tree, xpath, namespaces):
-    elements = collect_element_text(tree, xpath, namespaces)
-    if elements is None:
+    raw = collect_element_text(tree, xpath, namespaces)
+    if raw is None:
         module.fail_json(msg=f"Xpath {xpath} does not reference a node!")
+    elements = [{tag: text} for tag, text in raw]
     finish(module, tree, xpath, namespaces, changed=False, msg=len(elements), hitcount=len(elements), matches=elements)
 
 
 def get_element_attr(module, tree, xpath, namespaces):
-    elements = collect_element_attr(tree, xpath, namespaces)
-    if elements is None:
+    raw = collect_element_attr(tree, xpath, namespaces)
+    if raw is None:
         module.fail_json(msg=f"Xpath {xpath} does not reference a node!")
+    elements = [{tag: attribs} for tag, attribs in raw]
     finish(module, tree, xpath, namespaces, changed=False, msg=len(elements), hitcount=len(elements), matches=elements)
 
 

--- a/plugins/modules/xml.py
+++ b/plugins/modules/xml.py
@@ -344,7 +344,6 @@ from ansible_collections.community.general.plugins.module_utils._xml import (
     check_lxml,
     collect_element_attr,
     collect_element_text,
-    count_matches,
     etree,
     get_common_argument_spec,
     get_matches,
@@ -387,7 +386,8 @@ def do_print_match(module, tree, xpath, namespaces):
 
 def count_nodes(module, tree, xpath, namespaces):
     """Return the count of nodes matching the xpath"""
-    hits, msg = count_matches(tree, xpath, namespaces)
+    hits = int(tree.xpath(f"count(/{xpath})", namespaces=namespaces))
+    msg = f"found {hits} nodes"
     finish(module, tree, xpath, namespaces, changed=False, msg=msg, hitcount=hits)
 
 

--- a/plugins/modules/xml.py
+++ b/plugins/modules/xml.py
@@ -333,7 +333,6 @@ xmlstring:
 import copy
 import re
 import traceback
-import typing as t
 from collections.abc import MutableMapping
 from io import BytesIO
 
@@ -344,7 +343,6 @@ from ansible_collections.community.general.plugins.module_utils._xml import (
     check_lxml,
     collect_element_attr,
     collect_element_text,
-    etree,
     get_common_argument_spec,
     get_matches,
     is_node,
@@ -355,7 +353,7 @@ from ansible_collections.community.general.plugins.module_utils._xml import (
 
 objectify: t.Any = None
 try:
-    from lxml import objectify  # type: ignore[no-redef]
+    from lxml import etree, objectify
 except ImportError:
     pass
 

--- a/plugins/modules/xml.py
+++ b/plugins/modules/xml.py
@@ -351,7 +351,6 @@ from ansible_collections.community.general.plugins.module_utils._xml import (
     xpath_matches,
 )
 
-objectify: t.Any = None
 try:
     from lxml import etree, objectify
 except ImportError:

--- a/plugins/modules/xml_info.py
+++ b/plugins/modules/xml_info.py
@@ -1,0 +1,217 @@
+#!/usr/bin/python
+
+# Copyright (c) 2014, Red Hat, Inc.
+# Copyright (c) 2014, Tim Bielawa <tbielawa@redhat.com>
+# Copyright (c) 2014, Magnus Hedemark <mhedemar@redhat.com>
+# Copyright (c) 2017, Dag Wieers <dag@wieers.com>
+# Copyright (c) 2026, Shreyash Bhosale <shreyashpb16@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+DOCUMENTATION = r"""
+module: xml_info
+short_description: Query XML files or strings
+description:
+  - A read-only interface to query XML files or strings using XPath expressions.
+  - Supports counting matches, listing matched XPath paths, and retrieving element text or attributes.
+version_added: "13.1.0"
+extends_documentation_fragment:
+  - community.general._attributes
+  - community.general._attributes.info_module
+  - community.general._xml
+options:
+  xpath:
+    required: true
+seealso:
+  - module: community.general.xml
+    description: Manage bits and pieces of XML files or strings.
+  - name: Introduction to XPath
+    description: A brief tutorial on XPath (w3schools.com).
+    link: https://www.w3schools.com/xml/xpath_intro.asp
+  - name: XPath Reference document
+    description: The reference documentation on XSLT/XPath (developer.mozilla.org).
+    link: https://developer.mozilla.org/en-US/docs/Web/XPath
+author:
+  - Tim Bielawa (@tbielawa)
+  - Magnus Hedemark (@magnus919)
+  - Dag Wieers (@dagwieers)
+  - Shreyash Bhosale (@Shreyashxredhat)
+"""
+
+EXAMPLES = r"""
+# Consider the following XML file:
+#
+# <business type="bar">
+#   <name>Tasty Beverage Co.</name>
+#     <beers>
+#       <beer>Rochefort 10</beer>
+#       <beer>St. Bernardus Abbot 12</beer>
+#       <beer>Schlitz</beer>
+#    </beers>
+#   <rating subjective="true">10</rating>
+#   <website>
+#     <mobilefriendly/>
+#     <address>https://tastybeverageco.com</address>
+#   </website>
+# </business>
+
+# Retrieve and display the number of nodes
+- name: Get count of 'beers' nodes
+  community.general.xml_info:
+    path: /foo/bar.xml
+    xpath: /business/beers/beer
+    count: true
+  register: hits
+
+- ansible.builtin.debug:
+    var: hits.count
+
+# Retrieve and display the matching XPath paths
+- name: Get matching paths for 'beer' nodes
+  community.general.xml_info:
+    path: /foo/bar.xml
+    xpath: /business/beers/beer
+    print_match: true
+  register: hits
+
+- ansible.builtin.debug:
+    var: hits.matches
+
+# How to read an attribute value and access it in Ansible
+- name: Read an element's attribute values
+  community.general.xml_info:
+    path: /foo/bar.xml
+    xpath: /business/rating
+    content: attribute
+  register: xmlresp
+
+- name: Show an attribute value
+  ansible.builtin.debug:
+    var: xmlresp.matches[0].rating.subjective
+
+# How to read text content
+- name: Read an element's text content
+  community.general.xml_info:
+    path: /foo/bar.xml
+    xpath: /business/rating
+    content: text
+  register: xmlresp
+
+- name: Show text content
+  ansible.builtin.debug:
+    var: xmlresp.matches[0].rating
+
+# Using an XML string instead of a file
+- name: Count nodes in an XML string
+  community.general.xml_info:
+    xmlstring: "<config><item>1</item><item>2</item></config>"
+    xpath: /config/item
+    count: true
+  register: hits
+
+# Using namespaces
+- name: Count nodes in a namespaced XML file
+  community.general.xml_info:
+    path: /foo/bar.xml
+    xpath: /x:foo/x:bar/y:baz
+    namespaces:
+      x: http://x.test
+      y: http://y.test
+    count: true
+  register: hits
+"""
+
+RETURN = r"""
+count:
+  description: The count of xpath matches.
+  type: int
+  returned: when parameter O(count) is set
+  sample: 2
+matches:
+  description: The xpath matches found.
+  type: list
+  returned: when parameter O(print_match) or O(content) is set
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.community.general.plugins.module_utils._xml import (
+    check_lxml,
+    collect_element_attr,
+    collect_element_text,
+    count_matches,
+    get_matches,
+    parse_xml_doc,
+    validate_xpath,
+)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            path=dict(type="path", aliases=["dest", "file"]),
+            xmlstring=dict(type="str"),
+            xpath=dict(type="str", required=True),
+            namespaces=dict(type="dict", default={}),
+            count=dict(type="bool", default=False),
+            print_match=dict(type="bool", default=False),
+            content=dict(type="str", choices=["attribute", "text"]),
+            strip_cdata_tags=dict(type="bool", default=False),
+            huge_tree=dict(type="bool", default=False),
+        ),
+        supports_check_mode=True,
+        required_one_of=[
+            ["path", "xmlstring"],
+            ["count", "print_match", "content"],
+        ],
+        mutually_exclusive=[
+            ["count", "print_match", "content"],
+            ["path", "xmlstring"],
+        ],
+    )
+
+    xml_file = module.params["path"]
+    xml_string = module.params["xmlstring"]
+    xpath = module.params["xpath"]
+    namespaces = module.params["namespaces"]
+    content = module.params["content"]
+    print_match = module.params["print_match"]
+    count = module.params["count"]
+    strip_cdata_tags = module.params["strip_cdata_tags"]
+    huge_tree = module.params["huge_tree"]
+
+    check_lxml(module)
+    validate_xpath(module, xpath)
+    doc = parse_xml_doc(
+        module,
+        xml_file=xml_file,
+        xml_string=xml_string,
+        strip_cdata_tags=strip_cdata_tags,
+        huge_tree=huge_tree,
+        resolve_entities=False,
+    )
+
+    if print_match:
+        result = get_matches(doc, xpath, namespaces)
+        module.exit_json(**result)
+
+    if count:
+        result = count_matches(doc, xpath, namespaces)
+        module.exit_json(**result)
+
+    if content == "attribute":
+        elements = collect_element_attr(doc, xpath, namespaces)
+        if elements is None:
+            module.fail_json(msg=f"Xpath {xpath} does not reference a node!")
+        module.exit_json(count=len(elements), matches=elements)
+    elif content == "text":
+        elements = collect_element_text(doc, xpath, namespaces)
+        if elements is None:
+            module.fail_json(msg=f"Xpath {xpath} does not reference a node!")
+        module.exit_json(count=len(elements), matches=elements)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/xml_info.py
+++ b/plugins/modules/xml_info.py
@@ -32,8 +32,21 @@ options:
     choices:
       count: Returns the number of matches as RV(count).
       paths: Return the XPath paths for all matched elements as RV(matches).
-      content_text: Return the text content of the matched elements as RV(matches).
-      content_attributes: Return the attributes of the matched elements as RV(matches).
+      content_text: Return the text content of the matched elements as RV(elements).
+      content_attributes: Return the attributes of the matched elements as RV(elements).
+  count_mode:
+    description:
+      - How to determine the count of XPath matches when O(what=count).
+      - V(match) evaluates the XPath expression and counts the results with Python's C(len()).
+        This is always correct for any XPath expression.
+      - V(xpath) uses the XPath C(count()) function, which is more memory-efficient for large
+        result sets since it does not build the full list of matches in memory. However, it may
+        produce different results for XPath expressions that do not return node-sets.
+      - This option is only used when O(what=count). For other O(what) values, the count is
+        always derived from the number of returned items.
+    type: str
+    default: match
+    choices: [match, xpath]
 seealso:
   - module: community.general.xml
     description: Manage bits and pieces of XML files or strings.
@@ -101,7 +114,7 @@ EXAMPLES = r"""
 
 - name: Show an attribute value
   ansible.builtin.debug:
-    var: xmlresp.matches[0].attributes.subjective
+    var: xmlresp.elements[0].attributes.subjective
 
 # How to read text content
 - name: Read an element's text content
@@ -113,7 +126,7 @@ EXAMPLES = r"""
 
 - name: Show text content
   ansible.builtin.debug:
-    var: xmlresp.matches[0].text
+    var: xmlresp.elements[0].text
 
 # Using an XML string instead of a file
 - name: Count nodes in an XML string
@@ -139,16 +152,23 @@ RETURN = r"""
 count:
   description: The count of xpath matches.
   type: int
-  returned: always
+  returned: success
   sample: 2
 matches:
-  description:
-    - The xpath matches found.
-    - When O(what=paths), each element is a string with the XPath path to the matched node.
-    - When O(what=content_text) or O(what=content_attributes), each element is a dictionary
-      with the fields documented below.
+  description: The XPath paths of matched nodes.
   type: list
-  returned: when O(what) is V(paths), V(content_text), or V(content_attributes)
+  elements: str
+  returned: when O(what=paths)
+  sample:
+    - /business/beers/beer[1]
+    - /business/beers/beer[2]
+elements:
+  description:
+    - The content of matched elements.
+    - When O(what=content_text), each item contains the fields V(tag) and V(text).
+    - When O(what=content_attributes), each item contains the fields V(tag) and V(attributes).
+  type: list
+  returned: when O(what) is V(content_text) or V(content_attributes)
   sample:
     - tag: beer
       text: Rochefort 10
@@ -187,6 +207,7 @@ def main() -> None:
     argument_spec = get_common_argument_spec(xpath_required=True)
     argument_spec.update(
         what=dict(type="str", required=True, choices=["count", "paths", "content_text", "content_attributes"]),
+        count_mode=dict(type="str", default="match", choices=["match", "xpath"]),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -204,6 +225,7 @@ def main() -> None:
     xpath = module.params["xpath"]
     namespaces = module.params["namespaces"]
     what: t.Literal["count", "paths", "content_text", "content_attributes"] = module.params["what"]
+    count_mode: t.Literal["match", "xpath"] = module.params["count_mode"]
     strip_cdata_tags = module.params["strip_cdata_tags"]
     huge_tree = module.params["huge_tree"]
 
@@ -219,7 +241,10 @@ def main() -> None:
     )
 
     if what == "count":
-        hits, _msg = count_matches(doc, xpath, namespaces)
+        if count_mode == "xpath":
+            hits = int(doc.xpath(f"count({xpath})", namespaces=namespaces))
+        else:
+            hits, _msg = count_matches(doc, xpath, namespaces)
         module.exit_json(count=hits)
     elif what == "paths":
         match_xpaths, _msg = get_matches(doc, xpath, namespaces)
@@ -228,14 +253,14 @@ def main() -> None:
         raw_text = collect_element_text(doc, xpath, namespaces)
         if raw_text is None:
             module.fail_json(msg=f"Xpath {xpath} does not reference a node!")
-        text_matches = [{"tag": tag, "text": text} for tag, text in raw_text]
-        module.exit_json(count=len(text_matches), matches=text_matches)
+        text_elements = [{"tag": tag, "text": text} for tag, text in raw_text]
+        module.exit_json(count=len(text_elements), elements=text_elements)
     elif what == "content_attributes":
         raw_attr = collect_element_attr(doc, xpath, namespaces)
         if raw_attr is None:
             module.fail_json(msg=f"Xpath {xpath} does not reference a node!")
-        attr_matches = [{"tag": tag, "attributes": attribs} for tag, attribs in raw_attr]
-        module.exit_json(count=len(attr_matches), matches=attr_matches)
+        attr_elements = [{"tag": tag, "attributes": attribs} for tag, attribs in raw_attr]
+        module.exit_json(count=len(attr_elements), elements=attr_elements)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/xml_info.py
+++ b/plugins/modules/xml_info.py
@@ -75,7 +75,8 @@ EXAMPLES = r"""
     what: count
   register: hits
 
-- ansible.builtin.debug:
+- name: Show count
+  ansible.builtin.debug:
     var: hits.count
 
 # Retrieve and display the matching XPath paths
@@ -86,7 +87,8 @@ EXAMPLES = r"""
     what: paths
   register: hits
 
-- ansible.builtin.debug:
+- name: Show matching paths
+  ansible.builtin.debug:
     var: hits.matches
 
 # How to read attribute values and access them in Ansible
@@ -137,17 +139,35 @@ RETURN = r"""
 count:
   description: The count of xpath matches.
   type: int
-  returned: when O(what=count)
+  returned: always
   sample: 2
 matches:
-  description: The xpath matches found.
+  description:
+    - The xpath matches found.
+    - When O(what=paths), each element is a string with the XPath path to the matched node.
+    - When O(what=content_text) or O(what=content_attributes), each element is a dictionary
+      with the fields documented below.
   type: list
-  returned: when O(what=paths), O(what=content_text), or O(what=content_attributes)
-  elements: dict
+  returned: when O(what) is V(paths), V(content_text), or V(content_attributes)
   sample:
     - tag: beer
       text: Rochefort 10
+  contains:
+    tag:
+      description: The tag name of the matched element.
+      type: str
+      returned: when O(what=content_text) or O(what=content_attributes)
+    text:
+      description: The text content of the matched element.
+      type: str
+      returned: when O(what=content_text)
+    attributes:
+      description: The attributes of the matched element as key-value pairs.
+      type: dict
+      returned: when O(what=content_attributes)
 """
+
+import typing as t
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -163,7 +183,7 @@ from ansible_collections.community.general.plugins.module_utils._xml import (
 )
 
 
-def main():
+def main() -> None:
     argument_spec = get_common_argument_spec(xpath_required=True)
     argument_spec.update(
         what=dict(type="str", required=True, choices=["count", "paths", "content_text", "content_attributes"]),
@@ -183,7 +203,7 @@ def main():
     xml_string = module.params["xmlstring"]
     xpath = module.params["xpath"]
     namespaces = module.params["namespaces"]
-    what = module.params["what"]
+    what: t.Literal["count", "paths", "content_text", "content_attributes"] = module.params["what"]
     strip_cdata_tags = module.params["strip_cdata_tags"]
     huge_tree = module.params["huge_tree"]
 
@@ -204,21 +224,21 @@ def main():
 
     if what == "paths":
         match_xpaths, _msg = get_matches(doc, xpath, namespaces)
-        module.exit_json(matches=match_xpaths)
+        module.exit_json(count=len(match_xpaths), matches=match_xpaths)
 
     if what == "content_text":
         raw = collect_element_text(doc, xpath, namespaces)
         if raw is None:
             module.fail_json(msg=f"Xpath {xpath} does not reference a node!")
         matches = [{"tag": tag, "text": text} for tag, text in raw]
-        module.exit_json(matches=matches)
+        module.exit_json(count=len(matches), matches=matches)
 
     if what == "content_attributes":
         raw = collect_element_attr(doc, xpath, namespaces)
         if raw is None:
             module.fail_json(msg=f"Xpath {xpath} does not reference a node!")
         matches = [{"tag": tag, "attributes": attribs} for tag, attribs in raw]
-        module.exit_json(matches=matches)
+        module.exit_json(count=len(matches), matches=matches)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/xml_info.py
+++ b/plugins/modules/xml_info.py
@@ -24,25 +24,16 @@ extends_documentation_fragment:
 options:
   xpath:
     required: true
-  count:
+  what:
     description:
-      - Search for a given O(xpath) and provide the count of any matches.
-      - This parameter requires O(xpath) to be set.
-    type: bool
-    default: false
-  print_match:
-    description:
-      - Search for a given O(xpath) and return the XPath paths of any matches.
-      - This parameter requires O(xpath) to be set.
-    type: bool
-    default: false
-  content:
-    description:
-      - Search for a given O(xpath) and get content.
-      - If V(attribute), return the attributes of matched elements.
-      - If V(text), return the text content of matched elements.
+      - Select what kind of information to return for the given O(xpath).
+    required: true
     type: str
-    choices: [attribute, text]
+    choices:
+      count: Returns the number of matches as RV(count).
+      paths: Return the XPath paths for all matched elements as RV(matches).
+      content_text: Return the text content of the matched elements as RV(matches).
+      content_attributes: Return the attributes of the matched elements as RV(matches).
 seealso:
   - module: community.general.xml
     description: Manage bits and pieces of XML files or strings.
@@ -81,7 +72,7 @@ EXAMPLES = r"""
   community.general.xml_info:
     path: /foo/bar.xml
     xpath: /business/beers/beer
-    count: true
+    what: count
   register: hits
 
 - ansible.builtin.debug:
@@ -92,42 +83,42 @@ EXAMPLES = r"""
   community.general.xml_info:
     path: /foo/bar.xml
     xpath: /business/beers/beer
-    print_match: true
+    what: paths
   register: hits
 
 - ansible.builtin.debug:
     var: hits.matches
 
-# How to read an attribute value and access it in Ansible
+# How to read attribute values and access them in Ansible
 - name: Read an element's attribute values
   community.general.xml_info:
     path: /foo/bar.xml
     xpath: /business/rating
-    content: attribute
+    what: content_attributes
   register: xmlresp
 
 - name: Show an attribute value
   ansible.builtin.debug:
-    var: xmlresp.matches[0].rating.subjective
+    var: xmlresp.matches[0].attributes.subjective
 
 # How to read text content
 - name: Read an element's text content
   community.general.xml_info:
     path: /foo/bar.xml
     xpath: /business/rating
-    content: text
+    what: content_text
   register: xmlresp
 
 - name: Show text content
   ansible.builtin.debug:
-    var: xmlresp.matches[0].rating
+    var: xmlresp.matches[0].text
 
 # Using an XML string instead of a file
 - name: Count nodes in an XML string
   community.general.xml_info:
     xmlstring: "<config><item>1</item><item>2</item></config>"
     xpath: /config/item
-    count: true
+    what: count
   register: hits
 
 # Using namespaces
@@ -138,7 +129,7 @@ EXAMPLES = r"""
     namespaces:
       x: http://x.test
       y: http://y.test
-    count: true
+    what: count
   register: hits
 """
 
@@ -146,12 +137,16 @@ RETURN = r"""
 count:
   description: The count of xpath matches.
   type: int
-  returned: when parameter O(count) is set
+  returned: when O(what=count)
   sample: 2
 matches:
   description: The xpath matches found.
   type: list
-  returned: when parameter O(print_match) or O(content) is set
+  returned: when O(what=paths), O(what=content_text), or O(what=content_attributes)
+  elements: dict
+  sample:
+    - tag: beer
+      text: Rochefort 10
 """
 
 from ansible.module_utils.basic import AnsibleModule
@@ -171,19 +166,15 @@ from ansible_collections.community.general.plugins.module_utils._xml import (
 def main():
     argument_spec = get_common_argument_spec(xpath_required=True)
     argument_spec.update(
-        count=dict(type="bool", default=False),
-        print_match=dict(type="bool", default=False),
-        content=dict(type="str", choices=["attribute", "text"]),
+        what=dict(type="str", required=True, choices=["count", "paths", "content_text", "content_attributes"]),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_one_of=[
             ["path", "xmlstring"],
-            ["count", "print_match", "content"],
         ],
         mutually_exclusive=[
-            ["count", "print_match", "content"],
             ["path", "xmlstring"],
         ],
     )
@@ -192,9 +183,7 @@ def main():
     xml_string = module.params["xmlstring"]
     xpath = module.params["xpath"]
     namespaces = module.params["namespaces"]
-    content = module.params["content"]
-    print_match = module.params["print_match"]
-    count = module.params["count"]
+    what = module.params["what"]
     strip_cdata_tags = module.params["strip_cdata_tags"]
     huge_tree = module.params["huge_tree"]
 
@@ -209,24 +198,27 @@ def main():
         resolve_entities=False,
     )
 
-    if print_match:
-        result = get_matches(doc, xpath, namespaces)
-        module.exit_json(**result)
+    if what == "count":
+        hits, _msg = count_matches(doc, xpath, namespaces)
+        module.exit_json(count=hits)
 
-    if count:
-        result = count_matches(doc, xpath, namespaces)
-        module.exit_json(**result)
+    if what == "paths":
+        match_xpaths, _msg = get_matches(doc, xpath, namespaces)
+        module.exit_json(matches=match_xpaths)
 
-    if content == "attribute":
-        elements = collect_element_attr(doc, xpath, namespaces)
-        if elements is None:
+    if what == "content_text":
+        raw = collect_element_text(doc, xpath, namespaces)
+        if raw is None:
             module.fail_json(msg=f"Xpath {xpath} does not reference a node!")
-        module.exit_json(count=len(elements), matches=elements)
-    elif content == "text":
-        elements = collect_element_text(doc, xpath, namespaces)
-        if elements is None:
+        matches = [{"tag": tag, "text": text} for tag, text in raw]
+        module.exit_json(matches=matches)
+
+    if what == "content_attributes":
+        raw = collect_element_attr(doc, xpath, namespaces)
+        if raw is None:
             module.fail_json(msg=f"Xpath {xpath} does not reference a node!")
-        module.exit_json(count=len(elements), matches=elements)
+        matches = [{"tag": tag, "attributes": attribs} for tag, attribs in raw]
+        module.exit_json(matches=matches)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/xml_info.py
+++ b/plugins/modules/xml_info.py
@@ -32,8 +32,8 @@ options:
     choices:
       count: Returns the number of matches as RV(count).
       paths: Return the XPath paths for all matched elements as RV(matches).
-      content_text: Return the text content of the matched elements as RV(elements).
-      content_attributes: Return the attributes of the matched elements as RV(elements).
+      content_text: Return the text content of the matched elements as RV(content_text).
+      content_attributes: Return the attributes of the matched elements as RV(content_attributes).
   count_mode:
     description:
       - How to determine the count of XPath matches when O(what=count).
@@ -114,7 +114,7 @@ EXAMPLES = r"""
 
 - name: Show an attribute value
   ansible.builtin.debug:
-    var: xmlresp.elements[0].attributes.subjective
+    var: xmlresp.content_attributes[0].attributes.subjective
 
 # How to read text content
 - name: Read an element's text content
@@ -126,7 +126,7 @@ EXAMPLES = r"""
 
 - name: Show text content
   ansible.builtin.debug:
-    var: xmlresp.elements[0].text
+    var: xmlresp.content_text[0].text
 
 # Using an XML string instead of a file
 - name: Count nodes in an XML string
@@ -162,13 +162,10 @@ matches:
   sample:
     - /business/beers/beer[1]
     - /business/beers/beer[2]
-elements:
-  description:
-    - The content of matched elements.
-    - When O(what=content_text), each item contains the fields V(tag) and V(text).
-    - When O(what=content_attributes), each item contains the fields V(tag) and V(attributes).
+content_text:
+  description: The text content of matched elements.
   type: list
-  returned: when O(what) is V(content_text) or V(content_attributes)
+  returned: when O(what=content_text)
   sample:
     - tag: beer
       text: Rochefort 10
@@ -176,15 +173,28 @@ elements:
     tag:
       description: The tag name of the matched element.
       type: str
-      returned: when O(what=content_text) or O(what=content_attributes)
+      returned: always
     text:
       description: The text content of the matched element.
       type: str
-      returned: when O(what=content_text)
+      returned: always
+content_attributes:
+  description: The attributes of matched elements.
+  type: list
+  returned: when O(what=content_attributes)
+  sample:
+    - tag: rating
+      attributes:
+        subjective: "true"
+  contains:
+    tag:
+      description: The tag name of the matched element.
+      type: str
+      returned: always
     attributes:
       description: The attributes of the matched element as key-value pairs.
       type: dict
-      returned: when O(what=content_attributes)
+      returned: always
 """
 
 import typing as t
@@ -241,10 +251,7 @@ def main() -> None:
     )
 
     if what == "count":
-        if count_mode == "xpath":
-            hits = int(doc.xpath(f"count({xpath})", namespaces=namespaces))
-        else:
-            hits, _msg = count_matches(doc, xpath, namespaces)
+        hits, _msg = count_matches(doc, xpath, namespaces, count_mode=count_mode)
         module.exit_json(count=hits)
     elif what == "paths":
         match_xpaths, _msg = get_matches(doc, xpath, namespaces)
@@ -254,13 +261,13 @@ def main() -> None:
         if raw_text is None:
             module.fail_json(msg=f"Xpath {xpath} does not reference a node!")
         text_elements = [{"tag": tag, "text": text} for tag, text in raw_text]
-        module.exit_json(count=len(text_elements), elements=text_elements)
+        module.exit_json(count=len(text_elements), content_text=text_elements)
     elif what == "content_attributes":
         raw_attr = collect_element_attr(doc, xpath, namespaces)
         if raw_attr is None:
             module.fail_json(msg=f"Xpath {xpath} does not reference a node!")
         attr_elements = [{"tag": tag, "attributes": attribs} for tag, attribs in raw_attr]
-        module.exit_json(count=len(attr_elements), elements=attr_elements)
+        module.exit_json(count=len(attr_elements), content_attributes=attr_elements)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/xml_info.py
+++ b/plugins/modules/xml_info.py
@@ -165,6 +165,7 @@ matches:
 content_text:
   description: The text content of matched elements.
   type: list
+  elements: dict
   returned: when O(what=content_text)
   sample:
     - tag: beer
@@ -181,6 +182,7 @@ content_text:
 content_attributes:
   description: The attributes of matched elements.
   type: list
+  elements: dict
   returned: when O(what=content_attributes)
   sample:
     - tag: rating

--- a/plugins/modules/xml_info.py
+++ b/plugins/modules/xml_info.py
@@ -221,24 +221,21 @@ def main() -> None:
     if what == "count":
         hits, _msg = count_matches(doc, xpath, namespaces)
         module.exit_json(count=hits)
-
-    if what == "paths":
+    elif what == "paths":
         match_xpaths, _msg = get_matches(doc, xpath, namespaces)
         module.exit_json(count=len(match_xpaths), matches=match_xpaths)
-
-    if what == "content_text":
-        raw = collect_element_text(doc, xpath, namespaces)
-        if raw is None:
+    elif what == "content_text":
+        raw_text = collect_element_text(doc, xpath, namespaces)
+        if raw_text is None:
             module.fail_json(msg=f"Xpath {xpath} does not reference a node!")
-        matches = [{"tag": tag, "text": text} for tag, text in raw]
-        module.exit_json(count=len(matches), matches=matches)
-
-    if what == "content_attributes":
-        raw = collect_element_attr(doc, xpath, namespaces)
-        if raw is None:
+        text_matches = [{"tag": tag, "text": text} for tag, text in raw_text]
+        module.exit_json(count=len(text_matches), matches=text_matches)
+    elif what == "content_attributes":
+        raw_attr = collect_element_attr(doc, xpath, namespaces)
+        if raw_attr is None:
             module.fail_json(msg=f"Xpath {xpath} does not reference a node!")
-        matches = [{"tag": tag, "attributes": attribs} for tag, attribs in raw]
-        module.exit_json(count=len(matches), matches=matches)
+        attr_matches = [{"tag": tag, "attributes": attribs} for tag, attribs in raw_attr]
+        module.exit_json(count=len(attr_matches), matches=attr_matches)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/xml_info.py
+++ b/plugins/modules/xml_info.py
@@ -24,6 +24,25 @@ extends_documentation_fragment:
 options:
   xpath:
     required: true
+  count:
+    description:
+      - Search for a given O(xpath) and provide the count of any matches.
+      - This parameter requires O(xpath) to be set.
+    type: bool
+    default: false
+  print_match:
+    description:
+      - Search for a given O(xpath) and return the XPath paths of any matches.
+      - This parameter requires O(xpath) to be set.
+    type: bool
+    default: false
+  content:
+    description:
+      - Search for a given O(xpath) and get content.
+      - If V(attribute), return the attributes of matched elements.
+      - If V(text), return the text content of matched elements.
+    type: str
+    choices: [attribute, text]
 seealso:
   - module: community.general.xml
     description: Manage bits and pieces of XML files or strings.
@@ -142,6 +161,7 @@ from ansible_collections.community.general.plugins.module_utils._xml import (
     collect_element_attr,
     collect_element_text,
     count_matches,
+    get_common_argument_spec,
     get_matches,
     parse_xml_doc,
     validate_xpath,
@@ -149,18 +169,14 @@ from ansible_collections.community.general.plugins.module_utils._xml import (
 
 
 def main():
+    argument_spec = get_common_argument_spec(xpath_required=True)
+    argument_spec.update(
+        count=dict(type="bool", default=False),
+        print_match=dict(type="bool", default=False),
+        content=dict(type="str", choices=["attribute", "text"]),
+    )
     module = AnsibleModule(
-        argument_spec=dict(
-            path=dict(type="path", aliases=["dest", "file"]),
-            xmlstring=dict(type="str"),
-            xpath=dict(type="str", required=True),
-            namespaces=dict(type="dict", default={}),
-            count=dict(type="bool", default=False),
-            print_match=dict(type="bool", default=False),
-            content=dict(type="str", choices=["attribute", "text"]),
-            strip_cdata_tags=dict(type="bool", default=False),
-            huge_tree=dict(type="bool", default=False),
-        ),
+        argument_spec=argument_spec,
         supports_check_mode=True,
         required_one_of=[
             ["path", "xmlstring"],

--- a/plugins/modules/xml_info.py
+++ b/plugins/modules/xml_info.py
@@ -16,7 +16,7 @@ short_description: Query XML files or strings
 description:
   - A read-only interface to query XML files or strings using XPath expressions.
   - Supports counting matches, listing matched XPath paths, and retrieving element text or attributes.
-version_added: "13.1.0"
+version_added: "13.2.0"
 extends_documentation_fragment:
   - community.general._attributes
   - community.general._attributes.info_module
@@ -37,9 +37,9 @@ options:
   count_mode:
     description:
       - How to determine the count of XPath matches when O(what=count).
-      - V(match) evaluates the XPath expression and counts the results with Python's C(len()).
+      - V(match) evaluates the XPath expression and counts the results with Python's V(len(\)).
         This is always correct for any XPath expression.
-      - V(xpath) uses the XPath C(count()) function, which is more memory-efficient for large
+      - V(xpath) uses the XPath V(count(\)) function, which is more memory-efficient for large
         result sets since it does not build the full list of matches in memory. However, it may
         produce different results for XPath expressions that do not return node-sets.
       - This option is only used when O(what=count). For other O(what) values, the count is

--- a/tests/integration/targets/xml_info/aliases
+++ b/tests/integration/targets/xml_info/aliases
@@ -1,0 +1,6 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+azp/posix/3
+destructive

--- a/tests/integration/targets/xml_info/meta/main.yml
+++ b/tests/integration/targets/xml_info/meta/main.yml
@@ -1,0 +1,7 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependencies:
+  - setup_pkg_mgr

--- a/tests/integration/targets/xml_info/tasks/main.yml
+++ b/tests/integration/targets/xml_info/tasks/main.yml
@@ -1,0 +1,70 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Install lxml (FreeBSD)
+  package:
+    name: 'py{{ ansible_facts.python.version.major }}{{ ansible_facts.python.version.minor }}-lxml'
+    state: present
+  when: ansible_facts.os_family == "FreeBSD"
+
+- name: Install requirements (RHEL 8)
+  package:
+    name:
+      - libxml2-devel
+      - libxslt-devel
+      - python3-lxml
+    state: present
+  when: ansible_facts.distribution == "RedHat" and ansible_facts.distribution_major_version == "8"
+
+# Needed for MacOSX !
+- name: Install lxml
+  pip:
+    name: lxml
+    state: present
+
+- name: Get lxml version
+  command: "{{ ansible_python_interpreter }} -c 'from lxml import etree; print(\".\".join(str(v) for v in etree.LXML_VERSION))'"
+  register: lxml_version
+
+- name: Set lxml capabilities as variables
+  set_fact:
+    lxml_xpath_attribute_result_attrname: '{{ lxml_version.stdout is version("2.3.0", ">=") }}'
+
+- name: Define test XML content
+  set_fact:
+    xml_info_test_xml: |
+      <?xml version='1.0' encoding='UTF-8'?>
+      <business type="bar">
+        <name>Tasty Beverage Co.</name>
+        <beers>
+          <beer>Rochefort 10</beer>
+          <beer>St. Bernardus Abbot 12</beer>
+          <beer>Schlitz</beer>
+        </beers>
+        <rating subjective="true">10</rating>
+        <website>
+          <mobilefriendly/>
+          <address>https://tastybeverageco.com</address>
+        </website>
+      </business>
+
+- name: Write test XML to file
+  copy:
+    content: "{{ xml_info_test_xml }}"
+    dest: /tmp/ansible-xml-info-beers.xml
+
+- name: Only run the tests when lxml v2.3.0+
+  when: lxml_xpath_attribute_result_attrname
+  block:
+
+    - include_tasks: test-count.yml
+    - include_tasks: test-print-match.yml
+    - include_tasks: test-get-element-content.yml
+    - include_tasks: test-xmlstring.yml

--- a/tests/integration/targets/xml_info/tasks/test-count.yml
+++ b/tests/integration/targets/xml_info/tasks/test-count.yml
@@ -1,0 +1,17 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Count beer elements
+  xml_info:
+    path: /tmp/ansible-xml-info-beers.xml
+    xpath: /business/beers/beer
+    count: true
+  register: beers
+
+- name: Test expected result
+  assert:
+    that:
+      - beers is not changed
+      - beers.count == 3

--- a/tests/integration/targets/xml_info/tasks/test-count.yml
+++ b/tests/integration/targets/xml_info/tasks/test-count.yml
@@ -7,7 +7,7 @@
   xml_info:
     path: /tmp/ansible-xml-info-beers.xml
     xpath: /business/beers/beer
-    count: true
+    what: count
   register: beers
 
 - name: Test expected result

--- a/tests/integration/targets/xml_info/tasks/test-count.yml
+++ b/tests/integration/targets/xml_info/tasks/test-count.yml
@@ -15,3 +15,17 @@
     that:
       - beers is not changed
       - beers.count == 3
+
+- name: Count beer elements with xpath count mode
+  xml_info:
+    path: /tmp/ansible-xml-info-beers.xml
+    xpath: /business/beers/beer
+    what: count
+    count_mode: xpath
+  register: beers_xpath
+
+- name: Test expected result for xpath count mode
+  assert:
+    that:
+      - beers_xpath is not changed
+      - beers_xpath.count == 3

--- a/tests/integration/targets/xml_info/tasks/test-get-element-content.yml
+++ b/tests/integration/targets/xml_info/tasks/test-get-element-content.yml
@@ -15,8 +15,8 @@
     that:
       - get_element_attribute is not changed
       - get_element_attribute.count == 1
-      - get_element_attribute.elements[0].tag == 'rating'
-      - get_element_attribute.elements[0].attributes.subjective == 'true'
+      - get_element_attribute.content_attributes[0].tag == 'rating'
+      - get_element_attribute.content_attributes[0].attributes.subjective == 'true'
 
 - name: Get element text
   xml_info:
@@ -30,5 +30,5 @@
     that:
       - get_element_text is not changed
       - get_element_text.count == 1
-      - get_element_text.elements[0].tag == 'rating'
-      - get_element_text.elements[0].text == '10'
+      - get_element_text.content_text[0].tag == 'rating'
+      - get_element_text.content_text[0].text == '10'

--- a/tests/integration/targets/xml_info/tasks/test-get-element-content.yml
+++ b/tests/integration/targets/xml_info/tasks/test-get-element-content.yml
@@ -7,25 +7,26 @@
   xml_info:
     path: /tmp/ansible-xml-info-beers.xml
     xpath: /business/rating
-    content: attribute
+    what: content_attributes
   register: get_element_attribute
 
 - name: Test expected result
   assert:
     that:
       - get_element_attribute is not changed
-      - get_element_attribute.matches[0]['rating'] is defined
-      - get_element_attribute.matches[0]['rating']['subjective'] == 'true'
+      - get_element_attribute.matches[0].tag == 'rating'
+      - get_element_attribute.matches[0].attributes.subjective == 'true'
 
 - name: Get element text
   xml_info:
     path: /tmp/ansible-xml-info-beers.xml
     xpath: /business/rating
-    content: text
+    what: content_text
   register: get_element_text
 
 - name: Test expected result
   assert:
     that:
       - get_element_text is not changed
-      - get_element_text.matches[0]['rating'] == '10'
+      - get_element_text.matches[0].tag == 'rating'
+      - get_element_text.matches[0].text == '10'

--- a/tests/integration/targets/xml_info/tasks/test-get-element-content.yml
+++ b/tests/integration/targets/xml_info/tasks/test-get-element-content.yml
@@ -15,8 +15,8 @@
     that:
       - get_element_attribute is not changed
       - get_element_attribute.count == 1
-      - get_element_attribute.matches[0].tag == 'rating'
-      - get_element_attribute.matches[0].attributes.subjective == 'true'
+      - get_element_attribute.elements[0].tag == 'rating'
+      - get_element_attribute.elements[0].attributes.subjective == 'true'
 
 - name: Get element text
   xml_info:
@@ -30,5 +30,5 @@
     that:
       - get_element_text is not changed
       - get_element_text.count == 1
-      - get_element_text.matches[0].tag == 'rating'
-      - get_element_text.matches[0].text == '10'
+      - get_element_text.elements[0].tag == 'rating'
+      - get_element_text.elements[0].text == '10'

--- a/tests/integration/targets/xml_info/tasks/test-get-element-content.yml
+++ b/tests/integration/targets/xml_info/tasks/test-get-element-content.yml
@@ -14,6 +14,7 @@
   assert:
     that:
       - get_element_attribute is not changed
+      - get_element_attribute.count == 1
       - get_element_attribute.matches[0].tag == 'rating'
       - get_element_attribute.matches[0].attributes.subjective == 'true'
 
@@ -28,5 +29,6 @@
   assert:
     that:
       - get_element_text is not changed
+      - get_element_text.count == 1
       - get_element_text.matches[0].tag == 'rating'
       - get_element_text.matches[0].text == '10'

--- a/tests/integration/targets/xml_info/tasks/test-get-element-content.yml
+++ b/tests/integration/targets/xml_info/tasks/test-get-element-content.yml
@@ -1,0 +1,31 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Get element attributes
+  xml_info:
+    path: /tmp/ansible-xml-info-beers.xml
+    xpath: /business/rating
+    content: attribute
+  register: get_element_attribute
+
+- name: Test expected result
+  assert:
+    that:
+      - get_element_attribute is not changed
+      - get_element_attribute.matches[0]['rating'] is defined
+      - get_element_attribute.matches[0]['rating']['subjective'] == 'true'
+
+- name: Get element text
+  xml_info:
+    path: /tmp/ansible-xml-info-beers.xml
+    xpath: /business/rating
+    content: text
+  register: get_element_text
+
+- name: Test expected result
+  assert:
+    that:
+      - get_element_text is not changed
+      - get_element_text.matches[0]['rating'] == '10'

--- a/tests/integration/targets/xml_info/tasks/test-print-match.yml
+++ b/tests/integration/targets/xml_info/tasks/test-print-match.yml
@@ -3,31 +3,31 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: print_match returns matching xpath paths in matches
+- name: paths returns matching xpath paths in matches
   xml_info:
     path: /tmp/ansible-xml-info-beers.xml
     xpath: /business/beers/beer
-    print_match: true
-  register: print_match_result
+    what: paths
+  register: paths_result
 
 - name: Test expected result
   assert:
     that:
-      - print_match_result is not changed
-      - print_match_result.matches | length == 3
-      - "'/business/beers/beer[1]' in print_match_result.matches"
-      - "'/business/beers/beer[2]' in print_match_result.matches"
-      - "'/business/beers/beer[3]' in print_match_result.matches"
+      - paths_result is not changed
+      - paths_result.matches | length == 3
+      - "'/business/beers/beer[1]' in paths_result.matches"
+      - "'/business/beers/beer[2]' in paths_result.matches"
+      - "'/business/beers/beer[3]' in paths_result.matches"
 
-- name: print_match with no matches returns empty matches list
+- name: paths with no matches returns empty matches list
   xml_info:
     path: /tmp/ansible-xml-info-beers.xml
     xpath: /business/nonexistent
-    print_match: true
-  register: print_match_empty
+    what: paths
+  register: paths_empty
 
 - name: Test expected result for no matches
   assert:
     that:
-      - print_match_empty is not changed
-      - print_match_empty.matches | length == 0
+      - paths_empty is not changed
+      - paths_empty.matches | length == 0

--- a/tests/integration/targets/xml_info/tasks/test-print-match.yml
+++ b/tests/integration/targets/xml_info/tasks/test-print-match.yml
@@ -14,6 +14,7 @@
   assert:
     that:
       - paths_result is not changed
+      - paths_result.count == 3
       - paths_result.matches | length == 3
       - "'/business/beers/beer[1]' in paths_result.matches"
       - "'/business/beers/beer[2]' in paths_result.matches"
@@ -30,4 +31,5 @@
   assert:
     that:
       - paths_empty is not changed
+      - paths_empty.count == 0
       - paths_empty.matches | length == 0

--- a/tests/integration/targets/xml_info/tasks/test-print-match.yml
+++ b/tests/integration/targets/xml_info/tasks/test-print-match.yml
@@ -1,0 +1,33 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: print_match returns matching xpath paths in matches
+  xml_info:
+    path: /tmp/ansible-xml-info-beers.xml
+    xpath: /business/beers/beer
+    print_match: true
+  register: print_match_result
+
+- name: Test expected result
+  assert:
+    that:
+      - print_match_result is not changed
+      - print_match_result.matches | length == 3
+      - "'/business/beers/beer[1]' in print_match_result.matches"
+      - "'/business/beers/beer[2]' in print_match_result.matches"
+      - "'/business/beers/beer[3]' in print_match_result.matches"
+
+- name: print_match with no matches returns empty matches list
+  xml_info:
+    path: /tmp/ansible-xml-info-beers.xml
+    xpath: /business/nonexistent
+    print_match: true
+  register: print_match_empty
+
+- name: Test expected result for no matches
+  assert:
+    that:
+      - print_match_empty is not changed
+      - print_match_empty.matches | length == 0

--- a/tests/integration/targets/xml_info/tasks/test-xmlstring.yml
+++ b/tests/integration/targets/xml_info/tasks/test-xmlstring.yml
@@ -27,6 +27,7 @@
   assert:
     that:
       - text_result is not changed
+      - text_result.count == 1
       - text_result.matches[0].tag == 'rating'
       - text_result.matches[0].text == '10'
 
@@ -41,4 +42,5 @@
   assert:
     that:
       - match_result is not changed
+      - match_result.count == 3
       - match_result.matches | length == 3

--- a/tests/integration/targets/xml_info/tasks/test-xmlstring.yml
+++ b/tests/integration/targets/xml_info/tasks/test-xmlstring.yml
@@ -28,8 +28,8 @@
     that:
       - text_result is not changed
       - text_result.count == 1
-      - text_result.elements[0].tag == 'rating'
-      - text_result.elements[0].text == '10'
+      - text_result.content_text[0].tag == 'rating'
+      - text_result.content_text[0].text == '10'
 
 - name: Get paths from an XML string
   xml_info:

--- a/tests/integration/targets/xml_info/tasks/test-xmlstring.yml
+++ b/tests/integration/targets/xml_info/tasks/test-xmlstring.yml
@@ -1,0 +1,43 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Count nodes in an XML string
+  xml_info:
+    xmlstring: "{{ xml_info_test_xml }}"
+    xpath: /business/beers/beer
+    count: true
+  register: count_result
+
+- name: Test expected result
+  assert:
+    that:
+      - count_result is not changed
+      - count_result.count == 3
+
+- name: Get element text from an XML string
+  xml_info:
+    xmlstring: "{{ xml_info_test_xml }}"
+    xpath: /business/rating
+    content: text
+  register: text_result
+
+- name: Test expected result
+  assert:
+    that:
+      - text_result is not changed
+      - text_result.matches[0]['rating'] == '10'
+
+- name: Print match from an XML string
+  xml_info:
+    xmlstring: "{{ xml_info_test_xml }}"
+    xpath: /business/beers/beer
+    print_match: true
+  register: match_result
+
+- name: Test expected result
+  assert:
+    that:
+      - match_result is not changed
+      - match_result.matches | length == 3

--- a/tests/integration/targets/xml_info/tasks/test-xmlstring.yml
+++ b/tests/integration/targets/xml_info/tasks/test-xmlstring.yml
@@ -7,7 +7,7 @@
   xml_info:
     xmlstring: "{{ xml_info_test_xml }}"
     xpath: /business/beers/beer
-    count: true
+    what: count
   register: count_result
 
 - name: Test expected result
@@ -20,20 +20,21 @@
   xml_info:
     xmlstring: "{{ xml_info_test_xml }}"
     xpath: /business/rating
-    content: text
+    what: content_text
   register: text_result
 
 - name: Test expected result
   assert:
     that:
       - text_result is not changed
-      - text_result.matches[0]['rating'] == '10'
+      - text_result.matches[0].tag == 'rating'
+      - text_result.matches[0].text == '10'
 
-- name: Print match from an XML string
+- name: Get paths from an XML string
   xml_info:
     xmlstring: "{{ xml_info_test_xml }}"
     xpath: /business/beers/beer
-    print_match: true
+    what: paths
   register: match_result
 
 - name: Test expected result

--- a/tests/integration/targets/xml_info/tasks/test-xmlstring.yml
+++ b/tests/integration/targets/xml_info/tasks/test-xmlstring.yml
@@ -28,8 +28,8 @@
     that:
       - text_result is not changed
       - text_result.count == 1
-      - text_result.matches[0].tag == 'rating'
-      - text_result.matches[0].text == '10'
+      - text_result.elements[0].tag == 'rating'
+      - text_result.elements[0].text == '10'
 
 - name: Get paths from an XML string
   xml_info:


### PR DESCRIPTION
##### SUMMARY

Add a new `xml_info` module that provides read-only query functionality for XML
files/strings using XPath expressions. This extracts the `count`, `print_match`, and
`content` parameters from the existing `xml` module into a dedicated `_info` module,
following Ansible's convention for read-only operations.

~~The `count`, `print_match`, and `content` parameters in the `xml` module are deprecated and
will be removed in community.general 15.0.0.~~

Fixes part of #12029

##### ISSUE TYPE
- Feature Pull Request
- New Module/Plugin Pull Request

##### COMPONENT NAME
xml_info
xml

##### ADDITIONAL INFORMATION

**New module: `community.general.xml_info`**

Supports three query operations (mutually exclusive):
- `print_match: true` — return XPath paths of matches
- `content: attribute|text` — return element attributes or text content

Accepts input from `path` (file) or `xmlstring` (string), same as the `xml` module.

**Deprecation in `community.general.xml`**

The `count`, `print_match`, and `content` parameters now emit deprecation warnings pointing 
users to `xml_info`. Removal target: 15.0.0.

**Migration example:**
```yaml
# Before (deprecated)
- community.general.xml:
    path: /foo/bar.xml
    xpath: /business/beers/beer
    count: true

# After
- community.general.xml_info:
    path: /foo/bar.xml
    xpath: /business/beers/beer
    count: true

# Sanity tests pass:
$ nox -Re ansible-test-sanity-devel -- --python 3.14 plugins/modules/xml_info.py
plugins/modules/xml.py
# Session ansible-test-sanity-devel-3.14 was successful