### PR TITLE
Nmap address list

### DIFF
--- a/changelogs/fragments/12384-nmap-address-list.yml
+++ b/changelogs/fragments/12384-nmap-address-list.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmap inventory plugin - allow ``address`` to be a list of networks/IP ranges to scan, in addition to a single string (https://github.com/ansible-collections/community.general/issues/12379, https://github.com/ansible-collections/community.general/pull/12384).

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -28,7 +28,8 @@ options:
     type: boolean
   address:
     description: Network IP or range of IPs to scan, you can use a simple range (10.2.2.15-25) or CIDR notation.
-    type: string
+    type: list
+    elements: string
     required: true
     env:
       - name: ANSIBLE_NMAP_ADDRESS
@@ -277,7 +278,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             if self.get_option("skip_host_discovery"):
                 cmd.append("-Pn")
 
-            cmd.append(self.get_option("address"))
+            cmd.extend(self.get_option("address"))
             try:
                 # execute
                 p = Popen(cmd, stdout=PIPE, stderr=PIPE)

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -157,8 +157,11 @@ from ansible.errors import AnsibleParserError
 from ansible.module_utils.common.process import get_bin_path
 from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable, Constructable
+from ansible.utils.display import Display
 
 from ansible_collections.community.general.plugins.plugin_utils._unsafe import make_unsafe
+
+display = Display()
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
@@ -279,6 +282,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 cmd.append("-Pn")
 
             cmd.extend(self.get_option("address"))
+
+            display.v(f"nmap: scanning {', '.join(self.get_option('address'))}")
             try:
                 # execute
                 p = Popen(cmd, stdout=PIPE, stderr=PIPE)

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -27,7 +27,9 @@ options:
     default: false
     type: boolean
   address:
-    description: Network IP or range of IPs to scan, you can use a simple range (10.2.2.15-25) or CIDR notation.
+    description:
+      - Network IP or range of IPs to scan, you can use a simple range (10.2.2.15-25) or CIDR notation.
+      - Since community.general 13.2.0 this can be a list of networks or IP ranges.
     type: list
     elements: string
     required: true


### PR DESCRIPTION
##### SUMMARY
nmap inventory plugin's address option only accepted a single network/IP range, making it impossible to scan multiple networks from one inventory file. The exclude option already used `type: list` / `elements: string`, so this brings `address` in line with that pattern.

- `address` is now `type: list` / `elements: string` (was `type: string`). 
- `cmd.append(self.get_option("address"))` is replaced with `cmd.extend(self.get_option("address"))` 
- Added a verbose (`-v`) log line reporting the networks being scanned.

Fixes #12379

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
nmap

##### ADDITIONAL INFORMATION
Example inventory config with multiple networks:
```yaml
plugin: community.general.nmap
strict: false
address:
  - 192.168.1.0/27
  - 192.168.2.0/27
