### PR TITLE
keycloak_realm_users_info: add missing doc fragment

### DIFF
--- a/plugins/modules/keycloak_realm_users_info.py
+++ b/plugins/modules/keycloak_realm_users_info.py
@@ -35,6 +35,7 @@ options:
 
 extends_documentation_fragment:
   - community.general._keycloak
+  - community.general._keycloak.actiongroup_keycloak
   - community.general._attributes
   - community.general._attributes.info_module
 


### PR DESCRIPTION
##### SUMMARY
For some reason, the keycloak module defaults group doc fragment was missing, and CI in #12105 didn't notice / complain.

My guess is that this is due to change detection in antsibull-nox. This is something I need to fix...

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
keycloak_realm_users_info
