### PR TITLE
version_sort filter: fix example's description

### DIFF
--- a/plugins/filter/version_sort.py
+++ b/plugins/filter/version_sort.py
@@ -20,9 +20,9 @@ options:
 """
 
 EXAMPLES = r"""
-- name: Convert list of tuples into dictionary
+- name: Sort a list of strings by version
   ansible.builtin.set_fact:
-    dictionary: "{{ ['2.1', '2.10', '2.9'] | community.general.version_sort }}"
+    sorted_list: "{{ ['2.1', '2.10', '2.9'] | community.general.version_sort }}"
     # Result is ['2.1', '2.9', '2.10']
 """
 


### PR DESCRIPTION
##### SUMMARY
Example had some left overs, that were not aligned with code. It was explaining conversion between tuples and dict. But example here maps list of strings to list of strings.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
version_sort

##### ADDITIONAL INFORMATION

