### PR TITLE
pacemaker_resource: fix non-idempotent clone of an already-cloned gro…

### DIFF
--- a/changelogs/fragments/12169-pacemaker_resource-clone-idempotency.yml
+++ b/changelogs/fragments/12169-pacemaker_resource-clone-idempotency.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - pacemaker_resource - fix non-idempotent behaviour when ``state=cloned`` is applied to a resource or group that is already part of a clone set (https://github.com/ansible-collections/community.general/issues/12217).
+  - pacemaker_resource - fix non-idempotent behaviour when ``state=cloned`` is applied to a resource or group that is already part of a clone set (https://github.com/ansible-collections/community.general/issues/12217, https://github.com/ansible-collections/community.general/pull/12288).

--- a/changelogs/fragments/12169-pacemaker_resource-clone-idempotency.yml
+++ b/changelogs/fragments/12169-pacemaker_resource-clone-idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pacemaker_resource - fix non-idempotent behaviour when ``state=cloned`` is applied to a resource or group that is already part of a clone set (https://github.com/ansible-collections/community.general/issues/12217).

--- a/changelogs/fragments/12169-pacemaker_resource-clone-idempotency.yml
+++ b/changelogs/fragments/12169-pacemaker_resource-clone-idempotency.yml
@@ -1,4 +1,4 @@
 bugfixes:
   - pacemaker_resource - fix non-idempotent behaviour when ``state=cloned`` is applied to a resource or group that is already part of a clone set (https://github.com/ansible-collections/community.general/issues/12217, https://github.com/ansible-collections/community.general/pull/12288).
 minor_changes:
-  - pacemaker_cluster, pacemaker_info, pacemaker_resource - added compatibility with older ``pcs`` versions that lack ``--output-format=json`` by probing ``pcs --version`` at runtime and dispatching to plaintext parsing on ``pcs`` < 0.11.6. On older ``pcs``, ``pacemaker_info`` returns raw ``pcs`` stdout strings under each ``*_info`` key instead of structured dictionaries; ``pacemaker_cluster`` and ``pacemaker_resource`` retain full functional and idempotency guarantees.
+  - pacemaker_cluster, pacemaker_resource - added json compatibility with ``--output-format=json`` by probing ``pcs --version`` at runtime and dispatching to plaintext parsing on ``pcs`` < 0.11.6. ``pacemaker_cluster`` and ``pacemaker_resource`` retain full functional and idempotency guarantees.

--- a/changelogs/fragments/12169-pacemaker_resource-clone-idempotency.yml
+++ b/changelogs/fragments/12169-pacemaker_resource-clone-idempotency.yml
@@ -1,2 +1,4 @@
 bugfixes:
   - pacemaker_resource - fix non-idempotent behaviour when ``state=cloned`` is applied to a resource or group that is already part of a clone set (https://github.com/ansible-collections/community.general/issues/12217, https://github.com/ansible-collections/community.general/pull/12288).
+minor_changes:
+  - pacemaker_cluster, pacemaker_info, pacemaker_resource - added compatibility with older ``pcs`` versions that lack ``--output-format=json`` by probing ``pcs --version`` at runtime and dispatching to plaintext parsing on ``pcs`` < 0.11.6. On older ``pcs``, ``pacemaker_info`` returns raw ``pcs`` stdout strings under each ``*_info`` key instead of structured dictionaries; ``pacemaker_cluster`` and ``pacemaker_resource`` retain full functional and idempotency guarantees.

--- a/plugins/module_utils/_pacemaker.py
+++ b/plugins/module_utils/_pacemaker.py
@@ -63,9 +63,7 @@ def get_pacemaker_maintenance_mode(runner: CmdRunner) -> bool:
     dependent text formatting cannot affect the result.
     """
     with runner("cli_action config output_format") as ctx:
-        rc, out, err = ctx.run(cli_action="property", output_format="json")
-    if not out:
-        return False
+        rc, out, err = ctx.run(cli_action="property")
     try:
         data = json.loads(out)
     except (TypeError, ValueError):
@@ -85,7 +83,7 @@ def get_pacemaker_resource_config(runner: CmdRunner) -> t.Optional[dict]:
     Requires pcs >= 0.11.3.
     """
     with runner("cli_action state name output_format") as ctx:
-        rc, out, err = ctx.run(cli_action="resource", state="config", output_format="json")
+        rc, out, err = ctx.run(cli_action="resource", state="config")
     if rc != 0 or not out:
         return None
     try:
@@ -99,8 +97,6 @@ def is_resource_cloned(config: t.Mapping, name: str) -> bool:
     config DTO. Matches both directly-cloned primitives and cloned groups, since pcs
     represents cloned-group membership the same way (``clones[].member_id == <group_id>``).
     """
-    if not name:
-        return False
     return any(clone.get("member_id") == name for clone in config.get("clones") or [])
 
 
@@ -158,7 +154,7 @@ def pacemaker_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
             config=cmd_runner_fmt.as_fixed("config"),
             force=cmd_runner_fmt.as_bool("--force"),
             version=cmd_runner_fmt.as_fixed("--version"),
-            output_format=cmd_runner_fmt.as_opt_eq_val("--output-format"),
+            output_format=cmd_runner_fmt.as_fixed("--output-format=json"),
         ),
         **kwargs,
     )

--- a/plugins/module_utils/_pacemaker.py
+++ b/plugins/module_utils/_pacemaker.py
@@ -5,15 +5,45 @@
 # Note that this module util is **PRIVATE** to the collection. It can have breaking changes at any time.
 # Do not use this from other collections or standalone plugins/modules!
 
+"""Private helpers for the ``community.general.pacemaker_*`` modules.
+
+Version-dispatch model
+----------------------
+``pcs`` versions ``0.11.6`` and newer support ``--output-format=json`` on
+``property config`` and ``resource config``, which is the parse-friendly form
+this collection prefers. Older ``pcs`` releases (RHEL 7/8 era, and any distro
+still shipping ``pcs`` < 0.11.6) only emit plaintext.
+
+To support both, :class:`PacemakerRunner` probes ``pcs --version`` once at
+construction and exposes the parsed tuple plus a ``supports_json`` bit. The
+helpers below then dispatch to a JSON path or a plaintext path based on that
+bit. On probe failure (``pcs`` missing, non-zero rc, unparseable output)
+callers fall open to the plaintext path so a transient ``pcs --version``
+glitch cannot break otherwise-functional automation.
+
+The plaintext path preserves the behavioural contract of each helper:
+
+* ``get_pacemaker_maintenance_mode`` still returns ``True``/``False``.
+* ``is_resource_cloned_any`` still returns ``True``/``False`` for clone
+  idempotency gating.
+
+``pacemaker_info`` is the one exception: its return value is user-facing and on
+older ``pcs`` it hands back raw plaintext strings under the ``*_info`` keys
+instead of parsed dicts.
+"""
+
 from __future__ import annotations
 
 import json
+import re
 import time
 import typing as t
 
 from ansible_collections.community.general.plugins.module_utils._cmd_runner import CmdRunner, cmd_runner_fmt
 
 if t.TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
     from ansible.module_utils.basic import AnsibleModule
 
 
@@ -30,6 +60,16 @@ _state_map = {
     "config": "config",
     "cleanup": "cleanup",
 }
+
+
+# ``pcs`` versions supporting ``--output-format=json`` on the subcommands this
+# collection needs. Bump if a new subcommand requires a newer floor.
+_PCS_JSON_MIN = (0, 11, 6)
+
+_PCS_VERSION_RE = re.compile(r"^\s*(\d+)\.(\d+)\.(\d+)")
+_MAINTENANCE_MODE_RE = re.compile(r"maintenance-mode\s*[:=]\s*(true|false)\b", re.IGNORECASE)
+# Accept both ``Clone:`` (modern pcs) and ``Clone Set:`` (older pcs) headers.
+_CLONE_HEADER_RE = re.compile(r"^\s*Clone(?:\s+Set)?:\s+\S+", re.MULTILINE)
 
 
 def fmt_resource_type(value):
@@ -55,61 +95,123 @@ def fmt_resource_argument(value):
     return ["--group" if value["argument_action"] == "group" else value["argument_action"]] + value["argument_option"]
 
 
-def get_pacemaker_maintenance_mode(runner: CmdRunner) -> bool:
-    """Return True if cluster property ``maintenance-mode`` is set to ``true``.
+def parse_pcs_version(raw: str) -> tuple[int, int, int] | None:
+    """Parse the leading ``MAJOR.MINOR.PATCH`` from a ``pcs --version`` output line.
 
-    Uses ``pcs property config --output-format=json`` (pcs >= 0.11.6) and parses the
-    structured output rather than scraping plaintext, so locale-dependent or version-
-    dependent text formatting cannot affect the result.
+    Returns ``None`` if the output is empty or does not begin with a
+    dotted-triple integer version. Trailing build/dev suffixes are ignored.
     """
+    if not raw:
+        return None
+    match = _PCS_VERSION_RE.match(raw)
+    if not match:
+        return None
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
+def _maintenance_mode_json(runner: PacemakerRunner) -> bool:
+    """JSON path: parse ``pcs property config --output-format=json``."""
     with runner("cli_action config output_format") as ctx:
         rc, out, err = ctx.run(cli_action="property")
     try:
         data = json.loads(out)
     except (TypeError, ValueError):
         return False
-    for nvset in data.get("nvsets") or []:
-        for nvpair in nvset.get("nvpairs") or []:
+    for nvset in data.get("nvsets", []):
+        for nvpair in nvset.get("nvpairs", []):
             if nvpair.get("name") == "maintenance-mode" and nvpair.get("value") == "true":
                 return True
     return False
 
 
-def get_pacemaker_resource_config(runner: CmdRunner) -> t.Optional[dict]:
-    """Return parsed ``pcs resource config <name> --output-format=json`` for the
-    runner-bound ``name``, or ``None`` if the resource does not exist or the output
-    cannot be parsed.
+def _maintenance_mode_plaintext(runner: PacemakerRunner) -> bool:
+    """Plaintext path: query the single property directly and regex-match.
 
-    Requires pcs >= 0.11.3.
+    Uses ``pcs property config maintenance-mode`` which returns output shaped
+    like ``maintenance-mode=true``, ``maintenance-mode: true``, or
+    ``maintenance-mode=false (default)`` depending on ``pcs`` version.
     """
+    with runner("cli_action config name") as ctx:
+        rc, out, err = ctx.run(cli_action="property", name="maintenance-mode")
+    if rc != 0 or not out:
+        return False
+    match = _MAINTENANCE_MODE_RE.search(out)
+    return bool(match and match.group(1).lower() == "true")
+
+
+def get_pacemaker_maintenance_mode(runner: PacemakerRunner) -> bool:
+    """Return ``True`` if cluster property ``maintenance-mode`` is set to ``true``.
+
+    Dispatches to a JSON parser on ``pcs`` >= 0.11.6 and to a plaintext parser
+    on older versions.
+    """
+    if runner.supports_json:
+        return _maintenance_mode_json(runner)
+    return _maintenance_mode_plaintext(runner)
+
+
+def get_pacemaker_resource_config(runner: PacemakerRunner) -> dict | None:
+    """Return parsed ``pcs resource config <name> --output-format=json`` for the
+    runner-bound ``name``, or ``None`` if the output cannot be parsed or the
+    installed ``pcs`` does not support JSON output.
+
+    Callers requiring clone-idempotency on both new and old ``pcs`` should use
+    :func:`is_resource_cloned_any` instead of consuming this DTO directly.
+    """
+    if not runner.supports_json:
+        return None
     with runner("cli_action state name output_format") as ctx:
         rc, out, err = ctx.run(cli_action="resource", state="config")
-    if rc != 0 or not out:
-        return None
     try:
         return json.loads(out)
     except (TypeError, ValueError):
         return None
 
 
-def is_resource_cloned(config: t.Mapping, name: str) -> bool:
+def is_resource_cloned(config: Mapping, name: str) -> bool:
     """Return True if *name* appears as a clone ``member_id`` in the given resource
     config DTO. Matches both directly-cloned primitives and cloned groups, since pcs
     represents cloned-group membership the same way (``clones[].member_id == <group_id>``).
     """
-    return any(clone.get("member_id") == name for clone in config.get("clones") or [])
+    return any(clone.get("member_id") == name for clone in config.get("clones", []))
+
+
+def is_resource_cloned_plaintext(runner: PacemakerRunner) -> bool:
+    """Plaintext path: run ``pcs resource config <name>`` (no JSON) and check
+    for a ``Clone:`` / ``Clone Set:`` header line in the output.
+
+    The runner must already be bound to a resource ``name``.
+    """
+    with runner("cli_action state name") as ctx:
+        rc, out, err = ctx.run(cli_action="resource", state="config")
+    if rc != 0 or not out:
+        return False
+    return bool(_CLONE_HEADER_RE.search(out))
+
+
+def is_resource_cloned_any(runner: PacemakerRunner, name: str) -> bool:
+    """Version-dispatched idempotency check: is *name* already part of a clone?
+
+    Uses structured JSON on ``pcs`` >= 0.11.6 and falls back to plaintext
+    header matching on older versions. Both paths preserve idempotency of
+    clone creation.
+    """
+    if runner.supports_json:
+        config = get_pacemaker_resource_config(runner)
+        return config is not None and is_resource_cloned(config, name)
+    return is_resource_cloned_plaintext(runner)
 
 
 _DEFAULT_RESOURCE_READY_STATES = ("Started",)
 
 
 def wait_for_resource(
-    runner: CmdRunner,
+    runner: PacemakerRunner,
     cli_noun: str,
     name: str,
     wait: int,
     sleep_interval: int = 5,
-    ready_states: t.Iterable[str] = _DEFAULT_RESOURCE_READY_STATES,
+    ready_states: Iterable[str] = _DEFAULT_RESOURCE_READY_STATES,
 ) -> None:
     """Poll ``pcs <cli_noun> status <name>`` until the resource reports a ready state or the wait budget expires.
 
@@ -132,30 +234,63 @@ def wait_for_resource(
         time.sleep(sleep_interval)
 
 
-def pacemaker_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
-    runner_command = ["pcs"]
-    runner = CmdRunner(
-        module,
-        command=runner_command,
-        arg_formats=dict(
-            cli_action=cmd_runner_fmt.as_list(),
-            state=cmd_runner_fmt.as_map(_state_map),
-            name=cmd_runner_fmt.as_list(),
-            resource_type=cmd_runner_fmt.as_func(fmt_resource_type),
-            resource_option=cmd_runner_fmt.as_list(),
-            resource_operation=cmd_runner_fmt.as_func(fmt_resource_operation),
-            resource_meta=cmd_runner_fmt.stack(cmd_runner_fmt.as_opt_val)("meta"),
-            resource_argument=cmd_runner_fmt.as_func(fmt_resource_argument),
-            resource_clone_ids=cmd_runner_fmt.as_list(),
-            resource_clone_meta=cmd_runner_fmt.as_list(),
-            apply_all=cmd_runner_fmt.as_bool("--all"),
-            agent_validation=cmd_runner_fmt.as_bool("--agent-validation"),
-            wait=cmd_runner_fmt.as_opt_eq_val("--wait"),
-            config=cmd_runner_fmt.as_fixed("config"),
-            force=cmd_runner_fmt.as_bool("--force"),
-            version=cmd_runner_fmt.as_fixed("--version"),
-            output_format=cmd_runner_fmt.as_fixed("--output-format=json"),
-        ),
-        **kwargs,
-    )
-    return runner
+class PacemakerRunner(CmdRunner):
+    """CmdRunner subclass for the ``pcs`` CLI.
+
+    Probes ``pcs --version`` once at construction and exposes:
+
+    * :attr:`raw_version` — the trimmed raw output of ``pcs --version`` (with
+      any distro build suffix retained, for user-facing display).
+    * :attr:`version` — the parsed ``(major, minor, patch)`` tuple, or ``None``
+      when the probe fails or the output is unparseable.
+    * :attr:`supports_json` — ``True`` when :attr:`version` is at least
+      :data:`_PCS_JSON_MIN`. Version-dispatch helpers read this attribute to
+      choose between the JSON and plaintext code paths; fails open (plaintext)
+      on probe failure so a transient ``pcs --version`` glitch cannot break
+      otherwise-functional automation.
+    """
+
+    def __init__(self, module: AnsibleModule, **kwargs) -> None:
+        super().__init__(
+            module,
+            command=["pcs"],
+            arg_formats=dict(
+                cli_action=cmd_runner_fmt.as_list(),
+                state=cmd_runner_fmt.as_map(_state_map),
+                name=cmd_runner_fmt.as_list(),
+                resource_type=cmd_runner_fmt.as_func(fmt_resource_type),
+                resource_option=cmd_runner_fmt.as_list(),
+                resource_operation=cmd_runner_fmt.as_func(fmt_resource_operation),
+                resource_meta=cmd_runner_fmt.stack(cmd_runner_fmt.as_opt_val)("meta"),
+                resource_argument=cmd_runner_fmt.as_func(fmt_resource_argument),
+                resource_clone_ids=cmd_runner_fmt.as_list(),
+                resource_clone_meta=cmd_runner_fmt.as_list(),
+                apply_all=cmd_runner_fmt.as_bool("--all"),
+                agent_validation=cmd_runner_fmt.as_bool("--agent-validation"),
+                wait=cmd_runner_fmt.as_opt_eq_val("--wait"),
+                config=cmd_runner_fmt.as_fixed("config"),
+                force=cmd_runner_fmt.as_bool("--force"),
+                version=cmd_runner_fmt.as_fixed("--version"),
+                output_format=cmd_runner_fmt.as_fixed("--output-format=json"),
+            ),
+            **kwargs,
+        )
+        self.raw_version = self._probe_version()
+        self.version = parse_pcs_version(self.raw_version)
+        self.supports_json = self.version is not None and self.version >= _PCS_JSON_MIN
+
+    def _probe_version(self) -> str:
+        """Shell out ``pcs --version`` and return the trimmed raw output.
+
+        Returns an empty string on any probe failure so the parsers downstream
+        gracefully treat the result as "unknown" (fails open to the plaintext
+        path). Extracted as a method so tests can patch it via
+        ``mocker.patch.object(PacemakerRunner, "_probe_version", ...)``.
+        """
+        with self("version") as ctx:
+            rc, out, err = ctx.run()
+        return out.strip() if rc == 0 and out else ""
+
+
+def pacemaker_runner(module: AnsibleModule, **kwargs) -> PacemakerRunner:
+    return PacemakerRunner(module, **kwargs)

--- a/plugins/module_utils/_pacemaker.py
+++ b/plugins/module_utils/_pacemaker.py
@@ -7,7 +7,7 @@
 
 from __future__ import annotations
 
-import re
+import json
 import time
 import typing as t
 
@@ -56,11 +56,52 @@ def fmt_resource_argument(value):
 
 
 def get_pacemaker_maintenance_mode(runner: CmdRunner) -> bool:
-    with runner("cli_action config") as ctx:
-        rc, out, err = ctx.run(cli_action="property")
-        maint_mode_re = re.compile(r"maintenance-mode.*true", re.IGNORECASE)
-        maintenance_mode_output = [line for line in out.splitlines() if maint_mode_re.search(line)]
-        return bool(maintenance_mode_output)
+    """Return True if cluster property ``maintenance-mode`` is set to ``true``.
+
+    Uses ``pcs property config --output-format=json`` (pcs >= 0.11.6) and parses the
+    structured output rather than scraping plaintext, so locale-dependent or version-
+    dependent text formatting cannot affect the result.
+    """
+    with runner("cli_action config output_format") as ctx:
+        rc, out, err = ctx.run(cli_action="property", output_format="json")
+    if not out:
+        return False
+    try:
+        data = json.loads(out)
+    except (TypeError, ValueError):
+        return False
+    for nvset in data.get("nvsets") or []:
+        for nvpair in nvset.get("nvpairs") or []:
+            if nvpair.get("name") == "maintenance-mode" and nvpair.get("value") == "true":
+                return True
+    return False
+
+
+def get_pacemaker_resource_config(runner: CmdRunner) -> t.Optional[dict]:
+    """Return parsed ``pcs resource config <name> --output-format=json`` for the
+    runner-bound ``name``, or ``None`` if the resource does not exist or the output
+    cannot be parsed.
+
+    Requires pcs >= 0.11.3.
+    """
+    with runner("cli_action state name output_format") as ctx:
+        rc, out, err = ctx.run(cli_action="resource", state="config", output_format="json")
+    if rc != 0 or not out:
+        return None
+    try:
+        return json.loads(out)
+    except (TypeError, ValueError):
+        return None
+
+
+def is_resource_cloned(config: t.Mapping, name: str) -> bool:
+    """Return True if *name* appears as a clone ``member_id`` in the given resource
+    config DTO. Matches both directly-cloned primitives and cloned groups, since pcs
+    represents cloned-group membership the same way (``clones[].member_id == <group_id>``).
+    """
+    if not name:
+        return False
+    return any(clone.get("member_id") == name for clone in config.get("clones") or [])
 
 
 _DEFAULT_RESOURCE_READY_STATES = ("Started",)

--- a/plugins/modules/pacemaker_cluster.py
+++ b/plugins/modules/pacemaker_cluster.py
@@ -14,6 +14,11 @@ author:
   - Dexter Le (@munchtoast)
 description:
   - This module can manage a pacemaker cluster and nodes from Ansible using the pacemaker CLI.
+requirements:
+  - pcs
+notes:
+  - Maintenance-mode detection uses C(pcs property config --output-format=json) on C(pcs) >= 0.11.6
+    and falls back to plaintext parsing of C(pcs property config maintenance-mode) on older versions.
 extends_documentation_fragment:
   - community.general._attributes
 attributes:

--- a/plugins/modules/pacemaker_info.py
+++ b/plugins/modules/pacemaker_info.py
@@ -95,7 +95,7 @@ class PacemakerInfo(ModuleHelper):
         with self.runner(
             "cli_action config output_format", output_process=self._process_command_output(cli_action)
         ) as ctx:
-            return ctx.run(cli_action=cli_action, output_format="json")
+            return ctx.run(cli_action=cli_action)
 
     def __run__(self):
         for key, cli_action in sorted(self.info_vars.items()):

--- a/plugins/modules/pacemaker_info.py
+++ b/plugins/modules/pacemaker_info.py
@@ -14,6 +14,14 @@ author:
 version_added: 11.2.0
 description:
   - Gather information about a Pacemaker cluster.
+requirements:
+  - pcs
+notes:
+  - On C(pcs) >= 0.11.6, the module invokes C(pcs <subcommand> config --output-format=json) and
+    returns parsed dictionaries under each C(*_info) key. On older C(pcs) versions that do not
+    support JSON output, the raw plaintext C(pcs) output is returned as a string under each
+    C(*_info) key instead. Consumers can distinguish shapes at run time with a
+    C({{ cluster_info is mapping }}) guard.
 extends_documentation_fragment:
   - community.general._attributes
   - community.general._attributes.info_module
@@ -35,25 +43,35 @@ version:
   returned: always
   type: str
 cluster_info:
-  description: Cluster information such as the name, UUID, and nodes.
+  description:
+    - Cluster information such as the name, UUID, and nodes.
+    - Structured dictionary on C(pcs) >= 0.11.6; raw C(pcs) stdout string on older versions.
   returned: always
-  type: dict
+  type: raw
 resource_info:
-  description: All resources available on the cluster and their status.
+  description:
+    - All resources available on the cluster and their status.
+    - Structured dictionary on C(pcs) >= 0.11.6; raw C(pcs) stdout string on older versions.
   returned: success
-  type: dict
+  type: raw
 stonith_info:
-  description: All STONITH information on the cluster.
+  description:
+    - All STONITH information on the cluster.
+    - Structured dictionary on C(pcs) >= 0.11.6; raw C(pcs) stdout string on older versions.
   returned: success
-  type: dict
+  type: raw
 constraint_info:
-  description: All cluster resource constraints on the cluster.
+  description:
+    - All cluster resource constraints on the cluster.
+    - Structured dictionary on C(pcs) >= 0.11.6; raw C(pcs) stdout string on older versions.
   returned: success
-  type: dict
+  type: raw
 property_info:
-  description: All properties present on the cluster.
+  description:
+    - All properties present on the cluster.
+    - Structured dictionary on C(pcs) >= 0.11.6; raw C(pcs) stdout string on older versions.
   returned: success
-  type: dict
+  type: raw
 """
 
 import json
@@ -78,23 +96,25 @@ class PacemakerInfo(ModuleHelper):
 
     def __init_module__(self):
         self.runner = pacemaker_runner(self.module)
-        with self.runner("version") as ctx:
-            rc, out, err = ctx.run()
-            self.vars.version = out.strip()
+        self.vars.version = self.runner.raw_version
 
     def _process_command_output(self, cli_action=""):
+        supports_json = self.runner.supports_json
+
         def process(rc, out, err):
             if rc != 0:
                 self.do_raise(f"pcs {cli_action} config failed with error (rc={rc}): {err}")
-            out = json.loads(out)
-            return None if out == "" else out
+            if supports_json:
+                parsed = json.loads(out) if out else None
+                return parsed if parsed else None
+            stripped = out.strip() if out else ""
+            return stripped or None
 
         return process
 
     def _get_info(self, cli_action):
-        with self.runner(
-            "cli_action config output_format", output_process=self._process_command_output(cli_action)
-        ) as ctx:
+        spec = "cli_action config output_format" if self.runner.supports_json else "cli_action config"
+        with self.runner(spec, output_process=self._process_command_output(cli_action)) as ctx:
             return ctx.run(cli_action=cli_action)
 
     def __run__(self):

--- a/plugins/modules/pacemaker_info.py
+++ b/plugins/modules/pacemaker_info.py
@@ -16,12 +16,6 @@ description:
   - Gather information about a Pacemaker cluster.
 requirements:
   - pcs
-notes:
-  - On C(pcs) >= 0.11.6, the module invokes C(pcs <subcommand> config --output-format=json) and
-    returns parsed dictionaries under each C(*_info) key. On older C(pcs) versions that do not
-    support JSON output, the raw plaintext C(pcs) output is returned as a string under each
-    C(*_info) key instead. Consumers can distinguish shapes at run time with a
-    C({{ cluster_info is mapping }}) guard.
 extends_documentation_fragment:
   - community.general._attributes
   - community.general._attributes.info_module
@@ -45,33 +39,28 @@ version:
 cluster_info:
   description:
     - Cluster information such as the name, UUID, and nodes.
-    - Structured dictionary on C(pcs) >= 0.11.6; raw C(pcs) stdout string on older versions.
   returned: always
-  type: raw
+  type: dict
 resource_info:
   description:
     - All resources available on the cluster and their status.
-    - Structured dictionary on C(pcs) >= 0.11.6; raw C(pcs) stdout string on older versions.
   returned: success
-  type: raw
+  type: dict
 stonith_info:
   description:
     - All STONITH information on the cluster.
-    - Structured dictionary on C(pcs) >= 0.11.6; raw C(pcs) stdout string on older versions.
   returned: success
-  type: raw
+  type: dict
 constraint_info:
   description:
     - All cluster resource constraints on the cluster.
-    - Structured dictionary on C(pcs) >= 0.11.6; raw C(pcs) stdout string on older versions.
   returned: success
-  type: raw
+  type: dict
 property_info:
   description:
     - All properties present on the cluster.
-    - Structured dictionary on C(pcs) >= 0.11.6; raw C(pcs) stdout string on older versions.
   returned: success
-  type: raw
+  type: dict
 """
 
 import json
@@ -99,23 +88,20 @@ class PacemakerInfo(ModuleHelper):
         self.vars.version = self.runner.raw_version
 
     def _process_command_output(self, cli_action=""):
-        supports_json = self.runner.supports_json
 
         def process(rc, out, err):
             if rc != 0:
                 self.do_raise(f"pcs {cli_action} config failed with error (rc={rc}): {err}")
-            if supports_json:
-                parsed = json.loads(out) if out else None
-                return parsed if parsed else None
-            stripped = out.strip() if out else ""
-            return stripped or None
+            parsed = json.loads(out) if out else None
+            return parsed if parsed else None
 
         return process
 
     def _get_info(self, cli_action):
-        spec = "cli_action config output_format" if self.runner.supports_json else "cli_action config"
-        with self.runner(spec, output_process=self._process_command_output(cli_action)) as ctx:
-            return ctx.run(cli_action=cli_action)
+        with self.runner(
+            "cli_action config output_format", output_process=self._process_command_output(cli_action)
+        ) as ctx:
+            return ctx.run(cli_action=cli_action, output_format="json")
 
     def __run__(self):
         for key, cli_action in sorted(self.info_vars.items()):

--- a/plugins/modules/pacemaker_info.py
+++ b/plugins/modules/pacemaker_info.py
@@ -15,7 +15,7 @@ version_added: 11.2.0
 description:
   - Gather information about a Pacemaker cluster.
 requirements:
-  - pcs
+  - pcs >= 0.11.6
 extends_documentation_fragment:
   - community.general._attributes
   - community.general._attributes.info_module
@@ -37,28 +37,23 @@ version:
   returned: always
   type: str
 cluster_info:
-  description:
-    - Cluster information such as the name, UUID, and nodes.
+  description: Cluster information such as the name, UUID, and nodes.
   returned: always
   type: dict
 resource_info:
-  description:
-    - All resources available on the cluster and their status.
+  description: All resources available on the cluster and their status.
   returned: success
   type: dict
 stonith_info:
-  description:
-    - All STONITH information on the cluster.
+  description: All STONITH information on the cluster.
   returned: success
   type: dict
 constraint_info:
-  description:
-    - All cluster resource constraints on the cluster.
+  description: All cluster resource constraints on the cluster.
   returned: success
   type: dict
 property_info:
-  description:
-    - All properties present on the cluster.
+  description: All properties present on the cluster.
   returned: success
   type: dict
 """
@@ -88,7 +83,6 @@ class PacemakerInfo(ModuleHelper):
         self.vars.version = self.runner.raw_version
 
     def _process_command_output(self, cli_action=""):
-
         def process(rc, out, err):
             if rc != 0:
                 self.do_raise(f"pcs {cli_action} config failed with error (rc={rc}): {err}")

--- a/plugins/modules/pacemaker_resource.py
+++ b/plugins/modules/pacemaker_resource.py
@@ -148,6 +148,8 @@ cluster_resources:
 from ansible_collections.community.general.plugins.module_utils._module_helper import StateModuleHelper
 from ansible_collections.community.general.plugins.module_utils._pacemaker import (
     get_pacemaker_maintenance_mode,
+    get_pacemaker_resource_config,
+    is_resource_cloned,
     pacemaker_runner,
     wait_for_resource,
 )
@@ -255,6 +257,8 @@ class PacemakerResource(StateModuleHelper):
             wait_for_resource(self.runner, "resource", self.vars.name, self.vars.wait, ready_states=_READY_STATES)
 
     def state_cloned(self):
+        if self._is_already_cloned():
+            return
         with self.runner(
             "cli_action state name resource_clone_ids resource_clone_meta",
             output_process=self._process_command_output(
@@ -268,6 +272,23 @@ class PacemakerResource(StateModuleHelper):
             )
         if not self.module.check_mode and self.vars.wait and not get_pacemaker_maintenance_mode(self.runner):
             wait_for_resource(self.runner, "resource", self.vars.name, self.vars.wait, ready_states=_READY_STATES)
+
+    def _is_already_cloned(self):
+        """Return True if the named resource (or group) is already part of a clone set.
+
+        Queries ``pcs resource config <name> --output-format=json`` and checks whether
+        any clone object's ``member_id`` matches the requested name. This avoids the
+        previous fragile approach of inspecting pcs stderr for a hard-coded substring,
+        which only matched the "resource is already cloned" wording and not the
+        "cannot clone a group that has already been cloned" wording.
+        """
+        name = self.module.params["name"]
+        if not name:
+            return False
+        config = get_pacemaker_resource_config(self.runner)
+        if config is None:
+            return False
+        return is_resource_cloned(config, name)
 
     def state_enabled(self):
         with self.runner(

--- a/plugins/modules/pacemaker_resource.py
+++ b/plugins/modules/pacemaker_resource.py
@@ -289,7 +289,7 @@ class PacemakerResource(StateModuleHelper):
         which only matched the "resource is already cloned" wording and not the
         "cannot clone a group that has already been cloned" wording.
         """
-        name = self.module.params["name"]
+        name = self.vars.name
         if not name:
             return False
         return is_resource_cloned_any(self.runner, name)

--- a/plugins/modules/pacemaker_resource.py
+++ b/plugins/modules/pacemaker_resource.py
@@ -14,6 +14,12 @@ author:
 version_added: 10.5.0
 description:
   - This module can manage resources in a Pacemaker cluster using the pacemaker CLI.
+requirements:
+  - pcs
+notes:
+  - Clone-idempotency detection uses structured JSON output on C(pcs) >= 0.11.6 and falls back to
+    plaintext parsing of C(pcs resource config <name>) on older versions. Both paths preserve
+    idempotency of clone creation.
 extends_documentation_fragment:
   - community.general._attributes
 attributes:
@@ -148,8 +154,7 @@ cluster_resources:
 from ansible_collections.community.general.plugins.module_utils._module_helper import StateModuleHelper
 from ansible_collections.community.general.plugins.module_utils._pacemaker import (
     get_pacemaker_maintenance_mode,
-    get_pacemaker_resource_config,
-    is_resource_cloned,
+    is_resource_cloned_any,
     pacemaker_runner,
     wait_for_resource,
 )
@@ -276,8 +281,10 @@ class PacemakerResource(StateModuleHelper):
     def _is_already_cloned(self):
         """Return True if the named resource (or group) is already part of a clone set.
 
-        Queries ``pcs resource config <name> --output-format=json`` and checks whether
-        any clone object's ``member_id`` matches the requested name. This avoids the
+        On ``pcs`` >= 0.11.6 this queries ``pcs resource config <name> --output-format=json``
+        and checks whether any clone object's ``member_id`` matches the requested name.
+        On older ``pcs`` it falls back to matching a ``Clone:`` / ``Clone Set:`` header
+        line in plaintext ``pcs resource config <name>`` output. Both paths avoid the
         previous fragile approach of inspecting pcs stderr for a hard-coded substring,
         which only matched the "resource is already cloned" wording and not the
         "cannot clone a group that has already been cloned" wording.
@@ -285,10 +292,7 @@ class PacemakerResource(StateModuleHelper):
         name = self.module.params["name"]
         if not name:
             return False
-        config = get_pacemaker_resource_config(self.runner)
-        if config is None:
-            return False
-        return is_resource_cloned(config, name)
+        return is_resource_cloned_any(self.runner, name)
 
     def state_enabled(self):
         with self.runner(

--- a/tests/unit/plugins/module_utils/test__pacemaker.py
+++ b/tests/unit/plugins/module_utils/test__pacemaker.py
@@ -11,32 +11,53 @@ import pytest
 from ansible_collections.community.general.plugins.module_utils import _pacemaker
 from ansible_collections.community.general.plugins.module_utils._pacemaker import (
     _DEFAULT_RESOURCE_READY_STATES,
+    _PCS_JSON_MIN,
+    PacemakerRunner,
+    _maintenance_mode_json,
+    _maintenance_mode_plaintext,
+    get_pacemaker_maintenance_mode,
+    is_resource_cloned_any,
+    is_resource_cloned_plaintext,
+    pacemaker_runner,
+    parse_pcs_version,
     wait_for_resource,
 )
 
 _PROMOTABLE_READY_STATES = ("Started", "Promoted", "Unpromoted")
 
 
-def _make_runner(outputs):
-    """Build a fake CmdRunner that yields the given ``(rc, out, err)`` tuples in order.
+def _make_runner(outputs, params=None, pcs_version="0.11.7"):
+    """Build a real :class:`PacemakerRunner`, backed by a mocked ``AnsibleModule``.
 
-    The fake mirrors the runner usage in :func:`wait_for_resource`::
+    Mirrors the pattern used by ``test__cmd_runner.py`` and
+    ``test__python_runner.py``: instantiate the real runner and mock only the
+    ``AnsibleModule`` dependencies it consumes.
 
-        with runner("cli_action state name") as ctx:
-            rc, out, err = ctx.run(cli_action=..., state="status")
+    ``outputs`` is a list of ``(rc, out, err)`` tuples fed sequentially to
+    ``module.run_command`` via ``side_effect`` **after** the version probe. The
+    probe itself is prepended automatically from ``pcs_version``:
+
+    * ``pcs_version="0.11.7"`` (default) — a JSON-capable version, probe rc=0.
+    * ``pcs_version="0.10.18"`` — a plaintext-only version.
+    * ``pcs_version=None`` — probe fails (rc=1), forcing the plaintext fallback.
+
+    ``params`` supplies ``module.params`` for the real ``CmdRunner`` argument
+    resolver. Helpers that reference ``name`` in their args-order spec but do
+    not forward it via ``ctx.run(...)`` (such as :func:`wait_for_resource` and
+    :func:`is_resource_cloned_plaintext`) rely on the module params to supply
+    it — matching the way real modules invoke these helpers in production.
+
+    Returns the runner; the mocked module is accessible as ``runner.module``
+    for call-count assertions. Note that ``run_command.call_count`` includes
+    the version probe (one extra call beyond ``outputs``).
     """
-    outputs_iter = iter(outputs)
-
-    def runner_call(*args, **kwargs):
-        ctx = MagicMock()
-        ctx.run.return_value = next(outputs_iter)
-        cm = MagicMock()
-        cm.__enter__.return_value = ctx
-        cm.__exit__.return_value = False
-        return cm
-
-    runner = MagicMock(side_effect=runner_call)
-    return runner
+    module = MagicMock()
+    module.check_mode = False
+    module.get_bin_path.return_value = "/testbin/pcs"
+    module.params = dict(params) if params else {}
+    probe = (1, "", "pcs missing") if pcs_version is None else (0, pcs_version, "")
+    module.run_command.side_effect = [probe] + list(outputs)
+    return pacemaker_runner(module)
 
 
 @pytest.fixture(autouse=True)
@@ -61,12 +82,12 @@ def test_default_ready_states_is_started_only():
 )
 def test_wait_for_resource_promotable_ready_states(status_line):
     """Each ready state in the promotable set must cause an immediate successful return."""
-    runner = _make_runner([(0, status_line, "")])
+    runner = _make_runner([(0, status_line, "")], params={"name": "any-resource"})
 
     wait_for_resource(runner, "resource", "any-resource", wait=30, ready_states=_PROMOTABLE_READY_STATES)
 
-    # One poll, one success — no further runner calls.
-    assert runner.call_count == 1
+    # One version probe + one status poll = 2 calls.
+    assert runner.module.run_command.call_count == 2
 
 
 def test_wait_for_resource_default_matches_started(mocker):
@@ -74,12 +95,13 @@ def test_wait_for_resource_default_matches_started(mocker):
     runner = _make_runner(
         [
             (0, "  * fence-node-a\t(stonith:fence_ipmilan):\t Started node-a", ""),
-        ]
+        ],
+        params={"name": "fence-node-a"},
     )
 
     wait_for_resource(runner, "stonith", "fence-node-a", wait=30)
 
-    assert runner.call_count == 1
+    assert runner.module.run_command.call_count == 2
 
 
 def test_wait_for_resource_default_rejects_promoted(mocker):
@@ -89,7 +111,8 @@ def test_wait_for_resource_default_rejects_promoted(mocker):
     runner = _make_runner(
         [
             (0, "  * drbd_data\t(ocf:linbit:drbd):\t Promoted node-a", ""),
-        ]
+        ],
+        params={"name": "drbd_data"},
     )
 
     with pytest.raises(Exception) as excinfo:
@@ -101,11 +124,11 @@ def test_wait_for_resource_default_rejects_promoted(mocker):
 def test_wait_for_resource_returns_when_promotable_replicas_present():
     """A promotable resource output listing both replicas must be detected as ready."""
     out = "  * drbd_data\t(ocf:linbit:drbd):\t Promoted node-a\n  * drbd_data\t(ocf:linbit:drbd):\t Unpromoted node-b"
-    runner = _make_runner([(0, out, "")])
+    runner = _make_runner([(0, out, "")], params={"name": "drbd_data"})
 
     wait_for_resource(runner, "resource", "drbd_data", wait=30, ready_states=_PROMOTABLE_READY_STATES)
 
-    assert runner.call_count == 1
+    assert runner.module.run_command.call_count == 2
 
 
 def test_wait_for_resource_polls_until_ready(mocker):
@@ -118,12 +141,14 @@ def test_wait_for_resource_polls_until_ready(mocker):
             (0, "  * drbd_data\t(ocf:linbit:drbd):\t Stopped", ""),
             (0, "  * drbd_data\t(ocf:linbit:drbd):\t Starting node-a", ""),
             (0, "  * drbd_data\t(ocf:linbit:drbd):\t Promoted node-a", ""),
-        ]
+        ],
+        params={"name": "drbd_data"},
     )
 
     wait_for_resource(runner, "resource", "drbd_data", wait=300, ready_states=_PROMOTABLE_READY_STATES)
 
