### PR TITLE
xbps: include `stdout` and `stderr` in module output

### DIFF
--- a/changelogs/fragments/12234-xbps-report-command-output.yml
+++ b/changelogs/fragments/12234-xbps-report-command-output.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "xbps - include ``stdout`` and ``stderr`` from the last executed command in module output (https://github.com/ansible-collections/community.general/issues/2478, https://github.com/ansible-collections/community.general/pull/12234)."

--- a/plugins/modules/xbps.py
+++ b/plugins/modules/xbps.py
@@ -155,6 +155,16 @@ packages:
   type: list
   sample: ["ansible"]
   returned: success
+stdout:
+  description: Standard output of the last executed command.
+  returned: when a package manager command was executed
+  type: str
+  sample: ''
+stderr:
+  description: Standard error of the last executed command.
+  returned: when a package manager command was executed
+  type: str
+  sample: ''
 """
 
 
@@ -202,7 +212,7 @@ def query_package(module, xbps_path, name, state="present"):
 
 
 def update_package_db(module, xbps_path):
-    """Returns True if update_package_db changed"""
+    """Returns (changed, stdout, stderr) for the sync command"""
     cmd = [xbps_path["install"], "-S"]
     cmd = append_flags(module, xbps_path, cmd)
     if module.params["accept_pubkey"]:
@@ -212,10 +222,10 @@ def update_package_db(module, xbps_path):
     rc, stdout, stderr = module.run_command(cmd, check_rc=False, data=stdin)
 
     if "Failed to import pubkey" in stderr:
-        module.fail_json(msg="Failed to import pubkey for repository")
+        module.fail_json(msg="Failed to import pubkey for repository", stdout=stdout, stderr=stderr)
     if rc != 0:
-        module.fail_json(msg="Could not update package db")
-    return "avg rate" in stdout
+        module.fail_json(msg="Could not update package db", stdout=stdout, stderr=stderr)
+    return "avg rate" in stdout, stdout, stderr
 
 
 def upgrade_xbps(module, xbps_path, exit_on_success=False):
@@ -223,7 +233,7 @@ def upgrade_xbps(module, xbps_path, exit_on_success=False):
     cmdupgradexbps = append_flags(module, xbps_path, cmdupgradexbps)
     rc, stdout, stderr = module.run_command(cmdupgradexbps, check_rc=False)
     if rc != 0:
-        module.fail_json(msg="Could not upgrade xbps itself")
+        module.fail_json(msg="Could not upgrade xbps itself", stdout=stdout, stderr=stderr)
 
 
 def upgrade(module, xbps_path):
@@ -236,27 +246,29 @@ def upgrade(module, xbps_path):
     rc, stdout, stderr = module.run_command(cmdneedupgrade, check_rc=False)
     if rc == 0:
         if len(stdout.splitlines()) == 0:
-            module.exit_json(changed=False, msg="Nothing to upgrade")
+            module.exit_json(changed=False, msg="Nothing to upgrade", stdout=stdout, stderr=stderr)
         elif module.check_mode:
-            module.exit_json(changed=True, msg="Would have performed upgrade")
+            module.exit_json(changed=True, msg="Would have performed upgrade", stdout=stdout, stderr=stderr)
         else:
             rc, stdout, stderr = module.run_command(cmdupgrade, check_rc=False)
             if rc == 0:
-                module.exit_json(changed=True, msg="System upgraded")
+                module.exit_json(changed=True, msg="System upgraded", stdout=stdout, stderr=stderr)
             elif rc == 16 and module.params["upgrade_xbps"]:
                 upgrade_xbps(module, xbps_path)
                 # avoid loops by not trying self-upgrade again
                 module.params["upgrade_xbps"] = False
                 upgrade(module, xbps_path)
             else:
-                module.fail_json(msg="Could not upgrade")
+                module.fail_json(msg="Could not upgrade", stdout=stdout, stderr=stderr)
     else:
-        module.fail_json(msg="Could not upgrade")
+        module.fail_json(msg="Could not upgrade", stdout=stdout, stderr=stderr)
 
 
 def remove_packages(module, xbps_path, packages):
     """Returns true if package removal succeeds"""
     changed_packages = []
+    last_stdout = ""
+    last_stderr = ""
     # Using a for loop in case of error, we can report the package that failed
     for package in packages:
         # Query the package first, to see if we even need to remove
@@ -269,12 +281,20 @@ def remove_packages(module, xbps_path, packages):
         rc, stdout, stderr = module.run_command(cmd, check_rc=False)
 
         if rc != 0:
-            module.fail_json(msg=f"failed to remove {package}")
+            module.fail_json(msg=f"failed to remove {package}", stdout=stdout, stderr=stderr)
 
+        last_stdout = stdout
+        last_stderr = stderr
         changed_packages.append(package)
 
     if len(changed_packages) > 0:
-        module.exit_json(changed=True, msg=f"removed {len(changed_packages)} package(s)", packages=changed_packages)
+        module.exit_json(
+            changed=True,
+            msg=f"removed {len(changed_packages)} package(s)",
+            packages=changed_packages,
+            stdout=last_stdout,
+            stderr=last_stderr,
+        )
 
     module.exit_json(changed=False, msg="package(s) already absent")
 
@@ -304,9 +324,13 @@ def install_packages(module, xbps_path, state, packages):
         module.params["upgrade_xbps"] = False
         install_packages(module, xbps_path, state, packages)
     elif rc != 0 and not (state == "latest" and rc == 17):
-        module.fail_json(msg=f"failed to install {len(toInstall)} packages(s)", packages=toInstall)
+        module.fail_json(
+            msg=f"failed to install {len(toInstall)} package(s)", packages=toInstall, stdout=stdout, stderr=stderr
+        )
 
-    module.exit_json(changed=True, msg=f"installed {len(toInstall)} package(s)", packages=toInstall)
+    module.exit_json(
+        changed=True, msg=f"installed {len(toInstall)} package(s)", packages=toInstall, stdout=stdout, stderr=stderr
+    )
 
 
 def check_packages(module, xbps_path, packages, state):
@@ -336,10 +360,13 @@ def update_cache(module, xbps_path, upgrade_planned):
         if upgrade_planned:
             return
         module.exit_json(changed=True, msg="Would have updated the package cache")
-    changed = update_package_db(module, xbps_path)
+    changed, stdout, stderr = update_package_db(module, xbps_path)
     if not upgrade_planned:
         module.exit_json(
-            changed=changed, msg=("Updated the package master lists" if changed else "Package list already up to date")
+            changed=changed,
+            msg=("Updated the package master lists" if changed else "Package list already up to date"),
+            stdout=stdout,
+            stderr=stderr,
         )
 
 

--- a/plugins/modules/xbps.py
+++ b/plugins/modules/xbps.py
@@ -160,11 +160,13 @@ stdout:
   returned: when a package manager command was executed
   type: str
   sample: ''
+  version_added: 13.1.0
 stderr:
   description: Standard error of the last executed command.
   returned: when a package manager command was executed
   type: str
   sample: ''
+  version_added: 13.1.0
 """
 
 

