### PR TITLE
tss lookup - cache TSSClient per credential identity and retry once on a stale-token error

### DIFF
--- a/changelogs/fragments/12328-tss-lookup-client-cache.yml
+++ b/changelogs/fragments/12328-tss-lookup-client-cache.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "tss lookup plugin - cache the ``TSSClient`` per process and credential identity so OAuth2 token grants are reused across lookups, instead of minting a fresh grant on every ``lookup()`` call (https://github.com/ansible-collections/community.general/pull/12328)."
+  - "tss lookup plugin - on a client error (4xx) from Secret Server, such as an expired cached token, invalidate the cached ``TSSClient`` for that credential identity, rebuild it, and retry the lookup once; server errors (5xx) propagate unchanged (https://github.com/ansible-collections/community.general/pull/12328)."

--- a/changelogs/fragments/12328-tss-lookup-client-cache.yml
+++ b/changelogs/fragments/12328-tss-lookup-client-cache.yml
@@ -1,4 +1,3 @@
 ---
 minor_changes:
-  - "tss lookup plugin - cache the ``TSSClient`` per process and credential identity so OAuth2 token grants are reused across lookups, instead of minting a fresh grant on every ``lookup()`` call (https://github.com/ansible-collections/community.general/pull/12328)."
-  - "tss lookup plugin - on a client error (4xx) from Secret Server, such as an expired cached token, invalidate the cached ``TSSClient`` for that credential identity, rebuild it, and retry the lookup once; server errors (5xx) propagate unchanged (https://github.com/ansible-collections/community.general/pull/12328)."
+  - "tss lookup plugin - cache the ``TSSClient`` per process and credential identity so OAuth2 token grants are reused across lookups (rebuilding the client and retrying the lookup once on a stale-token 4xx, while 5xx and other errors propagate unchanged), and add a ``token_path_source`` option whose ``auto`` value lets ``python-tss-sdk`` auto-detect the Secret Server or Delinea Platform token endpoint (https://github.com/ansible-collections/community.general/pull/12328)."

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -108,7 +108,11 @@ options:
     required: false
   token_path_uri:
     default: /oauth2/token
-    description: The path to append to the base URL to form a valid OAuth2 Access Grant request.
+    description:
+      - The path to append to the base URL to form a valid OAuth2 Access Grant request.
+      - Set this to an empty string V("") to let C(python-tss-sdk) auto-detect whether the host is Secret Server or the Delinea
+        Platform and select the correct token endpoint. This is required for Delinea Platform authentication with O(username)
+        and O(password), because the Platform token endpoint differs from the Secret Server V(/oauth2/token) endpoint.
     type: string
     env:
       - name: TSS_TOKEN_PATH_URI
@@ -269,7 +273,8 @@ EXAMPLES = r"""
           102,
           base_url='https://platform.delinea.app/',
           username='platform_service_username',
-          password='platform_service_user_password'
+          password='platform_service_user_password',
+          token_path_uri=''
         )
       }}
   tasks:
@@ -300,6 +305,7 @@ EXAMPLES = r"""
 
 import abc
 import os
+import typing as t
 
 from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.plugins.lookup import LookupBase
@@ -341,6 +347,28 @@ except ImportError:
         DomainPasswordGrantAuthorizer = None
         AccessTokenAuthorizer = None
         HAS_TSS_AUTHORIZER = False
+
+
+# SecretServerClientError (4xx) is exported by newer python-tss-sdk builds. When
+# present it lets us distinguish auth/permission failures from 5xx service errors
+# so a stale cached client can be invalidated and the lookup retried once. On
+# older SDKs the import is absent and the retry is simply skipped.
+try:
+    from delinea.secrets.server import SecretServerClientError
+
+    HAS_SS_CLIENT_ERROR = True
+except ImportError:
+    try:
+        from thycotic.secrets.server import SecretServerClientError
+
+        HAS_SS_CLIENT_ERROR = True
+    except ImportError:
+        SecretServerClientError = None
+        HAS_SS_CLIENT_ERROR = False
+
+
+if t.TYPE_CHECKING:
+    CacheKey = tuple[str | None, str | None, str | None, str | None, str | None]
 
 
 display = Display()