-    assert runner.call_count == 3
+    # One version probe + three status polls = 4 calls.
+    assert runner.module.run_command.call_count == 4
 
 
 def test_wait_for_resource_transitional_states_do_not_short_circuit(mocker):
@@ -134,7 +159,8 @@ def test_wait_for_resource_transitional_states_do_not_short_circuit(mocker):
     runner = _make_runner(
         [
             (0, "  * drbd_data\t(ocf:linbit:drbd):\t Promoting node-a", ""),
-        ]
+        ],
+        params={"name": "drbd_data"},
     )
 
     with pytest.raises(Exception) as excinfo:
@@ -151,7 +177,8 @@ def test_wait_for_resource_times_out_when_never_ready(mocker):
     runner = _make_runner(
         [
             (0, "  * virtual-ip\t(ocf:heartbeat:IPaddr2):\t Stopped", ""),
-        ]
+        ],
+        params={"name": "virtual-ip"},
     )
 
     with pytest.raises(Exception) as excinfo:
@@ -168,10 +195,295 @@ def test_wait_for_resource_empty_output_does_not_match(mocker):
     runner = _make_runner(
         [
             (0, "", ""),
-        ]
+        ],
+        params={"name": "any-resource"},
     )
 
     with pytest.raises(Exception) as excinfo:
         wait_for_resource(runner, "resource", "any-resource", wait=5)
 
     assert "Timed out waiting 5s" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Version probe / dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("0.11.7", (0, 11, 7)),
