### PR TITLE
jenkins_job_info: fix KeyError when filtering folder jobs by color

### DIFF
--- a/changelogs/fragments/12232-jenkins-job-info-color-keyerror.yml
+++ b/changelogs/fragments/12232-jenkins-job-info-color-keyerror.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "jenkins_job_info - fix ``KeyError: 'color'`` when filtering folder jobs by color
+    (https://github.com/ansible-collections/community.general/issues/12232)."

--- a/changelogs/fragments/12232-jenkins-job-info-color-keyerror.yml
+++ b/changelogs/fragments/12232-jenkins-job-info-color-keyerror.yml
@@ -1,3 +1,3 @@
 bugfixes:
   - "jenkins_job_info - fix ``KeyError: 'color'`` when filtering folder jobs by color
-    (https://github.com/ansible-collections/community.general/issues/12232)."
+    (https://github.com/ansible-collections/community.general/issues/12232), https://github.com/ansible-collections/community.general/pull/12369)."

--- a/plugins/modules/jenkins_job_info.py
+++ b/plugins/modules/jenkins_job_info.py
@@ -236,7 +236,7 @@ def get_jobs(module):
                 del job["_class"]
 
     if module.params.get("color"):
-        jobs = filter_jobs_by_color(jobs, module.params.get("color"))
+        jobs = filter_jobs_by_color(jobs, module.params["color"])
 
     return jobs
 

--- a/plugins/modules/jenkins_job_info.py
+++ b/plugins/modules/jenkins_job_info.py
@@ -235,7 +235,7 @@ def get_jobs(module):
             if "_class" in job:
                 del job["_class"]
 
-    if module.params.get("color"):
+    if module.params["color"]:
         jobs = filter_jobs_by_color(jobs, module.params["color"])
 
     return jobs

--- a/plugins/modules/jenkins_job_info.py
+++ b/plugins/modules/jenkins_job_info.py
@@ -181,6 +181,28 @@ def test_dependencies(module):
         )
 
 
+def filter_jobs_by_color(jobs, color):
+    """Return jobs matching the given Jenkins status color.
+
+    Folder jobs may not have a top-level color; nested jobs are checked
+    recursively and the folder is kept when any child matches.
+    """
+    filtered = []
+    for job in jobs:
+        if job.get("color") == color:
+            filtered.append(job)
+            continue
+        nested = job.get("jobs")
+        if not nested:
+            continue
+        nested_filtered = filter_jobs_by_color(nested, color)
+        if nested_filtered:
+            folder = job.copy()
+            folder["jobs"] = nested_filtered
+            filtered.append(folder)
+    return filtered
+
+
 def get_jobs(module):
     jenkins_conn = get_jenkins_connection(module)
     jobs = []
@@ -190,14 +212,14 @@ def get_jobs(module):
         except jenkins.NotFoundException:
             pass
         else:
-            jobs.append(
-                {
-                    "name": job_info["name"],
-                    "fullname": job_info["fullName"],
-                    "url": job_info["url"],
-                    "color": job_info["color"],
-                }
-            )
+            job = {
+                "name": job_info["name"],
+                "fullname": job_info["fullName"],
+                "url": job_info["url"],
+            }
+            if "color" in job_info:
+                job["color"] = job_info["color"]
+            jobs.append(job)
 
     else:
         all_jobs = jenkins_conn.get_all_jobs()
@@ -214,7 +236,7 @@ def get_jobs(module):
                 del job["_class"]
 
     if module.params.get("color"):
-        jobs = [j for j in jobs if j["color"] == module.params.get("color")]
+        jobs = filter_jobs_by_color(jobs, module.params.get("color"))
 
     return jobs
 

--- a/tests/unit/plugins/modules/test_jenkins_job_info.py
+++ b/tests/unit/plugins/modules/test_jenkins_job_info.py
@@ -18,14 +18,6 @@ from ansible_collections.community.internal_test_tools.tests.unit.plugins.module
 from ansible_collections.community.general.plugins.modules import jenkins_job_info
 
 
-class jenkins:
-    class JenkinsException(Exception):
-        pass
-
-    class NotFoundException(Exception):
-        pass
-
-
 FOLDER_JOB = {
     "name": "jobs_name_one",
     "fullname": "jobs_name_one",

--- a/tests/unit/plugins/modules/test_jenkins_job_info.py
+++ b/tests/unit/plugins/modules/test_jenkins_job_info.py
@@ -8,14 +8,13 @@ import unittest
 from unittest.mock import patch
 
 from ansible.module_utils import basic
+from ansible_collections.community.general.plugins.modules import jenkins_job_info
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
     AnsibleExitJson,
     exit_json,
     fail_json,
     set_module_args,
 )
-
-from ansible_collections.community.general.plugins.modules import jenkins_job_info
 
 
 FOLDER_JOB = {

--- a/tests/unit/plugins/modules/test_jenkins_job_info.py
+++ b/tests/unit/plugins/modules/test_jenkins_job_info.py
@@ -8,7 +8,6 @@ import unittest
 from unittest.mock import patch
 
 from ansible.module_utils import basic
-from ansible_collections.community.general.plugins.modules import jenkins_job_info
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
     AnsibleExitJson,
     exit_json,
@@ -16,6 +15,7 @@ from ansible_collections.community.internal_test_tools.tests.unit.plugins.module
     set_module_args,
 )
 
+from ansible_collections.community.general.plugins.modules import jenkins_job_info
 
 FOLDER_JOB = {
     "name": "jobs_name_one",

--- a/tests/unit/plugins/modules/test_jenkins_job_info.py
+++ b/tests/unit/plugins/modules/test_jenkins_job_info.py
@@ -1,0 +1,124 @@
+# Copyright (c) Ansible project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from ansible.module_utils import basic
+from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
+    AnsibleExitJson,
+    exit_json,
+    fail_json,
+    set_module_args,
+)
+
+from ansible_collections.community.general.plugins.modules import jenkins_job_info
+
+
+class jenkins:
+    class JenkinsException(Exception):
+        pass
+
+    class NotFoundException(Exception):
+        pass
+
+
+FOLDER_JOB = {
+    "name": "jobs_name_one",
+    "fullname": "jobs_name_one",
+    "url": "https://jenkins.example.com/job/jobs_name_one",
+    "jobs": [
+        {
+            "name": "master",
+            "fullname": "jobs_name_one/master",
+            "url": "https://jenkins.example.com/job/jobs_name_one/job/master/",
+            "color": "blue",
+        },
+    ],
+}
+
+FLAT_JOB = {
+    "name": "flat-job",
+    "fullname": "flat-job",
+    "url": "https://jenkins.example.com/job/flat-job/",
+    "color": "blue",
+}
+
+
+class JenkinsMock:
+    def get_all_jobs(self):
+        return [FOLDER_JOB, FLAT_JOB]
+
+
+class TestJenkinsJobInfo(unittest.TestCase):
+    def setUp(self):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+
+    @patch("ansible_collections.community.general.plugins.modules.jenkins_job_info.test_dependencies")
+    @patch("ansible_collections.community.general.plugins.modules.jenkins_job_info.get_jenkins_connection")
+    def test_glob_with_color_on_folder_job(self, jenkins_connection, test_deps):
+        """Folder jobs without a top-level color must not raise KeyError."""
+        test_deps.return_value = None
+        jenkins_connection.return_value = JenkinsMock()
+
+        with self.assertRaises(AnsibleExitJson) as return_json:
+            with set_module_args(
+                {
+                    "glob": "jobs_name_one",
+                    "color": "blue",
+                    "user": "user",
+                    "token": "token",
+                }
+            ):
+                jenkins_job_info.main()
+
+        result = return_json.exception.args[0]
+        self.assertFalse(result["changed"])
+        self.assertEqual(len(result["jobs"]), 1)
+        self.assertEqual(result["jobs"][0]["name"], "jobs_name_one")
+        self.assertEqual(result["jobs"][0]["jobs"][0]["color"], "blue")
+
+    @patch("ansible_collections.community.general.plugins.modules.jenkins_job_info.test_dependencies")
+    @patch("ansible_collections.community.general.plugins.modules.jenkins_job_info.get_jenkins_connection")
+    def test_glob_with_color_on_flat_job(self, jenkins_connection, test_deps):
+        test_deps.return_value = None
+        jenkins_connection.return_value = JenkinsMock()
+
+        with self.assertRaises(AnsibleExitJson) as return_json:
+            with set_module_args(
+                {
+                    "glob": "flat-job",
+                    "color": "blue",
+                    "user": "user",
+                    "token": "token",
+                }
+            ):
+                jenkins_job_info.main()
+
+        result = return_json.exception.args[0]
+        self.assertEqual(len(result["jobs"]), 1)
+        self.assertEqual(result["jobs"][0]["fullname"], "flat-job")
+
+    @patch("ansible_collections.community.general.plugins.modules.jenkins_job_info.test_dependencies")
+    @patch("ansible_collections.community.general.plugins.modules.jenkins_job_info.get_jenkins_connection")
+    def test_glob_with_color_no_match(self, jenkins_connection, test_deps):
+        test_deps.return_value = None
+        jenkins_connection.return_value = JenkinsMock()
+
+        with self.assertRaises(AnsibleExitJson) as return_json:
+            with set_module_args(
+                {
+                    "glob": "jobs_name_one",
+                    "color": "red",
+                    "user": "user",
+                    "token": "token",
+                }
+            ):
+                jenkins_job_info.main()
+
+        self.assertEqual(return_json.exception.args[0]["jobs"], [])


### PR DESCRIPTION
## Summary
- Fixed `KeyError: 'color'` when using the `color` parameter with folder jobs that lack a top-level `color` field
- Recursively filter nested jobs and keep parent folders when a child matches
- Added unit tests

Fixes #12232

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
- jenkins_job_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
