### PR TITLE
add new `google_chat` module 

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -678,6 +678,8 @@ files:
     maintainers: masa-orca
   $modules/golang_package.py:
     maintainers: shrbhosa
+  $modules/google_chat.py:
+    maintainers: tomscholz
   $modules/grove.py:
     maintainers: zimbatm
   $modules/gunicorn.py:

--- a/plugins/modules/google_chat.py
+++ b/plugins/modules/google_chat.py
@@ -20,10 +20,8 @@ extends_documentation_fragment:
 attributes:
   check_mode:
     support: full
-    description: Can run in C(check_mode) and return changed status prediction without modifying target.
   diff_mode:
     support: none
-    description: Will return details on what has changed (or possibly needs changing in C(check_mode)), when in diff mode.
 options:
   webhook_url:
     type: str

--- a/plugins/modules/google_chat.py
+++ b/plugins/modules/google_chat.py
@@ -35,20 +35,20 @@ options:
     description:
       - The text of the message to send.
       - 'Emoji must be supplied as Unicode characters (for example V(🚀)). The Chat API does not
-        render C(:shortcode:) style emoji in plain text messages; they appear as literal text.'
+        render C(:shortcode:) style emoji in plain text messages as they appear as literal text.'
   thread_key:
     type: str
     description:
       - An arbitrary key used to start or reply to a message thread.
-      - When set, O(message_reply_option) controls the behavior when the thread is not found.
-  message_reply_option:
-    type: str
+      - When set, O(create_new_thread) controls the behavior when the thread is not found.
+  create_new_thread:
+    type: bool
+    default: true
     description:
-      - Behavior when O(thread_key) is supplied but no matching thread exists.
+      - Controls behavior when O(thread_key) is set but no matching thread exists.
+      - When V(true), a new thread is started if no matching thread is found.
+      - When V(false), the message is only posted if a matching thread already exists, otherwise it fails.
       - Only used when O(thread_key) is set.
-    choices:
-      - REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD
-      - REPLY_MESSAGE_OR_FAIL
   validate_certs:
     type: bool
     default: true
@@ -73,18 +73,18 @@ EXAMPLES = r"""
     webhook_url: "https://chat.googleapis.com/v1/spaces/SPACE_ID/messages?key=KEY&token=TOKEN"
     text: 'Starting a thread'
     thread_key: 'deploy-2026-06-01'
-    message_reply_option: REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD
+    create_new_thread: true
 
 # Post each deploy step into a single thread. The first message creates the thread
-# with REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD; follow-ups use REPLY_MESSAGE_OR_FAIL so
-# they only post if the opening message landed, rather than leaving orphan threads.
+# with create_new_thread=true. Follow-ups use create_new_thread=false so they only
+# post if the opening message went through, rather than leaving orphan threads.
 # Note: webhooks are rate-limited to 1 request per second per space.
 - name: Announce deploy start (starts the thread)
   community.general.google_chat:
     webhook_url: "{{ chat_webhook }}"
     text: "🚀 Starting deploy of *{{ app_version | default('latest') }}* to {{ inventory_hostname }}"
     thread_key: "{{ deploy_thread }}"
-    message_reply_option: REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD
+    create_new_thread: true
   delegate_to: localhost
   run_once: true
   # deploy_thread is defined once for the play, for example:
@@ -93,9 +93,9 @@ EXAMPLES = r"""
 - name: Report a step into the same thread
   community.general.google_chat:
     webhook_url: "{{ chat_webhook }}"
-    text: "✅ Step 1/3 — code checked out"
+    text: "✅ Step 1/3 – code checked out"
     thread_key: "{{ deploy_thread }}"
-    message_reply_option: REPLY_MESSAGE_OR_FAIL
+    create_new_thread: false
   delegate_to: localhost
   run_once: true
 
