### PR TITLE
dnf_config_manager: Docs say module incompatible with dnf5 but compatibility was resolved

### DIFF
--- a/plugins/modules/dnf_config_manager.py
+++ b/plugins/modules/dnf_config_manager.py
@@ -35,8 +35,6 @@ options:
     default: enabled
     type: str
     choices: [enabled, disabled]
-notes:
-  - Does not work with C(dnf5).
 seealso:
   - module: ansible.builtin.dnf
   - module: ansible.builtin.yum_repository


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Incompatibility with DNF5 was resolved with #12206.
  - I have tested this resolution myself and noticed that I am able to mask packages on Fedora 44, DNF v5.4.1.0, with this Ansible module.
- While #9127, has been resolved, the underlying documentation has not been updated and still says that this module is incompatible with DNF5.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
dnf_config_manager

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
