### PR TITLE
portage: include msg in depclean failure fail_json

### DIFF
--- a/changelogs/fragments/portage-depclean-fail_json-msg.yml
+++ b/changelogs/fragments/portage-depclean-fail_json-msg.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "portage - fix ``depclean: true`` crashing with ``AnsibleModule.fail_json() missing 1 required positional argument: 'msg'`` instead of reporting the actual emerge failure (https://github.com/ansible-collections/community.general/pull/12168)."

--- a/plugins/modules/portage.py
+++ b/plugins/modules/portage.py
@@ -508,7 +508,13 @@ def cleanup_packages(module, packages):
 
     cmd, (rc, out, err) = run_emerge(module, packages, *args)
     if rc != 0:
-        module.fail_json(cmd=cmd, rc=rc, stdout=out, stderr=err)
+        module.fail_json(
+            cmd=cmd,
+            rc=rc,
+            stdout=out,
+            stderr=err,
+            msg="Packages not cleaned up.",
+        )
 
     removed = 0
     for line in out.splitlines():


### PR DESCRIPTION
## Summary

`cleanup_packages()` (the code path behind `depclean: true`) calls
`module.fail_json(cmd=..., rc=..., stdout=..., stderr=...)` without the
mandatory `msg=` argument. When the underlying `emerge --depclean` exits
non-zero, `AnsibleModule.fail_json()` itself crashes with:

```
AnsibleModule.fail_json() missing 1 required positional argument: 'msg'
```

before the real failure can reach the controller. The user is left with no
diagnostic about why depclean actually failed.

This adds `msg="Packages not cleaned up."`, mirroring the wording style of
the sibling `install_packages()` failure branch (`"Packages not installed."`).

## Issue type

Bugfix

## Component name

portage