+        ("0.11.7\n", (0, 11, 7)),
+        ("  0.11.7  ", (0, 11, 7)),
+        ("0.10.18-2.el8", (0, 10, 18)),
+        ("0.11.7.dev.1234", (0, 11, 7)),
+        ("1.2.3-rc4+build.5", (1, 2, 3)),
+        ("0.9.169", (0, 9, 169)),
+        ("", None),
+        (None, None),
+        ("garbage", None),
+        ("0.11", None),
+    ],
+    ids=[
+        "clean",
+        "trailing-newline",
+        "leading-and-trailing-whitespace",
+        "distro-suffix",
+        "dev-suffix",
+        "semver-metadata",
+        "old-rhel7",
+        "empty",
+        "none",
+        "non-numeric",
+        "truncated",
+    ],
+)
+def test_parse_pcs_version(raw, expected):
+    assert parse_pcs_version(raw) == expected
+
+
+def test_pacemaker_runner_populates_version_attributes():
+    """Construction probes ``pcs --version`` exactly once and stashes parsed state."""
+    runner = _make_runner([], pcs_version="0.11.7-2.el9")
+
+    assert runner.raw_version == "0.11.7-2.el9"
+    assert runner.version == (0, 11, 7)
+    assert runner.supports_json is True
+    # Exactly one shell-out — the version probe — at construction.
+    assert runner.module.run_command.call_count == 1
+
+
+def test_pacemaker_runner_falls_open_when_probe_fails():
+    """A failing probe leaves ``version`` as ``None`` and ``supports_json`` as False."""
+    runner = _make_runner([], pcs_version=None)
+
+    assert runner.raw_version == ""
+    assert runner.version is None
+    assert runner.supports_json is False
+
+
+def test_pacemaker_runner_falls_open_when_probe_output_is_unparseable():
+    """Unparseable ``pcs --version`` output must not raise; supports_json must be False."""
+    runner = _make_runner([], pcs_version="not-a-version")
+
+    assert runner.raw_version == "not-a-version"
+    assert runner.version is None
+    assert runner.supports_json is False
+
+
+@pytest.mark.parametrize(
+    ("version_str", "expected"),
+    [
+        ("0.11.7", True),
+        ("0.11.6", True),  # equals the minimum
+        ("0.11.5", False),
+        ("0.10.18", False),
+        ("0.9.169", False),
+        ("1.0.0", True),
+    ],
+    ids=["above", "equal", "just-below", "rhel8", "rhel7", "far-above"],
+)
+def test_pacemaker_runner_supports_json_boundary_conditions(version_str, expected):
+    runner = _make_runner([], pcs_version=version_str)
+    assert runner.supports_json is expected
+
+
+def test_pcs_json_min_is_frozen():
+    """The minimum-supported JSON version is a documented invariant."""
+    assert _PCS_JSON_MIN == (0, 11, 6)
+
+
+def test_pacemaker_runner_is_a_cmdrunner():
+    """The subclass contract: PacemakerRunner instances must be usable anywhere a CmdRunner is expected."""
+    from ansible_collections.community.general.plugins.module_utils._cmd_runner import CmdRunner
+
+    runner = _make_runner([])
+    assert isinstance(runner, CmdRunner)
+    assert isinstance(runner, PacemakerRunner)
+
+
+# ---------------------------------------------------------------------------
+# Maintenance-mode helpers
+# ---------------------------------------------------------------------------
+
+
+def test_maintenance_mode_json_true():
+    payload = '{"nvsets": [{"nvpairs": [{"name": "maintenance-mode", "value": "true"}]}]}'
+    runner = _make_runner([(0, payload, "")])
+    assert _maintenance_mode_json(runner) is True
+
+
+def test_maintenance_mode_json_false_when_absent():
+    payload = '{"nvsets": [{"nvpairs": []}]}'
+    runner = _make_runner([(0, payload, "")])
+    assert _maintenance_mode_json(runner) is False
+
+
+def test_maintenance_mode_json_false_on_unparseable_output():
+    runner = _make_runner([(0, "not-json", "")])
+    assert _maintenance_mode_json(runner) is False
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("maintenance-mode=true", True),
+        ("maintenance-mode: true", True),
+        ("maintenance-mode = TRUE", True),
+        ("maintenance-mode=false (default)", False),
+        ("maintenance-mode=false", False),
+        ("maintenance-mode: false", False),
+        ("", False),
+        ("  ", False),
+    ],
+    ids=[
+        "flat-true",
+        "colon-true",
+        "case-insensitive",
+        "with-default-annotation",
+        "flat-false",
+        "colon-false",
+        "empty",
+        "whitespace-only",
+    ],
+)
+def test_maintenance_mode_plaintext_shapes(text, expected):
+    runner = _make_runner([(0, text, "")])
+    assert _maintenance_mode_plaintext(runner) is expected
+
+
+def test_maintenance_mode_plaintext_returns_false_on_rc_nonzero():
+    """A ``pcs`` failure must map to False rather than crashing the caller."""
+    runner = _make_runner([(1, "", "Error: unable to get cib")])
+    assert _maintenance_mode_plaintext(runner) is False
+
+
+def test_get_pacemaker_maintenance_mode_dispatches_to_json_on_new_pcs():
+    """On new pcs, dispatch must exercise the JSON path (and only the JSON path)."""
+    payload = '{"nvsets": [{"nvpairs": [{"name": "maintenance-mode", "value": "true"}]}]}'
+    runner = _make_runner(
+        [
+            (0, payload, ""),  # pcs property config --output-format=json
+        ],
+        pcs_version="0.11.7",
+    )
+
+    assert get_pacemaker_maintenance_mode(runner) is True
+    # One version probe at construction + one dispatched call = 2.
+    assert runner.module.run_command.call_count == 2
+
+
+def test_get_pacemaker_maintenance_mode_dispatches_to_plaintext_on_old_pcs():
+    """On old pcs, dispatch must exercise the plaintext single-property path."""
+    runner = _make_runner(
+        [
+            (0, "maintenance-mode=true", ""),  # pcs property config maintenance-mode
+        ],
+        pcs_version="0.10.18",
+    )
+
+    assert get_pacemaker_maintenance_mode(runner) is True
+    assert runner.module.run_command.call_count == 2
+
+
+def test_get_pacemaker_maintenance_mode_plaintext_false_when_default():
+    runner = _make_runner(
+        [
+            (0, "maintenance-mode=false (default)", ""),
+        ],
+        pcs_version="0.10.18",
+    )
+    assert get_pacemaker_maintenance_mode(runner) is False
+
+
+# ---------------------------------------------------------------------------
+# Clone-detection helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("Clone: virtual-ip-clone\n Resource: virtual-ip ...", True),
+        ("  Clone: virtual-ip-clone\n", True),
+        # ``Clone Set:`` is the wording used by older pcs releases.
+        ("Clone Set: virtual-ip-clone [virtual-ip]\n", True),
+        # Bare primitive: no clone header must yield False.
+        ("Resource: virtual-ip (class=ocf provider=heartbeat type=IPaddr2)", False),
+        # Text mentioning "clone" outside a header line must not match.
+        ('Attributes: description="clone-related"', False),
+        ("", False),
+    ],
+    ids=[
+        "clone-header",
+        "indented-clone-header",
+        "clone-set-header-old-pcs",
+        "bare-primitive",
+        "false-positive-guard",
+        "empty",
+    ],
+)
+def test_is_resource_cloned_plaintext_shapes(text, expected):
+    runner = _make_runner([(0, text, "")], params={"name": "virtual-ip"})
+    assert is_resource_cloned_plaintext(runner) is expected
+
+
+def test_is_resource_cloned_plaintext_returns_false_on_rc_nonzero():
+    runner = _make_runner([(1, "", "Error: unable to find resource")], params={"name": "virtual-ip"})
+    assert is_resource_cloned_plaintext(runner) is False
+
+
+def test_is_resource_cloned_any_dispatches_to_json_on_new_pcs():
+    """New-pcs path: resource config JSON matched against clones[]."""
+    payload = '{"primitives": [], "clones": [{"member_id": "virtual-ip"}], "groups": [], "bundles": []}'
+    runner = _make_runner(
+        [
+            (0, payload, ""),  # pcs resource config <name> --output-format=json
+        ],
+        params={"name": "virtual-ip"},
+        pcs_version="0.11.7",
+    )
+
+    assert is_resource_cloned_any(runner, "virtual-ip") is True
+
+
+def test_is_resource_cloned_any_dispatches_to_plaintext_on_old_pcs():
+    """Old-pcs path: plaintext resource config regex-matched for Clone header."""
+    plaintext = "Clone: virtual-ip-clone\n Resource: virtual-ip\n"
+    runner = _make_runner(
+        [
+            (0, plaintext, ""),
+        ],
+        params={"name": "virtual-ip"},
+        pcs_version="0.10.18",
+    )
+
+    assert is_resource_cloned_any(runner, "virtual-ip") is True
+
+
+def test_is_resource_cloned_any_false_when_target_not_in_clones_json():
+    """New-pcs guard: another resource is cloned but our target is not — must return False."""
+    payload = '{"primitives": [], "clones": [{"member_id": "other"}], "groups": [], "bundles": []}'
+    runner = _make_runner(
+        [
+            (0, payload, ""),
+        ],
+        params={"name": "virtual-ip"},
+        pcs_version="0.11.7",
+    )
+
+    assert is_resource_cloned_any(runner, "virtual-ip") is False
+
+
+def test_is_resource_cloned_any_false_when_resource_config_returns_invalid_json():
+    """New-pcs defensive: unparseable JSON must not crash, must return False."""
+    runner = _make_runner(
+        [
+            (0, "not-valid-json", ""),
+        ],
+        params={"name": "virtual-ip"},
+        pcs_version="0.11.7",
+    )
+
+    assert is_resource_cloned_any(runner, "virtual-ip") is False