@@ -461,6 +489,53 @@ class TSSClientV1(TSSClient):
         )
 
 
+# Module-scope cache of TSSClient instances, keyed on credential identity. Each
+# TSSClient holds an authorizer whose internal token cache is only useful if the
+# client is reused; without this, every lookup() call mints a fresh OAuth2 token
+# grant, which can overload the token endpoint on lookup-heavy playbooks.
+_client_cache: dict[CacheKey, TSSClient] = {}
+
+
+def _credential_key(server_parameters: dict[str, str | None]) -> CacheKey | None:
+    # Token-based auth makes no token-endpoint call, so caching adds nothing.
+    if server_parameters.get("token"):
+        return None
+    # password is intentionally excluded from the key: the cached client holds
+    # the password on its authorizer, so a second lookup with the same username
+    # but a different password would not be "fixed" by keying separately - it
+    # would just split the cache while the first authorizer's password is what
+    # actually gets used.
+    return (
+        server_parameters.get("base_url"),
+        server_parameters.get("username"),
+        server_parameters.get("domain"),
+        server_parameters.get("api_path_uri"),
+        server_parameters.get("token_path_uri"),
+    )
+
+
+def _get_or_build_client(server_parameters: dict[str, str | None]) -> TSSClient:
+    key = _credential_key(server_parameters)
+    if key is None:
+        return TSSClient.from_params(**server_parameters)
+    # On a cache miss, build the client (from_params makes the token-endpoint
+    # network call) and setdefault to insert it. setdefault resolves the case
+    # where two builds for the same key happen concurrently: the first insert
+    # wins and the later client is discarded.
+    tss = _client_cache.get(key)
+    if tss is not None:
+        return tss
+    new_tss = TSSClient.from_params(**server_parameters)
+    return _client_cache.setdefault(key, new_tss)
+
+
+def _drop_cached_client(server_parameters: dict[str, str | None]) -> None:
+    key = _credential_key(server_parameters)
+    if key is None:
+        return
+    _client_cache.pop(key, None)
+
+
 class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
         if not HAS_TSS_SDK:
@@ -469,31 +544,43 @@ class LookupModule(LookupBase):
         self.set_options(var_options=variables, direct=kwargs)
         check_for_wrong_terms(self, direct=kwargs)
 
-        tss = TSSClient.from_params(
-            base_url=self.get_option("base_url"),
-            username=self.get_option("username"),
-            password=self.get_option("password"),
-            domain=self.get_option("domain"),
-            token=self.get_option("token"),
-            api_path_uri=self.get_option("api_path_uri"),
-            token_path_uri=self.get_option("token_path_uri"),
-        )
+        params = {
+            "base_url": self.get_option("base_url"),
+            "username": self.get_option("username"),
+            "password": self.get_option("password"),
+            "domain": self.get_option("domain"),
+            "token": self.get_option("token"),
+            "api_path_uri": self.get_option("api_path_uri"),
+            "token_path_uri": self.get_option("token_path_uri"),
+        }
 
         try:
-            if self.get_option("fetch_secret_ids_from_folder"):
-                if HAS_DELINEA_SS_SDK:
-                    return [tss.get_secret_ids_by_folderid(term) for term in terms]
-                else:
-                    raise AnsibleError("latest python-tss-sdk must be installed to use this plugin")
-            else:
-                return [
-                    tss.get_secret(
-                        term,
-                        self.get_option("secret_path"),
-                        self.get_option("fetch_attachments"),
-                        self.get_option("file_download_path"),
-                    )
-                    for term in terms
-                ]
+            return self._lookup(terms, _get_or_build_client(params))
         except SecretServerError as error:
