### PR TITLE
Add new module write_binary_file

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1472,6 +1472,8 @@ files:
     maintainers: $team_wdc
   $modules/wdc_redfish_info.py:
     maintainers: $team_wdc
+  $modules/write_binary_file.py:
+    maintainers: felixfontein
   $modules/xattr.py:
     labels: xattr
     maintainers: bcoca

--- a/plugins/lookup/binary_file.py
+++ b/plugins/lookup/binary_file.py
@@ -54,6 +54,7 @@ seealso:
       directory of a role.
   - ref: playbook_task_paths
     description: Search paths used for relative files.
+  - module: community.general.write_binary_file
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/write_binary_file.py
+++ b/plugins/modules/write_binary_file.py
@@ -1,0 +1,205 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# Copyright: (c) 2017, Ansible Project
+# Copyright 2026, Felix Fontein (felix@fontein.de)
+# Copyright 2026, Plexim GmbH
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+DOCUMENTATION = r"""
+module: write_binary_file
+short_description: Write binary file from Base64 encoded input
+version_added: 13.2.0
+description:
+  - Given Base64 encoded content, write it to a file.
+  - This is useful when Base64-encoded binary content (that is not valid UTF-8)
+    is retrieved from a credentials store (or similar sources) and needs to be written to a file.
+    The M(ansible.builtin.copy) module with its O(ansible.builtin.copy#module:content) parameter
+    can only be used to write content that is valid UTF-8 encoded text.
+extends_documentation_fragment:
+  - ansible.builtin.files
+  - community.general._attributes
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
+options:
+  path:
+    description:
+      - The file to write to.
+    type: path
+    required: true
+    aliases:
+      - dest
+  content:
+    description:
+      - The Base64 encoded content.
+    type: str
+    required: true
+  follow:
+    description:
+      - Whether filesystem links in the destination should be followed.
+      - If set to V(true) and O(path) is a symlink, the file pointed to by O(path)
+        (resp. after following further links) is modified, instead of O(path) itself.
+    type: bool
+    default: false
+  force:
+    description:
+      - Influence whether the remote file must always be replaced.
+      - If V(true), the remote file will be replaced when contents are different than the source.
+      - If V(false), the file will only be transferred if the destination does not exist.
+    type: bool
+    default: true
+  backup:
+    description:
+      - Create a backup file including the timestamp information so you can get the original file back if you somehow clobbered it incorrectly.
+    type: bool
+    default: false
+
+seealso:
+  - plugin: community.general.binary_file
+    plugin_type: lookup
+  - module: ansible.builtin.copy
+
+author:
+  - Felix Fontein (@felixfontein) <felix@fontein.de>
+"""
+
+EXAMPLES = r"""
+- name: Write binary file
+  community.general.write_binary_file:
+    path: /foo
+    content: "{{ lookup('community.general.binary_file', '/bar') }}"
+    mode: "0600"
+    owner: root
+    group: root
+  become: true
+
+- name: Write binary decrypted from SOPS
+  community.general.write_binary_file:
+    path: /etc/encrypted.bin
+    content: "{{ lookup('community.sops.sops', 'encrypted.sops.bin', base64=true, rstrip=false) }}"
+    mode: "0600"
+    owner: root
+    group: root
+  become: true
+"""
+
+RETURN = r"""
+backup_file:
+  description:
+    - Name of backup file created.
+  returned: changed and if O(backup=true)
+  type: str
+  sample: /path/to/file.txt.2015-02-12@22:09~
+"""
+
+import base64
+import os
+import tempfile
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main() -> None:
+    module = AnsibleModule(
+        {
+            "path": {"type": "path", "required": True, "aliases": ["dest"]},
+            "content": {"type": "str", "required": True, "no_log": True},
+            "follow": {"type": "bool", "default": False},
+            "force": {"type": "bool", "default": True},
+            "backup": {"type": "bool", "default": False},
+        },
+        supports_check_mode=True,
+        add_file_common_args=True,
+    )
+
+    path: str = module.params["path"]
+    content_b64: str = module.params["content"]
+    force: bool = module.params["force"]
+    follow: bool = module.params["follow"]
+    backup: bool = module.params["backup"]
+
+    try:
+        content = base64.b64decode(content_b64)
+    except Exception as exc:
+        module.fail_json(msg=f"Cannot decode Base64-encoded content: {exc}")
+
+    current_content: bytes | None = None
+    if os.path.exists(path):
+        if os.path.islink(path) and follow:
+            path = os.path.realpath(path)
+        dirname = os.path.dirname(path)
+        if os.path.isfile(path):
+            if not force:
+                module.exit_json(msg="File already exists", changed=False)
+            if not os.path.islink(path) and os.access(path, os.R_OK):
+                try:
+                    with open(path, "rb") as f:
+                        current_content = f.read()
+                except FileNotFoundError:
+                    pass
+                except Exception as exc:
+                    module.fail_json(msg=f"Cannot read {path}: {exc}")
+    else:
+        dirname = os.path.dirname(path)
+        if dirname and not os.path.exists(dirname):
+            try:
+                # os.path.exists() can return false in some
+                # circumstances where the directory does not have
+                # the execute bit for the current user set, in
+                # which case the stat() call will raise an OSError
+                os.stat(dirname)
+            except OSError as e:
+                if "permission denied" in str(e).lower():
+                    module.fail_json(msg=f"Destination directory {dirname} is not accessible")
+            module.fail_json(msg=f"Destination directory {dirname} does not exist")
+
+    if not os.access(dirname, os.W_OK) and not module.params["unsafe_writes"]:
+        module.fail_json(msg=f"Destination {dirname} not writable")
+
+    if force:
+        changed = content != current_content
+    else:
+        changed = current_content is None
+
+    backup_file: str | None = None
+    if changed and not module.check_mode:
+        if backup:
+            if os.path.exists(path):
+                backup_file = module.backup_local(path)
+        if os.path.islink(path):
+            try:
+                os.unlink(path)
+            except OSError as exc:
+                module.fail_json(msg=f"Cannot unlink symbolic link: {exc}")
+
+        try:
+            src_f, src = tempfile.mkstemp(dir=dirname)
+            module.add_cleanup_file(src)
+            try:
+                to_write = len(content)
+                while to_write > 0:
+                    written = os.write(src_f, content[-to_write:])
+                    if written <= 0:
+                        raise OSError(f"os.write returned {written}")
+                    to_write -= written
+            finally:
+                os.close(src_f)
+        except OSError as exc:
+            module.fail_json(msg=f"Cannot write data to temporary file: {exc}")
+
+        module.atomic_move(src, path, unsafe_writes=module.params["unsafe_writes"], keep_dest_attrs=True)
+
+    file_args = module.load_file_common_arguments(module.params, path=path)
+    changed = module.set_fs_attributes_if_different(file_args, changed)
+
+    module.exit_json(changed=changed, backup_file=backup_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/write_binary_file.py
+++ b/plugins/modules/write_binary_file.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
-# Copyright: (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
-# Copyright: (c) 2017, Ansible Project
+# Copyright (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# Copyright (c) 2017, Ansible Project
 # Copyright 2026, Felix Fontein (felix@fontein.de)
 # Copyright 2026, Plexim GmbH
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/write_binary_file.py
+++ b/plugins/modules/write_binary_file.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 DOCUMENTATION = r"""
 module: write_binary_file
 short_description: Write binary file from Base64 encoded input
-version_added: 13.2.0
+version_added: 13.3.0
 description:
   - Given Base64 encoded content, write it to a file.
   - This is useful when Base64-encoded binary content (that is not valid UTF-8)

--- a/tests/integration/targets/write_binary_file/aliases
+++ b/tests/integration/targets/write_binary_file/aliases
@@ -1,0 +1,5 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+azp/posix/3

--- a/tests/integration/targets/write_binary_file/meta/main.yml
+++ b/tests/integration/targets/write_binary_file/meta/main.yml
@@ -1,0 +1,7 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependencies:
+  - setup_remote_tmp_dir

--- a/tests/integration/targets/write_binary_file/tasks/main.yml
+++ b/tests/integration/targets/write_binary_file/tasks/main.yml
@@ -1,0 +1,327 @@
+---
+# Copyright (c) 2025, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Stat file
+  ansible.builtin.stat:
+    path: "{{ remote_tmp_dir }}/file_1"
+  register: stat_0
+
+- name: Write file (check mode)
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_1"
+    content: "{{ file_content_1 }}"
+    mode: "0600"
+  register: write_1_check
+  check_mode: true
+
+- name: Write file
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_1"
+    content: "{{ file_content_1 }}"
+    mode: "0600"
+  register: write_1
+
+- name: Stat file
+  ansible.builtin.stat:
+    path: "{{ remote_tmp_dir }}/file_1"
+  register: stat_1
+
+- name: Read file
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/file_1"
+  register: read_1
+
+- name: Write file (check mode, idempotent)
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_1"
+    content: "{{ file_content_1 }}"
+    mode: "0600"
+  register: write_2_check
+  check_mode: true
+
+- name: Write file (idempotent)
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_1"
+    content: "{{ file_content_1 }}"
+    mode: "0600"
+  register: write_2
+
+- name: Stat file
+  ansible.builtin.stat:
+    path: "{{ remote_tmp_dir }}/file_1"
+  register: stat_2
+
+- name: Read file
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/file_1"
+  register: read_2
+
+- name: Write file (check mode, changed)
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_1"
+    content: "{{ file_content_2 }}"
+    mode: "0600"
+  register: write_3_check
+  check_mode: true
+
+- name: Write file (changed)
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_1"
+    content: "{{ file_content_2 }}"
+    mode: "0600"
+  register: write_3
+
+- name: Stat file
+  ansible.builtin.stat:
+    path: "{{ remote_tmp_dir }}/file_1"
+  register: stat_3
+
+- name: Read file
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/file_1"
+  register: read_3
+
+- name: Write file (check mode, changed mode)
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_1"
+    content: "{{ file_content_2 }}"
+    mode: "0440"
+  register: write_4_check
+  check_mode: true
+
+- name: Write file (changed mode)
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_1"
+    content: "{{ file_content_2 }}"
+    mode: "0440"
+  register: write_4
+
+- name: Stat file
+  ansible.builtin.stat:
+    path: "{{ remote_tmp_dir }}/file_1"
+  register: stat_4
+
+- name: Read file
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/file_1"
+  register: read_4
+
+- name: Write read-only file (check mode, changed)
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_1"
+    content: "{{ file_content_1 }}"
+    mode: "0440"
+  register: write_5_check
+  check_mode: true
+
+- name: Write read-only file (changed)
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_1"
+    content: "{{ file_content_1 }}"
+    mode: "0440"
+  register: write_5
+
+- name: Stat file
+  ansible.builtin.stat:
+    path: "{{ remote_tmp_dir }}/file_1"
+  register: stat_5
+
+- name: Read file
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/file_1"
+  register: read_5
+
+- name: Create symlink
+  ansible.builtin.file:
+    dest: "{{ remote_tmp_dir }}/file_2"
+    src: "{{ remote_tmp_dir }}/file_1"
+    state: link
+
+- name: Write to symlink with follow (check mode, idempotent)
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_2"
+    content: "{{ file_content_1 }}"
+    mode: "0440"
+    follow: true
+  register: write_6_check
+  check_mode: true
+
+- name: Write to symlink with follow (idempotent)
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_2"
+    content: "{{ file_content_1 }}"
+    mode: "0440"
+    follow: true
+  register: write_6
+
+- name: Stat file
+  ansible.builtin.stat:
+    path: "{{ remote_tmp_dir }}/file_2"
+  register: stat_6
+
+- name: Stat destination file
+  ansible.builtin.stat:
+    path: "{{ remote_tmp_dir }}/file_1"
+  register: stat_6_dest
+
+- name: Read file
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/file_1"
+  register: read_6
+
+- name: Write to symlink with follow (check mode, changed)
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_2"
+    content: "{{ file_content_2 }}"
+    mode: "0400"
+    follow: true
+  register: write_7_check
+  check_mode: true
+
+- name: Write to symlink with follow (idempotent)
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_2"
+    content: "{{ file_content_2 }}"
+    mode: "0400"
+    follow: true
+  register: write_7
+
+- name: Stat file
+  ansible.builtin.stat:
+    path: "{{ remote_tmp_dir }}/file_2"
+  register: stat_7
+
+- name: Stat destination file
+  ansible.builtin.stat:
+    path: "{{ remote_tmp_dir }}/file_1"
+  register: stat_7_dest
+
+- name: Read file
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/file_1"
+  register: read_7
+
+- name: Replace link with content (check mode)
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_2"
+    content: "{{ file_content_2 }}"
+    mode: "0400"
+  register: write_8_check
+  check_mode: true
+
+- name: Replace link with content
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_2"
+    content: "{{ file_content_2 }}"
+    mode: "0400"
+  register: write_8
+
+- name: Stat file
+  ansible.builtin.stat:
+    path: "{{ remote_tmp_dir }}/file_2"
+  register: stat_8
+
+- name: Read file
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/file_2"
+  register: read_8
+
+- name: Do not replace existing content (check mode)
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_2"
+    content: "{{ file_content_1 }}"
+    force: false
+    mode: "0400"
+  register: write_9_check
+  check_mode: true
+
+- name: Do not replace existing content
+  community.general.write_binary_file:
+    path: "{{ remote_tmp_dir }}/file_2"
+    content: "{{ file_content_1 }}"
+    force: false
+    mode: "0400"
+  register: write_9
+
+- name: Stat file
+  ansible.builtin.stat:
+    path: "{{ remote_tmp_dir }}/file_2"
+  register: stat_9
+
+- name: Read file
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/file_2"
+  register: read_9
+
+- name: Verify tests
+  ansible.builtin.assert:
+    that:
+      - stat_0.stat.exists == false
+      # Write (first)
+      - write_1_check is changed
+      - write_1 is changed
+      - not stat_1.stat.islnk
+      - read_1.content == file_content_1
+      - stat_1.stat.mode == "0600"
+      # Write (idempotent)
+      - write_2_check is not changed
+      - write_2 is not changed
+      - read_2.content == file_content_1
+      - not stat_2.stat.islnk
+      - stat_2.stat.mode == "0600"
+      - stat_2.stat.mtime == stat_1.stat.mtime
+      # Write (changed)
+      - write_3_check is changed
+      - write_3 is changed
+      - read_3.content == file_content_2
+      - not stat_3.stat.islnk
+      - stat_3.stat.mode == "0600"
+      - stat_3.stat.mtime != stat_2.stat.mtime
+      # Write (changed mode)
+      - write_4_check is changed
+      - write_4 is changed
+      - read_4.content == file_content_2
+      - not stat_4.stat.islnk
+      - stat_4.stat.mode == "0440"
+      - stat_4.stat.mtime == stat_3.stat.mtime  # the file wasn't modified, only its metadata
+      # Write (read-only, changed)
+      - write_5_check is changed
+      - write_5 is changed
+      - read_5.content == file_content_1
+      - not stat_5.stat.islnk
+      - stat_5.stat.mode == "0440"
+      - stat_5.stat.mtime != stat_4.stat.mtime
+      # Write follow (read-only, idempotent)
+      - write_6_check is not changed
+      - write_6 is not changed
+      - read_6.content == file_content_1
+      - stat_6.stat.islnk
+      - stat_6.stat.lnk_target == (remote_tmp_dir ~ "/file_1")
+      - not stat_6_dest.stat.islnk
+      - stat_6_dest.stat.mode == "0440"
+      - stat_6_dest.stat.mtime == stat_5.stat.mtime
+      # Write follow (read-only, changed)
+      - write_7_check is changed
+      - write_7 is changed
+      - read_7.content == file_content_2
+      - stat_7.stat.islnk
+      - stat_7.stat.lnk_target == (remote_tmp_dir ~ "/file_1")
+      - not stat_7_dest.stat.islnk
+      - stat_7_dest.stat.mode == "0400"
+      - stat_7_dest.stat.mtime != stat_6_dest.stat.mtime
+      # Replace (changed)
+      - write_8_check is changed
+      - write_8 is changed
+      - read_8.content == file_content_2
+      - not stat_8.stat.islnk
+      - stat_8.stat.mode == "0400"
+      - stat_8.stat.mtime != stat_7_dest.stat.mtime
+      # Not replace (changed)
+      - write_9_check is not changed
+      - write_9 is not changed
+      - read_9.content == file_content_2
+      - not stat_9.stat.islnk
+      - stat_9.stat.mode == "0400"
+      - stat_9.stat.mtime == stat_8.stat.mtime

--- a/tests/integration/targets/write_binary_file/vars/main.yml
+++ b/tests/integration/targets/write_binary_file/vars/main.yml
@@ -1,0 +1,10 @@
+---
+# Copyright (c) 2025, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# base64.b64encode(b"\x01\x00\x02")
+file_content_1: AQAC
+
+# base64.b64encode(b"hello world")
+file_content_2: aGVsbG8gd29ybGQ=


### PR DESCRIPTION
##### SUMMARY
Recently at $JOB I needed to write some decrypted binary content to disk, and noticed that this seems to be impossible with Ansible. The `copy` module's `content` doesn't accept binary values, there's no "de-base64 `content`" option for `copy`, ...

So I hacked to gether a small module that allows me to do this. I got permission to contribute this module, extended it with some more features from the `copy` module (handling read-only files, following links, creating backup), and polished it a bit and added tests. Here is the result :)

##### ISSUE TYPE
- New Module/Plugin Pull Request

##### COMPONENT NAME
write_binary_file