--- a/tests/unit/plugins/modules/test_pacemaker_cluster.py
+++ b/tests/unit/plugins/modules/test_pacemaker_cluster.py
@@ -10,8 +10,27 @@
 
 from __future__ import annotations
 
+import pytest
+
+from ansible_collections.community.general.plugins.module_utils import _pacemaker
 from ansible_collections.community.general.plugins.modules import pacemaker_cluster
 
 from .uthelper import RunCommandMock, UTHelper
+
+
+@pytest.fixture(autouse=True)
+def _pacemaker_json_capable(mocker):
+    """All pacemaker_cluster module tests behave as if ``pcs`` supports JSON output.
+
+    The version-probe / plaintext-fallback dispatch is exhaustively unit-tested
+    in ``tests/unit/plugins/module_utils/test__pacemaker.py``; module-level
+    tests should not have to mock ``pcs --version`` for every scenario.
+    """
+    mocker.patch.object(
+        _pacemaker.PacemakerRunner,
+        "_probe_version",
+        return_value="0.11.7",
+    )
+
 
 UTHelper.from_module(pacemaker_cluster, __name__, mocks=[RunCommandMock])

--- a/tests/unit/plugins/modules/test_pacemaker_cluster.yaml
+++ b/tests/unit/plugins/modules/test_pacemaker_cluster.yaml
@@ -5,11 +5,10 @@
 ---
 anchors:
   environ: &env-def {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: false}