@@ -112,16 +112,16 @@ EXAMPLES = r"""
         webhook_url: "{{ chat_webhook }}"
         text: "🎉 Deploy to {{ inventory_hostname }} complete"
         thread_key: "{{ deploy_thread }}"
-        message_reply_option: REPLY_MESSAGE_OR_FAIL
+        create_new_thread: false
       delegate_to: localhost
       run_once: true
   rescue:
     - name: Report failure into the thread
       community.general.google_chat:
         webhook_url: "{{ chat_webhook }}"
-        text: "❌ Deploy to {{ inventory_hostname }} *failed* — {{ ansible_failed_task.name }}"
+        text: "❌ Deploy to {{ inventory_hostname }} *failed* – {{ ansible_failed_task.name }}"
         thread_key: "{{ deploy_thread }}"
-        message_reply_option: REPLY_MESSAGE_OR_FAIL
+        create_new_thread: false
       delegate_to: localhost
       run_once: true
 
@@ -156,11 +156,14 @@ def build_payload(text, thread_key):
     return payload
 
 
-def build_url(webhook_url, message_reply_option):
-    if message_reply_option is None:
-        return webhook_url
+def build_url(webhook_url, thread_key, create_new_thread):
+    params = {}
+    if thread_key is not None:
+        params["messageReplyOption"] = (
+            "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD" if create_new_thread else "REPLY_MESSAGE_OR_FAIL"
+        )
     sep = "&" if "?" in webhook_url else "?"
-    return f"{webhook_url}{sep}{urlencode({'messageReplyOption': message_reply_option})}"
+    return f"{webhook_url}{sep}{urlencode(params)}"
 
 
 def do_notify(module, url, payload):
@@ -188,10 +191,7 @@ def main():
             webhook_url=dict(type="str", required=True, no_log=True),
             text=dict(type="str", required=True),
             thread_key=dict(type="str", no_log=False),
-            message_reply_option=dict(
-                type="str",
-                choices=["REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD", "REPLY_MESSAGE_OR_FAIL"],
-            ),
+            create_new_thread=dict(type="bool", default=True),
             validate_certs=dict(type="bool", default=True),
         ),
         supports_check_mode=True,
@@ -201,7 +201,11 @@ def main():
         module.exit_json(changed=True)
 
     payload = build_payload(module.params["text"], module.params["thread_key"])
-    url = build_url(module.params["webhook_url"], module.params["message_reply_option"])
+    url = build_url(
+        module.params["webhook_url"],
+        module.params["thread_key"],
+        module.params["create_new_thread"],
+    )
 
     response = do_notify(module, url, payload)
 

--- a/plugins/modules/google_chat.py
+++ b/plugins/modules/google_chat.py
@@ -23,11 +23,24 @@ attributes:
   diff_mode:
     support: none
 options:
-  webhook_url:
+  space:
     type: str
     required: true
     description:
-      - The incoming webhook URL for the Chat space, including the C(key) and C(token) query parameters.
+      - The identifier of the Chat space to post to, taken from the incoming webhook URL.
+      - For a webhook URL of the form C(https://chat.googleapis.com/v1/spaces/AAAA/messages?key=...&token=...),
+        this is the C(AAAA) part.
+  key:
+    type: str
+    required: true
+    description:
+      - The C(key) request parameter from the incoming webhook URL.
+      - Keep this value secret as it grants the ability to post to the space.
+  token:
+    type: str
+    required: true
+    description:
+      - The C(token) request parameter from the incoming webhook URL.
       - Keep this value secret as it grants the ability to post to the space.
   text:
     type: str
@@ -64,13 +77,17 @@ seealso:
 EXAMPLES = r"""
 - name: Send a notification to Google Chat
   community.general.google_chat:
-    webhook_url: "https://chat.googleapis.com/v1/spaces/SPACE_ID/messages?key=KEY&token=TOKEN"
+    space: SPACE_ID
+    key: KEY
+    token: TOKEN
     text: '{{ inventory_hostname }} completed'
   delegate_to: localhost
 
 - name: Start a thread
   community.general.google_chat:
-    webhook_url: "https://chat.googleapis.com/v1/spaces/SPACE_ID/messages?key=KEY&token=TOKEN"
+    space: SPACE_ID
+    key: KEY
+    token: TOKEN
     text: 'Starting a thread'
     thread_key: 'deploy-2026-06-01'
     create_new_thread: true
@@ -81,7 +98,9 @@ EXAMPLES = r"""
 # Note: webhooks are rate-limited to 1 request per second per space.
 - name: Announce deploy start (starts the thread)
   community.general.google_chat:
-    webhook_url: "{{ chat_webhook }}"
+    space: "{{ chat_space }}"
+    key: "{{ chat_key }}"
+    token: "{{ chat_token }}"
     text: "🚀 Starting deploy of *{{ app_version | default('latest') }}* to {{ inventory_hostname }}"
     thread_key: "{{ deploy_thread }}"
     create_new_thread: true
@@ -92,8 +111,10 @@ EXAMPLES = r"""
 
 - name: Report a step into the same thread
   community.general.google_chat:
-    webhook_url: "{{ chat_webhook }}"
-    text: "✅ Step 1/3 – code checked out"
+    space: "{{ chat_space }}"
+    key: "{{ chat_key }}"
+    token: "{{ chat_token }}"
+    text: "✅ Step 1/3 — code checked out"
     thread_key: "{{ deploy_thread }}"
     create_new_thread: false
   delegate_to: localhost
@@ -109,7 +130,9 @@ EXAMPLES = r"""
 
     - name: Report success
       community.general.google_chat:
-        webhook_url: "{{ chat_webhook }}"
+        space: "{{ chat_space }}"
+        key: "{{ chat_key }}"
+        token: "{{ chat_token }}"
         text: "🎉 Deploy to {{ inventory_hostname }} complete"
         thread_key: "{{ deploy_thread }}"
         create_new_thread: false
@@ -118,8 +141,10 @@ EXAMPLES = r"""
   rescue:
     - name: Report failure into the thread
       community.general.google_chat:
-        webhook_url: "{{ chat_webhook }}"
-        text: "❌ Deploy to {{ inventory_hostname }} *failed* – {{ ansible_failed_task.name }}"
+        space: "{{ chat_space }}"
+        key: "{{ chat_key }}"
+        token: "{{ chat_token }}"
+        text: "❌ Deploy to {{ inventory_hostname }} *failed* — {{ ansible_failed_task.name }}"
         thread_key: "{{ deploy_thread }}"
         create_new_thread: false
       delegate_to: localhost
@@ -148,6 +173,8 @@ from urllib.parse import urlencode
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
 
+BASE_URL = "https://chat.googleapis.com/v1/spaces"
+
 
 def build_payload(text, thread_key):
     payload = {"text": text}
