### PR TITLE
opennebula inventory - expose UNAME/GNAME, fix SSH_PORT coercion, respect ansible_host

### DIFF
--- a/changelogs/fragments/12416-opennebula-inventory-enhancements.yml
+++ b/changelogs/fragments/12416-opennebula-inventory-enhancements.yml
@@ -1,0 +1,17 @@
+minor_changes:
+  - "opennebula inventory plugin - expose ``UNAME`` (VM owner) and ``GNAME`` (VM group)
+     as host variables, enabling ``keyed_groups`` based on ownership
+     (https://github.com/ansible-collections/community.general/pull/12416)."
+bugfixes:
+  - "opennebula inventory plugin - coerce ``SSH_PORT`` to an integer before setting
+     ``ansible_port``; pyone/XML-RPC sometimes returns a dict wrapper (e.g.
+     ``{\"#text\": \"22\"}``) which broke OpenSSH with ``Connection to UNKNOWN port 65535``
+     (https://github.com/ansible-collections/community.general/pull/12416)."
+  - "opennebula inventory plugin - do not overwrite ``ansible_host`` when a host already
+     has it set by an earlier inventory source, allowing static inventory overrides to
+     take precedence over the dynamic hostname preference
+     (https://github.com/ansible-collections/community.general/pull/12416)."
+  - "opennebula inventory plugin - fix EXAMPLES to use ``filters`` (plural) instead of
+     ``filter`` (singular), and add ``| default('')`` to prevent undefined variable errors
+     on VMs missing the filtered attributes
+     (https://github.com/ansible-collections/community.general/pull/12416)."

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2020, FELDSAM s.r.o. - FeldHost™ <support@feldhost.cz>
+# Copyright (c) 2026, Tom Paine, <github@aioue.net>
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,6 +9,7 @@ DOCUMENTATION = r"""
 name: opennebula
 author:
   - Kristian Feldsam (@feldsam)
+  - Tom Paine (@aioue)
 short_description: OpenNebula inventory source
 version_added: "3.8.0"
 extends_documentation_fragment:
@@ -87,14 +89,35 @@ api_url: https://opennebula:2633/RPC2
 filter_by_label: Cache
 
 ---
-# Only return VMs whose USER_TEMPLATE has both PROJECT=climb and ENVIRONMENT=test
+# Filter VMs by USER_TEMPLATE attributes on a shared instance.
+# Use "| default('')" so VMs missing the attribute are excluded rather than
+# causing an 'undefined' error.
 plugin: community.general.opennebula
 api_url: https://opennebula:2633/RPC2
-filter:
+filters:
   - include: >-
-      PROJECT == "climb" and
-      ENVIRONMENT == "test"
+      (PROJECT | default('')) == "climb" and
+      (ENVIRONMENT | default('')) == "test"
   - exclude: true
+
+---
+# Connect by VM name (useful with ~/.ssh/config Host aliases) and suppress
+# automatic label-based groups when labels are noisy or inconsistent.
+plugin: community.general.opennebula
+api_url: https://opennebula:2633/RPC2
+hostname: name
+group_by_labels: false
+
+---
+# Group VMs by their OpenNebula owner and group (UNAME/GNAME).
+# Produces groups like opennebula_group_EI_Training, opennebula_owner_angiolie.
+plugin: community.general.opennebula
+api_url: https://opennebula:2633/RPC2
+keyed_groups:
+  - key: GNAME
+    prefix: opennebula_group
+  - key: UNAME
+    prefix: opennebula_owner
 """
 
 try:
@@ -226,6 +249,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
             server["name"] = vm.NAME
             server["id"] = vm.ID
+            server["UNAME"] = getattr(vm, "UNAME", "")
+            server["GNAME"] = getattr(vm, "GNAME", "")
             if hasattr(vm.HISTORY_RECORDS, "HISTORY") and vm.HISTORY_RECORDS.HISTORY:
                 server["host"] = vm.HISTORY_RECORDS.HISTORY[-1].HOSTNAME
             server["LABELS"] = labels
@@ -235,6 +260,31 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             result.append(server)
 
         return result
+
+    @staticmethod
+    def _coerce_ssh_port(raw):
+        """Return a valid TCP port number, or ``None`` if the value is unusable.
+
+        XML-RPC responses from OpenNebula sometimes wrap scalar values in a
+        dict (e.g. ``{"#text": "22"}``).  Passing that through to
+        ``ansible_port`` breaks OpenSSH with errors like
+        ``Connection to UNKNOWN port 65535``.
+        """
+        if raw in (None, "", False):
+            return None
+        if isinstance(raw, dict):
+            raw = raw.get("#text") or raw.get("text") or next(
+                (v for v in raw.values() if isinstance(v, (str, int)) and str(v).strip()), None
+            )
+            if raw is None:
+                return None
+        try:
+            port = int(str(raw).strip(), 10)
+        except (TypeError, ValueError):
+            return None
+        if port < 1 or port > 65535:
+            return None
+        return port
 
     def _populate(self):
         hostname_preference = self.get_option("hostname")
@@ -266,10 +316,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 self.inventory.set_variable(hostname, attribute, value)
 
             if hostname_preference != "name":
-                self.inventory.set_variable(hostname, "ansible_host", server[hostname_preference])
+                existing = self.inventory.get_host(hostname)
+                if not existing or "ansible_host" not in existing.vars:
+                    self.inventory.set_variable(hostname, "ansible_host", server[hostname_preference])
 
-            if server.get("SSH_PORT"):
-                self.inventory.set_variable(hostname, "ansible_port", server["SSH_PORT"])
+            ssh_port = self._coerce_ssh_port(server.get("SSH_PORT"))
+            if ssh_port is not None:
+                self.inventory.set_variable(hostname, "ansible_port", ssh_port)
 
             # handle construcable implementation: get composed variables if any
             self._set_composite_vars(self.get_option("compose"), server, hostname, strict=strict)

--- a/tests/unit/plugins/inventory/test_opennebula.py
+++ b/tests/unit/plugins/inventory/test_opennebula.py
@@ -107,6 +107,7 @@ def get_vm_pool():
             "ETIME": 0,
             "GID": 132,
             "GNAME": "CSApparelVDC",
+            "UNAME": "sam-admin",
             "HISTORY_RECORDS": HistoryRecords(),
             "ID": 7157,
             "LAST_POLL": 1632762935,
@@ -163,6 +164,7 @@ def get_vm_pool():
             "ETIME": 0,
             "GID": 0,
             "GNAME": "oneadmin",
+            "UNAME": "oneadmin",
             "HISTORY_RECORDS": [],
             "ID": 327,
             "LAST_POLL": 1632763543,
@@ -238,6 +240,7 @@ def get_vm_pool():
             "ETIME": 0,
             "GID": 0,
             "GNAME": "oneadmin",
+            "UNAME": "gitlab-admin",
             "HISTORY_RECORDS": [],
             "ID": 107,
             "LAST_POLL": 1632764186,
@@ -426,7 +429,36 @@ def test_populate(inventory, mocker):
     assert host_gitlab.get_vars()["ansible_host"] == "185.165.1.3"
 
     # check for custom ssh port
-    assert host_gitlab.get_vars()["ansible_port"] == "8822"
+    assert host_gitlab.get_vars()["ansible_port"] == 8822
+
+
+def test_populate_uname_gname(inventory, mocker):
+    inventory._get_vm_pool = mocker.MagicMock(side_effect=get_vm_pool)
+    inventory.get_option = mocker.MagicMock(side_effect=mk_get_options(options_base_test))
+    inventory._populate()
+
+    host_sam = inventory.inventory.get_host("sam-691-sam")
+    host_zabbix = inventory.inventory.get_host("zabbix-327")
+
+    assert host_sam.get_vars()["UNAME"] == "sam-admin"
+    assert host_sam.get_vars()["GNAME"] == "CSApparelVDC"
+    assert host_zabbix.get_vars()["UNAME"] == "oneadmin"
+    assert host_zabbix.get_vars()["GNAME"] == "oneadmin"
+
+
+def test_coerce_ssh_port():
+    coerce = InventoryModule._coerce_ssh_port
+    assert coerce("22") == 22
+    assert coerce(22) == 22
+    assert coerce({"#text": "8822"}) == 8822
+    assert coerce({"text": "443"}) == 443
+    assert coerce(None) is None
+    assert coerce("") is None
+    assert coerce(False) is None
+    assert coerce({"unexpected": ""}) is None
+    assert coerce("0") is None
+    assert coerce("99999") is None
+    assert coerce("not_a_port") is None
 
 
 def test_populate_filters(inventory, mocker):


### PR DESCRIPTION
##### SUMMARY

Three enhancements to the `opennebula` inventory plugin, extracted from a production local override running on a shared OpenNebula instance:

1. **Expose `UNAME` (VM owner) and `GNAME` (VM group) as host variables.** On shared instances these enable `keyed_groups` like `opennebula_group_Development` or `opennebula_owner_jsmith` for scoping playbooks (e.g. patching VMs by group membership).

2. **Coerce `SSH_PORT` to an integer before setting `ansible_port`.** pyone/XML-RPC sometimes returns `USER_TEMPLATE` values as a dict wrapper (e.g. `{"#text": "22"}`). Passing that through to `ansible_port` breaks OpenSSH with `Connection to UNKNOWN port 65535`. The new `_coerce_ssh_port()` unwraps dicts, validates the port range (1-65535), and returns `None` for unusable values.

3. **Respect existing `ansible_host` from other inventory sources.** When `hostname` is not `name`, the plugin previously unconditionally set `ansible_host`. Now it checks whether the host already has `ansible_host` (e.g. from a static `hosts.yml` overlay) and preserves it, allowing per-host connection overrides without forking the plugin.

Also fixes EXAMPLES to use `filters` (plural, matching the actual option name) and adds `| default('')` to prevent undefined variable errors on VMs missing the filtered attributes.

All changes are backwards-compatible. The `UNAME`/`GNAME` vars are additive; `SSH_PORT` now works correctly where it was previously broken; and `ansible_host` is only preserved if already set by another source.

Tested against a live OpenNebula 6.x instance (32 VMs, shared multi-tenant).

##### ISSUE TYPE

- Feature Pull Request
- Bugfix Pull Request

##### COMPONENT NAME

opennebula inventory plugin

##### ADDITIONAL INFORMATION

Example `keyed_groups` usage with the new `UNAME`/`GNAME` vars:

```yaml
plugin: community.general.opennebula
api_url: https://opennebula:2633/RPC2
keyed_groups:
  - key: GNAME
    prefix: opennebula_group
  - key: UNAME
    prefix: opennebula_owner
```

This produces groups like `opennebula_group_Development`, `opennebula_owner_jsmith`, etc.

`SSH_PORT` coercion example - before this fix, a VM with `SSH_PORT` set in USER_TEMPLATE could produce:
```
fatal: [myhost]: UNREACHABLE! => {"msg": "Failed to connect to the host via ssh: ssh: connect to host 10.0.1.5 port 65535: Connection refused"}
```

Cross-references: #12213, #12302.