### PR TITLE
test(integration): explicitly add executable to iso_extract on Fedora

### DIFF
--- a/tests/integration/targets/iso_extract/tasks/main.yml
+++ b/tests/integration/targets/iso_extract/tasks/main.yml
@@ -13,12 +13,6 @@
 - set_fact:
     output_test_dir: '{{ remote_tmp_dir }}/test_iso_extract'
 
-# TODO: figure out and fix!
-- name: Doesn't work with Fedora 43+ for some reason
-  meta: end_play
-  when:
-    - ansible_facts.distribution == 'Fedora' and ansible_facts.distribution_major_version is version('43', '>=')
-
 - name: Install 7zip
   import_tasks: 7zip.yml
 

--- a/tests/integration/targets/iso_extract/tasks/tests.yml
+++ b/tests/integration/targets/iso_extract/tasks/tests.yml
@@ -12,6 +12,7 @@
     files:
       - 1.txt
       - 2.txt
+    executable: '{{ iso_extract_7zip_executable | default(omit) }}'
   register: iso_extract_test0
 
 - assert:
@@ -25,6 +26,7 @@
     files:
       - 1.txt
       - 2.txt
+    executable: '{{ iso_extract_7zip_executable | default(omit) }}'
   register: iso_extract_test0_again
 
 - name: Test iso_extract_test0_again (normal mode)
@@ -47,6 +49,7 @@
       - /1.txt
       - /2.txt
     force: true
+    executable: '{{ iso_extract_7zip_executable | default(omit) }}'
   register: iso_extract_leading_slash
 
 - name: Test iso_extract with leading slash succeeds (normal mode)

--- a/tests/integration/targets/iso_extract/vars/Fedora.yml
+++ b/tests/integration/targets/iso_extract/vars/Fedora.yml
@@ -1,0 +1,9 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Temporary workound for https://bugzilla.redhat.com/show_bug.cgi?id=2373874
+# TODO: Remove when eventually fixed upstream
+iso_extract_7zip_executable: /usr/bin/7z
+iso_extract_7zip_package: p7zip-plugins


### PR DESCRIPTION
##### SUMMARY
This provides a (temporary) workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2373874: On Fedora 43+ 7zip is unable to find the 7z.so module when it is not in the same path as the 7z binary or in /usr/bin/

I'm not sure if it fixes #11402, but I guess a running test (albeit fudged) is better than a disabled test.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
iso_extract module integration test

##### ADDITIONAL INFORMATION
n/a
