### PR TITLE
java_cert: detect silent `keytool` failures by verifying import outcome

### DIFF
--- a/changelogs/fragments/12238-java-cert-keytool-failure-detection.yml
+++ b/changelogs/fragments/12238-java-cert-keytool-failure-detection.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "java_cert - detect silent ``keytool`` failures by verifying the import outcome after the command exits with ``rc=0``
+    (https://github.com/ansible-collections/community.general/issues/6685,
+    https://github.com/ansible-collections/community.general/pull/12238)."

--- a/plugins/modules/java_cert.py
+++ b/plugins/modules/java_cert.py
@@ -411,6 +411,14 @@ def import_pkcs12_path(
     if import_rc != 0 or not os.path.exists(keystore_path):
         module.fail_json(msg=import_out, rc=import_rc, cmd=import_cmd, error=import_err)
 
+    check_alias = keystore_alias or pkcs12_alias
+    if check_alias:
+        alias_exists, _ = _check_cert_present(
+            module, executable, keystore_path, keystore_pass, check_alias, keystore_type
+        )
+        if not alias_exists:
+            module.fail_json(msg=import_out, rc=import_rc, cmd=import_cmd, error=import_err)
+
     return dict(
         changed=True, msg=import_out, rc=import_rc, cmd=import_cmd, stdout=import_out, error=import_err, diff=diff
     )
@@ -431,7 +439,11 @@ def import_cert_path(module, executable, path, keystore_path, keystore_pass, ali
     )
     diff = {"before": "\n", "after": f"{alias}\n"}
 
-    if import_rc != 0:
+    if import_rc != 0 or not os.path.exists(keystore_path):
+        module.fail_json(msg=import_out, rc=import_rc, cmd=import_cmd, error=import_err)
+
+    alias_exists, _ = _check_cert_present(module, executable, keystore_path, keystore_pass, alias, keystore_type)
+    if not alias_exists:
         module.fail_json(msg=import_out, rc=import_rc, cmd=import_cmd, error=import_err)
 
     return dict(

--- a/plugins/modules/java_cert.py
+++ b/plugins/modules/java_cert.py
@@ -413,7 +413,7 @@ def import_pkcs12_path(
 
     check_alias = keystore_alias or pkcs12_alias
     if check_alias:
-        alias_exists, _ = _check_cert_present(
+        alias_exists, dummy = _check_cert_present(
             module, executable, keystore_path, keystore_pass, check_alias, keystore_type
         )
         if not alias_exists:
@@ -442,7 +442,7 @@ def import_cert_path(module, executable, path, keystore_path, keystore_pass, ali
     if import_rc != 0 or not os.path.exists(keystore_path):
         module.fail_json(msg=import_out, rc=import_rc, cmd=import_cmd, error=import_err)
 
-    alias_exists, _ = _check_cert_present(module, executable, keystore_path, keystore_pass, alias, keystore_type)
+    alias_exists, dummy = _check_cert_present(module, executable, keystore_path, keystore_pass, alias, keystore_type)
     if not alias_exists:
         module.fail_json(msg=import_out, rc=import_rc, cmd=import_cmd, error=import_err)
 

--- a/tests/integration/targets/java_cert/tasks/state_change.yml
+++ b/tests/integration/targets/java_cert/tasks/state_change.yml
@@ -93,6 +93,40 @@
 # Run tests
 #
 
+- name: import cert with too-short keystore password should fail
+  community.general.java_cert:
+    cert_alias: test_cert
+    cert_path: "{{ test_cert_path }}"
+    keystore_path: "{{ remote_tmp_dir }}/keystore_short_pass.jks"
+    keystore_pass: ""
+    keystore_create: true
+    state: present
+  ignore_errors: true
+  register: result_short_pass_cert
+
+- name: verify failure with too-short keystore password for cert import
+  ansible.builtin.assert:
+    that:
+      - result_short_pass_cert is failed
+
+- name: import pkcs12 with too-short keystore password should fail
+  community.general.java_cert:
+    cert_alias: test_pkcs12_cert
+    pkcs12_alias: test_pkcs12_cert
+    pkcs12_path: "{{ test_pkcs_path }}"
+    pkcs12_password: "{{ test_keystore2_password }}"
+    keystore_path: "{{ remote_tmp_dir }}/keystore_short_pass_pkcs12.jks"
+    keystore_pass: ""
+    keystore_create: true
+    state: present
+  ignore_errors: true
+  register: result_short_pass_pkcs12
+
+- name: verify failure with too-short keystore password for pkcs12 import
+  ansible.builtin.assert:
+    that:
+      - result_short_pass_pkcs12 is failed
+
 - name: try to create the test keystore based on the just created pkcs12, keystore_create flag not enabled
   community.general.java_cert:
     cert_alias: test_pkcs12_cert


### PR DESCRIPTION
##### SUMMARY

OpenJDK's `keytool` can exit with `rc=0` even when an operation fails (e.g., when `keystore_pass` is too short). The module previously only checked the return code, so these silent failures went undetected and the task incorrectly reported success or `changed=true`.

Two complementary checks are now added to both `import_cert_path` and `import_pkcs12_path`:

1. **File existence check** (`not os.path.exists(keystore_path)`) — catches the case where a new keystore was never created despite `rc=0`. `import_pkcs12_path` already had this; it is now applied to `import_cert_path` as well.
2. **Alias presence verification** (via `_check_cert_present`) — catches the case where the keystore already exists but the import silently failed; the alias simply won't appear in the keystore.

Fixes #6685

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
java_cert

##### ADDITIONAL INFORMATION

```paste below

```