@@ -156,14 +183,13 @@ def build_payload(text, thread_key):
     return payload
 
 
-def build_url(webhook_url, thread_key, create_new_thread):
-    params = {}
+def build_url(space, key, token, thread_key, create_new_thread):
+    params = {"key": key, "token": token}
     if thread_key is not None:
         params["messageReplyOption"] = (
             "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD" if create_new_thread else "REPLY_MESSAGE_OR_FAIL"
         )
-    sep = "&" if "?" in webhook_url else "?"
-    return f"{webhook_url}{sep}{urlencode(params)}"
+    return f"{BASE_URL}/{space}/messages?{urlencode(params)}"
 
 
 def do_notify(module, url, payload):
@@ -188,7 +214,9 @@ def do_notify(module, url, payload):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            webhook_url=dict(type="str", required=True, no_log=True),
+            space=dict(type="str", required=True),
+            key=dict(type="str", required=True, no_log=True),
+            token=dict(type="str", required=True, no_log=True),
             text=dict(type="str", required=True),
             thread_key=dict(type="str", no_log=False),
             create_new_thread=dict(type="bool", default=True),
@@ -202,7 +230,9 @@ def main():
 
     payload = build_payload(module.params["text"], module.params["thread_key"])
     url = build_url(
-        module.params["webhook_url"],
+        module.params["space"],
+        module.params["key"],
+        module.params["token"],
         module.params["thread_key"],
         module.params["create_new_thread"],
     )

--- a/plugins/modules/google_chat.py
+++ b/plugins/modules/google_chat.py
@@ -62,12 +62,6 @@ options:
       - When V(true), a new thread is started if no matching thread is found.
       - When V(false), the message is only posted if a matching thread already exists, otherwise it fails.
       - Only used when O(thread_key) is set.
-  validate_certs:
-    type: bool
-    default: true
-    description:
-      - If V(false), SSL certificates are not validated. This should only be used on personally controlled sites using
-        self-signed certificates.
 seealso:
   - name: Google Chat incoming webhooks
     description: Google's reference for sending messages to Chat with incoming webhooks.
@@ -220,7 +214,6 @@ def main():
             text=dict(type="str", required=True),
             thread_key=dict(type="str", no_log=False),
             create_new_thread=dict(type="bool", default=True),
-            validate_certs=dict(type="bool", default=True),
         ),
         supports_check_mode=True,
     )