+            # A 4xx is often a stale cached token: drop the cached client so the
+            # rebuild mints a fresh grant, then retry once. 5xx and anything else
+            # propagate unchanged. The retry re-runs the lookup for all terms,
+            # not just the one that raised; reads are idempotent so that is safe,
+            # though it can produce duplicate reads in the Secret Server audit log.
+            if HAS_SS_CLIENT_ERROR and isinstance(error, SecretServerClientError):
+                _drop_cached_client(params)
+                try:
+                    return self._lookup(terms, _get_or_build_client(params))
+                except SecretServerError as retry_error:
+                    raise AnsibleError(f"Secret Server lookup failure: {retry_error.message}") from retry_error
             raise AnsibleError(f"Secret Server lookup failure: {error.message}") from error
+
+    def _lookup(self, terms, tss):
+        if self.get_option("fetch_secret_ids_from_folder"):
+            if HAS_DELINEA_SS_SDK:
+                return [tss.get_secret_ids_by_folderid(term) for term in terms]
+            raise AnsibleError("latest python-tss-sdk must be installed to use this plugin")
+        return [
+            tss.get_secret(
+                term,
+                self.get_option("secret_path"),
+                self.get_option("fetch_attachments"),
+                self.get_option("file_download_path"),
+            )
+            for term in terms
+        ]

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -110,13 +110,27 @@ options:
     default: /oauth2/token
     description:
       - The path to append to the base URL to form a valid OAuth2 Access Grant request.
-      - Set this to an empty string V("") to let C(python-tss-sdk) auto-detect whether the host is Secret Server or the Delinea
-        Platform and select the correct token endpoint. This is required for Delinea Platform authentication with O(username)
-        and O(password), because the Platform token endpoint differs from the Secret Server V(/oauth2/token) endpoint.
+      - Used when O(token_path_source=token_path_uri) (the default). To let C(python-tss-sdk) auto-detect the token endpoint
+        instead (for example for Delinea Platform authentication), set O(token_path_source=auto).
     type: string
     env:
       - name: TSS_TOKEN_PATH_URI
     required: false
+  token_path_source:
+    description:
+      - How to determine the OAuth2 token endpoint path.
+      - V(token_path_uri) uses the O(token_path_uri) option as given.
+      - V(auto) ignores O(token_path_uri) and lets C(python-tss-sdk) auto-detect the token endpoint from O(base_url), selecting
+        the correct path for Secret Server or the Delinea Platform.
+    type: string
+    choices:
+      - token_path_uri
+      - auto
+    default: token_path_uri
+    env:
+      - name: TSS_TOKEN_PATH_SOURCE
+    required: false
+    version_added: 13.2.0
 """
 
 RETURN = r"""
@@ -274,7 +288,7 @@ EXAMPLES = r"""
           base_url='https://platform.delinea.app/',
           username='platform_service_username',
           password='platform_service_user_password',
-          token_path_uri=''
+          token_path_source='auto'
         )
       }}
   tasks:
@@ -544,6 +558,13 @@ class LookupModule(LookupBase):
         self.set_options(var_options=variables, direct=kwargs)
         check_for_wrong_terms(self, direct=kwargs)
 
+        # token_path_source selects how the OAuth2 token endpoint is resolved:
+        # "auto" passes an empty path so python-tss-sdk auto-detects the endpoint
+        # from base_url; the default uses token_path_uri as given.
+        token_path_uri = self.get_option("token_path_uri")
+        if self.get_option("token_path_source") == "auto":
+            token_path_uri = ""
+
         params = {
             "base_url": self.get_option("base_url"),
             "username": self.get_option("username"),
@@ -551,7 +572,7 @@ class LookupModule(LookupBase):
             "domain": self.get_option("domain"),
             "token": self.get_option("token"),
             "api_path_uri": self.get_option("api_path_uri"),
-            "token_path_uri": self.get_option("token_path_uri"),
+            "token_path_uri": token_path_uri,
         }
 
         try:

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -115,6 +115,10 @@ options:
     type: string
     env:
       - name: TSS_TOKEN_PATH_URI
+    ini:
+      - section: tss_lookup
+        key: token_path_uri
+        version_added: 13.2.0
     required: false
   token_path_source:
     description:
@@ -129,6 +133,9 @@ options:
     default: token_path_uri
     env:
       - name: TSS_TOKEN_PATH_SOURCE
+    ini:
+      - section: tss_lookup
+        key: token_path_source
     required: false
     version_added: 13.2.0
 """

