### PR TITLE
Unhardcode dnf_config_manager DNF bin path

### DIFF
--- a/changelogs/fragments/12219-unhardcode-dnf_config_manger-dnf-path.yml
+++ b/changelogs/fragments/12219-unhardcode-dnf_config_manger-dnf-path.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - dnf_config_manager - lookup path to the ``dnf`` binary in ``PATH``. It used to be fixed to ``/usr/bin/dnf`` (https://github.com/ansible-collections/community.general/pull/12219).

--- a/plugins/modules/dnf_config_manager.py
+++ b/plugins/modules/dnf_config_manager.py
@@ -119,26 +119,24 @@ changed_repos:
   sample: ["crb"]
 """
 
-import os
 import re
 import typing as t
 
 from ansible.module_utils.basic import AnsibleModule
 
-DNF_BIN = "/usr/bin/dnf"
 REPO_ID_RE = re.compile(r"^Repo[-\s]id\s*:\s*(\S+)$", re.IGNORECASE)
 REPO_STATUS_RE = re.compile(r"^(?:Repo-)?status\s*:\s*(disabled|enabled)$", re.IGNORECASE)
 
 
-def get_dnf_version(module) -> t.Literal[4, 5]:
-    rc, out, err = module.run_command([DNF_BIN, "--version"], check_rc=True)
+def get_dnf_version(module, dnf) -> t.Literal[4, 5]:
+    rc, out, err = module.run_command([dnf, "--version"], check_rc=True)
     line, separator, rest = out.partition("\n")
 
     return 5 if re.match(r"^dnf5\s*", line) else 4
 
 
-def get_repo_states(module, dnf_v):
-    command = [DNF_BIN]
+def get_repo_states(module, dnf, dnf_v):
+    command = [dnf]
     if dnf_v == 4:
         command.extend(["repolist", "--all", "--verbose"])
     else:
@@ -164,13 +162,13 @@ def get_repo_states(module, dnf_v):
     return repos
 
 
-def set_repo_states(module, dnf_v, repo_ids, state):
+def set_repo_states(module, dnf, dnf_v, repo_ids, state):
     if dnf_v == 4:
-        module.run_command([DNF_BIN, "config-manager", "--assumeyes", f"--set-{state}"] + repo_ids, check_rc=True)
+        module.run_command([dnf, "config-manager", "--assumeyes", f"--set-{state}"] + repo_ids, check_rc=True)
     else:
         state = "1" if state == "enabled" else "0"
         opts = map(lambda v: f"{v}.enabled={state}", repo_ids)
-        module.run_command([DNF_BIN, "config-manager", "setopt"] + list(opts), check_rc=True)
+        module.run_command([dnf, "config-manager", "setopt"] + list(opts), check_rc=True)
 
 
 def pack_repo_states_for_return(states):
@@ -200,12 +198,11 @@ def main():
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
     module.run_command_environ_update = dict(LANGUAGE="C", LC_ALL="C")
 
-    if not os.path.exists(DNF_BIN):
-        module.fail_json(msg=f"{DNF_BIN} was not found")
+    dnf = module.get_bin_path("dnf", True)
 
-    dnf_v = get_dnf_version(module)
+    dnf_v = get_dnf_version(module, dnf)
 
-    repo_states = get_repo_states(module, dnf_v)
+    repo_states = get_repo_states(module, dnf, dnf_v)
     result["repo_states_pre"] = pack_repo_states_for_return(repo_states)
 
     desired_repo_state = module.params["state"]
@@ -224,9 +221,9 @@ def main():
         module.exit_json(**result)
 
     if len(to_change) > 0:
-        set_repo_states(module, dnf_v, to_change, desired_repo_state)
+        set_repo_states(module, dnf, dnf_v, to_change, desired_repo_state)
 
-    repo_states_post = get_repo_states(module, dnf_v)
+    repo_states_post = get_repo_states(module, dnf, dnf_v)
     result["repo_states_post"] = pack_repo_states_for_return(repo_states_post)
 
     for repo_id in to_change:

--- a/tests/unit/plugins/modules/dnf_config_manager/test_dnf_config_manager.py
+++ b/tests/unit/plugins/modules/dnf_config_manager/test_dnf_config_manager.py
@@ -111,9 +111,9 @@ class TestDNFConfigManager(ModuleTestCase):
         super().setUp()
         self.mock_run_command = patch("ansible.module_utils.basic.AnsibleModule.run_command")
         self.run_command = self.mock_run_command.start()
-        self.mock_path_exists = patch("os.path.exists")
-        self.path_exists = self.mock_path_exists.start()
-        self.path_exists.return_value = True
+        self.mock_get_bin_path = patch("ansible.module_utils.basic.AnsibleModule.get_bin_path")
+        self.get_bin_path = self.mock_get_bin_path.start()
+        self.get_bin_path.return_value = "/usr/bin/dnf"
         self.module = dnf_config_manager_module
         self.mock_dnf4_version = fixture("mock_dnf4_version.txt")
         self.mock_dnf5_version = fixture("mock_dnf5_version.txt")
@@ -127,7 +127,7 @@ class TestDNFConfigManager(ModuleTestCase):
     def tearDown(self):
         super().tearDown()
         self.mock_run_command.stop()
-        self.mock_path_exists.stop()
+        self.mock_get_bin_path.stop()
 
     def set_command_mock(self, execute_return=(0, "", ""), execute_side_effect=None):
         self.run_command.reset_mock()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

As noted in #9127, the dnf_config_manager module hardcodes the path to the DNF binary, and this PR is undoing that. I believe the intention in hardcoding it was to make the tests run on distributions without DNF, using mocking. This PR keeps the DNF mocking and is able to run on non-DNF distros all the same.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request
- Refactoring Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
dnf_config_manager

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
