### PR TITLE
lvol: resize filesystem when LV already has the requested size

### DIFF
--- a/changelogs/fragments/11620-lvol-resizefs.yml
+++ b/changelogs/fragments/11620-lvol-resizefs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lvol - ``resizefs`` now resizes the filesystem even when the logical volume already has the requested size (https://github.com/ansible-collections/community.general/issues/11620).

--- a/plugins/modules/lvol.py
+++ b/plugins/modules/lvol.py
@@ -90,6 +90,8 @@ options:
       - Resize the underlying filesystem together with the logical volume.
       - Supported for C(ext2), C(ext3), C(ext4), C(reiserfs) and C(XFS) filesystems. Attempts to resize other filesystem types
         result in failure.
+      - When the logical volume already has the requested size, the filesystem will still be resized to fill the logical volume
+        if needed.
     type: bool
     default: false
 notes:
@@ -661,6 +663,18 @@ def main():
                     )
                 else:
                     module.fail_json(msg=f"Unable to resize {lv} to {size}{size_unit}", rc=rc, err=err)
+
+        if resizefs and not changed and size:
+            lv_path = f"/dev/{vg}/{this_lv['name']}"
+            if module.check_mode:
+                changed = True
+            else:
+                fsadm = module.get_bin_path("fsadm", required=True)
+                rc, out, err = module.run_command([fsadm, "resize", lv_path])
+                if rc == 0:
+                    changed = True
+                else:
+                    module.fail_json(msg=f"Failed to resize filesystem on {lv_path}", rc=rc, err=err, out=out)
 
     if this_lv is not None:
         if active:


### PR DESCRIPTION
##### SUMMARY

When `resizefs=true` but the logical volume is already at the requested
size, the filesystem resize step is currently skipped because no LV
resize operation is performed.

Run `fsadm resize` in this scenario to ensure the filesystem grows to
fill the logical volume even when the LV itself does not need resizing.

Also update the `resizefs` parameter documentation to clarify this
behavior.

Fixes #11620

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

lvol

##### ADDITIONAL INFORMATION

Reproduction:

```yaml
- name: Extend logical volume without resizing filesystem
  community.general.lvol:
    vg: vg00
    lv: home
    size: 20G

- name: Attempt to resize filesystem later
  community.general.lvol:
    vg: vg00
    lv: home
    size: 20G
    resizefs: true
````

Before this change, the second task did nothing because the logical
volume already matched the requested size, so the filesystem resize
logic was skipped.

After this change, the module invokes `fsadm resize` when
`resizefs=true` and the logical volume already has the requested size,
allowing the filesystem to grow and consume the available space.

Validation performed:

* `python -m py_compile plugins/modules/lvol.py`
* `ansible-test sanity --test validate-modules plugins/modules/lvol.py`
* `ansible-test sanity --test pep8 plugins/modules/lvol.py`
* `ansible-test sanity --test pylint plugins/modules/lvol.py`