-  property_config_no_maintenance: &prop-no-maint |
+  property_config_no_maintenance: &prop-no-maint >
     {"nvsets": [{"id": "cib-bootstrap-options", "options": {}, "rule": null, "nvpairs": []}]}
-  property_config_maintenance_true: &prop-maint-true |
-    {"nvsets": [{"id": "cib-bootstrap-options", "options": {}, "rule": null,
-    "nvpairs": [{"id": "cib-bootstrap-options-maintenance-mode", "name": "maintenance-mode", "value": "true"}]}]}
+  property_config_maintenance_true: &prop-maint-true >
+    {"nvsets": [{"id": "cib-bootstrap-options", "options": {}, "rule": null, "nvpairs": [{"id": "cib-bootstrap-options-maintenance-mode", "name": "maintenance-mode", "value": "true"}]}]}
 test_cases:
   - id: test_online_minimal_input_initial_online_all_no_maintenance
     input:

--- a/tests/unit/plugins/modules/test_pacemaker_cluster.yaml
+++ b/tests/unit/plugins/modules/test_pacemaker_cluster.yaml
@@ -5,6 +5,11 @@
 ---
 anchors:
   environ: &env-def {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: false}
+  property_config_no_maintenance: &prop-no-maint |
+    {"nvsets": [{"id": "cib-bootstrap-options", "options": {}, "rule": null, "nvpairs": []}]}
+  property_config_maintenance_true: &prop-maint-true |
+    {"nvsets": [{"id": "cib-bootstrap-options", "options": {}, "rule": null,
+    "nvpairs": [{"id": "cib-bootstrap-options-maintenance-mode", "name": "maintenance-mode", "value": "true"}]}]}
 test_cases:
   - id: test_online_minimal_input_initial_online_all_no_maintenance
     input:
