### PR TITLE
Revert "filesystem module gfs2 support (#12218)"

### DIFF
--- a/changelogs/fragments/12218-filesystem-gfs2.yaml
+++ b/changelogs/fragments/12218-filesystem-gfs2.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - filesystem - adds GFS2 support (https://github.com/ansible-collections/community.general/pull/12218).

--- a/plugins/modules/filesystem.py
+++ b/plugins/modules/filesystem.py
@@ -35,12 +35,11 @@ options:
     default: present
     version_added: 1.3.0
   fstype:
-    choices: [bcachefs, btrfs, ext2, ext3, ext4, ext4dev, f2fs, lvm, ocfs2, reiserfs, xfs, vfat, swap, ufs, gfs2]
+    choices: [bcachefs, btrfs, ext2, ext3, ext4, ext4dev, f2fs, lvm, ocfs2, reiserfs, xfs, vfat, swap, ufs]
     description:
       - Filesystem type to be created. This option is required with O(state=present) (or if O(state) is omitted).
       - V(ufs) support has been added in community.general 3.4.0.
       - V(bcachefs) support has been added in community.general 8.6.0.
-      - V(gfs2) support has been added in community.general 13.1.0.
     type: str
     aliases: [type]
   dev:
@@ -612,12 +611,6 @@ class UFS(Filesystem):
         return fragmentsize * providersize
 
 
-class GFS2(Filesystem):
-    MKFS = "mkfs.gfs2"
-    MKFS_FORCE_FLAGS = ["-O"]
-    MKFS_SET_UUID_OPTIONS = ["-U"]
-
-
 FILESYSTEMS = {
     "bcachefs": Bcachefs,
     "ext2": Ext2,
@@ -633,7 +626,6 @@ FILESYSTEMS = {
     "LVM2_member": LVM,
     "swap": Swap,
     "ufs": UFS,
-    "gfs2": GFS2,
 }
 
 

--- a/tests/integration/targets/filesystem/defaults/main.yml
+++ b/tests/integration/targets/filesystem/defaults/main.yml
@@ -29,8 +29,6 @@ tested_filesystems:
   lvm: {fssize: 20, grow: true, new_uuid: 'something'}
   swap: {fssize: 10, grow: false, new_uuid: null}  # grow not implemented
   ufs: {fssize: 10, grow: true, new_uuid: null}
-  # TODO: tests seem to be generally broken
-  # gfs2: {fssize: 10, grow: false, new_uuid: null}
 
 
 get_uuid_any: "blkid -c /dev/null -o value -s UUID {{ dev }}"

--- a/tests/integration/targets/filesystem/tasks/setup.yml
+++ b/tests/integration/targets/filesystem/tasks/setup.yml
@@ -99,12 +99,6 @@
     state: present
   when: ansible_facts.os_family == 'Debian'
 
-- name: "Install GFS2"
-  ansible.builtin.package:
-    name: gfs2-utils
-    state: present
-  when: ansible_facts.os_family in ['Debian', 'Suse', 'Ubuntu'] or ansible_facts.distribution in ['Fedora']
-
 - name: "Install f2fs tools and get version"
   when:
     - ansible_facts.os_family != 'RedHat' or ansible_facts.distribution == 'Fedora'


### PR DESCRIPTION
##### SUMMARY
This reverts commit 9c0051e3256f3550ddab5abd3f60bfc7cc02eb63, and thus PR #12218.

It turned out that the filesystem tests didn't run in CI *at all*. When reactivating them (#12258), it turned out that the gfs2 tests never succeeded; either required binaries weren't installed, or they failed with:
```
fatal: [testhost]: FAILED! => {"changed": false, "cmd": "/usr/sbin/mkfs.gfs2 -O /root/tmp/ansible.1bf6_nse.test/img", "msg": "No lock table specified.", "rc": 255, "stderr": "No lock table specified.\n", "stderr_lines": ["No lock table specified."], "stdout": "", "stdout_lines": []}
```
I'm revering the merge of PR #12218 so the PR can be re-created with passing tests. Sorry for inconvenience :(

CC @gurubert.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
filesystem
