### PR TITLE
Fix incus Windows modules with ansible-core 2.21

### DIFF
--- a/changelogs/fragments/12158-incus-windows-ansible-core-221.yml
+++ b/changelogs/fragments/12158-incus-windows-ansible-core-221.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - "incus connection plugin - improve Windows PowerShell argv handling by stripping wrapper quotes from payload arguments for ``-enc``, ``-encodedcommand``, ``-command``, ``-c``, ``-file`` and ``-f``(https://github.com/ansible-collections/community.general/pull/12158)."
+  - "incus connection plugin - improve Windows PowerShell argv handling by stripping wrapper quotes from payload arguments for ``-enc``, ``-encodedcommand``, ``-command``, ``-c``, ``-file`` and ``-f`` (https://github.com/ansible-collections/community.general/pull/12158)."
   - "incus connection plugin - return ``stdout``/``stderr`` as bytes instead of strings to restore compatibility with ansible-core 2.21 module execution (https://github.com/ansible-collections/community.general/pull/12158)."

--- a/changelogs/fragments/12158-incus-windows-ansible-core-221.yml
+++ b/changelogs/fragments/12158-incus-windows-ansible-core-221.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - "incus connection plugin - improve Windows PowerShell argv handling by stripping wrapper quotes from payload arguments for ``-enc``, ``-encodedcommand``, ``-command``, ``-c``, ``-file`` and ``-f`` (https://github.com/ansible-collections/community.general/pull/12158)."
-  - "incus connection plugin - return ``stdout``/``stderr`` as bytes instead of strings to restore compatibility with ansible-core 2.21 module execution (https://github.com/ansible-collections/community.general/pull/12158)."
+  - "incus connection plugin - improve Windows PowerShell argv handling by stripping wrapper quotes from payload arguments for ``-enc``, ``-encodedcommand``, ``-command``, ``-c``, ``-file`` and ``-f`` (https://github.com/ansible-collections/community.general/issues/12161, https://github.com/ansible-collections/community.general/pull/12158)."
+  - "incus connection plugin - return ``stdout``/``stderr`` as bytes instead of strings to restore compatibility with ansible-core 2.21 module execution (https://github.com/ansible-collections/community.general/issues/12161, https://github.com/ansible-collections/community.general/pull/12158)."

--- a/changelogs/fragments/12158-incus-windows-ansible-core-221.yml
+++ b/changelogs/fragments/12158-incus-windows-ansible-core-221.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "incus connection plugin - improve Windows PowerShell argv handling by stripping wrapper quotes from payload arguments for ``-enc``, ``-encodedcommand``, ``-command``, ``-c``, ``-file`` and ``-f``(https://github.com/ansible-collections/community.general/pull/12158)."
+  - "incus connection plugin - return ``stdout``/``stderr`` as bytes instead of strings to restore compatibility with ansible-core 2.21 module execution (https://github.com/ansible-collections/community.general/pull/12158)."

--- a/plugins/connection/incus.py
+++ b/plugins/connection/incus.py
@@ -83,7 +83,7 @@ from subprocess import PIPE, Popen, call
 
 from ansible.errors import AnsibleConnectionFailure, AnsibleError, AnsibleFileNotFound
 from ansible.module_utils.common.process import get_bin_path
-from ansible.module_utils.common.text.converters import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.plugins.connection import ConnectionBase
 
 
@@ -169,7 +169,13 @@ class Connection(ConnectionBase):
                     exec_cmd.append(post_args.strip())
             else:
                 # For anything else using -EncodedCommand or else, just split on space.
