### PR TITLE
CI: improve nox GHA workflow

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -22,12 +22,7 @@ concurrency:
 
 jobs:
   nox:
-    runs-on: ubuntu-latest
-    name: "Run extra sanity tests"
-    steps:
-      - name: Check out collection
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Run nox
-        uses: ansible-community/antsibull-nox@main
+    uses: ansible-community/antsibull-nox/.github/workflows/reusable-nox-run.yml@main
+    with:
+      session-name: Run extra sanity tests
+      change-detection-in-prs: true

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -15,6 +15,11 @@ name: nox
     - cron: '0 8 * * *'
   workflow_dispatch:
 
+concurrency:
+  # Make sure there is at most one active run per PR, but do not cancel any non-PR runs
+  group: ${{ github.workflow }}-${{ (github.head_ref && github.event.number) || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   nox:
     runs-on: ubuntu-latest


### PR DESCRIPTION
##### SUMMARY
Cancel older nox CI runs in PRs.
Also use the shared workflow (with change detection) instead of stupidly running all tests every time.

Essentially a copy of https://github.com/ansible-collections/community.crypto/pull/1027.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI