### PR TITLE
consul module utils: honor CONSUL_HTTP_* environment variables

### DIFF
--- a/changelogs/fragments/12216-consul-env-vars.yml
+++ b/changelogs/fragments/12216-consul-env-vars.yml
@@ -1,4 +1,4 @@
 minor_changes:
   - consul modules - connection options now fall back to the ``CONSUL_HTTP_ADDR``, ``CONSUL_HTTP_SSL``, ``CONSUL_HTTP_SSL_VERIFY``,
     ``CONSUL_HTTP_TOKEN`` and ``CONSUL_CACERT`` environment variables when not specified. This applies to all consul modules
-    except ``consul``, which does not use the shared connection option handling yet (https://github.com/ansible-collections/community.general/pull/12216).
+    except ``community.general.consul``, which does not use the shared connection option handling yet (https://github.com/ansible-collections/community.general/pull/12216).

--- a/changelogs/fragments/12216-consul-env-vars.yml
+++ b/changelogs/fragments/12216-consul-env-vars.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - consul modules - connection options now fall back to the ``CONSUL_HTTP_ADDR``, ``CONSUL_HTTP_SSL``, ``CONSUL_HTTP_SSL_VERIFY``,
+    ``CONSUL_HTTP_TOKEN`` and ``CONSUL_CACERT`` environment variables when not specified. This applies to all consul modules
+    except ``consul``, which does not use the shared connection option handling yet (https://github.com/ansible-collections/community.general/pull/12216).

--- a/changelogs/fragments/12216-consul-env-vars.yml
+++ b/changelogs/fragments/12216-consul-env-vars.yml
@@ -1,4 +1,7 @@
 minor_changes:
+  - consul modules - add an ``addr`` option taking the address of the Consul agent as a whole; the existing ``host``,
+    ``port`` and ``scheme`` options each override the matching component of it
+    (https://github.com/ansible-collections/community.general/pull/12216).
   - consul modules - connection options now fall back to the ``CONSUL_HTTP_ADDR``, ``CONSUL_HTTP_SSL``, ``CONSUL_HTTP_SSL_VERIFY``,
     ``CONSUL_HTTP_TOKEN`` and ``CONSUL_CACERT`` environment variables when not specified. This applies to all consul modules
     except ``community.general.consul``, which does not use the shared connection option handling yet (https://github.com/ansible-collections/community.general/pull/12216).

--- a/changelogs/fragments/12216-consul-env-vars.yml
+++ b/changelogs/fragments/12216-consul-env-vars.yml
@@ -1,7 +1,7 @@
 minor_changes:
-  - consul modules - add an ``addr`` option taking the address of the Consul agent as a whole; the existing ``host``,
-    ``port`` and ``scheme`` options each override the matching component of it
-    (https://github.com/ansible-collections/community.general/pull/12216).
+  - consul modules - add a ``url`` option taking the address of the Consul agent as a whole; the existing ``host``,
+    ``port`` and ``scheme`` options each override the matching component of it. This does not cover
+    ``community.general.consul`` (https://github.com/ansible-collections/community.general/pull/12216).
   - consul modules - connection options now fall back to the ``CONSUL_HTTP_ADDR``, ``CONSUL_HTTP_SSL``, ``CONSUL_HTTP_SSL_VERIFY``,
     ``CONSUL_HTTP_TOKEN`` and ``CONSUL_CACERT`` environment variables when not specified. This applies to all consul modules
     except ``community.general.consul``, which does not use the shared connection option handling yet (https://github.com/ansible-collections/community.general/pull/12216).

--- a/plugins/doc_fragments/_consul.py
+++ b/plugins/doc_fragments/_consul.py
@@ -16,6 +16,7 @@ options:
     description:
       - Host of the Consul agent.
       - If unset, the host component of the E(CONSUL_HTTP_ADDR) environment variable is used when set.
+        A value that cannot be parsed is ignored with a warning.
         This is supported since community.general 13.3.0.
     default: localhost
     type: str
@@ -24,6 +25,7 @@ options:
     description:
       - The port on which the consul agent is running.
       - If unset, the port component of the E(CONSUL_HTTP_ADDR) environment variable is used when set.
+        A value that cannot be parsed is ignored with a warning.
         This is supported since community.general 13.3.0.
     default: 8500
   scheme:
@@ -32,7 +34,8 @@ options:
         connections.
       - If unset, a C(true) value in the E(CONSUL_HTTP_SSL) environment variable selects V(https), otherwise the scheme component
         of E(CONSUL_HTTP_ADDR) is used when set. A C(false) E(CONSUL_HTTP_SSL) does not downgrade an V(https) scheme in
-        E(CONSUL_HTTP_ADDR). This is supported since community.general 13.3.0.
+        E(CONSUL_HTTP_ADDR). An E(CONSUL_HTTP_SSL) value that is not a valid boolean is treated as C(true) with a warning.
+        This is supported since community.general 13.3.0.
     default: http
     type: str
   validate_certs:

--- a/plugins/doc_fragments/_consul.py
+++ b/plugins/doc_fragments/_consul.py
@@ -15,37 +15,38 @@ options:
   host:
     description:
       - Host of the Consul agent.
-      - If unset, the host component of the E(CONSUL_HTTP_ADDR) environment variable is used when set (since community.general
-        13.2.0).
+      - If unset, the host component of the E(CONSUL_HTTP_ADDR) environment variable is used when set.
+        This is supported since community.general 13.3.0.
     default: localhost
     type: str
   port:
     type: int
     description:
       - The port on which the consul agent is running.
-      - If unset, the port component of the E(CONSUL_HTTP_ADDR) environment variable is used when set (since community.general
-        13.2.0).
+      - If unset, the port component of the E(CONSUL_HTTP_ADDR) environment variable is used when set.
+        This is supported since community.general 13.3.0.
     default: 8500
   scheme:
     description:
       - The protocol scheme on which the Consul agent is running. Defaults to V(http) and can be set to V(https) for secure
         connections.
-      - If unset, a true value in the E(CONSUL_HTTP_SSL) environment variable selects V(https), otherwise the scheme component
-        of E(CONSUL_HTTP_ADDR) is used when set (since community.general 13.2.0). A false E(CONSUL_HTTP_SSL) does not downgrade
-        an V(https) scheme in E(CONSUL_HTTP_ADDR).
+      - If unset, a C(true) value in the E(CONSUL_HTTP_SSL) environment variable selects V(https), otherwise the scheme component
+        of E(CONSUL_HTTP_ADDR) is used when set. A C(false) E(CONSUL_HTTP_SSL) does not downgrade an V(https) scheme in
+        E(CONSUL_HTTP_ADDR). This is supported since community.general 13.3.0.
     default: http
     type: str
   validate_certs:
     type: bool
     description:
       - Whether to verify the TLS certificate of the Consul agent.
-      - If unset, the value of the E(CONSUL_HTTP_SSL_VERIFY) environment variable is used when set (since community.general
-        13.2.0).
+      - If unset, the value of the E(CONSUL_HTTP_SSL_VERIFY) environment variable is used when set.
+        This is supported since community.general 13.3.0.
     default: true
   ca_path:
     description:
       - The CA bundle to use for https connections.
-      - If unset, the value of the E(CONSUL_CACERT) environment variable is used when set (since community.general 13.2.0).
+      - If unset, the value of the E(CONSUL_CACERT) environment variable is used when set.
+        This is supported since community.general 13.3.0.
     type: str
 """
 
@@ -54,7 +55,8 @@ options:
   token:
     description:
       - The token to use for authorization.
-      - If unset, the value of the E(CONSUL_HTTP_TOKEN) environment variable is used (since community.general 13.2.0).
+      - If unset, the value of the E(CONSUL_HTTP_TOKEN) environment variable is used.
+        This is supported since community.general 13.3.0.
     type: str
 """
 

--- a/plugins/doc_fragments/_consul.py
+++ b/plugins/doc_fragments/_consul.py
@@ -15,27 +15,37 @@ options:
   host:
     description:
       - Host of the Consul agent.
+      - If unset, the host component of the E(CONSUL_HTTP_ADDR) environment variable is used when set (since community.general
+        13.2.0).
     default: localhost
     type: str
   port:
     type: int
     description:
       - The port on which the consul agent is running.
+      - If unset, the port component of the E(CONSUL_HTTP_ADDR) environment variable is used when set (since community.general
+        13.2.0).
     default: 8500
   scheme:
     description:
       - The protocol scheme on which the Consul agent is running. Defaults to V(http) and can be set to V(https) for secure
         connections.
+      - If unset, a true value in the E(CONSUL_HTTP_SSL) environment variable selects V(https), otherwise the scheme component
+        of E(CONSUL_HTTP_ADDR) is used when set (since community.general 13.2.0). A false E(CONSUL_HTTP_SSL) does not downgrade
+        an V(https) scheme in E(CONSUL_HTTP_ADDR).
     default: http
     type: str
   validate_certs:
     type: bool
     description:
       - Whether to verify the TLS certificate of the Consul agent.
+      - If unset, the value of the E(CONSUL_HTTP_SSL_VERIFY) environment variable is used when set (since community.general
+        13.2.0).
     default: true
   ca_path:
     description:
       - The CA bundle to use for https connections.
+      - If unset, the value of the E(CONSUL_CACERT) environment variable is used when set (since community.general 13.2.0).
     type: str
 """
 
@@ -44,6 +54,7 @@ options:
   token:
     description:
       - The token to use for authorization.
+      - If unset, the value of the E(CONSUL_HTTP_TOKEN) environment variable is used (since community.general 13.2.0).
     type: str
 """
 

--- a/plugins/doc_fragments/_consul.py
+++ b/plugins/doc_fragments/_consul.py
@@ -12,7 +12,7 @@ class ModuleDocFragment:
     # Common parameters for Consul modules
     DOCUMENTATION = r"""
 options:
-  addr:
+  url:
     description:
       - The address of the Consul agent, in the V(host:port) or V(scheme://host:port) form. The scheme and the port are
         optional, the host is not.
@@ -21,36 +21,36 @@ options:
         cannot use, a C(unix://) socket for example, makes the module fail, unless O(host), O(port) and O(scheme) are all
         set, in which case the address is not consulted at all.
     type: str
-    version_added: 13.3.0
+    version_added: 13.4.0
   host:
     description:
       - Host of the Consul agent.
-      - If unset, the host component of O(addr) is used, and V(localhost) when O(addr) is not set either.
+      - If unset, the host component of O(url) is used, and V(localhost) when O(url) is not set either.
     type: str
   port:
     type: int
     description:
       - The port on which the consul agent is running.
-      - If unset, the port component of O(addr) is used, and V(8500) when that does not specify one either.
+      - If unset, the port component of O(url) is used, and V(8500) when that does not specify one either.
   scheme:
     description:
       - The protocol scheme on which the Consul agent is running.
       - If unset, a C(true) value in the E(CONSUL_HTTP_SSL) environment variable selects V(https), otherwise the scheme
-        component of O(addr) is used, and V(http) when that does not specify one either. A C(false) E(CONSUL_HTTP_SSL) does
-        not downgrade an V(https) O(addr).
+        component of O(url) is used, and V(http) when that does not specify one either. A C(false) E(CONSUL_HTTP_SSL) does
+        not downgrade an V(https) O(url).
     type: str
   validate_certs:
     type: bool
     description:
       - Whether to verify the TLS certificate of the Consul agent.
       - If unset, the value of the E(CONSUL_HTTP_SSL_VERIFY) environment variable is used when set.
-        This is supported since community.general 13.3.0.
+        This is supported since community.general 13.4.0.
     default: true
   ca_path:
     description:
       - The CA bundle to use for https connections.
       - If unset, the value of the E(CONSUL_CACERT) environment variable is used when set.
-        This is supported since community.general 13.3.0.
+        This is supported since community.general 13.4.0.
     type: str
 """
 
@@ -60,7 +60,7 @@ options:
     description:
       - The token to use for authorization.
       - If unset, the value of the E(CONSUL_HTTP_TOKEN) environment variable is used.
-        This is supported since community.general 13.3.0.
+        This is supported since community.general 13.4.0.
     type: str
 """
 

--- a/plugins/doc_fragments/_consul.py
+++ b/plugins/doc_fragments/_consul.py
@@ -12,31 +12,32 @@ class ModuleDocFragment:
     # Common parameters for Consul modules
     DOCUMENTATION = r"""
 options:
+  addr:
+    description:
+      - The address of the Consul agent, in the V(host:port) or V(scheme://host:port) form. The scheme and the port are
+        optional, the host is not.
+      - O(host), O(port) and O(scheme) take precedence over the components of this option.
+      - If unset, the value of the E(CONSUL_HTTP_ADDR) environment variable is used when set. An address these modules
+        cannot use, a C(unix://) socket for example, makes the module fail, unless O(host), O(port) and O(scheme) are all
+        set, in which case the address is not consulted at all.
+    type: str
+    version_added: 13.3.0
   host:
     description:
       - Host of the Consul agent.
-      - If unset, the host component of the E(CONSUL_HTTP_ADDR) environment variable is used when set.
-        A value that cannot be parsed is ignored with a warning.
-        This is supported since community.general 13.3.0.
-    default: localhost
+      - If unset, the host component of O(addr) is used, and V(localhost) when O(addr) is not set either.
     type: str
   port:
     type: int
     description:
       - The port on which the consul agent is running.
-      - If unset, the port component of the E(CONSUL_HTTP_ADDR) environment variable is used when set.
-        A value that cannot be parsed is ignored with a warning.
-        This is supported since community.general 13.3.0.
-    default: 8500
+      - If unset, the port component of O(addr) is used, and V(8500) when that does not specify one either.
   scheme:
     description:
-      - The protocol scheme on which the Consul agent is running. Defaults to V(http) and can be set to V(https) for secure
-        connections.
-      - If unset, a C(true) value in the E(CONSUL_HTTP_SSL) environment variable selects V(https), otherwise the scheme component
-        of E(CONSUL_HTTP_ADDR) is used when set. A C(false) E(CONSUL_HTTP_SSL) does not downgrade an V(https) scheme in
-        E(CONSUL_HTTP_ADDR). An E(CONSUL_HTTP_SSL) value that is not a valid boolean is treated as C(true) with a warning.
-        This is supported since community.general 13.3.0.
-    default: http
+      - The protocol scheme on which the Consul agent is running.
+      - If unset, a C(true) value in the E(CONSUL_HTTP_SSL) environment variable selects V(https), otherwise the scheme
+        component of O(addr) is used, and V(http) when that does not specify one either. A C(false) E(CONSUL_HTTP_SSL) does
+        not downgrade an V(https) O(addr).
     type: str
   validate_certs:
     type: bool

--- a/plugins/module_utils/_consul.py
+++ b/plugins/module_utils/_consul.py
@@ -9,12 +9,15 @@ from __future__ import annotations
 
 import copy
 import json
+import os
 import re
 import typing as t
 from http import HTTPStatus
 from urllib import error as urllib_error
-from urllib.parse import urlencode
+from urllib.parse import ParseResult, urlencode, urlparse
 
+from ansible.module_utils.basic import AnsibleFallbackNotFound
+from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.urls import open_url
 
 if t.TYPE_CHECKING:
@@ -50,13 +53,83 @@ def handle_consul_response_error(response):
         raise RequestError(f"{response.status_code} {response.content}")
 
 
+def parse_consul_http_addr() -> ParseResult | None:
+    addr = os.environ.get("CONSUL_HTTP_ADDR", "").strip()
+    if not addr:
+        return None
+    # CONSUL_HTTP_ADDR accepts both host:port and scheme://host:port.
+    # urlparse needs the leading // to treat the former as a netloc.
+    parsed = urlparse(addr if "://" in addr else "//" + addr)
+    # The variable may be set for the consul CLI, which also accepts unix://
+    # sockets, path prefixes, credentials and query strings. The modules cannot
+    # honor those faithfully, so such addresses are ignored rather than
+    # half-used, keeping playbooks that never relied on the variable working as
+    # before.
+    if parsed.scheme and parsed.scheme not in ("http", "https"):
+        return None
+    if parsed.path and parsed.path != "/":
+        return None
+    if parsed.query or parsed.fragment or parsed.username is not None:
+        return None
+    try:
+        # A mangled netloc (unbracketed IPv6, garbage port) must never hand
+        # out any component, so validate the port here for every consumer.
+        parsed.port  # noqa: B018
+    except ValueError as exc:
+        raise ValueError(f"CONSUL_HTTP_ADDR ({addr}) contains an invalid port") from exc
+    return parsed
+
+
+def env_consul_host(*args: t.Any, **kwargs: t.Any) -> str:
+    parsed = parse_consul_http_addr()
+    if parsed is not None and parsed.hostname:
+        # Re-bracket IPv6 addresses so composed URLs stay valid.
+        return f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+    raise AnsibleFallbackNotFound
+
+
+def env_consul_port(*args: t.Any, **kwargs: t.Any) -> int:
+    parsed = parse_consul_http_addr()
+    if parsed is not None and parsed.port is not None:
+        return parsed.port
+    raise AnsibleFallbackNotFound
+
+
+def env_consul_scheme(*args: t.Any, **kwargs: t.Any) -> str:
+    # A true CONSUL_HTTP_SSL forces https. A false one does NOT downgrade an
+    # https scheme in CONSUL_HTTP_ADDR, matching the consul CLI, which never
+    # reverts to http when TLS was explicitly requested.
+    ssl = os.environ.get("CONSUL_HTTP_SSL")
+    if ssl:
+        try:
+            use_ssl = boolean(ssl, strict=True)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"CONSUL_HTTP_SSL ({ssl}) is not a valid boolean") from exc
+        if use_ssl:
+            return "https"
+    parsed = parse_consul_http_addr()
+    if parsed is not None and parsed.scheme:
+        return parsed.scheme
+    raise AnsibleFallbackNotFound
+
+
+def nonempty_env_fallback(*names: str) -> str:
+    # Like env_fallback, but a variable that is set to an empty string counts
+    # as unset, matching how the consul CLI reads its environment.
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value
+    raise AnsibleFallbackNotFound
+
+
 AUTH_ARGUMENTS_SPEC = dict(
-    host=dict(default="localhost"),
-    port=dict(type="int", default=8500),
-    scheme=dict(default="http"),
-    validate_certs=dict(type="bool", default=True),
-    token=dict(no_log=True),
-    ca_path=dict(),
+    host=dict(default="localhost", fallback=(env_consul_host,)),
+    port=dict(type="int", default=8500, fallback=(env_consul_port,)),
+    scheme=dict(default="http", fallback=(env_consul_scheme,)),
+    validate_certs=dict(type="bool", default=True, fallback=(nonempty_env_fallback, ["CONSUL_HTTP_SSL_VERIFY"])),
+    token=dict(no_log=True, fallback=(nonempty_env_fallback, ["CONSUL_HTTP_TOKEN"])),
+    ca_path=dict(fallback=(nonempty_env_fallback, ["CONSUL_CACERT"])),
 )
 
 

--- a/plugins/module_utils/_consul.py
+++ b/plugins/module_utils/_consul.py
@@ -12,11 +12,13 @@ import json
 import os
 import re
 import typing as t
+from functools import lru_cache
 from http import HTTPStatus
 from urllib import error as urllib_error
 from urllib.parse import ParseResult, urlencode, urlparse
 
 from ansible.module_utils.basic import AnsibleFallbackNotFound
+from ansible.module_utils.common.warnings import warn
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.urls import open_url
 
@@ -53,31 +55,45 @@ def handle_consul_response_error(response):
         raise RequestError(f"{response.status_code} {response.content}")
 
 
+@lru_cache(maxsize=None)
+def _parse_addr(addr: str) -> ParseResult | None:
+    # Cached per address so the warning below fires once even though the host,
+    # port and scheme fallbacks each parse the variable independently.
+    try:
+        # CONSUL_HTTP_ADDR accepts both host:port and scheme://host:port.
+        # urlparse needs the leading // to treat the former as a netloc.
+        parsed = urlparse(addr if "://" in addr else "//" + addr)
+        # The variable may be set for the consul CLI, which also accepts unix://
+        # sockets, path prefixes, credentials and query strings. The modules
+        # cannot honor those faithfully, so such addresses are ignored rather
+        # than half-used, keeping playbooks that never relied on the variable
+        # working as before.
+        if parsed.scheme and parsed.scheme not in ("http", "https"):
+            return None
+        if parsed.path and parsed.path != "/":
+            return None
+        if parsed.query or parsed.fragment or parsed.username is not None:
+            return None
+        if not parsed.hostname:
+            return None
+        # A mangled netloc (unbracketed IPv6, garbage port) must never hand
+        # out any component, so trigger port validation here for every
+        # consumer.
+        parsed.port  # noqa: B018
+    except ValueError:
+        # Fallbacks may only raise AnsibleFallbackNotFound, anything else
+        # escapes ansible-core's argument handling as a traceback. Warn
+        # without echoing the value, which may embed credentials.
+        warn("The value of the CONSUL_HTTP_ADDR environment variable cannot be parsed and is ignored")
+        return None
+    return parsed
+
+
 def parse_consul_http_addr() -> ParseResult | None:
     addr = os.environ.get("CONSUL_HTTP_ADDR", "").strip()
     if not addr:
         return None
-    # CONSUL_HTTP_ADDR accepts both host:port and scheme://host:port.
-    # urlparse needs the leading // to treat the former as a netloc.
-    parsed = urlparse(addr if "://" in addr else "//" + addr)
-    # The variable may be set for the consul CLI, which also accepts unix://
-    # sockets, path prefixes, credentials and query strings. The modules cannot
-    # honor those faithfully, so such addresses are ignored rather than
-    # half-used, keeping playbooks that never relied on the variable working as
-    # before.
-    if parsed.scheme and parsed.scheme not in ("http", "https"):
-        return None
-    if parsed.path and parsed.path != "/":
-        return None
-    if parsed.query or parsed.fragment or parsed.username is not None:
-        return None
-    try:
-        # A mangled netloc (unbracketed IPv6, garbage port) must never hand
-        # out any component, so validate the port here for every consumer.
-        parsed.port  # noqa: B018
-    except ValueError as exc:
-        raise ValueError(f"CONSUL_HTTP_ADDR ({addr}) contains an invalid port") from exc
-    return parsed
+    return _parse_addr(addr)
 
 
 def env_consul_host(*args: t.Any, **kwargs: t.Any) -> str:
@@ -103,8 +119,13 @@ def env_consul_scheme(*args: t.Any, **kwargs: t.Any) -> str:
     if tls:
         try:
             use_tls = boolean(tls, strict=True)
-        except (TypeError, ValueError) as exc:
-            raise ValueError(f"CONSUL_HTTP_SSL ({tls}) is not a valid boolean") from exc
+        except (TypeError, ValueError):
+            # Fallbacks may only raise AnsibleFallbackNotFound, so this cannot
+            # fail the module. Assume TLS rather than plaintext: the safe
+            # failure mode is a refused connection, not a token sent over
+            # http. Like above, do not echo the value.
+            warn("The value of the CONSUL_HTTP_SSL environment variable is not a valid boolean and is treated as true")
+            use_tls = True
         if use_tls:
             return "https"
     parsed = parse_consul_http_addr()

--- a/plugins/module_utils/_consul.py
+++ b/plugins/module_utils/_consul.py
@@ -99,13 +99,13 @@ def env_consul_scheme(*args: t.Any, **kwargs: t.Any) -> str:
     # A true CONSUL_HTTP_SSL forces https. A false one does NOT downgrade an
     # https scheme in CONSUL_HTTP_ADDR, matching the consul CLI, which never
     # reverts to http when TLS was explicitly requested.
-    ssl = os.environ.get("CONSUL_HTTP_SSL")
-    if ssl:
+    tls = os.environ.get("CONSUL_HTTP_SSL")
+    if tls:
         try:
-            use_ssl = boolean(ssl, strict=True)
+            use_tls = boolean(tls, strict=True)
         except (TypeError, ValueError) as exc:
-            raise ValueError(f"CONSUL_HTTP_SSL ({ssl}) is not a valid boolean") from exc
-        if use_ssl:
+            raise ValueError(f"CONSUL_HTTP_SSL ({tls}) is not a valid boolean") from exc
+        if use_tls:
             return "https"
     parsed = parse_consul_http_addr()
     if parsed is not None and parsed.scheme:

--- a/plugins/module_utils/_consul.py
+++ b/plugins/module_utils/_consul.py
@@ -55,7 +55,7 @@ def handle_consul_response_error(response):
         raise RequestError(f"{response.status_code} {response.content}")
 
 
-@lru_cache(maxsize=None)
+@lru_cache
 def _parse_addr(addr: str) -> ParseResult | None:
     # Cached per address so the warning below fires once even though the host,
     # port and scheme fallbacks each parse the variable independently.

--- a/plugins/module_utils/_consul.py
+++ b/plugins/module_utils/_consul.py
@@ -10,12 +10,15 @@ from __future__ import annotations
 import base64
 import copy
 import json
+import os
 import re
 import typing as t
 from http import HTTPStatus
 from urllib import error as urllib_error
-from urllib.parse import quote, urlencode
+from urllib.parse import ParseResult, quote, urlencode, urlparse
 
+from ansible.module_utils.basic import AnsibleFallbackNotFound
+from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.urls import open_url
 
 if t.TYPE_CHECKING:
@@ -51,13 +54,83 @@ def handle_consul_response_error(response):
         raise RequestError(f"{response.status_code} {response.content}")
 
 
+def parse_consul_http_addr() -> ParseResult | None:
+    addr = os.environ.get("CONSUL_HTTP_ADDR", "").strip()
+    if not addr:
+        return None
+    # CONSUL_HTTP_ADDR accepts both host:port and scheme://host:port.
+    # urlparse needs the leading // to treat the former as a netloc.
+    parsed = urlparse(addr if "://" in addr else "//" + addr)
+    # The variable may be set for the consul CLI, which also accepts unix://
+    # sockets, path prefixes, credentials and query strings. The modules cannot
+    # honor those faithfully, so such addresses are ignored rather than
+    # half-used, keeping playbooks that never relied on the variable working as
+    # before.
+    if parsed.scheme and parsed.scheme not in ("http", "https"):
+        return None
+    if parsed.path and parsed.path != "/":
+        return None
+    if parsed.query or parsed.fragment or parsed.username is not None:
+        return None
+    try:
+        # A mangled netloc (unbracketed IPv6, garbage port) must never hand
+        # out any component, so validate the port here for every consumer.
+        parsed.port  # noqa: B018
+    except ValueError as exc:
+        raise ValueError(f"CONSUL_HTTP_ADDR ({addr}) contains an invalid port") from exc
+    return parsed
+
+
+def env_consul_host(*args: t.Any, **kwargs: t.Any) -> str:
+    parsed = parse_consul_http_addr()
+    if parsed is not None and parsed.hostname:
+        # Re-bracket IPv6 addresses so composed URLs stay valid.
+        return f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+    raise AnsibleFallbackNotFound
+
+
+def env_consul_port(*args: t.Any, **kwargs: t.Any) -> int:
+    parsed = parse_consul_http_addr()
+    if parsed is not None and parsed.port is not None:
+        return parsed.port
+    raise AnsibleFallbackNotFound
+
+
+def env_consul_scheme(*args: t.Any, **kwargs: t.Any) -> str:
+    # A true CONSUL_HTTP_SSL forces https. A false one does NOT downgrade an
+    # https scheme in CONSUL_HTTP_ADDR, matching the consul CLI, which never
+    # reverts to http when TLS was explicitly requested.
+    ssl = os.environ.get("CONSUL_HTTP_SSL")
+    if ssl:
+        try:
+            use_ssl = boolean(ssl, strict=True)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"CONSUL_HTTP_SSL ({ssl}) is not a valid boolean") from exc
+        if use_ssl:
+            return "https"
+    parsed = parse_consul_http_addr()
+    if parsed is not None and parsed.scheme:
+        return parsed.scheme
+    raise AnsibleFallbackNotFound
+
+
+def nonempty_env_fallback(*names: str) -> str:
+    # Like env_fallback, but a variable that is set to an empty string counts
+    # as unset, matching how the consul CLI reads its environment.
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value
+    raise AnsibleFallbackNotFound
+
+
 AUTH_ARGUMENTS_SPEC = dict(
-    host=dict(default="localhost"),
-    port=dict(type="int", default=8500),
-    scheme=dict(default="http"),
-    validate_certs=dict(type="bool", default=True),
-    token=dict(no_log=True),
-    ca_path=dict(),
+    host=dict(default="localhost", fallback=(env_consul_host,)),
+    port=dict(type="int", default=8500, fallback=(env_consul_port,)),
+    scheme=dict(default="http", fallback=(env_consul_scheme,)),
+    validate_certs=dict(type="bool", default=True, fallback=(nonempty_env_fallback, ["CONSUL_HTTP_SSL_VERIFY"])),
+    token=dict(no_log=True, fallback=(nonempty_env_fallback, ["CONSUL_HTTP_TOKEN"])),
+    ca_path=dict(fallback=(nonempty_env_fallback, ["CONSUL_CACERT"])),
 )
 
 

--- a/plugins/module_utils/_consul.py
+++ b/plugins/module_utils/_consul.py
@@ -55,12 +55,8 @@ def handle_consul_response_error(response):
 
 
 def nonempty_env_fallback(*names: str) -> str:
-    # Like env_fallback, but a variable that is set to an empty string counts as
-    # unset, matching how the consul CLI reads its environment. env_fallback
-    # hands the empty string on instead: an exported but empty
-    # CONSUL_HTTP_SSL_VERIFY then fails the boolean conversion with an error the
-    # playbook cannot avoid, and an empty CONSUL_HTTP_TOKEN sends an empty
-    # X-Consul-Token header rather than none at all.
+    # Unlike env_fallback, a variable set to an empty string counts as unset,
+    # the way the consul CLI reads its environment.
     for name in names:
         value = os.environ.get(name)
         if value:
@@ -74,9 +70,8 @@ CONNECTION_DEFAULTS: dict[str, t.Any] = {"host": "localhost", "port": 8500, "sch
 def url_password(url: str) -> str | None:
     """Return the password embedded in an address, if it carries one.
 
-    Deliberately string based rather than another urlparse call: urlparse
-    raises for exactly the malformed addresses whose password still has to be
-    kept out of the module output.
+    String based on purpose: urlparse raises for some of the malformed
+    addresses whose password still has to be kept out of the output.
     """
     netloc = url.split("://", 1)[-1].split("/", 1)[0]
     userinfo, separator = netloc.rpartition("@")[:2]
@@ -88,28 +83,18 @@ def url_password(url: str) -> str | None:
 def parse_url(url: str) -> dict[str, t.Any]:
     """Split an address into the connection components it specifies.
 
-    Accepts the ``host:port`` and ``scheme://host:port`` forms, where the
-    scheme and the port are optional. Raises :class:`ValueError` with a reason
-    for addresses these modules cannot use. The reason never repeats the
-    address itself, which may embed credentials.
+    Accepts ``host:port`` and ``scheme://host:port``, where the scheme and the
+    port are optional. Raises :class:`ValueError` with a reason that never
+    repeats the address, which may embed credentials.
     """
     try:
-        # urlparse only reads a netloc after a scheme, so a bare host:port
-        # needs the leading slashes.
         parsed = urlparse(url if "://" in url else "//" + url)
         scheme, hostname, port = parsed.scheme, parsed.hostname, parsed.port
     except ValueError as exc:
-        # urlparse itself rejects a mangled netloc, an unbracketed IPv6
-        # address for instance, and .port rejects a non-numeric port. Their
-        # messages are not reused: the one for a netloc that fails NFKC
-        # normalization quotes the netloc, credentials included.
         raise ValueError("cannot be parsed as host:port or scheme://host:port") from exc
     if scheme and scheme not in ("http", "https"):
-        # unix:// sockets in particular: the modules speak HTTP over TCP only.
         raise ValueError(f"uses the unsupported scheme {scheme}, only http and https work")
     if parsed.path not in ("", "/") or parsed.params:
-        # urlparse splits a trailing ;suffix of the path off into params, so
-        # both have to be checked to reject an address that carries a path.
         raise ValueError("must not contain a path")
     if parsed.query or parsed.fragment:
         raise ValueError("must not contain a query or a fragment")
@@ -118,11 +103,9 @@ def parse_url(url: str) -> dict[str, t.Any]:
     if not hostname:
         raise ValueError("does not contain a host")
     if any(char.isspace() or not char.isprintable() for char in hostname):
-        # urlparse keeps these in the host, where they would only surface much
-        # later as an unrelated error from the HTTP layer.
         raise ValueError("contains a host with whitespace or control characters")
     components: dict[str, t.Any] = {}
-    # Re-bracket IPv6 addresses so the composed URL stays valid.
+    # Keep IPv6 addresses bracketed so the composed URL stays valid.
     components["host"] = f"[{hostname}]" if ":" in hostname else hostname
     if port is not None:
         components["port"] = port
@@ -135,26 +118,20 @@ def resolve_connection_params(module: AnsibleModule) -> None:
     """Fill in host, port and scheme, in place.
 
     An explicitly set option wins over the matching component of ``url``, which
-    wins over the default. Options left unset are still ``None`` at this point,
-    since these three carry no default in the argument spec: ansible-core
-    applies spec defaults before a module runs, which would make an explicit
-    value indistinguishable from a default.
+    wins over the default. The three carry no default in the argument spec, so
+    that an unset one is still ``None`` here and can be told apart from one the
+    playbook set to the same value as the default.
     """
     params = module.params
-    # CONSUL_HTTP_ADDR is read here rather than through a fallback on the
-    # option, so that an address exported for the consul CLI is never copied
-    # into the module arguments, which ansible-core echoes back with the
-    # result before a module can mask anything.
+    # Read from the environment here rather than through a fallback on the
+    # option, which would copy the value into the module arguments.
     url = (params["url"] or os.environ.get("CONSUL_HTTP_ADDR") or "").strip()
     if params["url"]:
         password = url_password(url)
         if password:
             module.no_log_values.add(password)
     if all(params[name] is not None for name in CONNECTION_DEFAULTS):
-        # Everything is set explicitly, so neither the address nor the
-        # environment can contribute anything. Do not even look at them: a task
-        # that spells out its connection must not be broken by an address
-        # exported for the consul CLI that these modules cannot use.
+        # Nothing left for the address or the environment to contribute.
         return
     components: dict[str, t.Any] = {}
     if url:
@@ -171,10 +148,7 @@ def resolve_connection_params(module: AnsibleModule) -> None:
                 use_tls = boolean(tls, strict=True)
             except (TypeError, ValueError):
                 module.fail_json(msg="The CONSUL_HTTP_SSL environment variable is not a valid boolean.")
-            # A true CONSUL_HTTP_SSL selects https even when the address says
-            # http. A false one does not downgrade an https address, matching
-            # the consul CLI, which never reverts to http once TLS was asked
-            # for.
+            # A false value never downgrades an https address, as in the CLI.
             if use_tls:
                 components["scheme"] = "https"
     for name, default in CONNECTION_DEFAULTS.items():

--- a/plugins/module_utils/_consul.py
+++ b/plugins/module_utils/_consul.py
@@ -13,11 +13,13 @@ import json
 import os
 import re
 import typing as t
+from functools import lru_cache
 from http import HTTPStatus
 from urllib import error as urllib_error
 from urllib.parse import ParseResult, quote, urlencode, urlparse
 
 from ansible.module_utils.basic import AnsibleFallbackNotFound
+from ansible.module_utils.common.warnings import warn
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.urls import open_url
 
@@ -54,31 +56,45 @@ def handle_consul_response_error(response):
         raise RequestError(f"{response.status_code} {response.content}")
 
 
+@lru_cache(maxsize=None)
+def _parse_addr(addr: str) -> ParseResult | None:
+    # Cached per address so the warning below fires once even though the host,
+    # port and scheme fallbacks each parse the variable independently.
+    try:
+        # CONSUL_HTTP_ADDR accepts both host:port and scheme://host:port.
+        # urlparse needs the leading // to treat the former as a netloc.
+        parsed = urlparse(addr if "://" in addr else "//" + addr)
+        # The variable may be set for the consul CLI, which also accepts unix://
+        # sockets, path prefixes, credentials and query strings. The modules
+        # cannot honor those faithfully, so such addresses are ignored rather
+        # than half-used, keeping playbooks that never relied on the variable
+        # working as before.
+        if parsed.scheme and parsed.scheme not in ("http", "https"):
+            return None
+        if parsed.path and parsed.path != "/":
+            return None
+        if parsed.query or parsed.fragment or parsed.username is not None:
+            return None
+        if not parsed.hostname:
+            return None
+        # A mangled netloc (unbracketed IPv6, garbage port) must never hand
+        # out any component, so trigger port validation here for every
+        # consumer.
+        parsed.port  # noqa: B018
+    except ValueError:
+        # Fallbacks may only raise AnsibleFallbackNotFound, anything else
+        # escapes ansible-core's argument handling as a traceback. Warn
+        # without echoing the value, which may embed credentials.
+        warn("The value of the CONSUL_HTTP_ADDR environment variable cannot be parsed and is ignored")
+        return None
+    return parsed
+
+
 def parse_consul_http_addr() -> ParseResult | None:
     addr = os.environ.get("CONSUL_HTTP_ADDR", "").strip()
     if not addr:
         return None
-    # CONSUL_HTTP_ADDR accepts both host:port and scheme://host:port.
-    # urlparse needs the leading // to treat the former as a netloc.
-    parsed = urlparse(addr if "://" in addr else "//" + addr)
-    # The variable may be set for the consul CLI, which also accepts unix://
-    # sockets, path prefixes, credentials and query strings. The modules cannot
-    # honor those faithfully, so such addresses are ignored rather than
-    # half-used, keeping playbooks that never relied on the variable working as
-    # before.
-    if parsed.scheme and parsed.scheme not in ("http", "https"):
-        return None
-    if parsed.path and parsed.path != "/":
-        return None
-    if parsed.query or parsed.fragment or parsed.username is not None:
-        return None
-    try:
-        # A mangled netloc (unbracketed IPv6, garbage port) must never hand
-        # out any component, so validate the port here for every consumer.
-        parsed.port  # noqa: B018
-    except ValueError as exc:
-        raise ValueError(f"CONSUL_HTTP_ADDR ({addr}) contains an invalid port") from exc
-    return parsed
+    return _parse_addr(addr)
 
 
 def env_consul_host(*args: t.Any, **kwargs: t.Any) -> str:
@@ -104,8 +120,13 @@ def env_consul_scheme(*args: t.Any, **kwargs: t.Any) -> str:
     if tls:
         try:
             use_tls = boolean(tls, strict=True)
-        except (TypeError, ValueError) as exc:
-            raise ValueError(f"CONSUL_HTTP_SSL ({tls}) is not a valid boolean") from exc
+        except (TypeError, ValueError):
+            # Fallbacks may only raise AnsibleFallbackNotFound, so this cannot
+            # fail the module. Assume TLS rather than plaintext: the safe
+            # failure mode is a refused connection, not a token sent over
+            # http. Like above, do not echo the value.
+            warn("The value of the CONSUL_HTTP_SSL environment variable is not a valid boolean and is treated as true")
+            use_tls = True
         if use_tls:
             return "https"
     parsed = parse_consul_http_addr()

--- a/plugins/module_utils/_consul.py
+++ b/plugins/module_utils/_consul.py
@@ -55,8 +55,12 @@ def handle_consul_response_error(response):
 
 
 def nonempty_env_fallback(*names: str) -> str:
-    # Like env_fallback, but a variable that is set to an empty string counts
-    # as unset, matching how the consul CLI reads its environment.
+    # Like env_fallback, but a variable that is set to an empty string counts as
+    # unset, matching how the consul CLI reads its environment. env_fallback
+    # hands the empty string on instead: an exported but empty
+    # CONSUL_HTTP_SSL_VERIFY then fails the boolean conversion with an error the
+    # playbook cannot avoid, and an empty CONSUL_HTTP_TOKEN sends an empty
+    # X-Consul-Token header rather than none at all.
     for name in names:
         value = os.environ.get(name)
         if value:
@@ -67,15 +71,21 @@ def nonempty_env_fallback(*names: str) -> str:
 CONNECTION_DEFAULTS: dict[str, t.Any] = {"host": "localhost", "port": 8500, "scheme": "http"}
 
 
-def addr_password(addr: str) -> str | None:
-    """Return the password embedded in an address, if it carries one."""
-    try:
-        return urlparse(addr if "://" in addr else "//" + addr).password
-    except ValueError:
+def url_password(url: str) -> str | None:
+    """Return the password embedded in an address, if it carries one.
+
+    Deliberately string based rather than another urlparse call: urlparse
+    raises for exactly the malformed addresses whose password still has to be
+    kept out of the module output.
+    """
+    netloc = url.split("://", 1)[-1].split("/", 1)[0]
+    userinfo, separator = netloc.rpartition("@")[:2]
+    if not separator or ":" not in userinfo:
         return None
+    return userinfo.split(":", 1)[1] or None
 
 
-def parse_addr(addr: str) -> dict[str, t.Any]:
+def parse_url(url: str) -> dict[str, t.Any]:
     """Split an address into the connection components it specifies.
 
     Accepts the ``host:port`` and ``scheme://host:port`` forms, where the
@@ -86,12 +96,14 @@ def parse_addr(addr: str) -> dict[str, t.Any]:
     try:
         # urlparse only reads a netloc after a scheme, so a bare host:port
         # needs the leading slashes.
-        parsed = urlparse(addr if "://" in addr else "//" + addr)
+        parsed = urlparse(url if "://" in url else "//" + url)
         scheme, hostname, port = parsed.scheme, parsed.hostname, parsed.port
     except ValueError as exc:
         # urlparse itself rejects a mangled netloc, an unbracketed IPv6
-        # address for instance, and .port rejects a non-numeric port.
-        raise ValueError("cannot be parsed") from exc
+        # address for instance, and .port rejects a non-numeric port. Their
+        # messages are not reused: the one for a netloc that fails NFKC
+        # normalization quotes the netloc, credentials included.
+        raise ValueError("cannot be parsed as host:port or scheme://host:port") from exc
     if scheme and scheme not in ("http", "https"):
         # unix:// sockets in particular: the modules speak HTTP over TCP only.
         raise ValueError(f"uses the unsupported scheme {scheme}, only http and https work")
@@ -122,33 +134,35 @@ def parse_addr(addr: str) -> dict[str, t.Any]:
 def resolve_connection_params(module: AnsibleModule) -> None:
     """Fill in host, port and scheme, in place.
 
-    An explicitly set option wins over the matching component of ``addr``,
-    which wins over the default. Options left unset are still ``None`` at this
-    point, since these three carry no default in the argument spec: ansible-core
+    An explicitly set option wins over the matching component of ``url``, which
+    wins over the default. Options left unset are still ``None`` at this point,
+    since these three carry no default in the argument spec: ansible-core
     applies spec defaults before a module runs, which would make an explicit
     value indistinguishable from a default.
     """
     params = module.params
+    # CONSUL_HTTP_ADDR is read here rather than through a fallback on the
+    # option, so that an address exported for the consul CLI is never copied
+    # into the module arguments, which ansible-core echoes back with the
+    # result before a module can mask anything.
+    url = (params["url"] or os.environ.get("CONSUL_HTTP_ADDR") or "").strip()
+    if params["url"]:
+        password = url_password(url)
+        if password:
+            module.no_log_values.add(password)
     if all(params[name] is not None for name in CONNECTION_DEFAULTS):
-        # Everything is set explicitly, so neither addr nor the environment can
-        # contribute anything. Do not even look at them: a task that spells out
-        # its connection must not be broken by an address exported for the
-        # consul CLI that these modules happen not to support.
+        # Everything is set explicitly, so neither the address nor the
+        # environment can contribute anything. Do not even look at them: a task
+        # that spells out its connection must not be broken by an address
+        # exported for the consul CLI that these modules cannot use.
         return
     components: dict[str, t.Any] = {}
-    addr = params["addr"]
-    if addr and addr.strip():
-        addr = addr.strip()
-        password = addr_password(addr)
-        if password:
-            # ansible-core echoes the module arguments back with the result, so
-            # an embedded password has to be registered to be masked there.
-            module.no_log_values.add(password)
+    if url:
         try:
-            components = parse_addr(addr)
+            components = parse_url(url)
         except ValueError as exc:
             module.fail_json(
-                msg=f"The Consul address given in the addr option or the CONSUL_HTTP_ADDR environment variable {exc}."
+                msg=f"The Consul address given in the url option or the CONSUL_HTTP_ADDR environment variable {exc}."
             )
     if params["scheme"] is None:
         tls = os.environ.get("CONSUL_HTTP_SSL")
@@ -169,7 +183,7 @@ def resolve_connection_params(module: AnsibleModule) -> None:
 
 
 AUTH_ARGUMENTS_SPEC = dict(
-    addr=dict(fallback=(nonempty_env_fallback, ["CONSUL_HTTP_ADDR"])),
+    url=dict(),
     host=dict(),
     port=dict(type="int"),
     scheme=dict(),

--- a/plugins/module_utils/_consul.py
+++ b/plugins/module_utils/_consul.py
@@ -100,13 +100,13 @@ def env_consul_scheme(*args: t.Any, **kwargs: t.Any) -> str:
     # A true CONSUL_HTTP_SSL forces https. A false one does NOT downgrade an
     # https scheme in CONSUL_HTTP_ADDR, matching the consul CLI, which never
     # reverts to http when TLS was explicitly requested.
-    ssl = os.environ.get("CONSUL_HTTP_SSL")
-    if ssl:
+    tls = os.environ.get("CONSUL_HTTP_SSL")
+    if tls:
         try:
-            use_ssl = boolean(ssl, strict=True)
+            use_tls = boolean(tls, strict=True)
         except (TypeError, ValueError) as exc:
-            raise ValueError(f"CONSUL_HTTP_SSL ({ssl}) is not a valid boolean") from exc
-        if use_ssl:
+            raise ValueError(f"CONSUL_HTTP_SSL ({tls}) is not a valid boolean") from exc
+        if use_tls:
             return "https"
     parsed = parse_consul_http_addr()
     if parsed is not None and parsed.scheme:

--- a/plugins/module_utils/_consul.py
+++ b/plugins/module_utils/_consul.py
@@ -56,7 +56,7 @@ def handle_consul_response_error(response):
         raise RequestError(f"{response.status_code} {response.content}")
 
 
-@lru_cache(maxsize=None)
+@lru_cache
 def _parse_addr(addr: str) -> ParseResult | None:
     # Cached per address so the warning below fires once even though the host,
     # port and scheme fallbacks each parse the variable independently.

--- a/plugins/module_utils/_consul.py
+++ b/plugins/module_utils/_consul.py
@@ -13,13 +13,11 @@ import json
 import os
 import re
 import typing as t
-from functools import lru_cache
 from http import HTTPStatus
 from urllib import error as urllib_error
-from urllib.parse import ParseResult, quote, urlencode, urlparse
+from urllib.parse import quote, urlencode, urlparse
 
 from ansible.module_utils.basic import AnsibleFallbackNotFound
-from ansible.module_utils.common.warnings import warn
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.urls import open_url
 
@@ -56,85 +54,6 @@ def handle_consul_response_error(response):
         raise RequestError(f"{response.status_code} {response.content}")
 
 
-@lru_cache
-def _parse_addr(addr: str) -> ParseResult | None:
-    # Cached per address so the warning below fires once even though the host,
-    # port and scheme fallbacks each parse the variable independently.
-    try:
-        # CONSUL_HTTP_ADDR accepts both host:port and scheme://host:port.
-        # urlparse needs the leading // to treat the former as a netloc.
-        parsed = urlparse(addr if "://" in addr else "//" + addr)
-        # The variable may be set for the consul CLI, which also accepts unix://
-        # sockets, path prefixes, credentials and query strings. The modules
-        # cannot honor those faithfully, so such addresses are ignored rather
-        # than half-used, keeping playbooks that never relied on the variable
-        # working as before.
-        if parsed.scheme and parsed.scheme not in ("http", "https"):
-            return None
-        if parsed.path and parsed.path != "/":
-            return None
-        if parsed.query or parsed.fragment or parsed.username is not None:
-            return None
-        if not parsed.hostname:
-            return None
-        # A mangled netloc (unbracketed IPv6, garbage port) must never hand
-        # out any component, so trigger port validation here for every
-        # consumer.
-        parsed.port  # noqa: B018
-    except ValueError:
-        # Fallbacks may only raise AnsibleFallbackNotFound, anything else
-        # escapes ansible-core's argument handling as a traceback. Warn
-        # without echoing the value, which may embed credentials.
-        warn("The value of the CONSUL_HTTP_ADDR environment variable cannot be parsed and is ignored")
-        return None
-    return parsed
-
-
-def parse_consul_http_addr() -> ParseResult | None:
-    addr = os.environ.get("CONSUL_HTTP_ADDR", "").strip()
-    if not addr:
-        return None
-    return _parse_addr(addr)
-
-
-def env_consul_host(*args: t.Any, **kwargs: t.Any) -> str:
-    parsed = parse_consul_http_addr()
-    if parsed is not None and parsed.hostname:
-        # Re-bracket IPv6 addresses so composed URLs stay valid.
-        return f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
-    raise AnsibleFallbackNotFound
-
-
-def env_consul_port(*args: t.Any, **kwargs: t.Any) -> int:
-    parsed = parse_consul_http_addr()
-    if parsed is not None and parsed.port is not None:
-        return parsed.port
-    raise AnsibleFallbackNotFound
-
-
-def env_consul_scheme(*args: t.Any, **kwargs: t.Any) -> str:
-    # A true CONSUL_HTTP_SSL forces https. A false one does NOT downgrade an
-    # https scheme in CONSUL_HTTP_ADDR, matching the consul CLI, which never
-    # reverts to http when TLS was explicitly requested.
-    tls = os.environ.get("CONSUL_HTTP_SSL")
-    if tls:
-        try:
-            use_tls = boolean(tls, strict=True)
-        except (TypeError, ValueError):
-            # Fallbacks may only raise AnsibleFallbackNotFound, so this cannot
-            # fail the module. Assume TLS rather than plaintext: the safe
-            # failure mode is a refused connection, not a token sent over
-            # http. Like above, do not echo the value.
-            warn("The value of the CONSUL_HTTP_SSL environment variable is not a valid boolean and is treated as true")
-            use_tls = True
-        if use_tls:
-            return "https"
-    parsed = parse_consul_http_addr()
-    if parsed is not None and parsed.scheme:
-        return parsed.scheme
-    raise AnsibleFallbackNotFound
-
-
 def nonempty_env_fallback(*names: str) -> str:
     # Like env_fallback, but a variable that is set to an empty string counts
     # as unset, matching how the consul CLI reads its environment.
@@ -145,10 +64,115 @@ def nonempty_env_fallback(*names: str) -> str:
     raise AnsibleFallbackNotFound
 
 
+CONNECTION_DEFAULTS: dict[str, t.Any] = {"host": "localhost", "port": 8500, "scheme": "http"}
+
+
+def addr_password(addr: str) -> str | None:
+    """Return the password embedded in an address, if it carries one."""
+    try:
+        return urlparse(addr if "://" in addr else "//" + addr).password
+    except ValueError:
+        return None
+
+
+def parse_addr(addr: str) -> dict[str, t.Any]:
+    """Split an address into the connection components it specifies.
+
+    Accepts the ``host:port`` and ``scheme://host:port`` forms, where the
+    scheme and the port are optional. Raises :class:`ValueError` with a reason
+    for addresses these modules cannot use. The reason never repeats the
+    address itself, which may embed credentials.
+    """
+    try:
+        # urlparse only reads a netloc after a scheme, so a bare host:port
+        # needs the leading slashes.
+        parsed = urlparse(addr if "://" in addr else "//" + addr)
+        scheme, hostname, port = parsed.scheme, parsed.hostname, parsed.port
+    except ValueError as exc:
+        # urlparse itself rejects a mangled netloc, an unbracketed IPv6
+        # address for instance, and .port rejects a non-numeric port.
+        raise ValueError("cannot be parsed") from exc
+    if scheme and scheme not in ("http", "https"):
+        # unix:// sockets in particular: the modules speak HTTP over TCP only.
+        raise ValueError(f"uses the unsupported scheme {scheme}, only http and https work")
+    if parsed.path not in ("", "/") or parsed.params:
+        # urlparse splits a trailing ;suffix of the path off into params, so
+        # both have to be checked to reject an address that carries a path.
+        raise ValueError("must not contain a path")
+    if parsed.query or parsed.fragment:
+        raise ValueError("must not contain a query or a fragment")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("must not contain credentials")
+    if not hostname:
+        raise ValueError("does not contain a host")
+    if any(char.isspace() or not char.isprintable() for char in hostname):
+        # urlparse keeps these in the host, where they would only surface much
+        # later as an unrelated error from the HTTP layer.
+        raise ValueError("contains a host with whitespace or control characters")
+    components: dict[str, t.Any] = {}
+    # Re-bracket IPv6 addresses so the composed URL stays valid.
+    components["host"] = f"[{hostname}]" if ":" in hostname else hostname
+    if port is not None:
+        components["port"] = port
+    if scheme:
+        components["scheme"] = scheme
+    return components
+
+
+def resolve_connection_params(module: AnsibleModule) -> None:
+    """Fill in host, port and scheme, in place.
+
+    An explicitly set option wins over the matching component of ``addr``,
+    which wins over the default. Options left unset are still ``None`` at this
+    point, since these three carry no default in the argument spec: ansible-core
+    applies spec defaults before a module runs, which would make an explicit
+    value indistinguishable from a default.
+    """
+    params = module.params
+    if all(params[name] is not None for name in CONNECTION_DEFAULTS):
+        # Everything is set explicitly, so neither addr nor the environment can
+        # contribute anything. Do not even look at them: a task that spells out
+        # its connection must not be broken by an address exported for the
+        # consul CLI that these modules happen not to support.
+        return
+    components: dict[str, t.Any] = {}
+    addr = params["addr"]
+    if addr and addr.strip():
+        addr = addr.strip()
+        password = addr_password(addr)
+        if password:
+            # ansible-core echoes the module arguments back with the result, so
+            # an embedded password has to be registered to be masked there.
+            module.no_log_values.add(password)
+        try:
+            components = parse_addr(addr)
+        except ValueError as exc:
+            module.fail_json(
+                msg=f"The Consul address given in the addr option or the CONSUL_HTTP_ADDR environment variable {exc}."
+            )
+    if params["scheme"] is None:
+        tls = os.environ.get("CONSUL_HTTP_SSL")
+        if tls:
+            try:
+                use_tls = boolean(tls, strict=True)
+            except (TypeError, ValueError):
+                module.fail_json(msg="The CONSUL_HTTP_SSL environment variable is not a valid boolean.")
+            # A true CONSUL_HTTP_SSL selects https even when the address says
+            # http. A false one does not downgrade an https address, matching
+            # the consul CLI, which never reverts to http once TLS was asked
+            # for.
+            if use_tls:
+                components["scheme"] = "https"
+    for name, default in CONNECTION_DEFAULTS.items():
+        if params[name] is None:
+            params[name] = components.get(name, default)
+
+
 AUTH_ARGUMENTS_SPEC = dict(
-    host=dict(default="localhost", fallback=(env_consul_host,)),
-    port=dict(type="int", default=8500, fallback=(env_consul_port,)),
-    scheme=dict(default="http", fallback=(env_consul_scheme,)),
+    addr=dict(fallback=(nonempty_env_fallback, ["CONSUL_HTTP_ADDR"])),
+    host=dict(),
+    port=dict(type="int"),
+    scheme=dict(),
     validate_certs=dict(type="bool", default=True, fallback=(nonempty_env_fallback, ["CONSUL_HTTP_SSL_VERIFY"])),
     token=dict(no_log=True, fallback=(nonempty_env_fallback, ["CONSUL_HTTP_TOKEN"])),
     ca_path=dict(fallback=(nonempty_env_fallback, ["CONSUL_CACERT"])),
@@ -224,6 +248,7 @@ class _ConsulModule:
 
     def __init__(self, module: AnsibleModule) -> None:
         self._module = module
+        resolve_connection_params(module)
         self.params = _normalize_params(module.params, module.argument_spec)
         self.api_params = {
             k: camel_case_key(k) for k in self.params if k not in STATE_PARAMETER and k not in AUTH_ARGUMENTS_SPEC

--- a/tests/unit/plugins/module_utils/test__consul.py
+++ b/tests/unit/plugins/module_utils/test__consul.py
@@ -193,6 +193,7 @@ def test_nonempty_env_fallback_unset(monkeypatch, env, names):
 # The cases below run the spec through ansible-core's own argument handling,
 # pinning the fallback contract itself rather than the callables in isolation.
 
+
 def validate_spec():
     return ModuleArgumentSpecValidator(_consul.AUTH_ARGUMENTS_SPEC).validate({})
 

--- a/tests/unit/plugins/module_utils/test__consul.py
+++ b/tests/unit/plugins/module_utils/test__consul.py
@@ -5,7 +5,11 @@
 from __future__ import annotations
 
 import pytest
+from ansible.module_utils import _internal
 from ansible.module_utils.basic import AnsibleFallbackNotFound
+from ansible.module_utils.common import warnings as _warnings
+from ansible.module_utils.common.arg_spec import ModuleArgumentSpecValidator
+from ansible.module_utils.common.warnings import get_warning_messages
 
 from ansible_collections.community.general.plugins.module_utils import _consul
 
@@ -14,6 +18,13 @@ from ansible_collections.community.general.plugins.module_utils import _consul
 def scrub_consul_env(monkeypatch):
     for name in ("CONSUL_HTTP_ADDR", "CONSUL_HTTP_SSL", "CONSUL_HTTP_SSL_VERIFY", "CONSUL_HTTP_TOKEN", "CONSUL_CACERT"):
         monkeypatch.delenv(name, raising=False)
+    # The parse cache and the warning store are process-global; both must be
+    # fresh so warning assertions cannot leak between cases. warn() only
+    # records to the store when not running as controller code, so pin the
+    # flag like ansible-core's own warning tests do (absent on older cores).
+    _consul._parse_addr.cache_clear()
+    monkeypatch.setattr(_warnings, "_global_warnings", type(_warnings._global_warnings)())
+    monkeypatch.setattr(_internal, "is_controller", False, raising=False)
 
 
 HOST_CASES = [
@@ -83,7 +94,11 @@ FALLBACK_NOT_FOUND_CASES = [
     ({"CONSUL_HTTP_ADDR": "http://user:pass@consul.example.com:8500"}, _consul.env_consul_host),
     ({"CONSUL_HTTP_ADDR": "http://consul.example.com:8500?dc=dc1"}, _consul.env_consul_host),
     ({"CONSUL_HTTP_ADDR": "   "}, _consul.env_consul_host),
+    # an address without a host is ignored entirely, no component is half-used
     ({"CONSUL_HTTP_ADDR": "http://:8500"}, _consul.env_consul_host),
+    ({"CONSUL_HTTP_ADDR": "http://:8500"}, _consul.env_consul_port),
+    ({"CONSUL_HTTP_ADDR": "https://"}, _consul.env_consul_scheme),
+    ({"CONSUL_HTTP_ADDR": ":8500"}, _consul.env_consul_port),
 ]
 
 
@@ -93,6 +108,7 @@ def test_fallback_not_found(monkeypatch, env, func):
         monkeypatch.setenv(key, value)
     with pytest.raises(AnsibleFallbackNotFound):
         func()
+    assert get_warning_messages() == ()
 
 
 def test_trailing_slash_is_tolerated(monkeypatch):
@@ -102,21 +118,49 @@ def test_trailing_slash_is_tolerated(monkeypatch):
     assert _consul.env_consul_scheme() == "https"
 
 
-ERROR_CASES = [
-    # (env, callable, message fragment)
-    ({"CONSUL_HTTP_ADDR": "consul.example.com:notaport"}, _consul.env_consul_port, "CONSUL_HTTP_ADDR"),
-    ({"CONSUL_HTTP_ADDR": "consul.example.com:notaport"}, _consul.env_consul_host, "CONSUL_HTTP_ADDR"),
-    ({"CONSUL_HTTP_ADDR": "2001:db8::1"}, _consul.env_consul_host, "CONSUL_HTTP_ADDR"),
-    ({"CONSUL_HTTP_SSL": "maybe"}, _consul.env_consul_scheme, "CONSUL_HTTP_SSL"),
+# Fallback callables may only raise AnsibleFallbackNotFound; ansible-core's
+# set_fallbacks catches nothing else, so an unparsable value must warn and
+# fall back instead of raising. Only shapes every supported Python rejects
+# belong here: newer interpreters reject more bracket forms than older ones.
+MALFORMED_ADDR_CASES = [
+    "consul.example.com:notaport",
+    "consul.example.com:99999",
+    "2001:db8::1",
+    "[::1",
 ]
 
 
-@pytest.mark.parametrize("env, func, fragment", ERROR_CASES)
-def test_invalid_values_fail_loud(monkeypatch, env, func, fragment):
-    for key, value in env.items():
-        monkeypatch.setenv(key, value)
-    with pytest.raises(ValueError, match=fragment):
+@pytest.mark.parametrize("addr", MALFORMED_ADDR_CASES)
+@pytest.mark.parametrize("func", [_consul.env_consul_host, _consul.env_consul_port, _consul.env_consul_scheme])
+def test_malformed_addr_warns_and_falls_back(monkeypatch, addr, func):
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
+    with pytest.raises(AnsibleFallbackNotFound):
         func()
+    warnings = get_warning_messages()
+    assert len(warnings) == 1
+    assert "CONSUL_HTTP_ADDR" in warnings[0]
+    # the value may embed credentials, so the warning must not echo it
+    assert addr not in warnings[0]
+
+
+def test_malformed_addr_warns_once_across_consumers(monkeypatch):
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", "[::1")
+    for func in (_consul.env_consul_host, _consul.env_consul_port, _consul.env_consul_scheme):
+        with pytest.raises(AnsibleFallbackNotFound):
+            func()
+    assert len(get_warning_messages()) == 1
+
+
+def test_invalid_ssl_boolean_warns_and_selects_https(monkeypatch):
+    # An unparsable CONSUL_HTTP_SSL must not silently pick plaintext: the
+    # token fallback would still apply and be sent over http.
+    monkeypatch.setenv("CONSUL_HTTP_SSL", "maybe")
+    assert _consul.env_consul_scheme() == "https"
+    warnings = get_warning_messages()
+    assert len(warnings) == 1
+    assert "CONSUL_HTTP_SSL" in warnings[0]
+    # a value in the wrong variable may be a credential, never echo it
+    assert "maybe" not in warnings[0]
 
 
 NONEMPTY_FALLBACK_CASES = [
@@ -144,3 +188,62 @@ def test_nonempty_env_fallback_unset(monkeypatch, env, names):
         monkeypatch.setenv(key, value)
     with pytest.raises(AnsibleFallbackNotFound):
         _consul.nonempty_env_fallback(*names)
+
+
+# The cases below run the spec through ansible-core's own argument handling,
+# pinning the fallback contract itself rather than the callables in isolation.
+
+def validate_spec():
+    return ModuleArgumentSpecValidator(_consul.AUTH_ARGUMENTS_SPEC).validate({})
+
+
+def test_spec_resolves_env(monkeypatch):
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", "https://consul.example.com:8501")
+    monkeypatch.setenv("CONSUL_HTTP_TOKEN", "tok")
+    monkeypatch.setenv("CONSUL_HTTP_SSL_VERIFY", "false")
+    monkeypatch.setenv("CONSUL_CACERT", "/etc/ssl/ca.pem")
+    result = validate_spec()
+    assert result.error_messages == []
+    parameters = result.validated_parameters
+    assert parameters["host"] == "consul.example.com"
+    assert parameters["port"] == 8501
+    assert parameters["scheme"] == "https"
+    assert parameters["token"] == "tok"
+    assert parameters["validate_certs"] is False
+    assert parameters["ca_path"] == "/etc/ssl/ca.pem"
+
+
+def test_spec_defaults_without_env():
+    result = validate_spec()
+    assert result.error_messages == []
+    parameters = result.validated_parameters
+    assert parameters["host"] == "localhost"
+    assert parameters["port"] == 8500
+    assert parameters["scheme"] == "http"
+    assert parameters["token"] is None
+
+
+@pytest.mark.parametrize("addr", MALFORMED_ADDR_CASES)
+def test_spec_survives_malformed_addr(monkeypatch, addr):
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
+    result = validate_spec()
+    assert result.error_messages == []
+    assert result.validated_parameters["host"] == "localhost"
+    assert result.validated_parameters["port"] == 8500
+    assert len(get_warning_messages()) == 1
+
+
+def test_spec_survives_invalid_ssl_boolean(monkeypatch):
+    monkeypatch.setenv("CONSUL_HTTP_SSL", "maybe")
+    result = validate_spec()
+    assert result.error_messages == []
+    assert result.validated_parameters["scheme"] == "https"
+    assert len(get_warning_messages()) == 1
+
+
+def test_spec_rejects_invalid_ssl_verify_cleanly(monkeypatch):
+    # garbage CONSUL_HTTP_SSL_VERIFY reaches the type='bool' coercion and must
+    # surface as a clean validation error, never an exception
+    monkeypatch.setenv("CONSUL_HTTP_SSL_VERIFY", "maybe")
+    result = validate_spec()
+    assert result.error_messages

--- a/tests/unit/plugins/module_utils/test__consul.py
+++ b/tests/unit/plugins/module_utils/test__consul.py
@@ -1,0 +1,146 @@
+# Copyright (c) Ansible project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import pytest
+from ansible.module_utils.basic import AnsibleFallbackNotFound
+
+from ansible_collections.community.general.plugins.module_utils import _consul
+
+
+@pytest.fixture(autouse=True)
+def scrub_consul_env(monkeypatch):
+    for name in ("CONSUL_HTTP_ADDR", "CONSUL_HTTP_SSL", "CONSUL_HTTP_SSL_VERIFY", "CONSUL_HTTP_TOKEN", "CONSUL_CACERT"):
+        monkeypatch.delenv(name, raising=False)
+
+
+HOST_CASES = [
+    ("consul.example.com:8500", "consul.example.com"),
+    ("http://consul.example.com:8500", "consul.example.com"),
+    ("https://consul.example.com", "consul.example.com"),
+    ("consul.example.com", "consul.example.com"),
+    ("[2001:db8::1]:8500", "[2001:db8::1]"),
+]
+
+
+@pytest.mark.parametrize("addr, expected", HOST_CASES)
+def test_env_consul_host(monkeypatch, addr, expected):
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
+    assert _consul.env_consul_host() == expected
+
+
+PORT_CASES = [
+    ("consul.example.com:8501", 8501),
+    ("https://consul.example.com:8501", 8501),
+    ("[2001:db8::1]:8500", 8500),
+]
+
+
+@pytest.mark.parametrize("addr, expected", PORT_CASES)
+def test_env_consul_port(monkeypatch, addr, expected):
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
+    assert _consul.env_consul_port() == expected
+
+
+SCHEME_CASES = [
+    # (CONSUL_HTTP_SSL, CONSUL_HTTP_ADDR, expected)
+    ("true", None, "https"),
+    ("1", None, "https"),
+    ("true", "http://consul.example.com:8500", "https"),
+    # a false CONSUL_HTTP_SSL must not downgrade an https address
+    ("false", "https://consul.example.com:8500", "https"),
+    (None, "https://consul.example.com:8500", "https"),
+    (None, "http://consul.example.com:8500", "http"),
+]
+
+
+@pytest.mark.parametrize("ssl, addr, expected", SCHEME_CASES)
+def test_env_consul_scheme(monkeypatch, ssl, addr, expected):
+    if ssl is not None:
+        monkeypatch.setenv("CONSUL_HTTP_SSL", ssl)
+    if addr is not None:
+        monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
+    assert _consul.env_consul_scheme() == expected
+
+
+FALLBACK_NOT_FOUND_CASES = [
+    # (env, callable) -> no usable value in the environment
+    ({}, _consul.env_consul_host),
+    ({}, _consul.env_consul_port),
+    ({}, _consul.env_consul_scheme),
+    ({"CONSUL_HTTP_ADDR": "consul.example.com"}, _consul.env_consul_port),
+    ({"CONSUL_HTTP_ADDR": "consul.example.com:8500"}, _consul.env_consul_scheme),
+    ({"CONSUL_HTTP_SSL": "false"}, _consul.env_consul_scheme),
+    # set-but-empty variables count as unset, like the consul CLI treats them
+    ({"CONSUL_HTTP_ADDR": ""}, _consul.env_consul_host),
+    ({"CONSUL_HTTP_SSL": ""}, _consul.env_consul_scheme),
+    # addresses the consul CLI accepts but the modules cannot honor faithfully
+    # are ignored, so playbooks that never relied on the variable keep working
+    ({"CONSUL_HTTP_ADDR": "unix:///var/run/consul.sock"}, _consul.env_consul_host),
+    ({"CONSUL_HTTP_ADDR": "https://proxy.example.com:443/consul"}, _consul.env_consul_host),
+    ({"CONSUL_HTTP_ADDR": "http://user:pass@consul.example.com:8500"}, _consul.env_consul_host),
+    ({"CONSUL_HTTP_ADDR": "http://consul.example.com:8500?dc=dc1"}, _consul.env_consul_host),
+    ({"CONSUL_HTTP_ADDR": "   "}, _consul.env_consul_host),
+    ({"CONSUL_HTTP_ADDR": "http://:8500"}, _consul.env_consul_host),
+]
+
+
+@pytest.mark.parametrize("env, func", FALLBACK_NOT_FOUND_CASES)
+def test_fallback_not_found(monkeypatch, env, func):
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    with pytest.raises(AnsibleFallbackNotFound):
+        func()
+
+
+def test_trailing_slash_is_tolerated(monkeypatch):
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", "https://consul.example.com:8501/")
+    assert _consul.env_consul_host() == "consul.example.com"
+    assert _consul.env_consul_port() == 8501
+    assert _consul.env_consul_scheme() == "https"
+
+
+ERROR_CASES = [
+    # (env, callable, message fragment)
+    ({"CONSUL_HTTP_ADDR": "consul.example.com:notaport"}, _consul.env_consul_port, "CONSUL_HTTP_ADDR"),
+    ({"CONSUL_HTTP_ADDR": "consul.example.com:notaport"}, _consul.env_consul_host, "CONSUL_HTTP_ADDR"),
+    ({"CONSUL_HTTP_ADDR": "2001:db8::1"}, _consul.env_consul_host, "CONSUL_HTTP_ADDR"),
+    ({"CONSUL_HTTP_SSL": "maybe"}, _consul.env_consul_scheme, "CONSUL_HTTP_SSL"),
+]
+
+
+@pytest.mark.parametrize("env, func, fragment", ERROR_CASES)
+def test_invalid_values_fail_loud(monkeypatch, env, func, fragment):
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    with pytest.raises(ValueError, match=fragment):
+        func()
+
+
+NONEMPTY_FALLBACK_CASES = [
+    ({"CONSUL_HTTP_TOKEN": "tok"}, ["CONSUL_HTTP_TOKEN"], "tok"),
+    ({"CONSUL_CACERT": "/etc/ssl/ca.pem"}, ["CONSUL_CACERT"], "/etc/ssl/ca.pem"),
+]
+
+
+@pytest.mark.parametrize("env, names, expected", NONEMPTY_FALLBACK_CASES)
+def test_nonempty_env_fallback(monkeypatch, env, names, expected):
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    assert _consul.nonempty_env_fallback(*names) == expected
+
+
+NONEMPTY_FALLBACK_UNSET_CASES = [
+    ({}, ["CONSUL_HTTP_TOKEN"]),
+    ({"CONSUL_HTTP_TOKEN": ""}, ["CONSUL_HTTP_TOKEN"]),
+]
+
+
+@pytest.mark.parametrize("env, names", NONEMPTY_FALLBACK_UNSET_CASES)
+def test_nonempty_env_fallback_unset(monkeypatch, env, names):
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    with pytest.raises(AnsibleFallbackNotFound):
+        _consul.nonempty_env_fallback(*names)

--- a/tests/unit/plugins/module_utils/test__consul.py
+++ b/tests/unit/plugins/module_utils/test__consul.py
@@ -56,10 +56,10 @@ SCHEME_CASES = [
 ]
 
 
-@pytest.mark.parametrize("ssl, addr, expected", SCHEME_CASES)
-def test_env_consul_scheme(monkeypatch, ssl, addr, expected):
-    if ssl is not None:
-        monkeypatch.setenv("CONSUL_HTTP_SSL", ssl)
+@pytest.mark.parametrize("tls, addr, expected", SCHEME_CASES)
+def test_env_consul_scheme(monkeypatch, tls, addr, expected):
+    if tls is not None:
+        monkeypatch.setenv("CONSUL_HTTP_SSL", tls)
     if addr is not None:
         monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
     assert _consul.env_consul_scheme() == expected

--- a/tests/unit/plugins/module_utils/test__consul.py
+++ b/tests/unit/plugins/module_utils/test__consul.py
@@ -51,8 +51,8 @@ def resolve(explicit=None):
     return module.params
 
 
-ADDR_CASES = [
-    # (addr, host, port, scheme)
+URL_CASES = [
+    # (url, host, port, scheme)
     ("consul.example.com:8501", "consul.example.com", 8501, "http"),
     ("http://consul.example.com:8501", "consul.example.com", 8501, "http"),
     ("https://consul.example.com:8501", "consul.example.com", 8501, "https"),
@@ -66,28 +66,28 @@ ADDR_CASES = [
 ]
 
 
-@pytest.mark.parametrize("addr, host, port, scheme", ADDR_CASES)
-def test_addr_option_components(addr, host, port, scheme):
-    params = resolve({"addr": addr})
+@pytest.mark.parametrize("url, host, port, scheme", URL_CASES)
+def test_url_option_components(url, host, port, scheme):
+    params = resolve({"url": url})
     assert (params["host"], params["port"], params["scheme"]) == (host, port, scheme)
 
 
-@pytest.mark.parametrize("addr, host, port, scheme", ADDR_CASES)
-def test_addr_environment_components(monkeypatch, addr, host, port, scheme):
-    monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
+@pytest.mark.parametrize("url, host, port, scheme", URL_CASES)
+def test_url_environment_components(monkeypatch, url, host, port, scheme):
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", url)
     params = resolve()
     assert (params["host"], params["port"], params["scheme"]) == (host, port, scheme)
 
 
-def test_defaults_without_addr():
+def test_defaults_without_url():
     params = resolve()
     assert (params["host"], params["port"], params["scheme"]) == ("localhost", 8500, "http")
 
 
 EXPLICIT_WINS_CASES = [
     ({"host": "explicit.example.com"}, "explicit.example.com", 8501, "https"),
-    ({"port": 9999}, "addr.example.com", 9999, "https"),
-    ({"scheme": "http"}, "addr.example.com", 8501, "http"),
+    ({"port": 9999}, "env.example.com", 9999, "https"),
+    ({"scheme": "http"}, "env.example.com", 8501, "http"),
     (
         {"host": "explicit.example.com", "port": 9999, "scheme": "http"},
         "explicit.example.com",
@@ -98,20 +98,20 @@ EXPLICIT_WINS_CASES = [
 
 
 @pytest.mark.parametrize("explicit, host, port, scheme", EXPLICIT_WINS_CASES)
-def test_explicit_options_win_over_addr(monkeypatch, explicit, host, port, scheme):
-    monkeypatch.setenv("CONSUL_HTTP_ADDR", "https://addr.example.com:8501")
+def test_explicit_options_win_over_url(monkeypatch, explicit, host, port, scheme):
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", "https://env.example.com:8501")
     params = resolve(explicit)
     assert (params["host"], params["port"], params["scheme"]) == (host, port, scheme)
 
 
-def test_addr_option_wins_over_environment(monkeypatch):
+def test_url_option_wins_over_environment(monkeypatch):
     monkeypatch.setenv("CONSUL_HTTP_ADDR", "http://environment.example.com:8500")
-    params = resolve({"addr": "https://option.example.com:8501"})
+    params = resolve({"url": "https://option.example.com:8501"})
     assert (params["host"], params["port"], params["scheme"]) == ("option.example.com", 8501, "https")
 
 
 SSL_CASES = [
-    # (CONSUL_HTTP_SSL, addr, expected scheme)
+    # (CONSUL_HTTP_SSL, url, expected scheme)
     ("true", None, "https"),
     ("1", None, "https"),
     ("yes", None, "https"),
@@ -126,11 +126,11 @@ SSL_CASES = [
 ]
 
 
-@pytest.mark.parametrize("tls, addr, scheme", SSL_CASES)
-def test_consul_http_ssl(monkeypatch, tls, addr, scheme):
+@pytest.mark.parametrize("tls, url, scheme", SSL_CASES)
+def test_consul_http_ssl(monkeypatch, tls, url, scheme):
     monkeypatch.setenv("CONSUL_HTTP_SSL", tls)
-    if addr is not None:
-        monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
+    if url is not None:
+        monkeypatch.setenv("CONSUL_HTTP_ADDR", url)
     assert resolve()["scheme"] == scheme
 
 
@@ -142,7 +142,7 @@ def test_explicit_scheme_wins_over_consul_http_ssl(monkeypatch):
 # Addresses these modules cannot use fail instead of silently connecting
 # somewhere else. Only shapes every supported Python rejects belong in the
 # parse-failure cases: newer interpreters reject more bracket forms.
-UNUSABLE_ADDR_CASES = [
+UNUSABLE_URL_CASES = [
     ("unix:///var/run/consul.sock", "unsupported scheme"),
     ("ftp://consul.example.com:8500", "unsupported scheme"),
     ("https://consul.example.com:8500/prefix", "must not contain a path"),
@@ -157,29 +157,39 @@ UNUSABLE_ADDR_CASES = [
 ]
 
 
-@pytest.mark.parametrize("addr, reason", UNUSABLE_ADDR_CASES)
-def test_unusable_addr_option_fails(addr, reason):
+@pytest.mark.parametrize("url, reason", UNUSABLE_URL_CASES)
+def test_unusable_url_option_fails(url, reason):
     with pytest.raises(FailJson) as exc:
-        resolve({"addr": addr})
+        resolve({"url": url})
     assert reason in str(exc.value)
     # the address may embed credentials, so the failure must not repeat it
-    assert addr not in str(exc.value)
+    assert url not in str(exc.value)
 
 
-@pytest.mark.parametrize("addr, reason", UNUSABLE_ADDR_CASES)
-def test_unusable_addr_environment_fails(monkeypatch, addr, reason):
-    monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
+@pytest.mark.parametrize("url, reason", UNUSABLE_URL_CASES)
+def test_unusable_url_environment_fails(monkeypatch, url, reason):
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", url)
     with pytest.raises(FailJson) as exc:
         resolve()
     assert reason in str(exc.value)
-    assert addr not in str(exc.value)
+    assert url not in str(exc.value)
 
 
-@pytest.mark.parametrize("addr, reason", UNUSABLE_ADDR_CASES)
-def test_unusable_addr_is_ignored_when_nothing_is_needed(monkeypatch, addr, reason):
+def test_parse_failure_does_not_reuse_the_underlying_message(monkeypatch):
+    # The message for a netloc that fails NFKC normalization quotes the whole
+    # netloc, credentials included, so it must not be passed on.
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", "http://user:s3cr3t@consul℀.example.com:8500")
+    with pytest.raises(FailJson) as exc:
+        resolve()
+    assert "cannot be parsed" in str(exc.value)
+    assert "s3cr3t" not in str(exc.value)
+
+
+@pytest.mark.parametrize("url, reason", UNUSABLE_URL_CASES)
+def test_unusable_url_is_ignored_when_nothing_is_needed(monkeypatch, url, reason):
     # A task that spells out its connection must not be broken by an address
     # exported for the consul CLI that these modules happen not to support.
-    monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", url)
     params = resolve({"host": "consul.example.com", "port": 8501, "scheme": "https"})
     assert (params["host"], params["port"], params["scheme"]) == ("consul.example.com", 8501, "https")
 
@@ -190,29 +200,65 @@ def test_invalid_consul_http_ssl_is_ignored_when_scheme_is_set(monkeypatch):
     assert params["scheme"] == "https"
 
 
-def test_embedded_password_is_registered_for_masking(monkeypatch):
-    # ansible-core echoes the module arguments back with the result, so a
-    # password in the address has to be masked there as well as kept out of
-    # the failure message.
-    monkeypatch.setenv("CONSUL_HTTP_ADDR", "https://user:s3cr3t@consul.example.com:8501")
-    result = ModuleArgumentSpecValidator(_consul.AUTH_ARGUMENTS_SPEC).validate({})
+MASKING_CASES = [
+    # a url given as an option is echoed back with the result, so a password in
+    # it has to be registered for masking whatever else happens to the value
+    "https://user:s3cr3t@consul.example.com:8501",
+    "http://user:s3cr3t@consul\u2100.example.com:8500",
+    "http://user:s3cr3t@[::1",
+    "http://user:s3cr3t@consul.example.com:notaport",
+]
+
+
+@pytest.mark.parametrize("url", MASKING_CASES)
+def test_password_in_the_url_option_is_registered_for_masking(url):
+    result = ModuleArgumentSpecValidator(_consul.AUTH_ARGUMENTS_SPEC).validate({"url": url})
     module = ModuleStub(dict(result.validated_parameters))
-    module.no_log_values = set()
     with pytest.raises(FailJson):
         _consul.resolve_connection_params(module)
     assert "s3cr3t" in module.no_log_values
 
 
-@pytest.mark.parametrize(
-    "addr, password",
-    [
-        ("https://user:s3cr3t@consul.example.com:8501", "s3cr3t"),
-        ("https://consul.example.com:8501", None),
-        ("[::1", None),
-    ],
-)
-def test_addr_password(addr, password):
-    assert _consul.addr_password(addr) == password
+@pytest.mark.parametrize("url", MASKING_CASES)
+def test_password_in_the_url_option_is_registered_even_when_unused(url):
+    # host, port and scheme are all set, so the url is never parsed, but it is
+    # still echoed back with the result
+    result = ModuleArgumentSpecValidator(_consul.AUTH_ARGUMENTS_SPEC).validate(
+        {"url": url, "host": "consul.example.com", "port": 8501, "scheme": "https"}
+    )
+    module = ModuleStub(dict(result.validated_parameters))
+    _consul.resolve_connection_params(module)
+    assert "s3cr3t" in module.no_log_values
+
+
+@pytest.mark.parametrize("url", MASKING_CASES)
+def test_environment_address_never_reaches_the_module_arguments(monkeypatch, url):
+    # CONSUL_HTTP_ADDR is read in code rather than through a fallback, so a
+    # password exported for the consul CLI is never copied where ansible-core
+    # echoes it back
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", url)
+    result = ModuleArgumentSpecValidator(_consul.AUTH_ARGUMENTS_SPEC).validate({})
+    assert result.validated_parameters["url"] is None
+
+
+URL_PASSWORD_CASES = [
+    ("https://user:s3cr3t@consul.example.com:8501", "s3cr3t"),
+    ("user:s3cr3t@consul.example.com:8501", "s3cr3t"),
+    ("http://user:s3cr3t@[::1", "s3cr3t"),
+    # the last @ separates the userinfo, and the first colon in it separates
+    # the password, so the password is everything between, as urlparse reads it
+    ("http://user:p@ss:w0rd@consul.example.com:8501", "p@ss:w0rd"),
+    ("https://consul.example.com:8501", None),
+    ("https://user@consul.example.com:8501", None),
+    ("https://user:@consul.example.com:8501", None),
+    ("consul.example.com:8501", None),
+    ("[::1", None),
+]
+
+
+@pytest.mark.parametrize("url, password", URL_PASSWORD_CASES)
+def test_url_password(url, password):
+    assert _consul.url_password(url) == password
 
 
 @pytest.mark.parametrize("tls", ["maybe", "2", "tru", "null"])
@@ -223,9 +269,9 @@ def test_invalid_consul_http_ssl_fails(monkeypatch, tls):
     assert "CONSUL_HTTP_SSL" in str(exc.value)
 
 
-@pytest.mark.parametrize("addr", ["", "   "])
-def test_blank_addr_is_unset(monkeypatch, addr):
-    monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
+@pytest.mark.parametrize("url", ["", "   "])
+def test_blank_url_is_unset(monkeypatch, url):
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", url)
     params = resolve()
     assert (params["host"], params["port"], params["scheme"]) == ("localhost", 8500, "http")
 
@@ -239,7 +285,6 @@ def test_surrounding_whitespace_is_tolerated(monkeypatch):
 NONEMPTY_FALLBACK_CASES = [
     ("token", "CONSUL_HTTP_TOKEN", "s3cr3t"),
     ("ca_path", "CONSUL_CACERT", "/etc/ssl/ca.pem"),
-    ("addr", "CONSUL_HTTP_ADDR", "consul.example.com"),
 ]
 
 

--- a/tests/unit/plugins/module_utils/test__consul.py
+++ b/tests/unit/plugins/module_utils/test__consul.py
@@ -5,246 +5,281 @@
 from __future__ import annotations
 
 import pytest
-from ansible.module_utils import _internal
 from ansible.module_utils.basic import AnsibleFallbackNotFound
-from ansible.module_utils.common import warnings as _warnings
 from ansible.module_utils.common.arg_spec import ModuleArgumentSpecValidator
-from ansible.module_utils.common.warnings import get_warning_messages
 
 from ansible_collections.community.general.plugins.module_utils import _consul
+
+CONSUL_ENV_VARS = (
+    "CONSUL_HTTP_ADDR",
+    "CONSUL_HTTP_SSL",
+    "CONSUL_HTTP_SSL_VERIFY",
+    "CONSUL_HTTP_TOKEN",
+    "CONSUL_CACERT",
+)
 
 
 @pytest.fixture(autouse=True)
 def scrub_consul_env(monkeypatch):
-    for name in ("CONSUL_HTTP_ADDR", "CONSUL_HTTP_SSL", "CONSUL_HTTP_SSL_VERIFY", "CONSUL_HTTP_TOKEN", "CONSUL_CACERT"):
+    for name in CONSUL_ENV_VARS:
         monkeypatch.delenv(name, raising=False)
-    # The parse cache and the warning store are process-global; both must be
-    # fresh so warning assertions cannot leak between cases. warn() only
-    # records to the store when not running as controller code, so pin the
-    # flag like ansible-core's own warning tests do (absent on older cores).
-    _consul._parse_addr.cache_clear()
-    monkeypatch.setattr(_warnings, "_global_warnings", type(_warnings._global_warnings)())
-    monkeypatch.setattr(_internal, "is_controller", False, raising=False)
 
 
-HOST_CASES = [
-    ("consul.example.com:8500", "consul.example.com"),
-    ("http://consul.example.com:8500", "consul.example.com"),
-    ("https://consul.example.com", "consul.example.com"),
-    ("consul.example.com", "consul.example.com"),
-    ("[2001:db8::1]:8500", "[2001:db8::1]"),
+class FailJson(Exception):
+    pass
+
+
+class ModuleStub:
+    """Just enough AnsibleModule for resolve_connection_params."""
+
+    def __init__(self, params):
+        self.params = params
+        self.fail_msg = None
+        self.no_log_values = set()
+
+    def fail_json(self, msg, **kwargs):
+        self.fail_msg = msg
+        raise FailJson(msg)
+
+
+def resolve(explicit=None):
+    """Run the real argument spec, then the resolution, like a module does."""
+    result = ModuleArgumentSpecValidator(_consul.AUTH_ARGUMENTS_SPEC).validate(explicit or {})
+    assert result.error_messages == []
+    module = ModuleStub(dict(result.validated_parameters))
+    _consul.resolve_connection_params(module)
+    return module.params
+
+
+ADDR_CASES = [
+    # (addr, host, port, scheme)
+    ("consul.example.com:8501", "consul.example.com", 8501, "http"),
+    ("http://consul.example.com:8501", "consul.example.com", 8501, "http"),
+    ("https://consul.example.com:8501", "consul.example.com", 8501, "https"),
+    # each component is optional and falls back on its own
+    ("consul.example.com", "consul.example.com", 8500, "http"),
+    ("https://consul.example.com", "consul.example.com", 8500, "https"),
+    ("https://consul.example.com/", "consul.example.com", 8500, "https"),
+    # IPv6 addresses stay bracketed so the composed URL is valid
+    ("[2001:db8::1]:8501", "[2001:db8::1]", 8501, "http"),
+    ("https://[2001:db8::1]", "[2001:db8::1]", 8500, "https"),
 ]
 
 
-@pytest.mark.parametrize("addr, expected", HOST_CASES)
-def test_env_consul_host(monkeypatch, addr, expected):
+@pytest.mark.parametrize("addr, host, port, scheme", ADDR_CASES)
+def test_addr_option_components(addr, host, port, scheme):
+    params = resolve({"addr": addr})
+    assert (params["host"], params["port"], params["scheme"]) == (host, port, scheme)
+
+
+@pytest.mark.parametrize("addr, host, port, scheme", ADDR_CASES)
+def test_addr_environment_components(monkeypatch, addr, host, port, scheme):
     monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
-    assert _consul.env_consul_host() == expected
+    params = resolve()
+    assert (params["host"], params["port"], params["scheme"]) == (host, port, scheme)
 
 
-PORT_CASES = [
-    ("consul.example.com:8501", 8501),
-    ("https://consul.example.com:8501", 8501),
-    ("[2001:db8::1]:8500", 8500),
+def test_defaults_without_addr():
+    params = resolve()
+    assert (params["host"], params["port"], params["scheme"]) == ("localhost", 8500, "http")
+
+
+EXPLICIT_WINS_CASES = [
+    ({"host": "explicit.example.com"}, "explicit.example.com", 8501, "https"),
+    ({"port": 9999}, "addr.example.com", 9999, "https"),
+    ({"scheme": "http"}, "addr.example.com", 8501, "http"),
+    (
+        {"host": "explicit.example.com", "port": 9999, "scheme": "http"},
+        "explicit.example.com",
+        9999,
+        "http",
+    ),
 ]
 
 
-@pytest.mark.parametrize("addr, expected", PORT_CASES)
-def test_env_consul_port(monkeypatch, addr, expected):
-    monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
-    assert _consul.env_consul_port() == expected
+@pytest.mark.parametrize("explicit, host, port, scheme", EXPLICIT_WINS_CASES)
+def test_explicit_options_win_over_addr(monkeypatch, explicit, host, port, scheme):
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", "https://addr.example.com:8501")
+    params = resolve(explicit)
+    assert (params["host"], params["port"], params["scheme"]) == (host, port, scheme)
 
 
-SCHEME_CASES = [
-    # (CONSUL_HTTP_SSL, CONSUL_HTTP_ADDR, expected)
+def test_addr_option_wins_over_environment(monkeypatch):
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", "http://environment.example.com:8500")
+    params = resolve({"addr": "https://option.example.com:8501"})
+    assert (params["host"], params["port"], params["scheme"]) == ("option.example.com", 8501, "https")
+
+
+SSL_CASES = [
+    # (CONSUL_HTTP_SSL, addr, expected scheme)
     ("true", None, "https"),
     ("1", None, "https"),
+    ("yes", None, "https"),
+    # a true value selects https even when the address says http
     ("true", "http://consul.example.com:8500", "https"),
-    # a false CONSUL_HTTP_SSL must not downgrade an https address
+    # a false value does not downgrade an https address
     ("false", "https://consul.example.com:8500", "https"),
-    (None, "https://consul.example.com:8500", "https"),
-    (None, "http://consul.example.com:8500", "http"),
+    ("false", "http://consul.example.com:8500", "http"),
+    ("false", None, "http"),
+    # an empty variable counts as unset, like the consul CLI treats it
+    ("", "https://consul.example.com:8500", "https"),
 ]
 
 
-@pytest.mark.parametrize("tls, addr, expected", SCHEME_CASES)
-def test_env_consul_scheme(monkeypatch, tls, addr, expected):
-    if tls is not None:
-        monkeypatch.setenv("CONSUL_HTTP_SSL", tls)
+@pytest.mark.parametrize("tls, addr, scheme", SSL_CASES)
+def test_consul_http_ssl(monkeypatch, tls, addr, scheme):
+    monkeypatch.setenv("CONSUL_HTTP_SSL", tls)
     if addr is not None:
         monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
-    assert _consul.env_consul_scheme() == expected
+    assert resolve()["scheme"] == scheme
 
 
-FALLBACK_NOT_FOUND_CASES = [
-    # (env, callable) -> no usable value in the environment
-    ({}, _consul.env_consul_host),
-    ({}, _consul.env_consul_port),
-    ({}, _consul.env_consul_scheme),
-    ({"CONSUL_HTTP_ADDR": "consul.example.com"}, _consul.env_consul_port),
-    ({"CONSUL_HTTP_ADDR": "consul.example.com:8500"}, _consul.env_consul_scheme),
-    ({"CONSUL_HTTP_SSL": "false"}, _consul.env_consul_scheme),
-    # set-but-empty variables count as unset, like the consul CLI treats them
-    ({"CONSUL_HTTP_ADDR": ""}, _consul.env_consul_host),
-    ({"CONSUL_HTTP_SSL": ""}, _consul.env_consul_scheme),
-    # addresses the consul CLI accepts but the modules cannot honor faithfully
-    # are ignored, so playbooks that never relied on the variable keep working
-    ({"CONSUL_HTTP_ADDR": "unix:///var/run/consul.sock"}, _consul.env_consul_host),
-    ({"CONSUL_HTTP_ADDR": "https://proxy.example.com:443/consul"}, _consul.env_consul_host),
-    ({"CONSUL_HTTP_ADDR": "http://user:pass@consul.example.com:8500"}, _consul.env_consul_host),
-    ({"CONSUL_HTTP_ADDR": "http://consul.example.com:8500?dc=dc1"}, _consul.env_consul_host),
-    ({"CONSUL_HTTP_ADDR": "   "}, _consul.env_consul_host),
-    # an address without a host is ignored entirely, no component is half-used
-    ({"CONSUL_HTTP_ADDR": "http://:8500"}, _consul.env_consul_host),
-    ({"CONSUL_HTTP_ADDR": "http://:8500"}, _consul.env_consul_port),
-    ({"CONSUL_HTTP_ADDR": "https://"}, _consul.env_consul_scheme),
-    ({"CONSUL_HTTP_ADDR": ":8500"}, _consul.env_consul_port),
+def test_explicit_scheme_wins_over_consul_http_ssl(monkeypatch):
+    monkeypatch.setenv("CONSUL_HTTP_SSL", "true")
+    assert resolve({"scheme": "http"})["scheme"] == "http"
+
+
+# Addresses these modules cannot use fail instead of silently connecting
+# somewhere else. Only shapes every supported Python rejects belong in the
+# parse-failure cases: newer interpreters reject more bracket forms.
+UNUSABLE_ADDR_CASES = [
+    ("unix:///var/run/consul.sock", "unsupported scheme"),
+    ("ftp://consul.example.com:8500", "unsupported scheme"),
+    ("https://consul.example.com:8500/prefix", "must not contain a path"),
+    ("https://consul.example.com:8500?dc=dc1", "must not contain a query"),
+    ("https://user:pass@consul.example.com:8500", "must not contain credentials"),
+    ("https://", "does not contain a host"),
+    ("http://:8500", "does not contain a host"),
+    ("consul.example.com:notaport", "cannot be parsed"),
+    ("consul.example.com:99999", "cannot be parsed"),
+    ("2001:db8::1", "cannot be parsed"),
+    ("[::1", "cannot be parsed"),
 ]
 
 
-@pytest.mark.parametrize("env, func", FALLBACK_NOT_FOUND_CASES)
-def test_fallback_not_found(monkeypatch, env, func):
-    for key, value in env.items():
-        monkeypatch.setenv(key, value)
-    with pytest.raises(AnsibleFallbackNotFound):
-        func()
-    assert get_warning_messages() == ()
+@pytest.mark.parametrize("addr, reason", UNUSABLE_ADDR_CASES)
+def test_unusable_addr_option_fails(addr, reason):
+    with pytest.raises(FailJson) as exc:
+        resolve({"addr": addr})
+    assert reason in str(exc.value)
+    # the address may embed credentials, so the failure must not repeat it
+    assert addr not in str(exc.value)
 
 
-def test_trailing_slash_is_tolerated(monkeypatch):
-    monkeypatch.setenv("CONSUL_HTTP_ADDR", "https://consul.example.com:8501/")
-    assert _consul.env_consul_host() == "consul.example.com"
-    assert _consul.env_consul_port() == 8501
-    assert _consul.env_consul_scheme() == "https"
-
-
-# Fallback callables may only raise AnsibleFallbackNotFound; ansible-core's
-# set_fallbacks catches nothing else, so an unparsable value must warn and
-# fall back instead of raising. Only shapes every supported Python rejects
-# belong here: newer interpreters reject more bracket forms than older ones.
-MALFORMED_ADDR_CASES = [
-    "consul.example.com:notaport",
-    "consul.example.com:99999",
-    "2001:db8::1",
-    "[::1",
-]
-
-
-@pytest.mark.parametrize("addr", MALFORMED_ADDR_CASES)
-@pytest.mark.parametrize("func", [_consul.env_consul_host, _consul.env_consul_port, _consul.env_consul_scheme])
-def test_malformed_addr_warns_and_falls_back(monkeypatch, addr, func):
+@pytest.mark.parametrize("addr, reason", UNUSABLE_ADDR_CASES)
+def test_unusable_addr_environment_fails(monkeypatch, addr, reason):
     monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
-    with pytest.raises(AnsibleFallbackNotFound):
-        func()
-    warnings = get_warning_messages()
-    assert len(warnings) == 1
-    assert "CONSUL_HTTP_ADDR" in warnings[0]
-    # the value may embed credentials, so the warning must not echo it
-    assert addr not in warnings[0]
+    with pytest.raises(FailJson) as exc:
+        resolve()
+    assert reason in str(exc.value)
+    assert addr not in str(exc.value)
 
 
-def test_malformed_addr_warns_once_across_consumers(monkeypatch):
-    monkeypatch.setenv("CONSUL_HTTP_ADDR", "[::1")
-    for func in (_consul.env_consul_host, _consul.env_consul_port, _consul.env_consul_scheme):
-        with pytest.raises(AnsibleFallbackNotFound):
-            func()
-    assert len(get_warning_messages()) == 1
+@pytest.mark.parametrize("addr, reason", UNUSABLE_ADDR_CASES)
+def test_unusable_addr_is_ignored_when_nothing_is_needed(monkeypatch, addr, reason):
+    # A task that spells out its connection must not be broken by an address
+    # exported for the consul CLI that these modules happen not to support.
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
+    params = resolve({"host": "consul.example.com", "port": 8501, "scheme": "https"})
+    assert (params["host"], params["port"], params["scheme"]) == ("consul.example.com", 8501, "https")
 
 
-def test_invalid_ssl_boolean_warns_and_selects_https(monkeypatch):
-    # An unparsable CONSUL_HTTP_SSL must not silently pick plaintext: the
-    # token fallback would still apply and be sent over http.
+def test_invalid_consul_http_ssl_is_ignored_when_scheme_is_set(monkeypatch):
     monkeypatch.setenv("CONSUL_HTTP_SSL", "maybe")
-    assert _consul.env_consul_scheme() == "https"
-    warnings = get_warning_messages()
-    assert len(warnings) == 1
-    assert "CONSUL_HTTP_SSL" in warnings[0]
-    # a value in the wrong variable may be a credential, never echo it
-    assert "maybe" not in warnings[0]
+    params = resolve({"host": "consul.example.com", "port": 8501, "scheme": "https"})
+    assert params["scheme"] == "https"
+
+
+def test_embedded_password_is_registered_for_masking(monkeypatch):
+    # ansible-core echoes the module arguments back with the result, so a
+    # password in the address has to be masked there as well as kept out of
+    # the failure message.
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", "https://user:s3cr3t@consul.example.com:8501")
+    result = ModuleArgumentSpecValidator(_consul.AUTH_ARGUMENTS_SPEC).validate({})
+    module = ModuleStub(dict(result.validated_parameters))
+    module.no_log_values = set()
+    with pytest.raises(FailJson):
+        _consul.resolve_connection_params(module)
+    assert "s3cr3t" in module.no_log_values
+
+
+@pytest.mark.parametrize(
+    "addr, password",
+    [
+        ("https://user:s3cr3t@consul.example.com:8501", "s3cr3t"),
+        ("https://consul.example.com:8501", None),
+        ("[::1", None),
+    ],
+)
+def test_addr_password(addr, password):
+    assert _consul.addr_password(addr) == password
+
+
+@pytest.mark.parametrize("tls", ["maybe", "2", "tru", "null"])
+def test_invalid_consul_http_ssl_fails(monkeypatch, tls):
+    monkeypatch.setenv("CONSUL_HTTP_SSL", tls)
+    with pytest.raises(FailJson) as exc:
+        resolve()
+    assert "CONSUL_HTTP_SSL" in str(exc.value)
+
+
+@pytest.mark.parametrize("addr", ["", "   "])
+def test_blank_addr_is_unset(monkeypatch, addr):
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
+    params = resolve()
+    assert (params["host"], params["port"], params["scheme"]) == ("localhost", 8500, "http")
+
+
+def test_surrounding_whitespace_is_tolerated(monkeypatch):
+    monkeypatch.setenv("CONSUL_HTTP_ADDR", "  https://consul.example.com:8501  ")
+    params = resolve()
+    assert (params["host"], params["port"], params["scheme"]) == ("consul.example.com", 8501, "https")
 
 
 NONEMPTY_FALLBACK_CASES = [
-    ({"CONSUL_HTTP_TOKEN": "tok"}, ["CONSUL_HTTP_TOKEN"], "tok"),
-    ({"CONSUL_CACERT": "/etc/ssl/ca.pem"}, ["CONSUL_CACERT"], "/etc/ssl/ca.pem"),
+    ("token", "CONSUL_HTTP_TOKEN", "s3cr3t"),
+    ("ca_path", "CONSUL_CACERT", "/etc/ssl/ca.pem"),
+    ("addr", "CONSUL_HTTP_ADDR", "consul.example.com"),
 ]
 
 
-@pytest.mark.parametrize("env, names, expected", NONEMPTY_FALLBACK_CASES)
-def test_nonempty_env_fallback(monkeypatch, env, names, expected):
-    for key, value in env.items():
-        monkeypatch.setenv(key, value)
-    assert _consul.nonempty_env_fallback(*names) == expected
+@pytest.mark.parametrize("option, name, value", NONEMPTY_FALLBACK_CASES)
+def test_environment_fills_option(monkeypatch, option, name, value):
+    monkeypatch.setenv(name, value)
+    assert resolve()[option] == value
 
 
-NONEMPTY_FALLBACK_UNSET_CASES = [
-    ({}, ["CONSUL_HTTP_TOKEN"]),
-    ({"CONSUL_HTTP_TOKEN": ""}, ["CONSUL_HTTP_TOKEN"]),
-]
+@pytest.mark.parametrize("option, name, value", NONEMPTY_FALLBACK_CASES)
+def test_empty_environment_variable_counts_as_unset(monkeypatch, option, name, value):
+    monkeypatch.setenv(name, "")
+    assert resolve()[option] is None
 
 
-@pytest.mark.parametrize("env, names", NONEMPTY_FALLBACK_UNSET_CASES)
-def test_nonempty_env_fallback_unset(monkeypatch, env, names):
-    for key, value in env.items():
-        monkeypatch.setenv(key, value)
-    with pytest.raises(AnsibleFallbackNotFound):
-        _consul.nonempty_env_fallback(*names)
-
-
-# The cases below run the spec through ansible-core's own argument handling,
-# pinning the fallback contract itself rather than the callables in isolation.
-
-
-def validate_spec():
-    return ModuleArgumentSpecValidator(_consul.AUTH_ARGUMENTS_SPEC).validate({})
-
-
-def test_spec_resolves_env(monkeypatch):
-    monkeypatch.setenv("CONSUL_HTTP_ADDR", "https://consul.example.com:8501")
-    monkeypatch.setenv("CONSUL_HTTP_TOKEN", "tok")
+def test_validate_certs_from_environment(monkeypatch):
     monkeypatch.setenv("CONSUL_HTTP_SSL_VERIFY", "false")
-    monkeypatch.setenv("CONSUL_CACERT", "/etc/ssl/ca.pem")
-    result = validate_spec()
-    assert result.error_messages == []
-    parameters = result.validated_parameters
-    assert parameters["host"] == "consul.example.com"
-    assert parameters["port"] == 8501
-    assert parameters["scheme"] == "https"
-    assert parameters["token"] == "tok"
-    assert parameters["validate_certs"] is False
-    assert parameters["ca_path"] == "/etc/ssl/ca.pem"
+    assert resolve()["validate_certs"] is False
 
 
-def test_spec_defaults_without_env():
-    result = validate_spec()
-    assert result.error_messages == []
-    parameters = result.validated_parameters
-    assert parameters["host"] == "localhost"
-    assert parameters["port"] == 8500
-    assert parameters["scheme"] == "http"
-    assert parameters["token"] is None
+def test_validate_certs_defaults_to_true():
+    assert resolve()["validate_certs"] is True
 
 
-@pytest.mark.parametrize("addr", MALFORMED_ADDR_CASES)
-def test_spec_survives_malformed_addr(monkeypatch, addr):
-    monkeypatch.setenv("CONSUL_HTTP_ADDR", addr)
-    result = validate_spec()
-    assert result.error_messages == []
-    assert result.validated_parameters["host"] == "localhost"
-    assert result.validated_parameters["port"] == 8500
-    assert len(get_warning_messages()) == 1
-
-
-def test_spec_survives_invalid_ssl_boolean(monkeypatch):
-    monkeypatch.setenv("CONSUL_HTTP_SSL", "maybe")
-    result = validate_spec()
-    assert result.error_messages == []
-    assert result.validated_parameters["scheme"] == "https"
-    assert len(get_warning_messages()) == 1
-
-
-def test_spec_rejects_invalid_ssl_verify_cleanly(monkeypatch):
-    # garbage CONSUL_HTTP_SSL_VERIFY reaches the type='bool' coercion and must
-    # surface as a clean validation error, never an exception
+def test_invalid_validate_certs_fails_cleanly(monkeypatch):
+    # garbage reaches the type='bool' coercion and must surface as a clean
+    # validation error rather than an exception
     monkeypatch.setenv("CONSUL_HTTP_SSL_VERIFY", "maybe")
-    result = validate_spec()
+    result = ModuleArgumentSpecValidator(_consul.AUTH_ARGUMENTS_SPEC).validate({})
     assert result.error_messages
+
+
+def test_nonempty_env_fallback(monkeypatch):
+    monkeypatch.setenv("CONSUL_HTTP_TOKEN", "s3cr3t")
+    assert _consul.nonempty_env_fallback("CONSUL_HTTP_TOKEN") == "s3cr3t"
+
+
+@pytest.mark.parametrize("value", [None, ""])
+def test_nonempty_env_fallback_unset(monkeypatch, value):
+    if value is not None:
+        monkeypatch.setenv("CONSUL_HTTP_TOKEN", value)
+    with pytest.raises(AnsibleFallbackNotFound):
+        _consul.nonempty_env_fallback("CONSUL_HTTP_TOKEN")


### PR DESCRIPTION
##### SUMMARY

Rescope per the earlier discussion here: the env handling moves into the shared consul
argument spec instead of consul_kv's own options, so every module built on it picks the
behavior up.

Connection options now fall back to `CONSUL_HTTP_ADDR` (host, port and scheme; both
`host:port` and `scheme://host:port` forms), `CONSUL_HTTP_SSL`, `CONSUL_HTTP_SSL_VERIFY`,
`CONSUL_HTTP_TOKEN` and `CONSUL_CACERT` when not specified. Explicit options always win,
and the existing defaults apply when neither is set, so nothing changes for current
playbooks.

Semantics:

- booleans go through Ansible's boolean conversion, so `CONSUL_HTTP_SSL=1` means https and
  `CONSUL_HTTP_SSL_VERIFY=1` means verify. An invalid `CONSUL_HTTP_SSL` selects https with a
  warning rather than plaintext, so a token is never sent over http by a typo. An invalid
  `CONSUL_HTTP_SSL_VERIFY` fails validation cleanly.
- a false `CONSUL_HTTP_SSL` does not downgrade an `https://` scheme in `CONSUL_HTTP_ADDR`,
  matching the consul CLI, which never reverts to http once TLS was requested.
- addresses the CLI accepts but the modules cannot honor (`unix://` sockets, path prefixes)
  and set-but-empty variables are treated as unset, so environments where these variables
  are exported for the consul CLI keep working exactly as before. Addresses that cannot be
  parsed at all, including malformed ports, are ignored with a warning that never echoes the
  value. IPv6 hosts are re-bracketed.
- not consulted (no matching module options): `CONSUL_HTTP_TOKEN_FILE`, `CONSUL_HTTP_AUTH`,
  `CONSUL_CLIENT_CERT`/`KEY`, `CONSUL_CAPATH`, `CONSUL_TLS_SERVER_NAME`.

Applies to all consul modules except `consul`, which still has its own connection handling
(#11040). The parsing semantics, including the security-relevant cases, are pinned by unit
tests.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
consul module utils

##### ADDITIONAL INFORMATION

Verified against live Consul 1.20 (ACLs on, plain and TLS with a private CA): consul_kv,
consul_session and consul_policy connecting with env vars only; `CONSUL_HTTP_SSL=1` and
`CONSUL_CACERT` against TLS; explicit options beating the environment; no-env defaults
unchanged; plus the full `tests/integration/targets/consul` target via
`ansible-test integration --docker`, sanity, mypy and the new unit tests.