-                exec_cmd.extend(cmd.split(" "))
+                # Ansible's PowerShell module wrapper can quote the encoded payload;
+                # since Incus receives an argv list directly, keep those quotes from
+                # becoming literal PowerShell argument content.
+                if re.search(r"\s-EncodedCommand\s", cmd, re.IGNORECASE):
+                    exec_cmd.extend(part.strip("'\"") for part in cmd.split(" ") if part)
+                else:
+                    exec_cmd.extend(cmd.split(" "))
         else:
             if self.get_option("remote_user") != "root":
                 self._display.vvv(
@@ -203,25 +209,22 @@ class Connection(ConnectionBase):
         process = Popen(local_cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
         stdout, stderr = process.communicate(in_data)
 
-        stdout = to_text(stdout)
-        stderr = to_text(stderr)
-
-        if stderr.startswith("Error: ") and stderr.rstrip().endswith(": Instance is not running"):
+        if stderr.startswith(b"Error: ") and stderr.rstrip().endswith(b": Instance is not running"):
             raise AnsibleConnectionFailure(
                 f"instance not running: {self._instance()} (remote={self.get_option('remote')}, project={self.get_option('project')})"
             )
 
-        if stderr.startswith("Error: ") and stderr.rstrip().endswith(": Instance not found"):
+        if stderr.startswith(b"Error: ") and stderr.rstrip().endswith(b": Instance not found"):
             raise AnsibleConnectionFailure(
                 f"instance not found: {self._instance()} (remote={self.get_option('remote')}, project={self.get_option('project')})"
             )
 
-        if stderr.startswith("Error: ") and ": User does not have permission " in stderr:
+        if stderr.startswith(b"Error: ") and b": User does not have permission " in stderr:
             raise AnsibleConnectionFailure(
                 f"instance access denied: {self._instance()} (remote={self.get_option('remote')}, project={self.get_option('project')})"
             )
 
-        if stderr.startswith("Error: ") and ": User does not have entitlement " in stderr:
+        if stderr.startswith(b"Error: ") and b": User does not have entitlement " in stderr:
             raise AnsibleConnectionFailure(
                 f"instance access denied: {self._instance()} (remote={self.get_option('remote')}, project={self.get_option('project')})"
             )

--- a/plugins/connection/incus.py
+++ b/plugins/connection/incus.py
@@ -173,6 +173,13 @@ class Connection(ConnectionBase):
 
                     # Keep quotes from becoming literal PowerShell argument content.
                     if len(post_args) >= 2 and post_args[0] == post_args[-1] and post_args[0] in ("'", '"'):
+                        self._display.v(
+                            "WARNING: PowerShell -Command argument is wrapped in outer quotes; "
+                            "this connection plugin strips those quotes and behavior may differ "
+                            "from a direct shell run. Prefer passing -Command without extra "
+                            "outer quoting.",
+                            host=self._instance(),
+                        )
                         post_args = post_args[1:-1]
 
                     exec_cmd.append(post_args)

--- a/plugins/connection/incus.py
+++ b/plugins/connection/incus.py
@@ -164,10 +164,10 @@ class Connection(ConnectionBase):
                 exec_cmd.append(regex_match.group("executable"))
                 if args := regex_match.group("args"):
                     exec_cmd.extend(args.strip().split(" "))
-                
+
                 # Set the command argument depending on cmd or powershell and the rest of it
                 exec_cmd.append(regex_match.group("command"))
-                
+
                 if post_args := regex_match.group("post_args"):
                     post_args = post_args.strip()
 

--- a/plugins/connection/incus.py
+++ b/plugins/connection/incus.py
@@ -79,42 +79,13 @@ options:
 
 import os
 import re
+import shlex
 from subprocess import PIPE, Popen, call
 
 from ansible.errors import AnsibleConnectionFailure, AnsibleError, AnsibleFileNotFound
 from ansible.module_utils.common.process import get_bin_path
 from ansible.module_utils.common.text.converters import to_bytes
 from ansible.plugins.connection import ConnectionBase
-
-
-def split_powershell_cmd(cmd: str) -> list[str]:
-    """Split a PowerShell command line into argv tokens, preserving quoted
-    strings as single tokens and stripping the surrounding quotes.
-    Only single and double quotes are treated as delimiters; backslashes
-    are not escape characters (Windows paths are passed through as-is)."""
-    parts = []
-    current = []
-    in_quote = None
-
-    for char in cmd:
-        if char in ('"', "'") and in_quote is None:
-            # Opening quote
-            in_quote = char
-        elif char == in_quote:
-            # Closing quote
-            in_quote = None
-        elif char == " " and in_quote is None:
-            # Unquoted space
-            if current:
-                parts.append("".join(current))
-                current = []
-        else:
-            current.append(char)
-
-    if current:
-        parts.append("".join(current))
-
-    return parts
 
 
 class Connection(ConnectionBase):
@@ -193,16 +164,29 @@ class Connection(ConnectionBase):
                 exec_cmd.append(regex_match.group("executable"))
                 if args := regex_match.group("args"):
                     exec_cmd.extend(args.strip().split(" "))
+                
                 # Set the command argument depending on cmd or powershell and the rest of it
                 exec_cmd.append(regex_match.group("command"))
+                
                 if post_args := regex_match.group("post_args"):
-                    exec_cmd.append(post_args.strip())
+                    post_args = post_args.strip()
+
+                    # Keep quotes from becoming literal PowerShell argument content.
+                    if len(post_args) >= 2 and post_args[0] == post_args[-1] and post_args[0] in ("'", '"'):
+                        post_args = post_args[1:-1]
+
+                    exec_cmd.append(post_args)
             else:
-                # Ansible's PowerShell module wrapper may quote the payload with single
-                # or double quotes; since Incus receives an argv list directly, those
-                # quotes would become literal argument content rather than shell syntax,
-                # so strip them here.
-                parts = split_powershell_cmd(cmd)
+                # Keep quotes from becoming literal PowerShell argument content.
+                # shlex is not a full PowerShell/Windows command-line parser,
+                # but with posix=False it reliably keeps quoted segments (for
+                # example, paths with spaces) as single argv items, which is
+                # what we need before passing arguments to incus exec.
+                parts = shlex.split(cmd, posix=False)
+                for i, part in enumerate(parts[:-1]):
+                    if part.lower() in {"-enc", "-encodedcommand", "-file", "-f"}:
+                        parts[i + 1] = parts[i + 1].strip("'\"")
+                        break
                 exec_cmd.extend(parts)
         else:
             if self.get_option("remote_user") != "root":

--- a/plugins/connection/incus.py
+++ b/plugins/connection/incus.py
@@ -87,6 +87,36 @@ from ansible.module_utils.common.text.converters import to_bytes
 from ansible.plugins.connection import ConnectionBase
 
 
+def split_powershell_cmd(cmd: str) -> list[str]:
+    """Split a PowerShell command line into argv tokens, preserving quoted
+    strings as single tokens and stripping the surrounding quotes.
+    Only single and double quotes are treated as delimiters; backslashes
+    are not escape characters (Windows paths are passed through as-is)."""
+    parts = []
+    current = []
+    in_quote = None
+
+    for char in cmd:
+        if char in ('"', "'") and in_quote is None:
+            # Opening quote
+            in_quote = char
+        elif char == in_quote:
+            # Closing quote
+            in_quote = None
+        elif char == " " and in_quote is None:
+            # Unquoted space
+            if current:
+                parts.append("".join(current))
+                current = []
+        else:
+            current.append(char)
+
+    if current:
+        parts.append("".join(current))
+
+    return parts
+
+
 class Connection(ConnectionBase):
     """Incus based connections"""
 
@@ -168,14 +198,12 @@ class Connection(ConnectionBase):
                 if post_args := regex_match.group("post_args"):
                     exec_cmd.append(post_args.strip())
             else:
-                # For anything else using -EncodedCommand or else, just split on space.
-                # Ansible's PowerShell module wrapper can quote the encoded payload;
-                # since Incus receives an argv list directly, keep those quotes from
-                # becoming literal PowerShell argument content.
-                if re.search(r"\s-EncodedCommand\s", cmd, re.IGNORECASE):
-                    exec_cmd.extend(part.strip("'\"") for part in cmd.split(" ") if part)
-                else:
-                    exec_cmd.extend(cmd.split(" "))
+                # Ansible's PowerShell module wrapper may quote the payload with single
+                # or double quotes; since Incus receives an argv list directly, those
+                # quotes would become literal argument content rather than shell syntax,
+                # so strip them here.
+                parts = split_powershell_cmd(cmd)
+                exec_cmd.extend(parts)
         else:
             if self.get_option("remote_user") != "root":
                 self._display.vvv(

--- a/tests/unit/plugins/connection/test_incus.py
+++ b/tests/unit/plugins/connection/test_incus.py
@@ -104,6 +104,22 @@ BUILD_CMD_TEST_CASES: list[dict[str, t.Any]] = [
         ),
         output=[r"C:\CMD", "/c", "some-command /flag1 /flag2"],
     ),
+    dict(
+        id="powershell encoded command strips quotes",
+        input=dict(
+            cmd="""powershell -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand 'cABhAHIAYQBtAA=='""",
+            shell="powershell",
+        ),
+        output=[
+            "powershell",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Unrestricted",
+            "-EncodedCommand",
+            "cABhAHIAYQBtAA==",
+        ],
+    ),
 ]
 
 

--- a/tests/unit/plugins/connection/test_incus.py
+++ b/tests/unit/plugins/connection/test_incus.py
@@ -174,6 +174,86 @@ BUILD_CMD_TEST_CASES: list[dict[str, t.Any]] = [
             "cABhAHIAYQBtAA==",
         ],
     ),
