### PR TITLE
bitwarden: add sync option

### DIFF
--- a/changelogs/fragments/12377-bitwarden-add-sync-option.yaml
+++ b/changelogs/fragments/12377-bitwarden-add-sync-option.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - bitwarden - add `sync` option to sync items from the vault before lookup (https://github.com/ansible-collections/community.general/pull/12377).
+  - bitwarden lookup plugin - add ``sync`` option to sync items from the vault before lookup (https://github.com/ansible-collections/community.general/pull/12377).

--- a/changelogs/fragments/12377-bitwarden-add-sync-option.yaml
+++ b/changelogs/fragments/12377-bitwarden-add-sync-option.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - bitwarden - add `sync` option to sync items from the vault before lookup (https://github.com/ansible-collections/community.general/pull/12377).

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -60,7 +60,7 @@ options:
     type: int
     version_added: 10.4.0
   sync:
-    description: Set to sync items from the Bitwarden vault in the beginning
+    description: Set to C(true) to sync items from the Bitwarden vault in the beginning.
     type: bool
     version_added: 13.2.0
 """

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -59,6 +59,10 @@ options:
         of query results. Leave empty to skip this check.
     type: int
     version_added: 10.4.0
+  sync:
+    description: Set to sync items from the Bitwarden vault in the beginning
+    type: bool
+    version_added: 13.2.0
 """
 
 EXAMPLES = r"""
@@ -154,6 +158,10 @@ class Bitwarden:
         out, err = self._run(["status"], stdin="")
         decoded = AnsibleJSONDecoder().raw_decode(out)[0]
         return decoded["status"] == "unlocked"
+
+    def sync(self):
+        out, err = self._run(["sync"], stdin="")
+        return out
 
     def _run(self, args, stdin=None, expected_rc=0):
         if self.session:
@@ -264,9 +272,13 @@ class LookupModule(LookupBase):
         organization_id = self.get_option("organization_id")
         result_count = self.get_option("result_count")
         _bitwarden.session = self.get_option("bw_session")
+        sync = self.get_option("sync")
 
         if not _bitwarden.unlocked:
             raise AnsibleError("Bitwarden Vault locked. Run 'bw unlock'.")
+
+        if sync:
+            _bitwarden.sync()
 
         if not terms:
             terms = [None]

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -62,6 +62,7 @@ options:
   sync:
     description: Set to C(true) to sync items from the Bitwarden vault in the beginning.
     type: bool
+    default: false
     version_added: 13.2.0
 """
 

--- a/tests/unit/plugins/lookup/test_bitwarden.py
+++ b/tests/unit/plugins/lookup/test_bitwarden.py
@@ -111,8 +111,12 @@ MOCK_RECORDS = [
 
 class MockBitwarden(Bitwarden):
     unlocked = True
+    synced = False
 
     def _run(self, args, stdin=None, expected_rc=0):
+        if args[0] == "sync":
+            self.synced = True
+            return "Syncing complete.", ""
         if args[0] == "get":
             if args[1] == "item":
                 for item in MOCK_RECORDS:
@@ -288,3 +292,9 @@ class TestLookupModule(unittest.TestCase):
         self.lookup.run(None, organization_id=MOCK_ORGANIZATION_ID, result_count=3)
         with self.assertRaises(BitwardenException):
             self.lookup.run(None, organization_id=MOCK_ORGANIZATION_ID, result_count=0)
+
+    def test_bitwarden_plugin_sync_option(self):
+        mock_bitwarden = MockBitwarden()
+        with patch("ansible_collections.community.general.plugins.lookup.bitwarden._bitwarden", mock_bitwarden):
+            self.lookup.run([], sync=True)
+            self.assertTrue(mock_bitwarden.synced)


### PR DESCRIPTION
##### SUMMARY
Adds the sync option to bitwarden lookup, wrapping `bw sync`.
This ensures the lookup searches for Bitwarden items updated from the vault.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
bitwarden