### PR TITLE
filesystem: handle BusyBox `blkid` output when detecting existing filesystem

### DIFF
--- a/changelogs/fragments/12235-filesystem-busybox-blkid.yml
+++ b/changelogs/fragments/12235-filesystem-busybox-blkid.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "filesystem - handle BusyBox ``blkid`` output to correctly detect existing filesystems on systems like Alpine Linux
+    (https://github.com/ansible-collections/community.general/issues/7283,
+    https://github.com/ansible-collections/community.general/pull/12235)."

--- a/plugins/modules/filesystem.py
+++ b/plugins/modules/filesystem.py
@@ -683,6 +683,11 @@ def main():
     cmd = module.get_bin_path("blkid", required=True)
     rc, raw_fs, err = module.run_command([cmd, "-c", os.devnull, "-o", "value", "-s", "TYPE", str(dev)])
     fs = raw_fs.strip()
+    # BusyBox blkid may ignore -o/-s flags and output the full device info line,
+    # e.g. '/dev/sda2: UUID="..." TYPE="btrfs"' instead of just 'btrfs'
+    if fs and " " in fs:
+        type_match = re.search(r'\bTYPE="?([^"\s]+)"?', raw_fs)
+        fs = type_match.group(1) if type_match else ""
     if not fs and platform.system() == "FreeBSD":
         cmd = module.get_bin_path("fstyp", required=True)
         rc, raw_fs, err = module.run_command([cmd, str(dev)])


### PR DESCRIPTION
##### SUMMARY

BusyBox `blkid` (used on Alpine Linux and similar systems) does not honour the util-linux `-o value -s TYPE` flags. Instead of outputting just the filesystem type (e.g. `btrfs`), it outputs the full device info line:

```
/dev/sda2: UUID="dd9b269b-..." TYPE="btrfs"
```

The module stored that raw string as `fs`, which did not match any key in the internal `FILESYSTEMS` dict, causing `same_fs` to evaluate to `False`. The code then fell through to the `elif fs and not force:` branch and raised the "already used as" error even when the correct filesystem was already present.

The fix parses the `TYPE=` field from the raw `blkid` output when it does not look like a plain type name (i.e. when it contains spaces). Util-linux `blkid` with `-o value -s TYPE` still outputs just `btrfs` (no spaces), so the existing path is unaffected.

Fixes #7283

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
filesystem

##### ADDITIONAL INFORMATION

```paste below

```