+    dict(
+        id="powershell -Command with spaces in path",
+        input=dict(
+            cmd="""powershell.exe -NonInteractive -Command 'Write-Host "hello"; & \\'C:\\My Scripts\\run me.ps1\\''""",
+            shell="powershell",
+        ),
+        output=[
+            "powershell.exe",
+            "-NonInteractive",
+            "-Command",
+            """Write-Host "hello"; & \\'C:\\My Scripts\\run me.ps1\\'""",
+        ],
+    ),
+    dict(
+        id="powershell -File with spaces in path",
+        input=dict(
+            cmd='''powershell.exe -NonInteractive -File "C:\\My Scripts\\run me.ps1"''',
+            shell="powershell",
+        ),
+        output=[
+            "powershell.exe",
+            "-NonInteractive",
+            "-File",
+            r"C:\My Scripts\run me.ps1",
+        ],
+    ),
+    dict(
+        id="powershell -File single quoted path with trailing args",
+        input=dict(
+            cmd="""powershell.exe -NoProfile -File 'C:\\My Scripts\\run me.ps1' -Arg1 value""",
+            shell="powershell",
+        ),
+        output=[
+            "powershell.exe",
+            "-NoProfile",
+            "-File",
+            r"C:\My Scripts\run me.ps1",
+            "-Arg1",
+            "value",
+        ],
+    ),
+    dict(
+        id="powershell -F alias with spaces in path",
+        input=dict(
+            cmd='''powershell.exe -NoProfile -F "C:\\My Scripts\\run me.ps1"''',
+            shell="powershell",
+        ),
+        output=[
+            "powershell.exe",
+            "-NoProfile",
+            "-F",
+            r"C:\My Scripts\run me.ps1",
+        ],
+    ),
+    dict(
+        id="powershell -Command outer double quotes",
+        input=dict(
+            cmd='''powershell.exe -NoProfile -Command "Write-Host 'hello world'"''',
+            shell="powershell",
+        ),
+        output=[
+            "powershell.exe",
+            "-NoProfile",
+            "-Command",
+            "Write-Host 'hello world'",
+        ],
+    ),
+    dict(
+        id="powershell -Command empty quoted payload",
+        input=dict(
+            cmd='''powershell.exe -NoProfile -Command ""''',
+            shell="powershell",
+        ),
+        output=[
+            "powershell.exe",
+            "-NoProfile",
+            "-Command",
+            "",
+        ],
+    ),
 ]
 
 

