### PR TITLE
CI: Replace devel RHEL 9.7 and 10.1 remotes with 9.8 and 10.2

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -363,18 +363,18 @@ stages:
               test: ansible-test-integration-devel-macos-26.3-azp-posix-2
             - name: macOS 26.3 + group 3
               test: ansible-test-integration-devel-macos-26.3-azp-posix-3
-            - name: RHEL 10.1 + group 1
-              test: ansible-test-integration-devel-rhel-10.1-azp-posix-1
-            - name: RHEL 10.1 + group 2
-              test: ansible-test-integration-devel-rhel-10.1-azp-posix-2
-            - name: RHEL 10.1 + group 3
-              test: ansible-test-integration-devel-rhel-10.1-azp-posix-3
-            - name: RHEL 9.7 + group 1
-              test: ansible-test-integration-devel-rhel-9.7-azp-posix-1
-            - name: RHEL 9.7 + group 2
-              test: ansible-test-integration-devel-rhel-9.7-azp-posix-2
-            - name: RHEL 9.7 + group 3
-              test: ansible-test-integration-devel-rhel-9.7-azp-posix-3
+            - name: RHEL 10.2 + group 1
+              test: ansible-test-integration-devel-rhel-10.2-azp-posix-1
+            - name: RHEL 10.2 + group 2
+              test: ansible-test-integration-devel-rhel-10.2-azp-posix-2
+            - name: RHEL 10.2 + group 3
+              test: ansible-test-integration-devel-rhel-10.2-azp-posix-3
+            - name: RHEL 9.8 + group 1
+              test: ansible-test-integration-devel-rhel-9.8-azp-posix-1
+            - name: RHEL 9.8 + group 2
+              test: ansible-test-integration-devel-rhel-9.8-azp-posix-2
+            - name: RHEL 9.8 + group 3
+              test: ansible-test-integration-devel-rhel-9.8-azp-posix-3
             - name: Ubuntu 24.04 + extra VMs
               test: ansible-test-integration-devel-ubuntu-24.04-azp-posix-vm
             - name: Ubuntu 26.04 + extra VMs

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -287,8 +287,8 @@ ansible_core = "devel"
 target = [ "azp/posix/1/", "azp/posix/2/", "azp/posix/3/" ]
 remote = [
     "macos/26.3",
-    "rhel/10.1",
-    "rhel/9.7",
+    "rhel/10.2",
+    "rhel/9.8",
     # TODO: enable this ASAP!
     # "freebsd/15.0",
     # TODO: enable this ASAP!

--- a/tests/integration/targets/copr/aliases
+++ b/tests/integration/targets/copr/aliases
@@ -8,3 +8,4 @@ skip/macos
 skip/freebsd
 skip/rhel10.0  # FIXME
 skip/rhel10.1  # FIXME
+skip/rhel10.2  # FIXME

--- a/tests/integration/targets/django_command/aliases
+++ b/tests/integration/targets/django_command/aliases
@@ -8,5 +8,7 @@ skip/freebsd
 skip/macos
 skip/rhel9.3
 skip/rhel9.7
+skip/rhel9.8
 skip/rhel10.0
 skip/rhel10.1
+skip/rhel10.2

--- a/tests/integration/targets/django_manage/aliases
+++ b/tests/integration/targets/django_manage/aliases
@@ -8,5 +8,7 @@ skip/freebsd
 skip/macos
 skip/rhel9.3
 skip/rhel9.7
+skip/rhel9.8
 skip/rhel10.0
 skip/rhel10.1
+skip/rhel10.2

--- a/tests/integration/targets/iso_extract/aliases
+++ b/tests/integration/targets/iso_extract/aliases
@@ -7,8 +7,10 @@ needs/target/setup_epel
 destructive
 skip/rhel9.3  # FIXME
 skip/rhel9.7  # FIXME
+skip/rhel9.8  # FIXME
 skip/rhel10.0  # FIXME
 skip/rhel10.1  # FIXME
+skip/rhel10.2  # FIXME
 skip/freebsd13.5  # FIXME
 skip/freebsd14.1  # FIXME
 skip/freebsd14.2  # FIXME

--- a/tests/integration/targets/odbc/aliases
+++ b/tests/integration/targets/odbc/aliases
@@ -7,6 +7,8 @@ destructive
 skip/macos
 skip/rhel9.3
 skip/rhel9.7
+skip/rhel9.8
 skip/rhel10.0
 skip/rhel10.1
+skip/rhel10.2
 skip/freebsd

--- a/tests/integration/targets/setup_snap/tasks/D-RedHat-9.8.yml
+++ b/tests/integration/targets/setup_snap/tasks/D-RedHat-9.8.yml
@@ -1,0 +1,1 @@
+nothing.yml


### PR DESCRIPTION
##### SUMMARY
See https://forum.ansible.com/t/ansible-test-devel-rhel-9-7-and-10-1-remotes-replaced-by-9-8-and-10-2/45976.

Ref: https://github.com/ansible/ansible/commit/9cc7281c69fe74282fc8831fb6796d0700f8f9a6

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
