### PR TITLE
maven_artifact: make default explicit

### DIFF
--- a/changelogs/fragments/12411-maven-artifact.yml
+++ b/changelogs/fragments/12411-maven-artifact.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - maven_artifact - use Ansible construct to express the default value of parameter (https://github.com/ansible-collections/community.general/pull/12411).

--- a/plugins/modules/maven_artifact.py
+++ b/plugins/modules/maven_artifact.py
@@ -157,9 +157,8 @@ options:
     version_added: 5.2.0
     description:
       - A list of headers that should not be included in the redirection. This headers are sent to the C(fetch_url) function.
-      - On ansible-core version 2.12 or later, the default of this option is V([Authorization, Cookie]).
       - Useful if the redirection URL does not need to have sensitive headers in the request.
-      - Requires ansible-core version 2.12 or later.
+    default: ["Authorization", "Cookie"]
   directory_mode:
     type: str
     description:
@@ -665,16 +664,12 @@ def main():
             keep_name=dict(default=False, type="bool"),
             verify_checksum=dict(default="download", choices=["never", "download", "change", "always"]),
             checksum_alg=dict(default="md5", choices=["md5", "sha1"]),
-            unredirected_headers=dict(type="list", elements="str"),
+            unredirected_headers=dict(type="list", elements="str", default=["Authorization", "Cookie"]),
             directory_mode=dict(type="str"),
         ),
         add_file_common_args=True,
         mutually_exclusive=([("version", "version_by_spec")]),
     )
-
-    if module.params["unredirected_headers"] is None:
-        # if the user did not supply unredirected params, we use the default
-        module.params["unredirected_headers"] = ["Authorization", "Cookie"]
 
     if not HAS_LXML_ETREE:
         module.fail_json(msg=missing_required_lib("lxml"), exception=LXML_ETREE_IMP_ERR)

--- a/tests/integration/targets/callback_log_plays/runme.sh
+++ b/tests/integration/targets/callback_log_plays/runme.sh
@@ -5,8 +5,6 @@
 
 set -eux
 
-# ANSIBLE_CALLBACK_WHITELIST has been deprecated in ansible-base 2.11, ANSIBLE_CALLBACKS_ENABLED should be used
-export ANSIBLE_CALLBACK_WHITELIST="community.general.log_plays,${ANSIBLE_CALLBACK_WHITELIST:-}"
 export ANSIBLE_CALLBACKS_ENABLED="community.general.log_plays,${ANSIBLE_CALLBACKS_ENABLED:-}"
 
 # run play, should create log and dir if needed

--- a/tests/unit/plugins/module_utils/test__module_helper.py
+++ b/tests/unit/plugins/module_utils/test__module_helper.py
@@ -9,11 +9,6 @@ import pytest
 
 from ansible_collections.community.general.plugins.module_utils._module_helper import cause_changes
 
-#
-# DEPRECATION NOTICE
-# Parameters on_success and on_failure are deprecated and will be removed in community.general 12.0.0
-# Remove testcases with those params when releasing 12.0.0
-#
 CAUSE_CHG_DECO_PARAMS = ["deco_args", "expect_exception", "expect_changed"]
 CAUSE_CHG_DECO = dict(
     none_succ=dict(deco_args={}, expect_exception=False, expect_changed=None),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The value was default for ansible-core > 2.12, so now that his is the norm, this PR documents and configures the module properly for that defualt value.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
maven_artifact

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