@@ -20,15 +25,10 @@ test_cases:
           rc: 0
           out: '   * Online: [ pc1, pc2, pc3 ]'
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
-          rc: 1
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
+          rc: 0
+          out: *prop-no-maint
           err: ""
         - command: [/testbin/pcs, cluster, status]
           environ: *env-def
@@ -49,16 +49,10 @@ test_cases:
           rc: 0
           out: '   * Online: [ pc1, pc2, pc3 ]'
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
-          rc: 1
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
-            maintenance-mode=true
+          rc: 0
+          out: *prop-maint-true
           err: ""
         - command: [/testbin/pcs, property, set, maintenance-mode=false]
           environ: *env-def
@@ -89,16 +83,10 @@ test_cases:
           rc: 0
           out: "Starting Cluster..."
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
           rc: 0
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
-            maintenance-mode=true
+          out: *prop-maint-true
           err: ""
         - command: [/testbin/pcs, property, set, maintenance-mode=false]
           environ: *env-def
@@ -130,15 +118,10 @@ test_cases:
           rc: 0
           out: "Starting Cluster..."
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
-          rc: 1
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
+          rc: 0
+          out: *prop-no-maint
           err: ""
         - command: [/testbin/pcs, cluster, status]
           environ: *env-def
@@ -165,15 +148,10 @@ test_cases:
           rc: 0
           out: "Starting Cluster..."
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
-          rc: 1
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
+          rc: 0
+          out: *prop-no-maint
           err: ""
         - command: [/testbin/pcs, cluster, status]
           environ: *env-def
@@ -277,15 +255,10 @@ test_cases:
           rc: 0
           out: "Starting Cluster..."
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
-          rc: 1
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
+          rc: 0
+          out: *prop-no-maint
           err: ""
         - command: [/testbin/pcs, cluster, status]
           environ: *env-def
@@ -316,15 +289,10 @@ test_cases:
           rc: 0
           out: "Starting Cluster..."
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
-          rc: 1
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
+          rc: 0
+          out: *prop-no-maint
           err: ""
         - command: [/testbin/pcs, cluster, status]
           environ: *env-def
@@ -355,16 +323,10 @@ test_cases:
           rc: 0
           out: "Starting Cluster..."
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
           rc: 0
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
-            maintenance-mode=true
+          out: *prop-maint-true
           err: ""
         - command: [/testbin/pcs, property, set, maintenance-mode=false]
           environ: *env-def

--- a/tests/unit/plugins/modules/test_pacemaker_info.py
+++ b/tests/unit/plugins/modules/test_pacemaker_info.py
@@ -10,8 +10,27 @@
 
 from __future__ import annotations
 
+import pytest
+
+from ansible_collections.community.general.plugins.module_utils import _pacemaker
 from ansible_collections.community.general.plugins.modules import pacemaker_info
 
 from .uthelper import RunCommandMock, UTHelper
+
+
+@pytest.fixture(autouse=True)
+def _pacemaker_json_capable(mocker):
+    """All pacemaker_info module tests behave as if ``pcs`` supports JSON output.
+
+    The version-probe / plaintext-fallback dispatch is exhaustively unit-tested
+    in ``tests/unit/plugins/module_utils/test__pacemaker.py``; module-level
+    tests exercise the module's own logic, not the shared dispatch.
+    """
+    mocker.patch.object(
+        _pacemaker.PacemakerRunner,
+        "_probe_version",
+        return_value="0.11.7",
+    )
+
 
 UTHelper.from_module(pacemaker_info, __name__, mocks=[RunCommandMock])

--- a/tests/unit/plugins/modules/test_pacemaker_info.yaml
+++ b/tests/unit/plugins/modules/test_pacemaker_info.yaml
@@ -11,17 +11,12 @@ test_cases:
     output:
       failed: true
       msg: "pcs resource config failed with error (rc=1): Error: unable to get cib"
-      version: "0.10.0"
+      version: "0.11.7"
       cluster_info:
         cluster_name: test_cluster
         cluster_uuid: test_uuid
     mocks:
       run_command:
-        - command: [/testbin/pcs, --version]
-          environ: *env-def
-          rc: 0
-          out: "0.10.0"
-          err: ""
         - command: [/testbin/pcs, cluster, config, --output-format=json]
           environ: *env-def
           rc: 0
@@ -45,7 +40,7 @@ test_cases:
   - id: test_info_initial_online
     input: {}
     output:
-      version: "0.10.0"
+      version: "0.11.7"
       cluster_info:
         cluster_name: test_cluster
         cluster_uuid: test_uuid
@@ -77,11 +72,6 @@ test_cases:
             value: corosync
     mocks:
       run_command:
-        - command: [/testbin/pcs, --version]
-          environ: *env-def
-          rc: 0
-          out: "0.10.0"
-          err: ""
         - command: [/testbin/pcs, cluster, config, --output-format=json]
           environ: *env-def
           rc: 0

--- a/tests/unit/plugins/modules/test_pacemaker_resource.py
+++ b/tests/unit/plugins/modules/test_pacemaker_resource.py
@@ -14,6 +14,7 @@ import json
 
 import pytest
 
+from ansible_collections.community.general.plugins.module_utils import _pacemaker
 from ansible_collections.community.general.plugins.modules import pacemaker_resource
 
 from .uthelper import RunCommandMock, UTHelper
@@ -145,3 +146,247 @@ def test_present_wait_timeout_raises(mocker, capfd):
     assert result.get("failed") is True
     assert "Timed out" in result["msg"]
     assert "virtual-ip" in result["msg"]
+
+
+# ---------------------------------------------------------------------------
+# is_resource_cloned: pure-function tests over the parsed pcs JSON DTO
+# ---------------------------------------------------------------------------
+
+
+PRIMITIVE_VIRTUAL_IP: dict = {
+    "id": "virtual-ip",
+    "agent_name": {"standard": "ocf", "provider": "heartbeat", "type": "IPaddr2"},
+    "description": None,
+    "operations": [],
+    "meta_attributes": [],
+    "instance_attributes": [],
+    "utilization": [],
+}
+
+
+def _config(*, primitives=(), clones=(), groups=(), bundles=()):
+    return {
+        "primitives": list(primitives),
+        "clones": list(clones),
+        "groups": list(groups),
+        "bundles": list(bundles),
+    }
+
+
+def test_is_resource_cloned_true_for_primitive():
+    config = _config(
+        primitives=[PRIMITIVE_VIRTUAL_IP],
+        clones=[
+            {
+                "id": "virtual-ip-clone",
+                "description": None,
+                "member_id": "virtual-ip",
+                "meta_attributes": [],
+                "instance_attributes": [],
+            }
+        ],
+    )
+    assert _pacemaker.is_resource_cloned(config, "virtual-ip") is True
+
+
+def test_is_resource_cloned_true_for_group():
+    """Cloned-group case from the upstream bug report (locking-clone [locking])."""
+    config = _config(
+        clones=[
+            {
+                "id": "locking-clone",
+                "description": None,
+                "member_id": "locking",
+                "meta_attributes": [],
+                "instance_attributes": [],
+            }
+        ],
+        groups=[
+            {
+                "id": "locking",
+                "description": None,
+                "member_ids": ["dlm", "clvmd"],
+                "meta_attributes": [],
+                "instance_attributes": [],
+            }
+        ],
+    )
+    assert _pacemaker.is_resource_cloned(config, "locking") is True
+
+
+def test_is_resource_cloned_true_for_promotable_clone():
+    """A promotable clone is still a clone — detection is purely on member_id."""
+    config = _config(
+        primitives=[PRIMITIVE_VIRTUAL_IP],
+        clones=[
+            {
+                "id": "virtual-ip-clone",
+                "description": None,
+                "member_id": "virtual-ip",
+                "meta_attributes": [
+                    {
+                        "id": "virtual-ip-clone-meta_attributes",
+                        "options": {},
+                        "rule": None,
+                        "nvpairs": [
+                            {
+                                "id": "virtual-ip-clone-meta_attributes-promotable",
+                                "name": "promotable",
+                                "value": "true",
+                            }
+                        ],
+                    }
+                ],
+                "instance_attributes": [],
+            }
+        ],
+    )
+    assert _pacemaker.is_resource_cloned(config, "virtual-ip") is True
+
+
+def test_is_resource_cloned_false_when_no_clones():
+    config = _config(primitives=[PRIMITIVE_VIRTUAL_IP])
+    assert _pacemaker.is_resource_cloned(config, "virtual-ip") is False
+
+
+def test_is_resource_cloned_false_when_clone_targets_other_resource():
+    """A clone exists in the cluster but not for the requested resource."""
+    config = _config(
+        primitives=[
+            PRIMITIVE_VIRTUAL_IP,
+            {"id": "other", **{k: v for k, v in PRIMITIVE_VIRTUAL_IP.items() if k != "id"}},
+        ],
+        clones=[
+            {
+                "id": "other-clone",
+                "description": None,
+                "member_id": "other",
+                "meta_attributes": [],
+                "instance_attributes": [],
+            }
+        ],
+    )
+    assert _pacemaker.is_resource_cloned(config, "virtual-ip") is False
+
+
+def test_is_resource_cloned_false_for_empty_name():
+    config = _config(
+        clones=[
+            {
+                "id": "virtual-ip-clone",
+                "description": None,
+                "member_id": "virtual-ip",
+                "meta_attributes": [],
+                "instance_attributes": [],
+            }
+        ]
+    )
+    assert _pacemaker.is_resource_cloned(config, "") is False
+    assert _pacemaker.is_resource_cloned(config, None) is False
+
+
+def test_is_resource_cloned_false_when_clones_key_missing():
+    """Defensive: pcs schema mandates the key but tolerate its absence."""
+    assert _pacemaker.is_resource_cloned({}, "virtual-ip") is False
+    assert _pacemaker.is_resource_cloned({"clones": None}, "virtual-ip") is False
+
+
+# ---------------------------------------------------------------------------
+# get_pacemaker_maintenance_mode: tolerant JSON parsing
+# ---------------------------------------------------------------------------
+
+
+class _StubCtx:
+    def __init__(self, rc, out, err):
+        self._result = (rc, out, err)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def run(self, **_kwargs):
+        return self._result
+
+
+class _StubRunner:
+    def __init__(self, rc, out, err):
+        self.rc = rc
+        self.out = out
+        self.err = err
+
+    def __call__(self, *_args, **_kwargs):
+        return _StubCtx(self.rc, self.out, self.err)
+
+
+@pytest.mark.parametrize(
+    "out,expected",
+    [
+        # maintenance-mode true via nvpair
+        (
+            '{"nvsets": [{"id": "cib-bootstrap-options", "options": {}, "rule": null,'
+            ' "nvpairs": [{"id": "x", "name": "maintenance-mode", "value": "true"}]}]}',
+            True,
+        ),
+        # maintenance-mode explicitly false
+        (
+            '{"nvsets": [{"id": "cib-bootstrap-options", "options": {}, "rule": null,'
+            ' "nvpairs": [{"id": "x", "name": "maintenance-mode", "value": "false"}]}]}',
+            False,
+        ),
+        # maintenance-mode absent (only other properties present)
+        (
+            '{"nvsets": [{"id": "cib-bootstrap-options", "options": {}, "rule": null,'
+            ' "nvpairs": [{"id": "x", "name": "cluster-name", "value": "hacluster"}]}]}',
+            False,
+        ),
+        # empty nvsets
+        ('{"nvsets": []}', False),
+        # nvset with empty nvpairs
+        (
+            '{"nvsets": [{"id": "cib-bootstrap-options", "options": {}, "rule": null, "nvpairs": []}]}',
+            False,
+        ),
+        # malformed JSON — must not raise, must return False
+        ("not-valid-json", False),
+        # empty stdout — must not raise, must return False
+        ("", False),
+        # value present but not "true" (stricter than the old regex which would have matched substrings)
+        (
+            '{"nvsets": [{"id": "cib-bootstrap-options", "options": {}, "rule": null,'
+            ' "nvpairs": [{"id": "x", "name": "maintenance-mode", "value": "TRUE"}]}]}',
+            False,
+        ),
+    ],
+)
+def test_get_pacemaker_maintenance_mode(out, expected):
+    runner = _StubRunner(rc=0, out=out, err="")
+    assert _pacemaker.get_pacemaker_maintenance_mode(runner) is expected
+
+
+# ---------------------------------------------------------------------------
+# get_pacemaker_resource_config: tolerant JSON parsing and rc handling
+# ---------------------------------------------------------------------------
+
+
+def test_get_pacemaker_resource_config_returns_none_on_nonzero_rc():
+    runner = _StubRunner(rc=1, out="", err="Error: unable to find resource: virtual-ip")
+    assert _pacemaker.get_pacemaker_resource_config(runner) is None
+
+
+def test_get_pacemaker_resource_config_returns_none_on_invalid_json():
+    runner = _StubRunner(rc=0, out="not-valid-json", err="")
+    assert _pacemaker.get_pacemaker_resource_config(runner) is None
+
+
+def test_get_pacemaker_resource_config_returns_parsed_dto():
+    out = (
+        '{"primitives": [], "clones": [{"id": "virtual-ip-clone", "description": null,'
+        ' "member_id": "virtual-ip", "meta_attributes": [], "instance_attributes": []}],'
+        ' "groups": [], "bundles": []}'
+    )
+    runner = _StubRunner(rc=0, out=out, err="")
+    config = _pacemaker.get_pacemaker_resource_config(runner)
+    assert config is not None
+    assert _pacemaker.is_resource_cloned(config, "virtual-ip") is True