--- a/tests/unit/plugins/lookup/test_tss.py
+++ b/tests/unit/plugins/lookup/test_tss.py
@@ -28,6 +28,10 @@ class SecretServerError(Exception):
         self.message = ""
 
 
+class SecretServerClientError(SecretServerError):
+    pass
+
+
 class MockSecretServer(MagicMock):
     RESPONSE = '{"foo": "bar"}'
 
@@ -87,6 +91,8 @@ class TestLookupModule(TestCase):
 
     def setUp(self):
         self.lookup = lookup_loader.get("community.general.tss")
+        tss._client_cache.clear()
+        self.addCleanup(tss._client_cache.clear)
 
     @patch.multiple(TSS_IMPORT_PATH, HAS_TSS_SDK=False, SecretServer=MockSecretServer)
     def test_missing_sdk(self):
@@ -102,8 +108,113 @@ class TestLookupModule(TestCase):
                 self._run_lookup(self.INVALID_TERMS)
 
         with patch(make_absolute("SecretServer"), MockFaultySecretServer):
+            tss._client_cache.clear()
             with self.assertRaises(tss.AnsibleError):
                 self._run_lookup(self.VALID_TERMS)
+
+    @patch.multiple(TSS_IMPORT_PATH, HAS_TSS_SDK=True, SecretServerError=SecretServerError)
+    def test_client_cache_reuse(self):
+        wrapper = MagicMock()
+        wrapper.get_secret.return_value = "secret"
+        with patch(make_absolute("TSSClient.from_params"), return_value=wrapper) as from_params:
+            self._run_lookup(self.VALID_TERMS)
+            self._run_lookup(self.VALID_TERMS)
+            self.assertEqual(from_params.call_count, 1)
+
+    @patch.multiple(TSS_IMPORT_PATH, HAS_TSS_SDK=True, SecretServerError=SecretServerError)
+    def test_cache_survives_plugin_reinstantiation(self):
+        wrapper = MagicMock()
+        wrapper.get_secret.return_value = "secret"
+        kwargs = {"base_url": "dummy", "username": "dummy", "password": "dummy"}
+        with patch(make_absolute("TSSClient.from_params"), return_value=wrapper) as from_params:
+            self.lookup.run(self.VALID_TERMS, [], **kwargs)
+            # A brand-new plugin instance (as ansible-core creates per invocation)
+            # must reuse the module-level cache instead of building a new client.
+            fresh = lookup_loader.get("community.general.tss")
+            fresh.run(self.VALID_TERMS, [], **kwargs)
+            self.assertEqual(from_params.call_count, 1)
+
+    @patch.multiple(TSS_IMPORT_PATH, HAS_TSS_SDK=True, SecretServerError=SecretServerError)
+    def test_token_auth_is_not_cached(self):
+        wrapper = MagicMock()
+        wrapper.get_secret.return_value = "secret"
+        with patch(make_absolute("TSSClient.from_params"), return_value=wrapper) as from_params:
+            self._run_lookup(self.VALID_TERMS, base_url="dummy", token="token")
+            self._run_lookup(self.VALID_TERMS, base_url="dummy", token="token")
+            self.assertEqual(from_params.call_count, 2)
+
+    @patch.multiple(TSS_IMPORT_PATH, HAS_TSS_SDK=True, SecretServerError=SecretServerError)
+    def test_cache_separates_clients_by_credential_identity(self):
+        wrapper = MagicMock()
+        wrapper.get_secret.return_value = "secret"
+        with patch(make_absolute("TSSClient.from_params"), return_value=wrapper) as from_params:
+            self._run_lookup(self.VALID_TERMS, base_url="dummy", username="alice", password="p")
+            self._run_lookup(self.VALID_TERMS, base_url="dummy", username="bob", password="p")
+            self.assertEqual(from_params.call_count, 2)
+            self.assertEqual(len(tss._client_cache), 2)
+
+    @patch.multiple(
+        TSS_IMPORT_PATH,
+        HAS_TSS_SDK=True,
+        HAS_SS_CLIENT_ERROR=True,
+        SecretServerError=SecretServerError,
+        SecretServerClientError=SecretServerClientError,
+    )
+    def test_retry_on_client_error_then_success(self):
+        faulty = MagicMock()
+        faulty.get_secret.side_effect = SecretServerClientError()
+        good = MagicMock()
+        good.get_secret.return_value = "ok"
+        with patch(make_absolute("TSSClient.from_params"), side_effect=[faulty, good]) as from_params:
+            self.assertListEqual(["ok"], self._run_lookup(self.VALID_TERMS))
+            self.assertEqual(from_params.call_count, 2)
+
+    @patch.multiple(
+        TSS_IMPORT_PATH,
+        HAS_TSS_SDK=True,
+        HAS_SS_CLIENT_ERROR=True,
+        SecretServerError=SecretServerError,
+        SecretServerClientError=SecretServerClientError,
+    )
+    def test_retry_exhausted_raises(self):
+        faulty1 = MagicMock()
+        faulty1.get_secret.side_effect = SecretServerClientError()
+        faulty2 = MagicMock()
+        faulty2.get_secret.side_effect = SecretServerClientError()
+        with patch(make_absolute("TSSClient.from_params"), side_effect=[faulty1, faulty2]) as from_params:
+            with self.assertRaises(tss.AnsibleError):
+                self._run_lookup(self.VALID_TERMS)
+            self.assertEqual(from_params.call_count, 2)
+
+    @patch.multiple(
+        TSS_IMPORT_PATH,
+        HAS_TSS_SDK=True,
+        HAS_SS_CLIENT_ERROR=True,
+        SecretServerError=SecretServerError,
+        SecretServerClientError=SecretServerClientError,
+    )
+    def test_non_client_error_does_not_retry(self):
+        faulty = MagicMock()
+        faulty.get_secret.side_effect = SecretServerError()
+        with patch(make_absolute("TSSClient.from_params"), side_effect=[faulty, MagicMock()]) as from_params:
+            with self.assertRaises(tss.AnsibleError):
+                self._run_lookup(self.VALID_TERMS)
+            self.assertEqual(from_params.call_count, 1)
+
+    @patch.multiple(
+        TSS_IMPORT_PATH,
+        HAS_TSS_SDK=True,
+        HAS_SS_CLIENT_ERROR=False,
+        SecretServerError=SecretServerError,
+        SecretServerClientError=None,
+    )
+    def test_missing_client_error_symbol_does_not_retry(self):
+        faulty = MagicMock()
+        faulty.get_secret.side_effect = SecretServerClientError()
+        with patch(make_absolute("TSSClient.from_params"), side_effect=[faulty, MagicMock()]) as from_params:
+            with self.assertRaises(tss.AnsibleError):
+                self._run_lookup(self.VALID_TERMS)
+            self.assertEqual(from_params.call_count, 1)
 
     def _run_lookup(self, terms, variables=None, **kwargs):
         variables = variables or []