--- a/plugins/modules/google_chat.py
+++ b/plugins/modules/google_chat.py
@@ -162,6 +162,7 @@ thread_name:
   sample: "spaces/AAAA/threads/CCCC"
 """
 
+import typing as t
 from urllib.parse import urlencode
 
 from ansible.module_utils.basic import AnsibleModule
@@ -169,15 +170,18 @@ from ansible.module_utils.urls import fetch_url
 
 BASE_URL = "https://chat.googleapis.com/v1/spaces"
 
+Payload = dict[str, t.Any]
+Response = dict[str, t.Any]
 
-def build_payload(text, thread_key):
-    payload = {"text": text}
+def build_payload(text: str, thread_key: str | None) -> Payload:
+    payload: Payload = {"text": text}
+
     if thread_key is not None:
         payload["thread"] = {"threadKey": thread_key}
     return payload
 
 
-def build_url(space, key, token, thread_key, create_new_thread):
+def build_url(space: str, key: str, token: str, thread_key: str | None, create_new_thread: bool) -> str:
     params = {"key": key, "token": token}
     if thread_key is not None:
         params["messageReplyOption"] = (
@@ -186,7 +190,7 @@ def build_url(space, key, token, thread_key, create_new_thread):
     return f"{BASE_URL}/{space}/messages?{urlencode(params)}"
 
 
-def do_notify(module, url, payload):
+def do_notify(module: AnsibleModule, url: str, payload: Payload) -> Response:
     headers = {
         "Content-Type": "application/json; charset=UTF-8",
         "Accept": "application/json",
@@ -205,7 +209,7 @@ def do_notify(module, url, payload):
     return module.from_json(response.read())
 
 
-def main():
+def main() -> None:
     module = AnsibleModule(
         argument_spec=dict(
             space=dict(type="str", required=True),

--- a/plugins/modules/google_chat.py
+++ b/plugins/modules/google_chat.py
@@ -1,0 +1,220 @@
+#!/usr/bin/python
+
+# Copyright (c) 2026, Tom Scholz <tomscholz@outlook.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+DOCUMENTATION = r"""
+module: google_chat
+short_description: Send Google Chat notifications
+version_added: "13.1.0"
+description:
+  - Sends notifications to a Google Chat space using an incoming webhook.
+  - Incoming webhooks are one-way. They send messages but cannot receive or respond to them.
+author:
+  - Tom Scholz (@tomscholz)
+extends_documentation_fragment:
+  - community.general._attributes
+attributes:
+  check_mode:
+    support: full
+    description: Can run in C(check_mode) and return changed status prediction without modifying target.
+  diff_mode:
+    support: none
+    description: Will return details on what has changed (or possibly needs changing in C(check_mode)), when in diff mode.
+options:
+  webhook_url:
+    type: str
+    required: true
+    description:
+      - The incoming webhook URL for the Chat space, including the C(key) and C(token) query parameters.
+      - Keep this value secret as it grants the ability to post to the space.
+  text:
+    type: str
+    required: true
+    description:
+      - The text of the message to send.
+      - 'Emoji must be supplied as Unicode characters (for example V(🚀)). The Chat API does not
+        render C(:shortcode:) style emoji in plain text messages; they appear as literal text.'
+  thread_key:
+    type: str
+    description:
+      - An arbitrary key used to start or reply to a message thread.
+      - When set, O(message_reply_option) controls the behavior when the thread is not found.
+  message_reply_option:
+    type: str
+    description:
+      - Behavior when O(thread_key) is supplied but no matching thread exists.
+      - Only used when O(thread_key) is set.
+    choices:
+      - REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD
+      - REPLY_MESSAGE_OR_FAIL
+  validate_certs:
+    type: bool
+    default: true
+    description:
+      - If V(false), SSL certificates are not validated. This should only be used on personally controlled sites using
+        self-signed certificates.
+seealso:
+  - name: Google Chat incoming webhooks
+    description: Google's reference for sending messages to Chat with incoming webhooks.
+    link: https://developers.google.com/workspace/chat/quickstart/webhooks
+"""
+
+EXAMPLES = r"""
+- name: Send a notification to Google Chat
+  community.general.google_chat:
+    webhook_url: "https://chat.googleapis.com/v1/spaces/SPACE_ID/messages?key=KEY&token=TOKEN"
+    text: '{{ inventory_hostname }} completed'
+  delegate_to: localhost
+
+- name: Start a thread
+  community.general.google_chat:
+    webhook_url: "https://chat.googleapis.com/v1/spaces/SPACE_ID/messages?key=KEY&token=TOKEN"
+    text: 'Starting a thread'
+    thread_key: 'deploy-2026-06-01'
+    message_reply_option: REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD
+
+# Post each deploy step into a single thread. The first message creates the thread
+# with REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD; follow-ups use REPLY_MESSAGE_OR_FAIL so
+# they only post if the opening message landed, rather than leaving orphan threads.
+# Note: webhooks are rate-limited to 1 request per second per space.
+- name: Announce deploy start (starts the thread)
+  community.general.google_chat:
+    webhook_url: "{{ chat_webhook }}"
+    text: "🚀 Starting deploy of *{{ app_version | default('latest') }}* to {{ inventory_hostname }}"
+    thread_key: "{{ deploy_thread }}"
+    message_reply_option: REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD
+  delegate_to: localhost
+  run_once: true
+  # deploy_thread is defined once for the play, for example:
+  #   deploy_thread: "deploy-{{ inventory_hostname }}-{{ ansible_date_time.iso8601_basic_short }}"
+
+- name: Report a step into the same thread
+  community.general.google_chat:
+    webhook_url: "{{ chat_webhook }}"
+    text: "✅ Step 1/3 — code checked out"
+    thread_key: "{{ deploy_thread }}"
+    message_reply_option: REPLY_MESSAGE_OR_FAIL
+  delegate_to: localhost
+  run_once: true
+
+# Wrap risky tasks so a failure posts to the same thread before a play aborts.
+- name: Deploy with failure notification
+  block:
+    - name: Restart service
+      ansible.builtin.systemd:
+        name: app
+        state: restarted
+
+    - name: Report success
+      community.general.google_chat:
+        webhook_url: "{{ chat_webhook }}"
+        text: "🎉 Deploy to {{ inventory_hostname }} complete"
+        thread_key: "{{ deploy_thread }}"
+        message_reply_option: REPLY_MESSAGE_OR_FAIL
+      delegate_to: localhost
+      run_once: true
+  rescue:
+    - name: Report failure into the thread
+      community.general.google_chat:
+        webhook_url: "{{ chat_webhook }}"
+        text: "❌ Deploy to {{ inventory_hostname }} *failed* — {{ ansible_failed_task.name }}"
+        thread_key: "{{ deploy_thread }}"
+        message_reply_option: REPLY_MESSAGE_OR_FAIL
+      delegate_to: localhost
+      run_once: true
+
+    - name: Re-raise the failure
+      ansible.builtin.fail:
+        msg: "Deploy failed at {{ ansible_failed_task.name }}"
+"""
+
+RETURN = r"""
+name:
+  description: Resource name of the created message, returned by the Chat API.
+  returned: success
+  type: str
+  sample: "spaces/AAAA/messages/BBBB.BBBB"
+thread_name:
+  description: Resource name of the thread the message belongs to.
+  returned: when the response includes a thread
+  type: str
+  sample: "spaces/AAAA/threads/CCCC"
+"""
+
+from urllib.parse import urlencode
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import fetch_url
+
+
+def build_payload(text, thread_key):
+    payload = {"text": text}
+    if thread_key is not None:
+        payload["thread"] = {"threadKey": thread_key}
+    return payload
+
+
+def build_url(webhook_url, message_reply_option):
+    if message_reply_option is None:
+        return webhook_url
+    sep = "&" if "?" in webhook_url else "?"
+    return f"{webhook_url}{sep}{urlencode({'messageReplyOption': message_reply_option})}"
+
+
+def do_notify(module, url, payload):
+    headers = {
+        "Content-Type": "application/json; charset=UTF-8",
+        "Accept": "application/json",
+    }
+    data = module.jsonify(payload)
+    response, info = fetch_url(module=module, url=url, headers=headers, method="POST", data=data)
+
+    if info["status"] != 200:
+        body = info.get("body")
+        if hasattr(body, "decode"):
+            body = body.decode("utf-8", errors="replace")
+        module.fail_json(
+            msg=f"Failed to send message to Google Chat (HTTP {info['status']}): {body or info.get('msg')}"
+        )
+
+    return module.from_json(response.read())
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            webhook_url=dict(type="str", required=True, no_log=True),
+            text=dict(type="str", required=True),
+            thread_key=dict(type="str", no_log=False),
+            message_reply_option=dict(
+                type="str",
+                choices=["REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD", "REPLY_MESSAGE_OR_FAIL"],
+            ),
+            validate_certs=dict(type="bool", default=True),
+        ),
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(changed=True)
+
+    payload = build_payload(module.params["text"], module.params["thread_key"])
+    url = build_url(module.params["webhook_url"], module.params["message_reply_option"])
+
+    response = do_notify(module, url, payload)
+
+    result = {"changed": True}
+    if "name" in response:
+        result["name"] = response["name"]
+    if isinstance(response.get("thread"), dict) and "name" in response["thread"]:
+        result["thread_name"] = response["thread"]["name"]
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/google_chat.py
+++ b/plugins/modules/google_chat.py
@@ -170,8 +170,9 @@ from ansible.module_utils.urls import fetch_url
 
 BASE_URL = "https://chat.googleapis.com/v1/spaces"
 
-Payload = dict[str, t.Any]
-Response = dict[str, t.Any]
+if t.TYPE_CHECKING:
+    Payload = dict[str, t.Any]
+    Response = dict[str, t.Any]
 
 
 def build_payload(text: str, thread_key: str | None) -> Payload:

--- a/plugins/modules/google_chat.py
+++ b/plugins/modules/google_chat.py
@@ -108,7 +108,7 @@ EXAMPLES = r"""
     space: "{{ chat_space }}"
     key: "{{ chat_key }}"
     token: "{{ chat_token }}"
