### PR TITLE
pacemaker: accept Promoted/Unpromoted as ready states

### DIFF
--- a/changelogs/fragments/pacemaker_resource-ready-states.yml
+++ b/changelogs/fragments/pacemaker_resource-ready-states.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pacemaker_resource - fix bug where the resource-ready state check did not recognize all valid ready states, causing the module to time out on resources that never reach the ``Started`` state (https://github.com/ansible-collections/community.general/issues/12351, https://github.com/ansible-collections/community.general/pull/12355).

--- a/plugins/module_utils/_pacemaker.py
+++ b/plugins/module_utils/_pacemaker.py
@@ -63,15 +63,24 @@ def get_pacemaker_maintenance_mode(runner: CmdRunner) -> bool:
         return bool(maintenance_mode_output)
 
 
-_RESOURCE_READY_STATES = ("Started", "Promoted", "Unpromoted")
+_DEFAULT_RESOURCE_READY_STATES = ("Started",)
 
 
-def wait_for_resource(runner: CmdRunner, cli_noun: str, name: str, wait: int, sleep_interval: int = 5) -> None:
+def wait_for_resource(
+    runner: CmdRunner,
+    cli_noun: str,
+    name: str,
+    wait: int,
+    sleep_interval: int = 5,
+    ready_states: t.Iterable[str] = _DEFAULT_RESOURCE_READY_STATES,
+) -> None:
     """Poll ``pcs <cli_noun> status <name>`` until the resource reports a ready state or the wait budget expires.
 
     A resource is considered ready when its status output contains any of the states in
-    ``_RESOURCE_READY_STATES``. ``Started`` covers non-promotable resources, while ``Promoted``
-    and ``Unpromoted`` cover promotable resources, which never reach a ``Started`` state.
+    *ready_states*. The default ``("Started",)`` matches non-promotable resources and stonith
+    fencing devices. Callers managing promotable resources should pass
+    ``("Started", "Promoted", "Unpromoted")`` because promotable resources never reach
+    ``Started``.
 
     Raises an exception if the resource does not reach a ready state within *wait* seconds.
     """
@@ -79,7 +88,7 @@ def wait_for_resource(runner: CmdRunner, cli_noun: str, name: str, wait: int, sl
     while True:
         with runner("cli_action state name") as ctx:
             rc, out, err = ctx.run(cli_action=cli_noun, state="status")
-        if out and any(state in out for state in _RESOURCE_READY_STATES):
+        if out and any(state in out for state in ready_states):
             return
         if time.monotonic() >= deadline:
             raise Exception(f"Timed out waiting {wait}s for {cli_noun} resource '{name}' to start")

--- a/plugins/module_utils/_pacemaker.py
+++ b/plugins/module_utils/_pacemaker.py
@@ -63,16 +63,23 @@ def get_pacemaker_maintenance_mode(runner: CmdRunner) -> bool:
         return bool(maintenance_mode_output)
 
 
-def wait_for_resource(runner: CmdRunner, cli_noun: str, name: str, wait: int, sleep_interval: int = 5) -> None:
-    """Poll ``pcs <cli_noun> status <name>`` until the resource reports Started or the wait budget expires.
+_RESOURCE_READY_STATES = ("Started", "Promoted", "Unpromoted")
 
-    Raises an exception if the resource does not reach the Started state within *wait* seconds.
+
+def wait_for_resource(runner: CmdRunner, cli_noun: str, name: str, wait: int, sleep_interval: int = 5) -> None:
+    """Poll ``pcs <cli_noun> status <name>`` until the resource reports a ready state or the wait budget expires.
+
+    A resource is considered ready when its status output contains any of the states in
+    ``_RESOURCE_READY_STATES``. ``Started`` covers non-promotable resources, while ``Promoted``
+    and ``Unpromoted`` cover promotable resources, which never reach a ``Started`` state.
+
+    Raises an exception if the resource does not reach a ready state within *wait* seconds.
     """
     deadline = time.monotonic() + wait
     while True:
         with runner("cli_action state name") as ctx:
             rc, out, err = ctx.run(cli_action=cli_noun, state="status")
-        if out and "Started" in out:
+        if out and any(state in out for state in _RESOURCE_READY_STATES):
             return
         if time.monotonic() >= deadline:
             raise Exception(f"Timed out waiting {wait}s for {cli_noun} resource '{name}' to start")

--- a/plugins/modules/pacemaker_resource.py
+++ b/plugins/modules/pacemaker_resource.py
@@ -152,6 +152,9 @@ from ansible_collections.community.general.plugins.module_utils._pacemaker impor
     wait_for_resource,
 )
 
+# Resources may be non-promotable (Started) or promotable (Promoted/Unpromoted, never Started).
+_READY_STATES = ("Started", "Promoted", "Unpromoted")
+
 
 class PacemakerResource(StateModuleHelper):
     module = dict(
@@ -249,7 +252,7 @@ class PacemakerResource(StateModuleHelper):
                 resource_clone_ids=self.fmt_as_stack_argument(self.module.params["resource_clone_ids"], "clone"),
             )
         if not self.module.check_mode and self.vars.wait and not get_pacemaker_maintenance_mode(self.runner):
-            wait_for_resource(self.runner, "resource", self.vars.name, self.vars.wait)
+            wait_for_resource(self.runner, "resource", self.vars.name, self.vars.wait, ready_states=_READY_STATES)
 
     def state_cloned(self):
         with self.runner(
@@ -264,7 +267,7 @@ class PacemakerResource(StateModuleHelper):
                 resource_clone_meta=self.fmt_as_stack_argument(self.module.params["resource_clone_meta"], "meta"),
             )
         if not self.module.check_mode and self.vars.wait and not get_pacemaker_maintenance_mode(self.runner):
-            wait_for_resource(self.runner, "resource", self.vars.name, self.vars.wait)
+            wait_for_resource(self.runner, "resource", self.vars.name, self.vars.wait, ready_states=_READY_STATES)
 
     def state_enabled(self):
         with self.runner(

--- a/tests/unit/plugins/module_utils/test__pacemaker.py
+++ b/tests/unit/plugins/module_utils/test__pacemaker.py
@@ -10,9 +10,11 @@ import pytest
 
 from ansible_collections.community.general.plugins.module_utils import _pacemaker
 from ansible_collections.community.general.plugins.module_utils._pacemaker import (
-    _RESOURCE_READY_STATES,
+    _DEFAULT_RESOURCE_READY_STATES,
     wait_for_resource,
 )
+
+_PROMOTABLE_READY_STATES = ("Started", "Promoted", "Unpromoted")
 
 
 def _make_runner(outputs):
@@ -43,11 +45,9 @@ def _no_sleep(mocker):
     mocker.patch.object(_pacemaker.time, "sleep")
 
 
-def test_ready_states_constant_contents():
-    """The accepted ready-state set must cover non-promotable and promotable resources."""
-    assert "Started" in _RESOURCE_READY_STATES
-    assert "Promoted" in _RESOURCE_READY_STATES
-    assert "Unpromoted" in _RESOURCE_READY_STATES
+def test_default_ready_states_is_started_only():
+    """The default must preserve pre-fix behaviour for stonith and non-promotable callers."""
+    assert _DEFAULT_RESOURCE_READY_STATES == ("Started",)
 
 
 @pytest.mark.parametrize(
@@ -59,14 +59,43 @@ def test_ready_states_constant_contents():
     ],
     ids=["started", "promoted", "unpromoted"],
 )
-def test_wait_for_resource_returns_on_ready_state(status_line):
-    """Each ready state in the accepted set must cause an immediate successful return."""
+def test_wait_for_resource_promotable_ready_states(status_line):
+    """Each ready state in the promotable set must cause an immediate successful return."""
     runner = _make_runner([(0, status_line, "")])
 
-    wait_for_resource(runner, "resource", "any-resource", wait=30)
+    wait_for_resource(runner, "resource", "any-resource", wait=30, ready_states=_PROMOTABLE_READY_STATES)
 
     # One poll, one success — no further runner calls.
     assert runner.call_count == 1
+
+
+def test_wait_for_resource_default_matches_started(mocker):
+    """Calling without ready_states must match Started — the stonith and non-promotable default."""
+    runner = _make_runner(
+        [
+            (0, "  * fence-node-a\t(stonith:fence_ipmilan):\t Started node-a", ""),
+        ]
+    )
+
+    wait_for_resource(runner, "stonith", "fence-node-a", wait=30)
+
+    assert runner.call_count == 1
+
+
+def test_wait_for_resource_default_rejects_promoted(mocker):
+    """With the default ready_states, Promoted output must NOT short-circuit (stonith never promotes)."""
+    mocker.patch.object(_pacemaker.time, "monotonic", side_effect=[0.0, 999.0])
+
+    runner = _make_runner(
+        [
+            (0, "  * drbd_data\t(ocf:linbit:drbd):\t Promoted node-a", ""),
+        ]
+    )
+
+    with pytest.raises(Exception) as excinfo:
+        wait_for_resource(runner, "stonith", "drbd_data", wait=10)
+
+    assert "Timed out waiting 10s" in str(excinfo.value)
 
 
 def test_wait_for_resource_returns_when_promotable_replicas_present():
@@ -74,7 +103,7 @@ def test_wait_for_resource_returns_when_promotable_replicas_present():
     out = "  * drbd_data\t(ocf:linbit:drbd):\t Promoted node-a\n  * drbd_data\t(ocf:linbit:drbd):\t Unpromoted node-b"
     runner = _make_runner([(0, out, "")])
 
-    wait_for_resource(runner, "resource", "drbd_data", wait=30)
+    wait_for_resource(runner, "resource", "drbd_data", wait=30, ready_states=_PROMOTABLE_READY_STATES)
 
     assert runner.call_count == 1
 
@@ -92,7 +121,7 @@ def test_wait_for_resource_polls_until_ready(mocker):
         ]
     )
 
-    wait_for_resource(runner, "resource", "drbd_data", wait=300)
+    wait_for_resource(runner, "resource", "drbd_data", wait=300, ready_states=_PROMOTABLE_READY_STATES)
 
     assert runner.call_count == 3
 
@@ -109,7 +138,7 @@ def test_wait_for_resource_transitional_states_do_not_short_circuit(mocker):
     )
 
     with pytest.raises(Exception) as excinfo:
-        wait_for_resource(runner, "resource", "drbd_data", wait=10)
+        wait_for_resource(runner, "resource", "drbd_data", wait=10, ready_states=_PROMOTABLE_READY_STATES)
 
     assert "Timed out waiting 10s" in str(excinfo.value)
     assert "drbd_data" in str(excinfo.value)

--- a/tests/unit/plugins/module_utils/test__pacemaker.py
+++ b/tests/unit/plugins/module_utils/test__pacemaker.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026, community.general contributors
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ansible_collections.community.general.plugins.module_utils import _pacemaker
+from ansible_collections.community.general.plugins.module_utils._pacemaker import (
+    _RESOURCE_READY_STATES,
+    wait_for_resource,
+)
+
+
+def _make_runner(outputs):
+    """Build a fake CmdRunner that yields the given ``(rc, out, err)`` tuples in order.
+
+    The fake mirrors the runner usage in :func:`wait_for_resource`::
+
+        with runner("cli_action state name") as ctx:
+            rc, out, err = ctx.run(cli_action=..., state="status")
+    """
+    outputs_iter = iter(outputs)
+
+    def runner_call(*args, **kwargs):
+        ctx = MagicMock()
+        ctx.run.return_value = next(outputs_iter)
+        cm = MagicMock()
+        cm.__enter__.return_value = ctx
+        cm.__exit__.return_value = False
+        return cm
+
+    runner = MagicMock(side_effect=runner_call)
+    return runner
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(mocker):
+    """Avoid real sleeps in any test in this module."""
+    mocker.patch.object(_pacemaker.time, "sleep")
+
+
+def test_ready_states_constant_contents():
+    """The accepted ready-state set must cover non-promotable and promotable resources."""
+    assert "Started" in _RESOURCE_READY_STATES
+    assert "Promoted" in _RESOURCE_READY_STATES
+    assert "Unpromoted" in _RESOURCE_READY_STATES
+
+
+@pytest.mark.parametrize(
+    "status_line",
+    [
+        "  * virtual-ip\t(ocf:heartbeat:IPaddr2):\t Started node-a",
+        "  * drbd_data\t(ocf:linbit:drbd):\t Promoted node-a",
+        "  * drbd_data\t(ocf:linbit:drbd):\t Unpromoted node-b",
+    ],
+    ids=["started", "promoted", "unpromoted"],
+)
+def test_wait_for_resource_returns_on_ready_state(status_line):
+    """Each ready state in the accepted set must cause an immediate successful return."""
+    runner = _make_runner([(0, status_line, "")])
+
+    wait_for_resource(runner, "resource", "any-resource", wait=30)
+
+    # One poll, one success — no further runner calls.
+    assert runner.call_count == 1
+
+
+def test_wait_for_resource_returns_when_promotable_replicas_present():
+    """A promotable resource output listing both replicas must be detected as ready."""
+    out = "  * drbd_data\t(ocf:linbit:drbd):\t Promoted node-a\n  * drbd_data\t(ocf:linbit:drbd):\t Unpromoted node-b"
+    runner = _make_runner([(0, out, "")])
+
+    wait_for_resource(runner, "resource", "drbd_data", wait=30)
+
+    assert runner.call_count == 1
+
+
+def test_wait_for_resource_polls_until_ready(mocker):
+    """The wait loop must keep polling while the resource is not in a ready state."""
+    # Monotonic must not advance past the deadline before the ready output is seen.
+    mocker.patch.object(_pacemaker.time, "monotonic", side_effect=[0.0, 1.0, 2.0, 3.0])
+
+    runner = _make_runner(
+        [
+            (0, "  * drbd_data\t(ocf:linbit:drbd):\t Stopped", ""),
+            (0, "  * drbd_data\t(ocf:linbit:drbd):\t Starting node-a", ""),
+            (0, "  * drbd_data\t(ocf:linbit:drbd):\t Promoted node-a", ""),
+        ]
+    )
+
+    wait_for_resource(runner, "resource", "drbd_data", wait=300)
+
+    assert runner.call_count == 3
+
+
+def test_wait_for_resource_transitional_states_do_not_short_circuit(mocker):
+    """Transitional states (``Starting``/``Promoting``/``Demoting``) must not be treated as ready."""
+    # Force the deadline to expire after the first poll so the timeout exception fires.
+    mocker.patch.object(_pacemaker.time, "monotonic", side_effect=[0.0, 999.0])
+
+    runner = _make_runner(
+        [
+            (0, "  * drbd_data\t(ocf:linbit:drbd):\t Promoting node-a", ""),
+        ]
+    )
+
+    with pytest.raises(Exception) as excinfo:
+        wait_for_resource(runner, "resource", "drbd_data", wait=10)
+
+    assert "Timed out waiting 10s" in str(excinfo.value)
+    assert "drbd_data" in str(excinfo.value)
+
+
+def test_wait_for_resource_times_out_when_never_ready(mocker):
+    """The wait loop must raise a timeout error when the ready state is never observed."""
+    mocker.patch.object(_pacemaker.time, "monotonic", side_effect=[0.0, 999.0])
+
+    runner = _make_runner(
+        [
+            (0, "  * virtual-ip\t(ocf:heartbeat:IPaddr2):\t Stopped", ""),
+        ]
+    )
+
+    with pytest.raises(Exception) as excinfo:
+        wait_for_resource(runner, "resource", "virtual-ip", wait=10)
+
+    assert "Timed out waiting 10s" in str(excinfo.value)
+    assert "virtual-ip" in str(excinfo.value)
+
+
+def test_wait_for_resource_empty_output_does_not_match(mocker):
+    """An empty status output must not be treated as ready even though ``in`` of empty matches."""
+    mocker.patch.object(_pacemaker.time, "monotonic", side_effect=[0.0, 999.0])
+
+    runner = _make_runner(
+        [
+            (0, "", ""),
+        ]
+    )
+
+    with pytest.raises(Exception) as excinfo:
+        wait_for_resource(runner, "resource", "any-resource", wait=5)
+
+    assert "Timed out waiting 5s" in str(excinfo.value)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Additional accepted states for pacemaker modules.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible-collections/community.general/issues/12351

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
_pacemaker

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