--- a/tests/unit/plugins/connection/test_incus.py
+++ b/tests/unit/plugins/connection/test_incus.py
@@ -120,6 +120,60 @@ BUILD_CMD_TEST_CASES: list[dict[str, t.Any]] = [
             "cABhAHIAYQBtAA==",
         ],
     ),
+    dict(
+        id="powershell encoded command strips double quotes",
+        input=dict(
+            cmd='''powershell -NoProfile -EncodedCommand "cABhAHIAYQBtAA=="''',
+            shell="powershell",
+        ),
+        output=[
+            "powershell",
+            "-NoProfile",
+            "-EncodedCommand",
+            "cABhAHIAYQBtAA==",
+        ],
+    ),
+    dict(
+        id="powershell encoded command case-insensitive keyword",
+        input=dict(
+            cmd="""powershell -NoProfile -eNcOdEdCoMmAnD 'cABhAHIAYQBtAA=='""",
+            shell="powershell",
+        ),
+        output=[
+            "powershell",
+            "-NoProfile",
+            "-eNcOdEdCoMmAnD",
+            "cABhAHIAYQBtAA==",
+        ],
+    ),
+    dict(
+        id="powershell encoded command keeps surrounding flags",
+        input=dict(
+            cmd="""powershell -NoProfile -EncodedCommand 'cABhAHIAYQBtAA==' -InputFormat None""",
+            shell="powershell",
+        ),
+        output=[
+            "powershell",
+            "-NoProfile",
+            "-EncodedCommand",
+            "cABhAHIAYQBtAA==",
+            "-InputFormat",
+            "None",
+        ],
+    ),
+    dict(
+        id="powershell -enc alias strips quotes",
+        input=dict(
+            cmd="""powershell -NoProfile -enc 'cABhAHIAYQBtAA=='""",
+            shell="powershell",
+        ),
+        output=[
+            "powershell",
+            "-NoProfile",
+            "-enc",
+            "cABhAHIAYQBtAA==",
+        ],
+    ),
 ]
 
 


