### PR TITLE
pkgng: fix install from local package file reporting failure on success

### DIFF
--- a/changelogs/fragments/12233-pkgng-install-from-file.yml
+++ b/changelogs/fragments/12233-pkgng-install-from-file.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "pkgng - fix install from a local package file always reporting failure even when the package was installed successfully
+    (https://github.com/ansible-collections/community.general/issues/3428,
+    https://github.com/ansible-collections/community.general/pull/12233)."

--- a/plugins/modules/pkgng.py
+++ b/plugins/modules/pkgng.py
@@ -28,6 +28,8 @@ options:
     description:
       - Name or list of names of packages to install/remove.
       - With O(name=*), O(state=latest) operates, but O(state=present) and O(state=absent) are noops.
+      - A name can also be the path of a local package file, in which case the package is installed from that file. The
+        actual package name is read from the file to check and report the installation state.
     required: true
     aliases: [pkg]
     type: list
@@ -131,9 +133,14 @@ EXAMPLES = r"""
     name: foo/bar
     state: latest
     use_globs: false
+
+- name: Install package from a local package file
+  community.general.pkgng:
+    name: /tmp/mypackage-1.2.pkg
 """
 
 
+import os
 import re
 from collections import defaultdict
 
@@ -144,6 +151,14 @@ def query_package(module, run_pkgng, name):
     rc, out, err = run_pkgng("info", "-e", name)
 
     return rc == 0
+
+
+def query_file_package_name(module, run_pkgng, file_path):
+    # Resolve the real package name from a local package file
+    rc, out, err = run_pkgng("query", "-F", file_path, "%n")
+    if rc != 0:
+        module.fail_json(msg=f"failed to obtain package name from file {file_path}: {err}")
+    return out.strip()
 
 
 def query_update(module, run_pkgng, name):
@@ -220,6 +235,13 @@ def install_packages(module, run_pkgng, packages, cached, state):
     stdout = ""
     stderr = ""
 
+    # The package database cannot be queried by the path of a local package file,
+    # so resolve the real package name from the file and use it for all queries.
+    query_name = {
+        package: query_file_package_name(module, run_pkgng, package) if os.path.isfile(package) else package
+        for package in packages
+    }
+
     if not module.check_mode and not cached:
         rc, out, err = run_pkgng("update")
         stdout += out
@@ -228,11 +250,11 @@ def install_packages(module, run_pkgng, packages, cached, state):
             module.fail_json(msg=f"Could not update catalogue [{rc}]: {out} {err}", stdout=stdout, stderr=stderr)
 
     for package in packages:
-        already_installed = query_package(module, run_pkgng, package)
+        already_installed = query_package(module, run_pkgng, query_name[package])
         if already_installed and state == "present":
             continue
 
-        if already_installed and state == "latest" and not query_update(module, run_pkgng, package):
+        if already_installed and state == "latest" and not query_update(module, run_pkgng, query_name[package]):
             continue
 
         if already_installed:
@@ -258,9 +280,9 @@ def install_packages(module, run_pkgng, packages, cached, state):
         for package in package_list:
             verified = False
             if action == "install":
-                verified = query_package(module, run_pkgng, package)
+                verified = query_package(module, run_pkgng, query_name[package])
             elif action == "upgrade":
-                verified = not query_update(module, run_pkgng, package)
+                verified = not query_update(module, run_pkgng, query_name[package])
 
             if verified:
                 action_count[action] += 1

--- a/tests/integration/targets/pkgng/tasks/freebsd.yml
+++ b/tests/integration/targets/pkgng/tasks/freebsd.yml
@@ -177,6 +177,42 @@
           - pkgng_example4_nopower_wildcard.failed
 
 ##
+## pkgng - example - install package from local file
+##
+- name: Install package from local package file
+  block:
+    - name: Remove test package
+      pkgng:
+        name: '{{ pkgng_test_pkg_name }}'
+        state: absent
+
+    - name: Create local test package
+      import_tasks: create-outofdate-pkg.yml
+
+    - name: Install package from local package file
+      pkgng:
+        name: '{{ pkgng_test_outofdate_pkg_path }}'
+      register: pkgng_file_install
+
+    - name: Install package from local package file (idempotent)
+      pkgng:
+        name: '{{ pkgng_test_outofdate_pkg_path }}'
+      register: pkgng_file_install_idempotent
+
+    - name: Remove test package installed from file
+      pkgng:
+        name: '{{ pkgng_test_pkg_name }}'
+        state: absent
+      register: pkgng_file_install_cleanup
+
+    - name: Ensure pkgng installs from a local package file correctly
+      assert:
+        that:
+          - pkgng_file_install is changed
+          - pkgng_file_install_idempotent is not changed
+          - pkgng_file_install_cleanup is changed
+
+##
 ## pkgng - example - Install multiple packages in one command
 ##
 - name: Remove test package (checkmode)

--- a/tests/unit/plugins/modules/test_pkgng.py
+++ b/tests/unit/plugins/modules/test_pkgng.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026, Alexei Znamensky <russoz@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from ansible.module_utils import basic
+from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
+    AnsibleExitJson,
+    AnsibleFailJson,
+    exit_json,
+    fail_json,
+    set_module_args,
+)
+
+from ansible_collections.community.general.plugins.modules import pkgng
+
+PACKAGE_FILE = "/tmp/mymeta-1.2.pkg"
+PACKAGE_NAME = "mymeta"
+
+
+@pytest.fixture
+def run_command(mocker):
+    mocker.patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    )
+    mocker.patch.object(basic.AnsibleModule, "get_bin_path", return_value="/testbin/pkg")
+    # Make only the test package path look like an existing file
+    real_isfile = os.path.isfile
+    mocker.patch("os.path.isfile", side_effect=lambda path: path == PACKAGE_FILE or real_isfile(path))
+    return mocker.patch.object(basic.AnsibleModule, "run_command")
+
+
+def called_commands(run_command):
+    # dir_arg is None when rootdir/chroot/jail are not used; the real
+    # run_command ignores None args, so filter them out for comparison
+    return [[arg for arg in call.args[0] if arg is not None] for call in run_command.call_args_list]
+
+
+def test_install_from_package_file(run_command):
+    run_command.side_effect = [
+        (0, "1.18.4", ""),  # pkg -v
+        (0, f"{PACKAGE_NAME}\n", ""),  # pkg query -F <file> %n
+        (0, "", ""),  # pkg update
+        (1, "", ""),  # pkg info (package not yet installed)
+        (0, f"[1/1] Installing {PACKAGE_NAME}-1.2...\n", ""),  # pkg install
+        (0, "", ""),  # pkg info (verify package is installed)
+    ]
+
+    with set_module_args({"name": PACKAGE_FILE}):
+        with pytest.raises(AnsibleExitJson) as exc:
+            pkgng.main()
+
+    result = exc.value.args[0]
+    assert result["changed"]
+    assert "installed 1 package" in result["msg"]
+    assert called_commands(run_command) == [
+        ["/testbin/pkg", "-v"],
+        ["/testbin/pkg", "query", "-F", PACKAGE_FILE, "%n"],
+        ["/testbin/pkg", "update"],
+        ["/testbin/pkg", "info", "-g", "-e", PACKAGE_NAME],
+        ["/testbin/pkg", "install", "-g", "-U", "-y", PACKAGE_FILE],
+        ["/testbin/pkg", "info", "-g", "-e", PACKAGE_NAME],
+    ]
+
+
+def test_install_from_package_file_already_installed(run_command):
+    run_command.side_effect = [
+        (0, "1.18.4", ""),  # pkg -v
+        (0, f"{PACKAGE_NAME}\n", ""),  # pkg query -F <file> %n
+        (0, "", ""),  # pkg update
+        (0, "", ""),  # pkg info (package already installed)
+    ]
+
+    with set_module_args({"name": PACKAGE_FILE}):
+        with pytest.raises(AnsibleExitJson) as exc:
+            pkgng.main()
+
+    result = exc.value.args[0]
+    assert not result["changed"]
+    assert "package(s) already present" in result["msg"]
+    assert called_commands(run_command) == [
+        ["/testbin/pkg", "-v"],
+        ["/testbin/pkg", "query", "-F", PACKAGE_FILE, "%n"],
+        ["/testbin/pkg", "update"],
+        ["/testbin/pkg", "info", "-g", "-e", PACKAGE_NAME],
+    ]
+
+
+def test_install_from_unreadable_package_file(run_command):
+    run_command.side_effect = [
+        (0, "1.18.4", ""),  # pkg -v
+        (70, "", f"pkg: unable to read {PACKAGE_FILE}"),  # pkg query -F <file> %n
+    ]
+
+    with set_module_args({"name": PACKAGE_FILE}):
+        with pytest.raises(AnsibleFailJson) as exc:
+            pkgng.main()
+
+    result = exc.value.args[0]
+    assert result["msg"].startswith(f"failed to obtain package name from file {PACKAGE_FILE}")


### PR DESCRIPTION
##### SUMMARY

When `name` is a path to a local package file (e.g. `/tmp/pkg.txz`), `pkg install` succeeds but the module reports failure. The root cause: presence checks use `pkg info -e <name>`, which queries by package name, not by file path — so the post-install verification always fails.

The fix resolves the real package name from the file first (via `pkg query -F <file> %n`) and uses that name for all presence and update checks, while still passing the file path to `pkg install`. This also makes the task idempotent for file-path installs.

Fixes #3428

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pkgng

##### ADDITIONAL INFORMATION

Unit tests cover: install from file (happy path), idempotency (already installed), and unreadable file (fail gracefully). Integration test exercises the same on FreeBSD CI using the existing out-of-date package machinery.