### PR TITLE
CI: Remove FreeBSD 14.2

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -252,8 +252,8 @@ stages:
           targets:
             - name: RHEL 10.1
               test: rhel/10.1
-            - name: FreeBSD 14.2
-              test: freebsd/14.2
+            # - name: FreeBSD 14.2
+            #   test: freebsd/14.2
           groups:
             - 1
             - 2


### PR DESCRIPTION
##### SUMMARY
It seems to be finally EOL, with mirrors removed.

Ref: https://dev.azure.com/ansible/community.general/_build/results?buildId=182379&view=logs&j=9aa877d6-131c-5415-d803-444f7d88e7a6&t=361b6629-e703-5b35-d410-b7d87fc9dbf4&l=307

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
