### PR TITLE
nmcli: fix connection name matching for MAC addresses

### DIFF
--- a/changelogs/fragments/12386-nmcli-escape-no.yml
+++ b/changelogs/fragments/12386-nmcli-escape-no.yml
@@ -1,0 +1,3 @@
+minor_changes:
+ - the nmcli plugin now handles connection names derived from MAC addresses.
+   (https://github.com/ansible-collections/community.general/issues/12386)

--- a/changelogs/fragments/12386-nmcli-escape-no.yml
+++ b/changelogs/fragments/12386-nmcli-escape-no.yml
@@ -1,3 +1,5 @@
 minor_changes:
- - the nmcli plugin now handles connection names derived from MAC addresses.
-   (https://github.com/ansible-collections/community.general/issues/12386)
+ - nmcli - now handles connection names derived from MAC addresses,
+   and generally names that contain ``:`` or ``\\``
+   (https://github.com/ansible-collections/community.general/issues/12386,
+   https://github.com/ansible-collections/community.general/pull/12387).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -2402,7 +2402,7 @@ class Nmcli:
         return [self.route_to_string(route_params) for route_params in routes_params]
 
     def list_connection_info(self):
-        cmd = [self.nmcli_bin, "--fields", "name", "--terse", "con", "show"]
+        cmd = [self.nmcli_bin, "--fields", "name", "--terse", "--escape", "no", "con", "show"]
         (rc, out, err) = self.execute_command(cmd)
         if rc != 0:
             raise NmcliModuleError(err)
@@ -2417,7 +2417,7 @@ class Nmcli:
 
     def get_connection_state(self):
         """Get the current state of the connection"""
-        cmd = [self.nmcli_bin, "--terse", "--fields", "GENERAL.STATE", "con", "show", self.conn_name]
+        cmd = [self.nmcli_bin, "--terse", "--escape", "no", "--fields", "GENERAL.STATE", "con", "show", self.conn_name]
         (rc, out, err) = self.execute_command(cmd)
         if rc != 0:
             raise NmcliModuleError(err)


### PR DESCRIPTION
nmcli can identify network connections by MAC address. In this case, nmcli output by default escapes colons with backslashes, like `00\:62\:0B\:9D\:14\:6C`. Strings in this form cannot be used as argument to nmcli commands such as `nmcli con show`. Thus by using this form and not un-escaping the colons, connection name matching may break.

Fix this by using the nmcli parameter "--escape no".

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

nmcli can identify network connections by MAC address. In this case, nmcli output by default escapes colons with backslashes, like '00\\:62\\:0B\\:9D\\:14\\:6C'. Strings in this form cannot be used as argument to nmcli commands such as `nmcli con show`. Thus by using this form and not un-escaping the colons, connection name matching may break.

Fixes #12386.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

nmcli
