### PR TITLE
mark zypper tests (suse) as unsupported

### DIFF
--- a/tests/integration/targets/zypper/aliases
+++ b/tests/integration/targets/zypper/aliases
@@ -2,8 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-azp/posix/1
-destructive
-skip/freebsd
-skip/macos
-skip/rhel
+unsupported

--- a/tests/integration/targets/zypper_repository/aliases
+++ b/tests/integration/targets/zypper_repository/aliases
@@ -2,8 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-azp/posix/1
-destructive
-skip/freebsd
-skip/macos
-skip/rhel
+unsupported


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`zypper` being the pkg manager for SuSE, and that distro no longer being part of our CI runs, the tests are being marked as unsupported.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
