### PR TITLE
java_cert: fix PKCS12 password not passed to `keytool -list`

### DIFF
--- a/changelogs/fragments/12151-java-cert-pkcs12-password.yml
+++ b/changelogs/fragments/12151-java-cert-pkcs12-password.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "java_cert - fix ``NullPointerException`` when importing from a PKCS12 file with a password on Java 8
+    (https://github.com/ansible-collections/community.general/issues/3023,
+    https://github.com/ansible-collections/community.general/pull/12151)."

--- a/plugins/modules/java_cert.py
+++ b/plugins/modules/java_cert.py
@@ -279,7 +279,7 @@ def _get_digest_from_x509_file(module, pem_certificate_file, openssl_bin):
 
 def _export_public_cert_from_pkcs12(module, executable, pkcs_file, alias, password, dest):
     """Runs keytools to extract the public cert from a PKCS12 archive and write it to a file."""
-    export_cmd = [executable, "-list", "-noprompt", "-keystore", pkcs_file, "-storetype", "pkcs12", "-rfc"]
+    export_cmd = [executable, "-list", "-keystore", pkcs_file, "-storetype", "pkcs12", "-rfc"]
     # Append optional alias
     if alias:
         export_cmd.extend(["-alias", alias])

--- a/tests/integration/targets/java_cert/tasks/main.yml
+++ b/tests/integration/targets/java_cert/tasks/main.yml
@@ -32,6 +32,23 @@
         that:
           - result_success is successful
 
+    - name: import pkcs12 again to verify idempotency (tests password via stdin in _export_public_cert_from_pkcs12)
+      community.general.java_cert:
+        pkcs12_path: "{{ remote_tmp_dir }}/{{ test_pkcs12_path }}"
+        pkcs12_password: changeit
+        pkcs12_alias: default
+        cert_alias: default
+        keystore_path: "{{ remote_tmp_dir }}/{{ test_keystore_path }}"
+        keystore_pass: changeme_keystore
+        keystore_create: true
+        state: present
+      register: result_idempotent
+
+    - name: verify idempotency
+      ansible.builtin.assert:
+        that:
+          - result_idempotent is not changed
+
     - name: import pkcs12 without alias params
       community.general.java_cert:
         pkcs12_path: "{{ remote_tmp_dir }}/{{ test_pkcs12_path }}"


### PR DESCRIPTION
##### SUMMARY

`-noprompt` is not a documented or valid option for `keytool -list` (it applies to `importkeystore` and `importcert`). On Java 8, passing it caused keytool to skip reading the keystore password from stdin, leaving it as Java `null` and throwing `NullPointerException: no password supplied when one expected`.

The fix removes `-noprompt` from the `keytool -list` command in `_export_public_cert_from_pkcs12`. Without it, keytool prompts for the password and reads it from stdin as provided via `module.run_command(..., data=password)`.

An idempotency integration test is added that re-imports the same PKCS12 cert into an existing keystore, directly exercising the password-via-stdin path in `_export_public_cert_from_pkcs12`.

Fixes #3023

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
java_cert

##### ADDITIONAL INFORMATION

The `_export_public_cert_from_pkcs12` function runs `keytool -list` to extract the public certificate from a PKCS12 archive for digest comparison. The `-noprompt` flag was incorrectly included; on Java 8 this prevented stdin from being read for the store password.