### PR DESCRIPTION
##### SUMMARY

Fixes #12161

`ansible-core` 2.21 processes PowerShell module stderr through CLIXML handling and expects connection plugins to return `stdout` and `stderr` as bytes. The Incus connection plugin was decoding both streams to text before returning, which now caused Windows modules to fail with a type error. 

I checked the typing in ansible-core for the `exec_command` function, and the return arguments should be `tuple[int, bytes, bytes]`
https://github.com/ansible/ansible/blob/1d398ae8af25132dc5290226517a7c8763ae295b/lib/ansible/plugins/connection/__init__.py#L144

This PR keeps the raw byte streams as the return values from `exec_command` to match the expected interface.

It also strips literal surrounding quotes from `-EncodedCommand` (and -enc, -file, -f)  payloads when the command falls back to simple argument splitting. Without this, PowerShell receives the quotes as part of the base64 payload and rejects the encoded command.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
incus connection plugin

##### ADDITIONAL INFORMATION
A minimal example is running a Windows module through the Incus connection plugin with `ansible_shell_type: powershell` and `ansible-core 2.21.0`:

inventory.yml
```text
all:
  vars:
    ansible_connection: community.general.incus
    ansible_user: root
    ansible_incus_remote: local
    ansible_incus_project: lab

windows:
  hosts:
    windows-vm:
      ansible_incus_host: windows-vm
  vars:
    ansible_shell_type: powershell
```

```bash
ansible windows-vm \
  -i inventory.yml \
  -m ansible.windows.win_command \
  -a "cmd.exe /c ver" \
  -vv
```