### PR TITLE
gitlab_runners inventory: use context manager for API object

### DIFF
--- a/changelogs/fragments/12378-gitlab-runners-inventory-context-manager.yml
+++ b/changelogs/fragments/12378-gitlab-runners-inventory-context-manager.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - `plugins.inventory.gitlab_runners` - wrap the Gitlab API object in a context mananger and cleanup inventory group on exception (https://github.com/ansible-collections/community.general/pull/12378).

--- a/changelogs/fragments/12378-gitlab-runners-inventory-context-manager.yml
+++ b/changelogs/fragments/12378-gitlab-runners-inventory-context-manager.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - gitlab_runners inventory plugin - wrap the Gitlab API object in a context mananger and cleanup inventory group on exception (https://github.com/ansible-collections/community.general/pull/12378).
+  - gitlab_runners inventory plugin - wrap the Gitlab API object in a context mananger, and only create the ``gitlab_runners`` group after the API request was successful (https://github.com/ansible-collections/community.general/pull/12378).

--- a/changelogs/fragments/12378-gitlab-runners-inventory-context-manager.yml
+++ b/changelogs/fragments/12378-gitlab-runners-inventory-context-manager.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - `plugins.inventory.gitlab_runners` - wrap the Gitlab API object in a context mananger and cleanup inventory group on exception (https://github.com/ansible-collections/community.general/pull/12378).
+  - gitlab_runners inventory plugin - wrap the Gitlab API object in a context mananger and cleanup inventory group on exception (https://github.com/ansible-collections/community.general/pull/12378).

--- a/plugins/inventory/gitlab_runners.py
+++ b/plugins/inventory/gitlab_runners.py
@@ -113,7 +113,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                     self.inventory.set_variable(host, "ansible_host", make_unsafe(ip_address))
                     if self.get_option("verbose_output", True):
                         self.inventory.set_variable(host, "gitlab_runner_attributes", host_attrs)
-    
+
                     # Use constructed if applicable
                     strict = self.get_option("strict")
                     # Composed variables

--- a/plugins/inventory/gitlab_runners.py
+++ b/plugins/inventory/gitlab_runners.py
@@ -99,12 +99,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def _populate(self):
         with gitlab.Gitlab(self.get_option("server_url"), private_token=self.get_option("api_token")) as gl:
-            self.inventory.add_group("gitlab_runners")
             try:
                 if self.get_option("filter"):
                     runners = gl.runners.all(scope=self.get_option("filter"))
                 else:
                     runners = gl.runners.all()
+                self.inventory.add_group("gitlab_runners")
                 for runner in runners:
                     host = make_unsafe(str(runner["id"]))
                     ip_address = runner["ip_address"]
@@ -123,7 +123,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                     # Create groups based on variable values and add the corresponding hosts to it
                     self._add_host_to_keyed_groups(self.get_option("keyed_groups"), host_attrs, host, strict=strict)
             except Exception as e:
-                self.inventory.remove_group("gitlab_runners")
                 raise AnsibleParserError(
                     f"Unable to fetch hosts from GitLab API, this was the original exception: {e}"
                 ) from e

--- a/plugins/inventory/gitlab_runners.py
+++ b/plugins/inventory/gitlab_runners.py
@@ -98,34 +98,35 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     NAME = "community.general.gitlab_runners"
 
     def _populate(self):
-        gl = gitlab.Gitlab(self.get_option("server_url"), private_token=self.get_option("api_token"))
-        self.inventory.add_group("gitlab_runners")
-        try:
-            if self.get_option("filter"):
-                runners = gl.runners.all(scope=self.get_option("filter"))
-            else:
-                runners = gl.runners.all()
-            for runner in runners:
-                host = make_unsafe(str(runner["id"]))
-                ip_address = runner["ip_address"]
-                host_attrs = make_unsafe(vars(gl.runners.get(runner["id"]))["_attrs"])
-                self.inventory.add_host(host, group="gitlab_runners")
-                self.inventory.set_variable(host, "ansible_host", make_unsafe(ip_address))
-                if self.get_option("verbose_output", True):
-                    self.inventory.set_variable(host, "gitlab_runner_attributes", host_attrs)
-
-                # Use constructed if applicable
-                strict = self.get_option("strict")
-                # Composed variables
-                self._set_composite_vars(self.get_option("compose"), host_attrs, host, strict=strict)
-                # Complex groups based on jinja2 conditionals, hosts that meet the conditional are added to group
-                self._add_host_to_composed_groups(self.get_option("groups"), host_attrs, host, strict=strict)
-                # Create groups based on variable values and add the corresponding hosts to it
-                self._add_host_to_keyed_groups(self.get_option("keyed_groups"), host_attrs, host, strict=strict)
-        except Exception as e:
-            raise AnsibleParserError(
-                f"Unable to fetch hosts from GitLab API, this was the original exception: {e}"
-            ) from e
+        with gitlab.Gitlab(self.get_option("server_url"), private_token=self.get_option("api_token")) as gl:
+            self.inventory.add_group("gitlab_runners")
+            try:
+                if self.get_option("filter"):
+                    runners = gl.runners.all(scope=self.get_option("filter"))
+                else:
+                    runners = gl.runners.all()
+                for runner in runners:
+                    host = make_unsafe(str(runner["id"]))
+                    ip_address = runner["ip_address"]
+                    host_attrs = make_unsafe(vars(gl.runners.get(runner["id"]))["_attrs"])
+                    self.inventory.add_host(host, group="gitlab_runners")
+                    self.inventory.set_variable(host, "ansible_host", make_unsafe(ip_address))
+                    if self.get_option("verbose_output", True):
+                        self.inventory.set_variable(host, "gitlab_runner_attributes", host_attrs)
+    
+                    # Use constructed if applicable
+                    strict = self.get_option("strict")
+                    # Composed variables
+                    self._set_composite_vars(self.get_option("compose"), host_attrs, host, strict=strict)
+                    # Complex groups based on jinja2 conditionals, hosts that meet the conditional are added to group
+                    self._add_host_to_composed_groups(self.get_option("groups"), host_attrs, host, strict=strict)
+                    # Create groups based on variable values and add the corresponding hosts to it
+                    self._add_host_to_keyed_groups(self.get_option("keyed_groups"), host_attrs, host, strict=strict)
+            except Exception as e:
+                self.inventory.remove_group("gitlab_runners")
+                raise AnsibleParserError(
+                    f"Unable to fetch hosts from GitLab API, this was the original exception: {e}"
+                ) from e
 
     def verify_file(self, path):
         """Return the possibly of a file being consumable by this plugin."""


### PR DESCRIPTION
Refactor `community.general.plugins.inventory.gitlab_runners._populate` to use context manager for GitLab connection, and also ~~cleanup the inventory group on exception~~ add the inventory group in the protected block with the rest of the core logic.

##### SUMMARY
While working on a different feature for my own practice, I noticed the API object is instantiated at a module level and not explicitly cleaned up. Perhaps this is desirable behavior for the plugin lifecycle, to enhance performance. But in case it is not, I made this quick change to prevent abuse of the API session.

##### ISSUE TYPE
- Refactoring Pull Request

##### COMPONENT NAME
`plugins.inventory.gitlab_runners`

##### ADDITIONAL INFORMATION
I considered further enhancements, but I don't understand the plugin lifecycle and API well enough yet. Please be blunt and frank with any feedback or additional requirements. My time on this is not billable, and I can't afford any ego about it. Tell me what you need. Thank you for your time and attention, please thrive.