--- a/tests/unit/plugins/modules/test_xbps.py
+++ b/tests/unit/plugins/modules/test_xbps.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, Alexei Znamensky <russoz@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import pytest
+
+from ansible_collections.community.general.plugins.modules import xbps
+
+from .uthelper import RunCommandMock, UTHelper
+
+
+@pytest.fixture(autouse=True)
+def patch_os_path_exists(mocker):
+    mocker.patch("os.path.exists", return_value=True)
+
+
+UTHelper.from_module(xbps, __name__, mocks=[RunCommandMock])

--- a/tests/unit/plugins/modules/test_xbps.yaml
+++ b/tests/unit/plugins/modules/test_xbps.yaml
@@ -1,0 +1,120 @@
+# Copyright (c) 2025, Alexei Znamensky <russoz@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+---
+anchors:
+  sync_db: &sync_db
+    command: [/testbin/xbps-install, -S]
+    environ: {check_rc: false, data: "n\n"}
+    rc: 0
+    out: ''
+    err: ''
+  query_foo_absent: &query_foo_absent
+    command: [/testbin/xbps-query, foo]
+    environ: {check_rc: false}
+    rc: 1
+    out: ''
+    err: ''
+  query_foo_present: &query_foo_present
+    command: [/testbin/xbps-query, foo]
+    environ: {check_rc: false}
+    rc: 0
+    out: "foo-1.0_1 Description: Test package\n"
+    err: ''
+  check_updates_clean: &check_updates_clean
+    command: [/testbin/xbps-install, -Sun]
+    environ: {check_rc: false}
+    rc: 0
+    out: ''
+    err: ''
+  install_foo: &install_foo
+    command: [/testbin/xbps-install, -y, foo]
+    environ: {check_rc: false}
+    rc: 0
+    out: "foo-1.0_1: installing ...\n"
+    err: ''
+  remove_foo: &remove_foo
+    command: [/testbin/xbps-remove, -y, foo]
+    environ: {check_rc: false}
+    rc: 0
+    out: "foo-1.0_1: removing ...\n"
+    err: ''
+
+test_cases:
+  - id: test_install_new_package
+    input:
+      name: [foo]
+      state: present
+    output:
+      changed: true
+      packages: [foo]
+      stdout: "foo-1.0_1: installing ...\n"
+      stderr: ''
+    mocks:
+      run_command:
+        - *sync_db
+        - *query_foo_absent
+        - *install_foo
+
+  - id: test_install_already_present
+    input:
+      name: [foo]
+      state: present
+    output:
+      changed: false
+      msg: Nothing to Install
+    mocks:
+      run_command:
+        - *sync_db
+        - *query_foo_present
+        - *check_updates_clean
+
+  - id: test_install_fails
+    input:
+      name: [nonexistent]
+      state: present
+    output:
+      failed: true
+      packages: [nonexistent]
+      stderr: "ERROR: nonexistent: not found in repository pool.\n"
+    mocks:
+      run_command:
+        - *sync_db
+        - command: [/testbin/xbps-query, nonexistent]
+          environ: {check_rc: false}
+          rc: 1
+          out: ''
+          err: ''
+        - command: [/testbin/xbps-install, -y, nonexistent]
+          environ: {check_rc: false}
+          rc: 1
+          out: ''
+          err: "ERROR: nonexistent: not found in repository pool.\n"
+
+  - id: test_remove_installed_package
+    input:
+      name: [foo]
+      state: absent
+    output:
+      changed: true
+      packages: [foo]
+      stdout: "foo-1.0_1: removing ...\n"
+      stderr: ''
+    mocks:
+      run_command:
+        - *sync_db
+        - *query_foo_present
+        - *check_updates_clean
+        - *remove_foo
+
+  - id: test_remove_absent_package
+    input:
+      name: [foo]
+      state: absent
+    output:
+      changed: false
+      msg: "package(s) already absent"
+    mocks:
+      run_command:
+        - *sync_db
+        - *query_foo_absent


### PR DESCRIPTION
##### SUMMARY

Include \`stdout\` and \`stderr\` from the last executed xbps command in all \`exit_json\` and \`fail_json\` calls. Previously these were silently discarded, making it harder to understand what xbps actually reported.

Also fixes a typo in the install failure message (\`packages(s)\` → \`package(s)\`).

Adds basic unit tests using \`uthelper\`.

Fixes #2478

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
xbps

##### ADDITIONAL INFORMATION

Before this change, a failed install would report:
```
"msg": "failed to install 1 packages(s)"
```

After:
```
"msg": "failed to install 1 package(s)",
"stderr": "ERROR: nonexistent: not found in repository pool."
```