### PR TITLE
xenserver_guest_info: use fallback chain for VDI format detection

### DIFF
--- a/changelogs/fragments/12119-xenserver-vdi-type-fallback.yml
+++ b/changelogs/fragments/12119-xenserver-vdi-type-fallback.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - xenserver_guest_info - use fallback chain for determining VDI format from ``sm_config`` keys ``image-format``, ``vdi_type``, ``type``, defaulting to ``raw`` (https://github.com/ansible-collections/community.general/pull/12119).

--- a/changelogs/fragments/12119-xenserver-vdi-type-fallback.yml
+++ b/changelogs/fragments/12119-xenserver-vdi-type-fallback.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - xenserver_guest_info - use fallback chain for determining VDI format from ``sm_config`` keys ``image-format``, ``vdi_type``, ``type``, defaulting to ``raw`` (https://github.com/ansible-collections/community.general/pull/12119).
+  - xenserver_guest_info - use fallback chain for determining VDI format from ``sm_config`` keys ``image-format``, ``vdi_type``, ``type``, defaulting to ``raw`` (https://github.com/ansible-collections/community.general/pull/12119, https://github.com/ansible-collections/community.general/pull/12215).

--- a/plugins/module_utils/_xenserver.py
+++ b/plugins/module_utils/_xenserver.py
@@ -456,7 +456,13 @@ def gather_vm_facts(module: AnsibleModule, vm_params):
                 "os_device": vm_vbd_params["device"],
                 "uuid": vm_vbd_params["VDI"]["uuid"],
                 "vbd_userdevice": vm_vbd_params["userdevice"],
-                "vdi_type": vm_vbd_params["VDI"].get("sm_config", {}).get("vdi_type", ""),
+                "vdi_type": vm_vbd_params["VDI"]["sm_config"].get(
+                    "image-format",
+                    vm_vbd_params["VDI"]["sm_config"].get(
+                        "vdi_type",
+                        vm_vbd_params["VDI"]["sm_config"].get("type", "raw"),
+                    ),
+                ),
             }
 
             vm_facts["disks"].append(vm_disk_params)

--- a/plugins/modules/xenserver_guest.py
+++ b/plugins/modules/xenserver_guest.py
@@ -406,7 +406,9 @@ instance:
           "size": 42949672960,
           "sr": "Local storage",
           "sr_uuid": "0af1245e-bdb0-ba33-1446-57a962ec4075",
-          "vbd_userdevice": "0"
+          "uuid": "3f98b388-b2c0-4355-9a01-15c0e61b5a76",
+          "vbd_userdevice": "0",
+          "vdi_type": "vhd"
         },
         {
           "name": "testvm_11-1",
@@ -415,7 +417,9 @@ instance:
           "size": 42949672960,
           "sr": "Local storage",
           "sr_uuid": "0af1245e-bdb0-ba33-1446-57a962ec4075",
-          "vbd_userdevice": "1"
+          "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "vbd_userdevice": "1",
+          "vdi_type": "vhd"
         }
       ],
       "domid": "56",

--- a/plugins/modules/xenserver_guest_powerstate.py
+++ b/plugins/modules/xenserver_guest_powerstate.py
@@ -103,7 +103,9 @@ instance:
           "size": 42949672960,
           "sr": "Local storage",
           "sr_uuid": "0af1245e-bdb0-ba33-1446-57a962ec4075",
-          "vbd_userdevice": "0"
+          "uuid": "3f98b388-b2c0-4355-9a01-15c0e61b5a76",
+          "vbd_userdevice": "0",
+          "vdi_type": "vhd"
         },
         {
           "name": "windows-template-testing-1",
@@ -112,7 +114,9 @@ instance:
           "size": 42949672960,
           "sr": "Local storage",
           "sr_uuid": "0af1245e-bdb0-ba33-1446-57a962ec4075",
-          "vbd_userdevice": "1"
+          "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "vbd_userdevice": "1",
+          "vdi_type": "vhd"
         }
       ],
       "domid": "56",

--- a/tests/unit/plugins/module_utils/_xenserver/fixtures/ansible-test-vm-3-params.json
+++ b/tests/unit/plugins/module_utils/_xenserver/fixtures/ansible-test-vm-3-params.json
@@ -139,7 +139,7 @@
             "sharable": false,
             "sm_config": {
                 "image-format": "qcow2",
-                "vdi_type": "qcow2"
+                "vdi_type": "vhd"
             },
             "snapshot_of": "OpaqueRef:NULL",
             "snapshot_time": "19700101T00:00:00Z",


### PR DESCRIPTION
##### SUMMARY

Follow-up to #12119 based on feedback from @bvitnik (https://xcp-ng.org/forum/topic/12259).

This PR improves VDI format detection in `xenserver_guest_info` by using the following fallback chain when reading `sm_config`:

`image-format` → `vdi_type` → `type` → `raw`

Additional changes:
- Remove the unnecessary `.get()` default for `sm_config`, since it is a mandatory parameter and always present.
- Update RETURN documentation examples in `xenserver_guest` and `xenserver_guest_powerstate` to include the `uuid` and `vdi_type` fields.

Fixes #11998

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

xenserver_guest_info
xenserver_guest
xenserver_guest_powerstate

##### ADDITIONAL INFORMATION

This is a follow-up cleanup and compatibility improvement based on testing against both XenServer and XCP-ng environments. The updated fallback logic ensures the correct VDI format is reported across different storage backends and platform versions.