### PR TITLE
fix: treat chdev execution failures as module errors in aix_devices

### DIFF
--- a/changelogs/fragments/12185-aix-devices-chdev-fail.yml
+++ b/changelogs/fragments/12185-aix-devices-chdev-fail.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "aix_devices - fix ``chdev`` command failures being incorrectly reported as successful results, now properly fails the task when device attribute changes cannot be applied (https://github.com/ansible-collections/community.general/pull/12185)."

--- a/plugins/modules/aix_devices.py
+++ b/plugins/modules/aix_devices.py
@@ -235,7 +235,7 @@ def change_device_attr(module, attributes, device, force):
             if not module.check_mode:
                 rc, chdev_out, err = module.run_command(cmd)
                 if rc != 0:
-                    module.exit_json(msg="Failed to run chdev.", rc=rc, err=err)
+                    module.fail_json(msg="Failed to run chdev.", rc=rc, err=err)
 
             attr_changed.append(attributes[attr])
         else:


### PR DESCRIPTION
##### SUMMARY
Fix the aix_devices module so that a failed chdev command is reported as a module failure instead of a successful result.

The previous implementation called fail_json incorrectly by returning success through the normal completion path when chdev returned a non-zero exit status. This could allow a playbook to continue even though the requested device attribute change was not applied.

This change replaces the success-style error handling with proper failure handling in the chdev execution path, making task results consistent with the actual command outcome.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aix_devices

##### ADDITIONAL INFORMATION
The affected code path is in change_device_attr() when the module executes chdev to apply attribute updates.

Before this change:
- chdev could fail
- the module could still report success
- later tasks could run against an unexpected system state

After this change:
- chdev failures are returned through fail_json
- the task stops with an error
- playbook behavior matches the real execution result

```paste below
Before:
module.exit_json(msg="Failed to run chdev.", rc=rc, err=err)

After:
module.fail_json(msg="Failed to run chdev.", rc=rc, err=err)
```

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module/Plugin Pull Request
- Refactoring Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