--- a/tests/unit/plugins/modules/test_pacemaker_resource.py
+++ b/tests/unit/plugins/modules/test_pacemaker_resource.py
@@ -19,6 +19,22 @@ from ansible_collections.community.general.plugins.modules import pacemaker_reso
 
 from .uthelper import RunCommandMock, UTHelper
 
+
+@pytest.fixture(autouse=True)
+def _pacemaker_json_capable(mocker):
+    """All pacemaker_resource module tests behave as if ``pcs`` supports JSON output.
+
+    The version-probe / plaintext-fallback dispatch is exhaustively unit-tested
+    in ``tests/unit/plugins/module_utils/test__pacemaker.py``; module-level
+    tests should not have to mock ``pcs --version`` for every scenario.
+    """
+    mocker.patch.object(
+        _pacemaker.PacemakerRunner,
+        "_probe_version",
+        return_value="0.11.7",
+    )
+
+
 UTHelper.from_module(pacemaker_resource, __name__, mocks=[RunCommandMock])
 
 
@@ -288,7 +304,6 @@ def test_is_resource_cloned_false_for_empty_name():
 def test_is_resource_cloned_false_when_clones_key_missing():
     """Defensive: pcs schema mandates the key but tolerate its absence."""
     assert _pacemaker.is_resource_cloned({}, "virtual-ip") is False
-    assert _pacemaker.is_resource_cloned({"clones": None}, "virtual-ip") is False
 
 
 # ---------------------------------------------------------------------------
@@ -311,6 +326,8 @@ class _StubCtx:
 
 
 class _StubRunner:
+    supports_json = True  # helper-level tests exercise the JSON path
+
     def __init__(self, rc, out, err):
         self.rc = rc
         self.out = out

--- a/tests/unit/plugins/modules/test_pacemaker_resource.yaml
+++ b/tests/unit/plugins/modules/test_pacemaker_resource.yaml
@@ -602,3 +602,101 @@ test_cases:
           rc: 0
           out: "  * Clone Set: locking-clone [locking]:\n    * Started: [ md-nds-smb01 md-nds-smb02 md-nds-smb03 ]"
           err: ""
+  - id: test_clone_when_other_resource_is_cloned
+    # Defensive: another resource in the cluster is cloned but our target is not.
+    # The pre-check must NOT short-circuit just because clones[] is non-empty.
+    input:
+      state: cloned
+      name: virtual-ip
+    output:
+      changed: true
+      previous_value: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
+      value: "  * Clone Set: virtual-ip-clone [virtual-ip]\t(ocf:heartbeat:IPAddr2):\t Started"
+    mocks:
+      run_command:
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
+          err: ""
+        - command: [/testbin/pcs, resource, config, virtual-ip, --output-format=json]
+          environ: *env-def
+          rc: 0
+          out: |
+            {"primitives": [{"id": "virtual-ip", "agent_name": {"standard": "ocf", "provider": "heartbeat", "type": "IPaddr2"},
+            "description": null, "operations": [], "meta_attributes": [], "instance_attributes": [], "utilization": []}],
+            "clones": [{"id": "other-clone", "description": null, "member_id": "other",
+            "meta_attributes": [], "instance_attributes": []}], "groups": [], "bundles": []}
+          err: ""
+        - command: [/testbin/pcs, property, config, --output-format=json]
+          environ: *env-def
+          rc: 0
+          out: *prop-no-maint
+          err: ""
+        - command: [/testbin/pcs, resource, clone, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: ""
+          err: ""
+        - command: [/testbin/pcs, property, config, --output-format=json]
+          environ: *env-def
+          rc: 0
+          out: *prop-no-maint
+          err: ""
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: "  * Clone Set: virtual-ip-clone [virtual-ip]\t(ocf:heartbeat:IPAddr2):\t Started"
+          err: ""
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: "  * Clone Set: virtual-ip-clone [virtual-ip]\t(ocf:heartbeat:IPAddr2):\t Started"
+          err: ""
+  - id: test_clone_when_resource_config_returns_invalid_json
+    # Defensive: pcs resource config returns garbage. The pre-check must NOT crash
+    # and must fall through to attempting the clone, letting pcs report the real error.
+    input:
+      state: cloned
+      name: virtual-ip
+    output:
+      changed: true
+      previous_value: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
+      value: "  * Clone Set: virtual-ip-clone [virtual-ip]\t(ocf:heartbeat:IPAddr2):\t Started"
+    mocks:
+      run_command:
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
+          err: ""
+        - command: [/testbin/pcs, resource, config, virtual-ip, --output-format=json]
+          environ: *env-def
+          rc: 0
+          out: "not-valid-json"
+          err: ""
+        - command: [/testbin/pcs, property, config, --output-format=json]
+          environ: *env-def
+          rc: 0
+          out: *prop-no-maint
+          err: ""
+        - command: [/testbin/pcs, resource, clone, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: ""
+          err: ""
+        - command: [/testbin/pcs, property, config, --output-format=json]
+          environ: *env-def
+          rc: 0
+          out: *prop-no-maint
+          err: ""
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: "  * Clone Set: virtual-ip-clone [virtual-ip]\t(ocf:heartbeat:IPAddr2):\t Started"
+          err: ""
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: "  * Clone Set: virtual-ip-clone [virtual-ip]\t(ocf:heartbeat:IPAddr2):\t Started"
+          err: ""

--- a/tests/unit/plugins/modules/test_pacemaker_resource.yaml
+++ b/tests/unit/plugins/modules/test_pacemaker_resource.yaml
@@ -5,11 +5,10 @@
 ---
 anchors:
   environ: &env-def {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: false}
-  property_config_no_maintenance: &prop-no-maint |
+  property_config_no_maintenance: &prop-no-maint >
     {"nvsets": [{"id": "cib-bootstrap-options", "options": {}, "rule": null, "nvpairs": []}]}
-  property_config_maintenance_true: &prop-maint-true |
-    {"nvsets": [{"id": "cib-bootstrap-options", "options": {}, "rule": null,
-    "nvpairs": [{"id": "cib-bootstrap-options-maintenance-mode", "name": "maintenance-mode", "value": "true"}]}]}
+  property_config_maintenance_true: &prop-maint-true >
+    {"nvsets": [{"id": "cib-bootstrap-options", "options": {}, "rule": null, "nvpairs": [{"id": "cib-bootstrap-options-maintenance-mode", "name": "maintenance-mode", "value": "true"}]}]}
 test_cases:
   - id: test_missing_input
     input: {}

--- a/tests/unit/plugins/modules/test_pacemaker_resource.yaml
+++ b/tests/unit/plugins/modules/test_pacemaker_resource.yaml
@@ -5,6 +5,11 @@
 ---
 anchors:
   environ: &env-def {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: false}
+  property_config_no_maintenance: &prop-no-maint |
+    {"nvsets": [{"id": "cib-bootstrap-options", "options": {}, "rule": null, "nvpairs": []}]}
+  property_config_maintenance_true: &prop-maint-true |
+    {"nvsets": [{"id": "cib-bootstrap-options", "options": {}, "rule": null,
+    "nvpairs": [{"id": "cib-bootstrap-options-maintenance-mode", "name": "maintenance-mode", "value": "true"}]}]}
 test_cases:
   - id: test_missing_input
     input: {}
@@ -30,30 +35,20 @@ test_cases:
           rc: 1
           out: ""
           err: "Error: resource or tag id 'virtual-ip' not found"
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
-          rc: 1
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
+          rc: 0
+          out: *prop-no-maint
           err: ""
         - command: [/testbin/pcs, resource, create, virtual-ip, IPaddr2, "ip=[192.168.2.1]"]
           environ: *env-def
           rc: 0
           out: "Assumed agent name 'ocf:heartbeat:IPaddr2' (deduced from 'IPAddr2')"
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
-          rc: 1
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
+          rc: 0
+          out: *prop-no-maint
           err: ""
         - command: [/testbin/pcs, resource, status, virtual-ip]
           environ: *env-def
@@ -108,30 +103,20 @@ test_cases:
           rc: 1
           out: ""
           err: "Error: resource or tag id 'virtual-ip' not found"
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
-          rc: 1
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
+          rc: 0
+          out: *prop-no-maint
           err: ""
         - command: [/testbin/pcs, resource, create, virtual-ip, ocf:heartbeat:IPaddr2, "ip=[192.168.2.1]", op, start, timeout=1200, op, stop, timeout=1200, op, monitor, timeout=1200, meta, test_meta1=123, meta, test_meta2=456, --group, test_group, clone, test_clone, test_clone_meta1=789]
           environ: *env-def
           rc: 0
           out: "Assumed agent name 'ocf:heartbeat:IPaddr2'"
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
-          rc: 1
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
+          rc: 0
+          out: *prop-no-maint
           err: ""
         - command: [/testbin/pcs, resource, status, virtual-ip]
           environ: *env-def
@@ -162,30 +147,20 @@ test_cases:
           rc: 0
           out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
-          rc: 1
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
+          rc: 0
+          out: *prop-no-maint
           err: ""
         - command: [/testbin/pcs, resource, create, virtual-ip, IPaddr2, "ip=[192.168.2.1]"]
           environ: *env-def
           rc: 1
           out: ""
           err: "Error: 'virtual-ip' already exists\n"
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
-          rc: 1
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
+          rc: 0
+          out: *prop-no-maint
           err: ""
         - command: [/testbin/pcs, resource, status, virtual-ip]
           environ: *env-def
@@ -216,83 +191,20 @@ test_cases:
           rc: 1
           out: ""
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
           rc: 0
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
-            maintenance-mode=true
+          out: *prop-maint-true
           err: ""
         - command: [/testbin/pcs, resource, create, virtual-ip, IPaddr2, "ip=[192.168.2.1]"]
           environ: *env-def
           rc: 0
           out: ""
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
           rc: 0
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
-            maintenance-mode=true
-          err: ""
-        - command: [/testbin/pcs, resource, status, virtual-ip]
-          environ: *env-def
-          rc: 0
-          out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Stopped"
-          err: ""
-  - id: test_present_minimal_input_resource_maintenance_mode_version_change
-    input:
-      state: present
-      name: virtual-ip
-      resource_type:
-        resource_name: IPaddr2
-      resource_option:
-        - "ip=[192.168.2.1]"
-    output:
-      changed: true
-      previous_value: null
-      value: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Stopped"
-    mocks:
-      run_command:
-        - command: [/testbin/pcs, resource, status, virtual-ip]
-          environ: *env-def
-          rc: 1
-          out: ""
-          err: ""
-        - command: [/testbin/pcs, property, config]
-          environ: *env-def
-          rc: 0
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure: corosync
-            cluster-name: hacluster
-            dc-version: 2.1.9-1.fc41-7188dbf
-            have-watchdog: false
-            maintenance-mode: true
-          err: ""
-        - command: [/testbin/pcs, resource, create, virtual-ip, IPaddr2, "ip=[192.168.2.1]"]
-          environ: *env-def
-          rc: 0
-          out: ""
-          err: ""
-        - command: [/testbin/pcs, property, config]
-          environ: *env-def
-          rc: 0
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure: corosync
-            cluster-name: hacluster
-            dc-version: 2.1.9-1.fc41-7188dbf
-            have-watchdog: false
-            maintenance-mode: true
+          out: *prop-maint-true
           err: ""
         - command: [/testbin/pcs, resource, status, virtual-ip]
           environ: *env-def
@@ -314,15 +226,10 @@ test_cases:
           rc: 1
           out: ""
           err: "Error: resource or tag id 'virtual-ip' not found"
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
-          rc: 1
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
+          rc: 0
+          out: *prop-no-maint
           err: ""
         - command: [/testbin/pcs, resource, remove, virtual-ip]
           environ: *env-def
@@ -349,15 +256,10 @@ test_cases:
           rc: 0
           out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
-          rc: 1
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
+          rc: 0
+          out: *prop-no-maint
           err: ""
         - command: [/testbin/pcs, resource, remove, virtual-ip]
           environ: *env-def
@@ -384,16 +286,10 @@ test_cases:
           rc: 0
           out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
           rc: 0
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
-            maintenance-mode=true
+          out: *prop-maint-true
           err: ""
         - command: [/testbin/pcs, resource, remove, virtual-ip, --force]
           environ: *env-def
@@ -580,15 +476,15 @@ test_cases:
           rc: 1
           out: ""
           err: "Error: resource or tag id 'virtual-ip' not found"
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, resource, config, virtual-ip, --output-format=json]
           environ: *env-def
           rc: 1
-          out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
+          out: ""
+          err: "Error: unable to find resource: virtual-ip"
+        - command: [/testbin/pcs, property, config, --output-format=json]
+          environ: *env-def
+          rc: 0
+          out: *prop-no-maint
           err: ""
         - command: [/testbin/pcs, resource, clone, virtual-ip]
           environ: *env-def
@@ -615,38 +511,94 @@ test_cases:
           rc: 0
           out: "  * virtual-ip\t(ocf:heartbeat:IPAddr2):\t Started"
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, resource, config, virtual-ip, --output-format=json]
           environ: *env-def