-    text: "✅ Step 1/3 — code checked out"
+    text: "✅ Step 1/3 – code checked out"
     thread_key: "{{ deploy_thread }}"
     create_new_thread: false
   delegate_to: localhost
@@ -138,7 +138,7 @@ EXAMPLES = r"""
         space: "{{ chat_space }}"
         key: "{{ chat_key }}"
         token: "{{ chat_token }}"
-        text: "❌ Deploy to {{ inventory_hostname }} *failed* — {{ ansible_failed_task.name }}"
+        text: "❌ Deploy to {{ inventory_hostname }} *failed* – {{ ansible_failed_task.name }}"
         thread_key: "{{ deploy_thread }}"
         create_new_thread: false
       delegate_to: localhost
@@ -172,6 +172,7 @@ BASE_URL = "https://chat.googleapis.com/v1/spaces"
 
 Payload = dict[str, t.Any]
 Response = dict[str, t.Any]
+
 
 def build_payload(text: str, thread_key: str | None) -> Payload:
     payload: Payload = {"text": text}

--- a/tests/unit/plugins/modules/test_google_chat.py
+++ b/tests/unit/plugins/modules/test_google_chat.py
@@ -53,12 +53,6 @@ class TestGoogleChatModule(ModuleTestCase):
             with self.assertRaises(AnsibleFailJson):
                 self.module.main()
 
-    def test_invalid_message_reply_option(self):
-        """Failure when message_reply_option is not one of the valid choices"""
-        with set_module_args({"webhook_url": WEBHOOK, "text": "test", "message_reply_option": "BOGUS"}):
-            with self.assertRaises(AnsibleFailJson):
-                self.module.main()
-
     def test_successful_message(self):
         """tests sending a plain message"""
         with set_module_args({"webhook_url": WEBHOOK, "text": "test"}):
@@ -115,7 +109,7 @@ class TestGoogleChatModule(ModuleTestCase):
         assert call_data["thread"]["threadKey"] == "deploy-1"
         assert result.exception.args[0]["thread_name"] == "spaces/AAAA/threads/CCCC"
 
-    def test_message_reply_option_appended_to_url(self):
+    def test_create_new_thread_option(self):
         """message_reply_option must be added as a query parameter with & (webhook already has ?)"""
         with set_module_args(
             {
@@ -134,7 +128,7 @@ class TestGoogleChatModule(ModuleTestCase):
                     self.module.main()
 
         url = fetch_url_mock.call_args[1]["url"]
-        assert url == WEBHOOK + "&messageReplyOption=REPLY_MESSAGE_OR_FAIL"
+        assert "messageReplyOption=REPLY_MESSAGE_OR_FAIL" in url
 
     def test_check_mode(self):
         """check mode reports changed and never calls the API"""
@@ -158,22 +152,17 @@ def test_build_payload_with_thread():
     assert payload == {"text": "hello", "thread": {"threadKey": "deploy-1"}}
 
 
-build_url_cases = [
-    # (webhook_url, message_reply_option, expected_url)
-    (WEBHOOK, None, WEBHOOK),
-    (
-        WEBHOOK,
-        "REPLY_MESSAGE_OR_FAIL",
-        WEBHOOK + "&messageReplyOption=REPLY_MESSAGE_OR_FAIL",
-    ),
-    (
-        "https://chat.googleapis.com/v1/spaces/X/messages",
-        "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD",
-        "https://chat.googleapis.com/v1/spaces/X/messages?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD",
-    ),
-]
+def test_build_url_without_thread():
+    url = google_chat.build_url(WEBHOOK, None, True)
+    assert url.startswith(WEBHOOK + "?")
+    assert "messageReplyOption" not in url
 
 
-@pytest.mark.parametrize("webhook_url, option, expected", build_url_cases)
-def test_build_url(webhook_url, option, expected):
-    assert google_chat.build_url(webhook_url, option) == expected
+def test_build_url_create_new_thread_true():
+    url = google_chat.build_url(WEBHOOK, "deploy-1", True)
+    assert "messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD" in url
+
+
+def test_build_url_create_new_thread_false():
+    url = google_chat.build_url(WEBHOOK, "deploy-1", False)
+    assert "messageReplyOption=REPLY_MESSAGE_OR_FAIL" in url

--- a/tests/unit/plugins/modules/test_google_chat.py
+++ b/tests/unit/plugins/modules/test_google_chat.py
@@ -1,0 +1,179 @@
+# Copyright (c) Ansible project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
+    AnsibleExitJson,
+    AnsibleFailJson,
+    ModuleTestCase,
+    set_module_args,
+)
+
+from ansible_collections.community.general.plugins.modules import google_chat
+
+WEBHOOK = "https://chat.googleapis.com/v1/spaces/SPACE_ID/messages?key=KEY&token=TOKEN"
+
+
+def make_response(payload):
+    """Build a fake fetch_url file-like response whose read() returns JSON text."""
+    mock_response = Mock()
+    mock_response.read.return_value = json.dumps(payload)
+    return mock_response
+
+
+class TestGoogleChatModule(ModuleTestCase):
+    def setUp(self):
+        super().setUp()
+        self.module = google_chat
+
+    def tearDown(self):
+        super().tearDown()
+
+    def test_without_required_parameters(self):
+        """Failure must occur when all parameters are missing"""
+        with self.assertRaises(AnsibleFailJson):
+            with set_module_args({}):
+                self.module.main()
+
+    def test_missing_text(self):
+        """Failure when webhook_url is given but text is missing"""
+        with set_module_args({"webhook_url": WEBHOOK}):
+            with self.assertRaises(AnsibleFailJson):
+                self.module.main()
+
+    def test_missing_webhook_url(self):
+        """Failure when text is given but webhook_url is missing"""
+        with set_module_args({"text": "test"}):
+            with self.assertRaises(AnsibleFailJson):
+                self.module.main()
+
+    def test_invalid_message_reply_option(self):
+        """Failure when message_reply_option is not one of the valid choices"""
+        with set_module_args({"webhook_url": WEBHOOK, "text": "test", "message_reply_option": "BOGUS"}):
+            with self.assertRaises(AnsibleFailJson):
+                self.module.main()
+
+    def test_successful_message(self):
+        """tests sending a plain message"""
+        with set_module_args({"webhook_url": WEBHOOK, "text": "test"}):
+            with patch.object(google_chat, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (
+                    make_response({"name": "spaces/AAAA/messages/BBBB.BBBB"}),
+                    {"status": 200},
+                )
+                with self.assertRaises(AnsibleExitJson) as result:
+                    self.module.main()
+
+        self.assertTrue(fetch_url_mock.call_count, 1)
+        call_data = json.loads(fetch_url_mock.call_args[1]["data"])
+        assert call_data["text"] == "test"
+        assert "thread" not in call_data
+        assert fetch_url_mock.call_args[1]["url"] == WEBHOOK
+        assert fetch_url_mock.call_args[1]["method"] == "POST"
+        assert result.exception.args[0]["changed"]
+        assert result.exception.args[0]["name"] == "spaces/AAAA/messages/BBBB.BBBB"
+
+    def test_failed_message(self):
+        """tests failing to send a message (non-200 response)"""
+        with set_module_args({"webhook_url": WEBHOOK, "text": "test"}):
+            with patch.object(google_chat, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (
+                    None,
+                    {"status": 404, "msg": "not found", "body": b"NOT_FOUND"},
+                )
+                with self.assertRaises(AnsibleFailJson) as result:
+                    self.module.main()
+
+        assert "Google Chat" in result.exception.args[0]["msg"]
+        assert "404" in result.exception.args[0]["msg"]
+
+    def test_message_with_thread(self):
+        """tests sending a message with a thread_key and reading back the thread name"""
+        with set_module_args({"webhook_url": WEBHOOK, "text": "test", "thread_key": "deploy-1"}):
+            with patch.object(google_chat, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (
+                    make_response(
+                        {
+                            "name": "spaces/AAAA/messages/BBBB.BBBB",
+                            "thread": {"name": "spaces/AAAA/threads/CCCC"},
+                        }
+                    ),
+                    {"status": 200},
+                )
+                with self.assertRaises(AnsibleExitJson) as result:
+                    self.module.main()
+
+        self.assertTrue(fetch_url_mock.call_count, 1)
+        call_data = json.loads(fetch_url_mock.call_args[1]["data"])
+        assert call_data["text"] == "test"
+        assert call_data["thread"]["threadKey"] == "deploy-1"
+        assert result.exception.args[0]["thread_name"] == "spaces/AAAA/threads/CCCC"
+
+    def test_message_reply_option_appended_to_url(self):
+        """message_reply_option must be added as a query parameter with & (webhook already has ?)"""
+        with set_module_args(
+            {
+                "webhook_url": WEBHOOK,
+                "text": "test",
+                "thread_key": "deploy-1",
+                "message_reply_option": "REPLY_MESSAGE_OR_FAIL",
+            }
+        ):
+            with patch.object(google_chat, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (
+                    make_response({"name": "spaces/AAAA/messages/BBBB.BBBB"}),
+                    {"status": 200},
+                )
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
+
+        url = fetch_url_mock.call_args[1]["url"]
+        assert url == WEBHOOK + "&messageReplyOption=REPLY_MESSAGE_OR_FAIL"
+
+    def test_check_mode(self):
+        """check mode reports changed and never calls the API"""
+        with set_module_args({"webhook_url": WEBHOOK, "text": "test", "_ansible_check_mode": True}):
+            with patch.object(google_chat, "fetch_url") as fetch_url_mock:
+                with self.assertRaises(AnsibleExitJson) as result:
+                    self.module.main()
+
+        fetch_url_mock.assert_not_called()
+        assert result.exception.args[0]["changed"]
+        assert "name" not in result.exception.args[0]
+
+
+def test_build_payload_without_thread():
+    payload = google_chat.build_payload("hello", None)
+    assert payload == {"text": "hello"}
+
+
+def test_build_payload_with_thread():
+    payload = google_chat.build_payload("hello", "deploy-1")
+    assert payload == {"text": "hello", "thread": {"threadKey": "deploy-1"}}
+
+
+build_url_cases = [
+    # (webhook_url, message_reply_option, expected_url)
+    (WEBHOOK, None, WEBHOOK),
+    (
+        WEBHOOK,
+        "REPLY_MESSAGE_OR_FAIL",
+        WEBHOOK + "&messageReplyOption=REPLY_MESSAGE_OR_FAIL",
+    ),
+    (
+        "https://chat.googleapis.com/v1/spaces/X/messages",
+        "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD",
+        "https://chat.googleapis.com/v1/spaces/X/messages?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD",
+    ),
+]
+
+
+@pytest.mark.parametrize("webhook_url, option, expected", build_url_cases)
+def test_build_url(webhook_url, option, expected):
+    assert google_chat.build_url(webhook_url, option) == expected

--- a/tests/unit/plugins/modules/test_google_chat.py
+++ b/tests/unit/plugins/modules/test_google_chat.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import json
 from unittest.mock import Mock, patch
 
-import pytest
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
     AnsibleExitJson,
     AnsibleFailJson,

--- a/tests/unit/plugins/modules/test_google_chat.py
+++ b/tests/unit/plugins/modules/test_google_chat.py
@@ -17,7 +17,10 @@ from ansible_collections.community.internal_test_tools.tests.unit.plugins.module
 
 from ansible_collections.community.general.plugins.modules import google_chat
 
-WEBHOOK = "https://chat.googleapis.com/v1/spaces/SPACE_ID/messages?key=KEY&token=TOKEN"
+SPACE = "SPACE_ID"
+KEY = "KEY"
+TOKEN = "TOKEN"
+BASE = "https://chat.googleapis.com/v1/spaces/SPACE_ID/messages"
 
 
 def make_response(payload):
@@ -42,20 +45,20 @@ class TestGoogleChatModule(ModuleTestCase):
                 self.module.main()
 
     def test_missing_text(self):
-        """Failure when webhook_url is given but text is missing"""
-        with set_module_args({"webhook_url": WEBHOOK}):
+        """Failure when connection params are given but text is missing"""
+        with set_module_args({"space": SPACE, "key": KEY, "token": TOKEN}):
             with self.assertRaises(AnsibleFailJson):
                 self.module.main()
 
-    def test_missing_webhook_url(self):
-        """Failure when text is given but webhook_url is missing"""
-        with set_module_args({"text": "test"}):
+    def test_missing_space(self):
+        """Failure when text is given but space is missing"""
+        with set_module_args({"key": KEY, "token": TOKEN, "text": "test"}):
             with self.assertRaises(AnsibleFailJson):
                 self.module.main()
 
     def test_successful_message(self):
         """tests sending a plain message"""
-        with set_module_args({"webhook_url": WEBHOOK, "text": "test"}):
+        with set_module_args({"space": SPACE, "key": KEY, "token": TOKEN, "text": "test"}):
             with patch.object(google_chat, "fetch_url") as fetch_url_mock:
                 fetch_url_mock.return_value = (
                     make_response({"name": "spaces/AAAA/messages/BBBB.BBBB"}),
@@ -68,14 +71,18 @@ class TestGoogleChatModule(ModuleTestCase):
         call_data = json.loads(fetch_url_mock.call_args[1]["data"])
         assert call_data["text"] == "test"
         assert "thread" not in call_data
-        assert fetch_url_mock.call_args[1]["url"] == WEBHOOK
+        url = fetch_url_mock.call_args[1]["url"]
+        assert url.startswith(BASE + "?")
+        assert "key=KEY" in url
+        assert "token=TOKEN" in url
+        assert "messageReplyOption" not in url
         assert fetch_url_mock.call_args[1]["method"] == "POST"
         assert result.exception.args[0]["changed"]
         assert result.exception.args[0]["name"] == "spaces/AAAA/messages/BBBB.BBBB"
 
     def test_failed_message(self):
         """tests failing to send a message (non-200 response)"""
-        with set_module_args({"webhook_url": WEBHOOK, "text": "test"}):
+        with set_module_args({"space": SPACE, "key": KEY, "token": TOKEN, "text": "test"}):
             with patch.object(google_chat, "fetch_url") as fetch_url_mock:
                 fetch_url_mock.return_value = (
                     None,
@@ -89,7 +96,7 @@ class TestGoogleChatModule(ModuleTestCase):
 
     def test_message_with_thread(self):
         """tests sending a message with a thread_key and reading back the thread name"""
-        with set_module_args({"webhook_url": WEBHOOK, "text": "test", "thread_key": "deploy-1"}):
+        with set_module_args({"space": SPACE, "key": KEY, "token": TOKEN, "text": "test", "thread_key": "deploy-1"}):
             with patch.object(google_chat, "fetch_url") as fetch_url_mock:
                 fetch_url_mock.return_value = (
                     make_response(
@@ -109,14 +116,16 @@ class TestGoogleChatModule(ModuleTestCase):
         assert call_data["thread"]["threadKey"] == "deploy-1"
         assert result.exception.args[0]["thread_name"] == "spaces/AAAA/threads/CCCC"
 
-    def test_create_new_thread_option(self):
-        """message_reply_option must be added as a query parameter with & (webhook already has ?)"""
+    def test_create_new_thread_false_appends_reply_or_fail(self):
+        """create_new_thread=false must map to REPLY_MESSAGE_OR_FAIL in the URL"""
         with set_module_args(
             {
-                "webhook_url": WEBHOOK,
+                "space": SPACE,
+                "key": KEY,
+                "token": TOKEN,
                 "text": "test",
                 "thread_key": "deploy-1",
-                "message_reply_option": "REPLY_MESSAGE_OR_FAIL",
+                "create_new_thread": False,
             }
         ):
             with patch.object(google_chat, "fetch_url") as fetch_url_mock:
@@ -132,7 +141,7 @@ class TestGoogleChatModule(ModuleTestCase):
 
     def test_check_mode(self):
         """check mode reports changed and never calls the API"""
-        with set_module_args({"webhook_url": WEBHOOK, "text": "test", "_ansible_check_mode": True}):
+        with set_module_args({"space": SPACE, "key": KEY, "token": TOKEN, "text": "test", "_ansible_check_mode": True}):
             with patch.object(google_chat, "fetch_url") as fetch_url_mock:
                 with self.assertRaises(AnsibleExitJson) as result:
                     self.module.main()
@@ -153,16 +162,18 @@ def test_build_payload_with_thread():
 
 
 def test_build_url_without_thread():
-    url = google_chat.build_url(WEBHOOK, None, True)
-    assert url.startswith(WEBHOOK + "?")
+    url = google_chat.build_url(SPACE, KEY, TOKEN, None, True)
+    assert url.startswith(BASE + "?")
+    assert "key=KEY" in url
+    assert "token=TOKEN" in url
     assert "messageReplyOption" not in url
 
 
 def test_build_url_create_new_thread_true():
-    url = google_chat.build_url(WEBHOOK, "deploy-1", True)
+    url = google_chat.build_url(SPACE, KEY, TOKEN, "deploy-1", True)
     assert "messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD" in url
 
 
 def test_build_url_create_new_thread_false():
-    url = google_chat.build_url(WEBHOOK, "deploy-1", False)
+    url = google_chat.build_url(SPACE, KEY, TOKEN, "deploy-1", False)
     assert "messageReplyOption=REPLY_MESSAGE_OR_FAIL" in url


### PR DESCRIPTION
##### SUMMARY

Hi! First time contributer here.

This PR adds a new module, `community.general.google_chat` for sending notifications to a Google Chat space via an incoming webhook.

Incoming webhooks work one-way: the module posts messages but cannot read or respond to them.

The module supports:

- Posting a plain-text message to a space.
- Starting or replying to a message thread via `thread_key`.
- Controlling thread-fallback behaviour with `message_reply_option`
  (`REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD` / `REPLY_MESSAGE_OR_FAIL`).
- `check_mode` (reports `changed` without sending).

It returns the created message resource name (`name`) and, when the response includes a thread, the thread resource name (`thread_name`).

This fills a gap alongside the other notification modules in the collection
(`slack`, `rocketchat`, `mattermost`, etc.), none of which target Google Chat.

Docs: [https://developers.google.com/workspace/chat/quickstart/webhooks](https://developers.google.com/workspace/chat/quickstart/webhooks)

See also: [https://chat.google.com](https://chat.google.com)

##### ISSUE TYPE

- New Module Pull Request


##### COMPONENT NAME

`google_chat`

##### ADDITIONAL INFORMATION

- Uses `fetch_url` from `ansible.module_utils.urls` (no third-party dependencies).
- Unit tests are included at `tests/unit/plugins/modules/test_google_chat.py` covering argument validation, message/thread payload construction, the `messageReplyOption` URL handling, non-200 failure path and check mode. 
- Note for users: emoji must be supplied as Unicode characters; the Chat API does not render `:shortcode:` emojis in messages, unlike slack for example. This is documented in the `text` option.

I have read the contribution guidelines and am happy to maintain this module.