### PR TITLE
pacemaker_cluster: skip cluster start when already online

### DIFF
--- a/changelogs/fragments/12403-pacemaker-cluster-online-skip-start.yml
+++ b/changelogs/fragments/12403-pacemaker-cluster-online-skip-start.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - pacemaker_cluster - skip `pcs cluster start` in `state=online` when the cluster is already running, improving idempotency and allowing maintenance mode to be disabled without pcsd connectivity (https://github.com/ansible-collections/community.general/issues/12362).
+  - pacemaker_cluster - skip ``pcs cluster start`` in ``state=online`` when the cluster is already running, improving idempotency and allowing maintenance mode to be disabled without pcsd connectivity (https://github.com/ansible-collections/community.general/issues/12362, https://github.com/ansible-collections/community.general/pull/12403).

--- a/changelogs/fragments/12403-pacemaker-cluster-online-skip-start.yml
+++ b/changelogs/fragments/12403-pacemaker-cluster-online-skip-start.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - pacemaker_cluster - skip `pcs cluster start` in `state=online` when the cluster is already running, improving idempotency and allowing maintenance mode to be disabled without pcsd connectivity (https://github.com/ansible-collections/community.general/issues/12362).

--- a/plugins/modules/pacemaker_cluster.py
+++ b/plugins/modules/pacemaker_cluster.py
@@ -133,6 +133,19 @@ class PacemakerCluster(StateModuleHelper):
             )
             return dict(rc=result[0], out=(result[1] if result[1] != "" else None), err=result[2])
 
+    def _is_cluster_running(self) -> bool:
+        status = self.vars.previous_value
+        if not status or "not currently running" in status:
+            return False
+
+        node_name = self.runner.module.params.get("name")
+        if node_name:
+            for line in status.splitlines():
+                if line.strip().startswith(f"* Node {node_name}:") and "(offline)" in line.lower():
+                    return False
+
+        return True
+
     def state_cleanup(self):
         with self.runner(
             "cli_action state name", output_process=self._process_command_output(True, "Fail"), check_mode_skip=True
@@ -148,18 +161,20 @@ class PacemakerCluster(StateModuleHelper):
             ctx.run(cli_action="cluster", apply_all=self.vars.apply_all, wait=self.module.params["timeout"])
 
     def state_online(self):
-        with self.runner(
-            "cli_action state name apply_all wait",
-            output_process=self._process_command_output(True, "currently running"),
-            check_mode_skip=True,
-        ) as ctx:
-            ctx.run(cli_action="cluster", apply_all=self.vars.apply_all, wait=self.module.params["timeout"])
+        if not self._is_cluster_running():
+            with self.runner(
+                "cli_action state name apply_all wait",
+                output_process=self._process_command_output(True, "currently running"),
+                check_mode_skip=True,
+            ) as ctx:
+                ctx.run(cli_action="cluster", apply_all=self.vars.apply_all, wait=self.module.params["timeout"])
 
         if get_pacemaker_maintenance_mode(self.runner):
             with self.runner(
                 "cli_action state name", output_process=self._process_command_output(True, "Fail"), check_mode_skip=True
             ) as ctx:
                 ctx.run(cli_action="property", state="maintenance", name="maintenance-mode=false")
+            self.changed = True
 
     def state_maintenance(self):
         with self.runner(

--- a/tests/unit/plugins/modules/test_pacemaker_cluster.yaml
+++ b/tests/unit/plugins/modules/test_pacemaker_cluster.yaml
@@ -20,10 +20,34 @@ test_cases:
           rc: 0
           out: '   * Online: [ pc1, pc2, pc3 ]'
           err: ""
-        - command: [/testbin/pcs, cluster, start, --all, --wait=300]
+        - command: [/testbin/pcs, property, config]
+          environ: *env-def
+          rc: 1
+          out: |
+            Cluster Properties: cib-bootstrap-options
+            cluster-infrastructure=corosync
+            cluster-name=hacluster
+            dc-version=2.1.9-1.fc41-7188dbf
+            have-watchdog=false
+          err: ""
+        - command: [/testbin/pcs, cluster, status]
           environ: *env-def
           rc: 0
-          out: "Starting Cluster..."
+          out: '   * Online: [ pc1, pc2, pc3 ]'
+          err: ""
+  - id: test_online_minimal_input_initial_online_all_maintenance
+    input:
+      state: online
+    output:
+      changed: true
+      previous_value: '   * Online: [ pc1, pc2, pc3 ]'
+      value: '   * Online: [ pc1, pc2, pc3 ]'
+    mocks:
+      run_command:
+        - command: [/testbin/pcs, cluster, status]
+          environ: *env-def
+          rc: 0
+          out: '   * Online: [ pc1, pc2, pc3 ]'
           err: ""
         - command: [/testbin/pcs, property, config]
           environ: *env-def
@@ -34,6 +58,12 @@ test_cases:
             cluster-name=hacluster
             dc-version=2.1.9-1.fc41-7188dbf
             have-watchdog=false
+            maintenance-mode=true
+          err: ""
+        - command: [/testbin/pcs, property, set, maintenance-mode=false]
+          environ: *env-def
+          rc: 0
+          out: ""
           err: ""
         - command: [/testbin/pcs, cluster, status]
           environ: *env-def


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Skip `pcs cluster start` in `state: online` when the cluster is already running.
This complements #12364 by implementing option 2 from #12362: improves idempotency, avoids unnecessary pcsd calls, and allows exiting maintenance mode with `state: online` when pcsd is unreachable.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
pacemaker_cluster

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Follow-up to #12364 / #12362.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