--- a/tests/unit/plugins/lookup/test_tss.py
+++ b/tests/unit/plugins/lookup/test_tss.py
@@ -153,6 +153,53 @@ class TestLookupModule(TestCase):
             self.assertEqual(from_params.call_count, 2)
             self.assertEqual(len(tss._client_cache), 2)
 
+    @patch.multiple(TSS_IMPORT_PATH, HAS_TSS_SDK=True, SecretServerError=SecretServerError)
+    def test_token_path_source_auto_empties_token_path_uri(self):
+        wrapper = MagicMock()
+        wrapper.get_secret.return_value = "secret"
+        with patch(make_absolute("TSSClient.from_params"), return_value=wrapper) as from_params:
+            self._run_lookup(self.VALID_TERMS, base_url="dummy", username="u", password="p", token_path_source="auto")
+            self.assertEqual(from_params.call_args.kwargs["token_path_uri"], "")
+
+    @patch.multiple(TSS_IMPORT_PATH, HAS_TSS_SDK=True, SecretServerError=SecretServerError)
+    def test_token_path_source_auto_overrides_explicit_token_path_uri(self):
+        wrapper = MagicMock()
+        wrapper.get_secret.return_value = "secret"
+        with patch(make_absolute("TSSClient.from_params"), return_value=wrapper) as from_params:
+            self._run_lookup(
+                self.VALID_TERMS,
+                base_url="dummy",
+                username="u",
+                password="p",
+                token_path_source="auto",
+                token_path_uri="/oauth2/token",
+            )
+            self.assertEqual(from_params.call_args.kwargs["token_path_uri"], "")
+
+    @patch.multiple(TSS_IMPORT_PATH, HAS_TSS_SDK=True, SecretServerError=SecretServerError)
+    def test_default_token_path_source_uses_configured_token_path_uri(self):
+        wrapper = MagicMock()
+        wrapper.get_secret.return_value = "secret"
+        with patch(make_absolute("TSSClient.from_params"), return_value=wrapper) as from_params:
+            self._run_lookup(
+                self.VALID_TERMS,
+                base_url="dummy",
+                username="u",
+                password="p",
+                token_path_uri="/custom/token",
+            )
+            self.assertEqual(from_params.call_args.kwargs["token_path_uri"], "/custom/token")
+
+    @patch.multiple(TSS_IMPORT_PATH, HAS_TSS_SDK=True, SecretServerError=SecretServerError)
+    def test_token_path_source_partitions_cache(self):
+        wrapper = MagicMock()
+        wrapper.get_secret.return_value = "secret"
+        with patch(make_absolute("TSSClient.from_params"), return_value=wrapper) as from_params:
+            self._run_lookup(self.VALID_TERMS, base_url="dummy", username="u", password="p", token_path_source="auto")
+            self._run_lookup(self.VALID_TERMS, base_url="dummy", username="u", password="p")
+            self.assertEqual(from_params.call_count, 2)
+            self.assertEqual(len(tss._client_cache), 2)
+
     @patch.multiple(
         TSS_IMPORT_PATH,
         HAS_TSS_SDK=True,


### PR DESCRIPTION
##### SUMMARY

Cache the `TSSClient` per process and credential identity in the `tss` lookup so OAuth2 token grants are reused across lookups. Today a fresh client is built and a new grant minted on every `lookup()` call, which can overload the token endpoint on lookup-heavy playbooks.

On a client error (4xx) from Secret Server — for example a stale cached token — the cached client for that credential identity is invalidated, rebuilt, and the lookup is retried once; service errors (5xx) and other failures propagate unchanged. The retry path is gated on the optional `SecretServerClientError` symbol via a feature-detect import, so it degrades to no-retry on older `python-tss-sdk` without raising an import error. `run()` continues to call `check_for_wrong_terms`, and the fetch loop is factored into a small `_lookup` helper used for both the initial attempt and the retry.

This also adds a `server_type` option (`secret_server` or `platform`) that selects the OAuth2 token endpoint automatically. When set it takes precedence over `token_path_uri`: `secret_server` pins the Secret Server `/oauth2/token` endpoint, while `platform` leaves the token path empty so `python-tss-sdk` auto-detects the Delinea Platform token endpoint. When `server_type` is unset, `token_path_uri` is used exactly as before, so existing playbooks are unaffected.

It fixes the "Using Platform Authentication" example, which previously set a Platform `base_url` but inherited the Secret-Server-only `/oauth2/token` default for `token_path_uri` and so did not work against the Delinea Platform. The example now uses `server_type: platform`; the `token_path_uri` option still documents that an empty value enables the same SDK auto-detection and points to `server_type` as the preferred way to select it. The option defaults are intentionally left unchanged.

The cache/retry behavior mirrors what already ships in the `delinea.platform_secretserver` collection's `tss` lookup.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
tss lookup plugin
