### PR TITLE
dnf_versionlock: Docs say module incompatible with dnf5 but compatibility was resolved

### DIFF
--- a/plugins/modules/dnf_versionlock.py
+++ b/plugins/modules/dnf_versionlock.py
@@ -57,7 +57,6 @@ notes:
   - In an ideal world, the C(versionlock) plugin would have a dry-run option to know for sure what is going to happen. So
     far we have to work with a best guess as close as possible to the behaviour inferred from its code.
   - For most of cases where you want to lock and unlock specific versions of a package, this works fairly well.
-  - Does not work with C(dnf5).
 requirements:
   - dnf
   - dnf-plugin-versionlock


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Almost a year ago, incompatibility with DNF5 was resolved with #9846.
  - I have tested this resolution myself and noticed that I am able to mask packages on Fedora 44, DNF v5.4.1.0, with this Ansible module.
- While presumably #10237 has been resolved, the underlying documentation has not been updated and still says that this module is incompatible with DNF5.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
dnf_versionlock

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
