### PR TITLE
Passwordstore lookup: make directory an INI option

### DIFF
--- a/changelogs/fragments/12298-passwordstore-directory-as-ini-option.yml
+++ b/changelogs/fragments/12298-passwordstore-directory-as-ini-option.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "passwordstore lookup plugin - make ``directory`` configurable as an ini configuration file option."

--- a/changelogs/fragments/12298-passwordstore-directory-as-ini-option.yml
+++ b/changelogs/fragments/12298-passwordstore-directory-as-ini-option.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "passwordstore lookup plugin - make ``directory`` configurable as an ini configuration file option."
+  - "passwordstore lookup plugin - make ``directory`` configurable through ``ansible.cfg`` (https://github.com/ansible-collections/community.general/pull/12298)."

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -25,6 +25,10 @@ options:
       - If O(backend=gopass), then the default is the C(path) field in C(~/.config/gopass/config.yml), falling back to V(~/.local/share/gopass/stores/root)
         if C(path) is not defined in the gopass config.
     type: path
+    ini:
+      - section: passwordstore_lookup
+        key: directory
+        version_added: 13.2.0
     vars:
       - name: passwordstore
     env:


### PR DESCRIPTION
##### SUMMARY

The passwordstore lookup plugin tries to load an ini option `directory` to use as the password store base directory, but did not declare this option in its docstring, making the call to `get_option` always return `None`.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

lookup_passwordstore

##### ADDITIONAL INFORMATION