### PR TITLE
OpenNebula inventory fails if VM without NIC exists

### DIFF
--- a/changelogs/fragments/fix-opennebula_vm_without_nic.yml
+++ b/changelogs/fragments/fix-opennebula_vm_without_nic.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - opennebula - fix crash when retrieving VM without NIC

--- a/changelogs/fragments/fix-opennebula_vm_without_nic.yml
+++ b/changelogs/fragments/fix-opennebula_vm_without_nic.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - opennebula - fix crash when retrieving VM without NIC
+  - opennebula inventory plugin - fix crash when retrieving VM without NIC (https://github.com/ansible-collections/community.general/pull/12361).

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -138,6 +138,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     def _get_vm_ipv4(self, vm):
         nic = vm.TEMPLATE.get("NIC")
 
+        if not nic:
+            return False
+
         if isinstance(nic, dict):
             nic = [nic]
 
@@ -149,6 +152,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def _get_vm_ipv6(self, vm):
         nic = vm.TEMPLATE.get("NIC")
+
+        if not nic:
+            return False
 
         if isinstance(nic, dict):
             nic = [nic]


### PR DESCRIPTION
##### SUMMARY
When using the OpenNebula inventory plugin to retrieve a list of running VMs, an error occurs and the plugin fails, if a VM has no NIC attached.

A simple conditional was added in `_get_vm_ipv4` and `_get_vm_ipv6` to check if the NIC is a valid object.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugin.inventory.opennebula

##### ADDITIONAL INFORMATION

##### Step-by-step reproduction

1. Create an OpenNebula inventory file with the following content:
    ```
    plugin: community.general.opennebula
    api_url: https://api.example.org
    ```
2. Retrieve the inventory with `uv run ansible-inventory -i opennebula.yml --list`
3. An error occurs if a VM exists without NICs
    ```
    [WARNING]: Failed to parse inventory with 'auto' plugin: 'NoneType' object is not iterable

    Failed to parse inventory with 'auto' plugin.
    
    <<< caused by >>>
    
    'NoneType' object is not iterable
    Origin: <inventory plugin 'auto' with source 'opennebula.yml'>
    
    [WARNING]: Failed to parse inventory with 'yaml' plugin: Plugin configuration YAML file, not YAML inventory
    
    Failed to parse inventory with 'yaml' plugin.
    
    <<< caused by >>>
    
    Plugin configuration YAML file, not YAML inventory
    Origin: <inventory plugin 'yaml' with source 'opennebula.yml'>
    
    [WARNING]: Failed to parse inventory with 'ini' plugin: Failed to parse inventory: Invalid host pattern 'plugin:' supplied, ending in ':' is not allowed, this character is reserved to provide a port.
    
    Failed to parse inventory with 'ini' plugin.
    
    <<< caused by >>>
    
    Failed to parse inventory: Invalid host pattern 'plugin:' supplied, ending in ':' is not allowed, this character is reserved to provide a port.
    Origin: opennebula.yml
    
    [WARNING]: Unable to parse opennebula.yml as an inventory source
    [WARNING]: No inventory was parsed, only implicit localhost is available
    {
        "_meta": {
            "hostvars": {},
            "profile": "inventory_legacy"
        },
        "all": {
            "children": [
                "ungrouped"
            ]
        }
    }
    ```

After the fix is applied, the inventory can be parsed and retrieved normally.
