### PR TITLE
Antsibull-nox: split up unit tests by Python version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,10 +145,10 @@ The following commands show how to run unit tests:
 ansible-test units --docker -v
 
 # Run all unit tests for one Python version (a lot faster):
-ansible-test units --docker -v --python 3.8
+ansible-test units --docker -v --python 3.14
 
 # Run a specific unit test (for the nmcli module) for one Python version:
-ansible-test units --docker -v --python 3.8 tests/unit/plugins/modules/net_tools/test_nmcli.py
+ansible-test units --docker -v --python 3.14 tests/unit/plugins/modules/net_tools/test_nmcli.py
 ```
 
 ### Integration tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,10 +93,10 @@ The following commands show how to run unit tests:
 nox -Re ansible-test-units-devel
 
 # Run all unit tests for one Python version (a lot faster):
-nox -Re ansible-test-units-devel -- --python 3.13
+nox -Re ansible-test-units-devel-3.14
 
 # Run a specific unit test (for the nmcli module) for one Python version:
-nox -Re ansible-test-units-devel -- --python 3.13 tests/unit/plugins/modules/net_tools/test_nmcli.py
+nox -Re ansible-test-units-devel-3.14 -- tests/unit/plugins/modules/net_tools/test_nmcli.py
 ```
 
 If you replace `-Re` with `-e`, then the virtual environments will be re-created. The `-R` re-uses them (if they already exist).

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -118,3 +118,10 @@ include_devel = true
 
 [sessions.ansible_test_units]
 include_devel = true
+split_by_python_version = true
+
+[sessions.ansible_test_units.core_python_versions]
+"2.18" = ["3.8", "3.11", "3.13"]
+"2.19" = ["3.8", "3.11", "3.13"]
+"2.20" = ["3.9", "3.12", "3.14"]
+"2.21" = ["3.9", "3.12", "3.14"]


### PR DESCRIPTION
##### SUMMARY
Similar to how they are split up in AZP.

Uses https://github.com/ansible-community/antsibull-nox/pull/209; shouldn't be merged before a new antsibull-nox version is out.

Needs manual backports to stable-12 and stable-11 (for explicit ansible-core / Python version lists).

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
