### PR TITLE
snap: fix misspelling

### DIFF
--- a/plugins/modules/snap.py
+++ b/plugins/modules/snap.py
@@ -102,7 +102,7 @@ options:
     type: int
     version_added: 13.0.0
 notes:
-  - Privileged operations, such as installing and configuring snaps, require root priviledges. This is only the case if the
+  - Privileged operations, such as installing and configuring snaps, require root privileges. This is only the case if the
     user has not logged in to the Snap Store.
 author:
   - Victor Carceler (@vcarceler) <vcarceler@iespuigcastellar.xeill.net>


### PR DESCRIPTION
##### SUMMARY

Fix a misspelled word in the documentation for the `community.general.snap` module.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

snap