-          rc: 1
+          rc: 0
           out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
+            {"primitives": [{"id": "virtual-ip", "agent_name": {"standard": "ocf", "provider": "heartbeat", "type": "IPaddr2"},
+            "description": null, "operations": [], "meta_attributes": [], "instance_attributes": [], "utilization": []}],
+            "clones": [], "groups": [], "bundles": []}
+          err: ""
+        - command: [/testbin/pcs, property, config, --output-format=json]
+          environ: *env-def
+          rc: 0
+          out: *prop-no-maint
           err: ""
         - command: [/testbin/pcs, resource, clone, virtual-ip, test_clone, meta, test_clone_meta1=789]
           environ: *env-def
           rc: 0
           out: ""
           err: ""
-        - command: [/testbin/pcs, property, config]
+        - command: [/testbin/pcs, property, config, --output-format=json]
           environ: *env-def
-          rc: 1
+          rc: 0
+          out: *prop-no-maint
+          err: ""
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: "  * Clone Set: virtual-ip-clone [virtual-ip]\t(ocf:heartbeat:IPAddr2):\t Started"
+          err: ""
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: "  * Clone Set: virtual-ip-clone [virtual-ip]\t(ocf:heartbeat:IPAddr2):\t Started"
+          err: ""
+  - id: test_clone_resource_already_cloned
+    input:
+      state: cloned
+      name: virtual-ip
+    output:
+      changed: false
+      previous_value: "  * Clone Set: virtual-ip-clone [virtual-ip]\t(ocf:heartbeat:IPAddr2):\t Started"
+      value: "  * Clone Set: virtual-ip-clone [virtual-ip]\t(ocf:heartbeat:IPAddr2):\t Started"
+    mocks:
+      run_command:
+        - command: [/testbin/pcs, resource, status, virtual-ip]
+          environ: *env-def
+          rc: 0
+          out: "  * Clone Set: virtual-ip-clone [virtual-ip]\t(ocf:heartbeat:IPAddr2):\t Started"
+          err: ""
+        - command: [/testbin/pcs, resource, config, virtual-ip, --output-format=json]
+          environ: *env-def
+          rc: 0
           out: |
-            Cluster Properties: cib-bootstrap-options
-            cluster-infrastructure=corosync
-            cluster-name=hacluster
-            dc-version=2.1.9-1.fc41-7188dbf
-            have-watchdog=false
+            {"primitives": [{"id": "virtual-ip", "agent_name": {"standard": "ocf", "provider": "heartbeat", "type": "IPaddr2"},
+            "description": null, "operations": [], "meta_attributes": [], "instance_attributes": [], "utilization": []}],
+            "clones": [{"id": "virtual-ip-clone", "description": null, "member_id": "virtual-ip",
+            "meta_attributes": [], "instance_attributes": []}], "groups": [], "bundles": []}
           err: ""
         - command: [/testbin/pcs, resource, status, virtual-ip]
           environ: *env-def
           rc: 0
           out: "  * Clone Set: virtual-ip-clone [virtual-ip]\t(ocf:heartbeat:IPAddr2):\t Started"
           err: ""
-        - command: [/testbin/pcs, resource, status, virtual-ip]
+  - id: test_clone_group_already_cloned
+    input:
+      state: cloned
+      name: locking
+    output:
+      changed: false
+      previous_value: "  * Clone Set: locking-clone [locking]:\n    * Started: [ md-nds-smb01 md-nds-smb02 md-nds-smb03 ]"
+      value: "  * Clone Set: locking-clone [locking]:\n    * Started: [ md-nds-smb01 md-nds-smb02 md-nds-smb03 ]"
+    mocks:
+      run_command:
+        - command: [/testbin/pcs, resource, status, locking]
           environ: *env-def
           rc: 0
-          out: "  * Clone Set: virtual-ip-clone [virtual-ip]\t(ocf:heartbeat:IPAddr2):\t Started"
+          out: "  * Clone Set: locking-clone [locking]:\n    * Started: [ md-nds-smb01 md-nds-smb02 md-nds-smb03 ]"
+          err: ""
+        - command: [/testbin/pcs, resource, config, locking, --output-format=json]
+          environ: *env-def
+          rc: 0
+          out: |
+            {"primitives": [], "clones": [{"id": "locking-clone", "description": null,
+            "member_id": "locking", "meta_attributes": [], "instance_attributes": []}],
+            "groups": [{"id": "locking", "description": null, "member_ids": ["dlm", "clvmd"],
+            "meta_attributes": [], "instance_attributes": []}], "bundles": []}
+          err: ""
+        - command: [/testbin/pcs, resource, status, locking]
+          environ: *env-def
+          rc: 0
+          out: "  * Clone Set: locking-clone [locking]:\n    * Started: [ md-nds-smb01 md-nds-smb02 md-nds-smb03 ]"
           err: ""

--- a/tests/unit/plugins/modules/test_pacemaker_stonith.py
+++ b/tests/unit/plugins/modules/test_pacemaker_stonith.py
@@ -14,9 +14,26 @@ import json
 
 import pytest
 
+from ansible_collections.community.general.plugins.module_utils import _pacemaker
 from ansible_collections.community.general.plugins.modules import pacemaker_stonith
 
 from .uthelper import RunCommandMock, UTHelper
+
+
+@pytest.fixture(autouse=True)
+def _pacemaker_json_capable(mocker):
+    """All pacemaker_stonith module tests behave as if ``pcs`` supports JSON output.
+
+    The version-probe / plaintext-fallback dispatch is exhaustively unit-tested
+    in ``tests/unit/plugins/module_utils/test__pacemaker.py``; module-level
+    tests should not have to mock ``pcs --version`` for every scenario.
+    """
+    mocker.patch.object(
+        _pacemaker.PacemakerRunner,
+        "_probe_version",
+        return_value="0.11.7",
+    )
+
 
 UTHelper.from_module(pacemaker_stonith, __name__, mocks=[RunCommandMock])
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Fix idempotency for `pacemaker_resource` cloned state.
* Move plaintext comparison to json when determining pacemaker cluster properties

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible-collections/community.general/issues/12217

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
`pacemaker_resource`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
