### PR TITLE
opkg - path_prefix needs to be a list

### DIFF
--- a/changelogs/fragments/12182-opkg-path-prefix.yml
+++ b/changelogs/fragments/12182-opkg-path-prefix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - opkg - correctly set executable search path (https://github.com/ansible-collections/community.general/pull/12182).

--- a/plugins/modules/opkg.py
+++ b/plugins/modules/opkg.py
@@ -166,7 +166,7 @@ class Opkg(StateModuleHelper):
                 update_cache=cmd_runner_fmt.as_bool("update"),
                 version=cmd_runner_fmt.as_fixed("--version"),
             ),
-            path_prefix=dir,
+            path_prefix=[dir],
         )
 
         with self.runner("version") as ctx:


### PR DESCRIPTION
##### SUMMARY
`path_prefix` is passed to `get_bin_path()` which expects `opt_dirs` to be a list of paths. Passing in a string instead of a list of paths results in incorrect values being added to the path when searching for the command to run.

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
`community.general.opkg`

##### ADDITIONAL INFORMATION
 None
