### PR TITLE
opennebula inventory - add filter_by_attributes option

### DIFF
--- a/changelogs/fragments/12213-opennebula-inventory-filter-by-attributes.yml
+++ b/changelogs/fragments/12213-opennebula-inventory-filter-by-attributes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - opennebula inventory plugin - add ``filter_by_attributes`` option to only return VMs whose ``USER_TEMPLATE`` matches every given attribute name/value pair, allowing an inventory to be scoped to a subset of VMs on a shared OpenNebula instance (https://github.com/ansible-collections/community.general/pull/12213).

--- a/changelogs/fragments/opennebula-inventory-filter-by-attributes.yml
+++ b/changelogs/fragments/opennebula-inventory-filter-by-attributes.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - opennebula inventory plugin - add ``filter_by_attributes`` option to only return VMs whose ``USER_TEMPLATE`` matches every given attribute name/value pair, allowing an inventory to be scoped to a subset of VMs on a shared OpenNebula instance (https://github.com/ansible-collections/community.general/pull/XXXXX).

--- a/changelogs/fragments/opennebula-inventory-filter-by-attributes.yml
+++ b/changelogs/fragments/opennebula-inventory-filter-by-attributes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - opennebula inventory plugin - add ``filter_by_attributes`` option to only return VMs whose ``USER_TEMPLATE`` matches every given attribute name/value pair, allowing an inventory to be scoped to a subset of VMs on a shared OpenNebula instance (https://github.com/ansible-collections/community.general/pull/XXXXX).

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -66,6 +66,15 @@ options:
   filter_by_label:
     description: Only return servers filtered by this label.
     type: string
+  filter_by_attributes:
+    description:
+      - A dictionary of VM C(USER_TEMPLATE) attribute names and values that are AND-matched against each VM.
+      - Only VMs whose C(USER_TEMPLATE) contains every listed attribute set to the exact given value are returned.
+      - Useful to scope an inventory to a subset of VMs on a shared OpenNebula instance, for example by a project or environment tag.
+      - Matching is case-sensitive and compares values as strings.
+    type: dict
+    default: {}
+    version_added: 13.2.0
   group_by_labels:
     description: Create host groups by VM labels.
     type: bool
@@ -80,6 +89,14 @@ EXAMPLES = r"""
 plugin: community.general.opennebula
 api_url: https://opennebula:2633/RPC2
 filter_by_label: Cache
+
+---
+# Only return VMs whose USER_TEMPLATE has both PROJECT=climb and ENVIRONMENT=test
+plugin: community.general.opennebula
+api_url: https://opennebula:2633/RPC2
+filter_by_attributes:
+  PROJECT: climb
+  ENVIRONMENT: test
 """
 
 try:
@@ -175,7 +192,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         return vm_pool
 
-    def _retrieve_servers(self, label_filter=None):
+    def _retrieve_servers(self, label_filter=None, attribute_filter=None):
         vm_pool = self._get_vm_pool()
 
         result = []
@@ -199,6 +216,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 if label_filter not in labels:
                     continue
 
+            # filter by USER_TEMPLATE attributes (AND-match), scoping the
+            # inventory to a subset of VMs on a shared instance
+            if attribute_filter:
+                if any(str(server.get(key)) != str(value) for key, value in attribute_filter.items()):
+                    continue
+
             server["name"] = vm.NAME
             server["id"] = vm.ID
             if hasattr(vm.HISTORY_RECORDS, "HISTORY") and vm.HISTORY_RECORDS.HISTORY:
@@ -220,7 +243,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self.inventory.add_group(group="all")
 
         filter_by_label = self.get_option("filter_by_label")
-        servers = self._retrieve_servers(filter_by_label)
+        filter_by_attributes = self.get_option("filter_by_attributes")
+        servers = self._retrieve_servers(filter_by_label, filter_by_attributes)
         for server in servers:
             server = make_unsafe(server)
             hostname = server["name"]


### PR DESCRIPTION
##### SUMMARY
Add a `filter_by_attributes` dict option to the `opennebula` inventory plugin that AND-matches `USER_TEMPLATE` attribute name/value pairs against each VM. This lets an inventory be scoped to a subset of VMs on a shared OpenNebula instance (for example by a project or environment tag), which the existing single `filter_by_label` option cannot express.

Only VMs whose `USER_TEMPLATE` contains every listed attribute set to the exact given value are returned. Matching is case-sensitive and compares values as strings. The option defaults to `{}` (no filtering), so existing behaviour is unchanged.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
opennebula

##### ADDITIONAL INFORMATION
On a shared OpenNebula instance, VMs belonging to different projects/environments often live in the same pool. `filter_by_label` only matches a single value against the flat `LABELS` comma-list, so it cannot express "give me only the VMs tagged with both PROJECT=foo and ENVIRONMENT=test". Tagging VMs with real `USER_TEMPLATE` attributes and AND-matching on them is a clean way to scope an inventory to a subset of VMs and bound the blast radius of a run.

Example configuration:

```yaml
# inventory_opennebula.yml
plugin: community.general.opennebula
api_url: https://opennebula:2633/RPC2
filter_by_attributes:
  PROJECT: foo
  ENVIRONMENT: test
```

Behaviour (verified against a live OpenNebula instance):

```
# Without filter_by_attributes: all VMs in the pool are returned
$ ansible-inventory -i inventory_opennebula.yml --list | jq '._meta.hostvars | keys | length'
21

# Single-attribute filter returns only the matching subset
filter_by_attributes:
  SOME_KEY: some-value
$ ansible-inventory -i inventory_opennebula.yml --list | jq '._meta.hostvars | keys | length'
14

# Multiple attributes are AND-matched (intersection)
filter_by_attributes:
  SOME_KEY: some-value
  OTHER_KEY: other-value
$ ansible-inventory -i inventory_opennebula.yml --list | jq '._meta.hostvars | keys | length'
2
```
