### PR TITLE
iptables_state integration tests: improve skip conditions

### DIFF
--- a/tests/integration/targets/iptables_state/aliases
+++ b/tests/integration/targets/iptables_state/aliases
@@ -9,5 +9,11 @@ skip/docker             # kernel modules not loadable
 skip/freebsd            # no iptables/netfilter (Linux specific)
 skip/macos              # no iptables/netfilter (Linux specific)
 
-skip/ubuntu22.04  # TODO there's a problem here!
-skip/rhel10.0     # TODO there's a problem here!
+# This test doesn't seem to work with split-controller testing.
+# That's the case when the target's Python version doesn't support
+# ansible-core's controller. (Would be good to debug this and try
+# to figure out **why** that's the case, because the module should
+# also work when that's **not** the case.)
+
+# The following makes sure that the test is only run if target == controller:
+context/controller


### PR DESCRIPTION
##### SUMMARY
Since a few days the iptable_state tests fail on Alpine 2.23 and Ubuntu 24.04 - exactly since ansible-core devel bumped it's controller Python requirement to >= 3.13; both Alpine 2.23 and Ubuntu 24.04 have Python 3.12.

We already skipped some targets for similar reasons before, I've now simplified that to `context/controller`.

It would be better to figure out why the tests don't work with split controller, since that's the actual use-case for the action, but I don't have time to work on that :)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
iptables_state integration tests
