### PR TITLE
Ansbile-lint: use FQCN for assert module

### DIFF
--- a/tests/integration/targets/alerta_customer/tasks/main.yml
+++ b/tests/integration/targets/alerta_customer/tasks/main.yml
@@ -19,7 +19,7 @@
   register: result
 
 - name: Check result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -33,7 +33,7 @@
   register: result
 
 - name: Check customer creation
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -47,7 +47,7 @@
   register: result
 
 - name: Check customer creation idempotency
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -63,7 +63,7 @@
   register: result
 
 - name: Check customer deletion (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -78,7 +78,7 @@
   register: result
 
 - name: Check customer deletion
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -93,7 +93,7 @@
   register: result
 
 - name: Check customer deletion idempotency
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -109,7 +109,7 @@
   register: result
 
 - name: Check non-existing customer deletion (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -122,7 +122,7 @@
   register: result
 
 - name: Check customer creation with api key
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -136,7 +136,7 @@
   register: result
 
 - name: Check customer deletion with api key
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -150,7 +150,7 @@
   ignore_errors: true
 
 - name: Check customer creation with api key
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result is failed

--- a/tests/integration/targets/alternatives/tasks/path_is_checked.yml
+++ b/tests/integration/targets/alternatives/tasks/path_is_checked.yml
@@ -12,6 +12,6 @@
   register: alternative
 
 - name: Check previous task failed
-  assert:
+  ansible.builtin.assert:
     that:
       - 'alternative is failed'

--- a/tests/integration/targets/alternatives/tasks/subcommands.yml
+++ b/tests/integration/targets/alternatives/tasks/subcommands.yml
@@ -15,7 +15,7 @@
   register: alternative
 
 - name: Check expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - 'alternative is changed'
 
@@ -24,7 +24,7 @@
   register: cmd
 
 - name: Ensure that the expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.stdout == "dummy1"
 
@@ -33,7 +33,7 @@
   register: cmd
 
 - name: Ensure that the expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.stdout == "dummy2"
 
@@ -54,7 +54,7 @@
   register: alternative
 
 - name: Check expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - 'alternative is not changed'
 
@@ -63,7 +63,7 @@
   register: cmd
 
 - name: Ensure that the expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.stdout == "dummy2"
 
@@ -76,7 +76,7 @@
   register: alternative
 
 - name: Check expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - 'alternative is changed'
 
@@ -86,7 +86,7 @@
   ignore_errors: true
 
 - name: Ensure that the subcommand is gone
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.rc == 2
       - '"No such file" in cmd.msg or "Error executing command." == cmd.msg'
@@ -112,7 +112,7 @@
   register: alternative
 
 - name: Check expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - 'alternative is changed'
 
@@ -121,7 +121,7 @@
   register: cmd
 
 - name: Ensure that the expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.stdout == "dummy3"
 
@@ -130,7 +130,7 @@
   register: cmd
 
 - name: Ensure that the expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.stdout == "dummy4"
 
@@ -150,7 +150,7 @@
   register: alternative
 
 - name: Check expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - 'alternative is changed'
 
@@ -159,7 +159,7 @@
   register: cmd
 
 - name: Ensure that the expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.stdout == "dummy1"
 
@@ -169,7 +169,7 @@
   ignore_errors: true
 
 - name: Ensure that the subcommand is gone
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.rc == 2
       - '"No such file" in cmd.msg or "Error executing command." == cmd.msg'
@@ -190,7 +190,7 @@
   register: alternative
 
 - name: Check expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - 'alternative is changed'
 
@@ -199,7 +199,7 @@
   register: cmd
 
 - name: Ensure that the expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.stdout == "dummy3"
 
@@ -208,7 +208,7 @@
   register: cmd
 
 - name: Ensure that the expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.stdout == "dummy4"
 

--- a/tests/integration/targets/alternatives/tasks/test.yml
+++ b/tests/integration/targets/alternatives/tasks/test.yml
@@ -15,7 +15,7 @@
       register: alternative
 
     - name: check expected command was executed
-      assert:
+      ansible.builtin.assert:
         that:
           - 'alternative is successful'
           - 'alternative is changed'
@@ -29,7 +29,7 @@
       register: alternative
 
     - name: check expected command was executed
-      assert:
+      ansible.builtin.assert:
         that:
           - 'alternative is successful'
           - 'alternative is changed'
@@ -40,7 +40,7 @@
   register: cmd
 
 - name: check expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - 'cmd.stdout == "dummy" ~ item'
 

--- a/tests/integration/targets/alternatives/tasks/tests_family.yml
+++ b/tests/integration/targets/alternatives/tasks/tests_family.yml
@@ -45,7 +45,7 @@
 # Despite the fact that there is alternative with higher priority (/usr/bin/dummy1),
 # it is not chosen as it doesn't belong to the selected family
 - name: Ensure that the alternative from the selected family is used
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.stdout == "dummy2"
 
@@ -60,6 +60,6 @@
   register: cmd
 
 - name: Ensure that the next alternative is selected as having the highest priority from the family
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.stdout == "dummy3"

--- a/tests/integration/targets/alternatives/tasks/tests_set_priority.yml
+++ b/tests/integration/targets/alternatives/tasks/tests_set_priority.yml
@@ -19,7 +19,7 @@
   shell: 'head -n1 {{ alternatives_dir }}/dummy | grep "^manual$"'
 
 - name: check expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - 'alternative is changed'
       - 'cmd.stdout == "dummy" ~ item'
@@ -46,7 +46,7 @@
   register: alternative
 
 - name: check no change was triggered without priority
-  assert:
+  ansible.builtin.assert:
     that:
       - 'alternative is not changed'
 

--- a/tests/integration/targets/alternatives/tasks/tests_state.yml
+++ b/tests/integration/targets/alternatives/tasks/tests_state.yml
@@ -26,7 +26,7 @@
   register: cmd
 
 - name: Ensure that the expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.stdout == "dummy2"
 
@@ -49,7 +49,7 @@
   register: cmd
 
 - name: Ensure that the expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.stdout == "dummy4"
 
@@ -71,7 +71,7 @@
   register: cmd
 
 - name: Ensure that the expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.stdout == "dummy4"
 
@@ -93,7 +93,7 @@
   register: cmd
 
 - name: Ensure that the expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.stdout == "dummy2"
 
@@ -115,6 +115,6 @@
   register: cmd
 
 - name: Ensure that the expected command was executed
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd.stdout == "dummy1"

--- a/tests/integration/targets/android_sdk/tasks/default-tests.yml
+++ b/tests/integration/targets/android_sdk/tasks/default-tests.yml
@@ -78,7 +78,7 @@
   register: package_canary
 
 - name: Run tests
-  assert:
+  ansible.builtin.assert:
     that:
       - skiaparser_1_stat.stat.exists
       - skiaparser_1_installed is changed

--- a/tests/integration/targets/android_sdk/tasks/freebsd-tests.yml
+++ b/tests/integration/targets/android_sdk/tasks/freebsd-tests.yml
@@ -60,7 +60,7 @@
   register: package_canary
 
 - name: Run tests (FreeBSD)
-  assert:
+  ansible.builtin.assert:
     that:
       - sources_android_26.stat.exists
       - sources_android_26_installed is changed

--- a/tests/integration/targets/ansible_galaxy_install/tasks/main.yml
+++ b/tests/integration/targets/ansible_galaxy_install/tasks/main.yml
@@ -17,7 +17,7 @@
   register: install_c0
 
 - name: Assert collection netbox.netbox was installed
-  assert:
+  ansible.builtin.assert:
     that:
       - install_c0 is changed
       - '"netbox.netbox" in install_c0.new_collections'
@@ -30,7 +30,7 @@
   register: install_c1
 
 - name: Assert collection was not installed
-  assert:
+  ansible.builtin.assert:
     that:
       - install_c1 is not changed
 
@@ -48,7 +48,7 @@
   register: install_r0
 
 - name: Assert collection ansistrano.deploy was installed
-  assert:
+  ansible.builtin.assert:
     that:
       - install_r0 is changed
       - '"ansistrano.deploy" in install_r0.new_roles'
@@ -61,7 +61,7 @@
   register: install_r1
 
 - name: Assert role was not installed
-  assert:
+  ansible.builtin.assert:
     that:
       - install_r1 is not changed
 
@@ -83,7 +83,7 @@
   ignore_errors: true
 
 - name: Assert requirements file was installed
-  assert:
+  ansible.builtin.assert:
     that:
       - install_rq0 is changed
       - '"geerlingguy.java" in install_rq0.new_roles'
@@ -97,7 +97,7 @@
   ignore_errors: true
 
 - name: Assert requirements file was not installed
-  assert:
+  ansible.builtin.assert:
     that:
       - install_rq1 is not changed
 
@@ -115,7 +115,7 @@
   register: upgrade_c0
 
 - name: Assert collection netbox.netbox was installed
-  assert:
+  ansible.builtin.assert:
     that:
       - upgrade_c0 is changed
       - '"netbox.netbox" in upgrade_c0.new_collections'
@@ -137,7 +137,7 @@
   register: upgrade_c2
 
 - name: Assert collection was not installed
-  assert:
+  ansible.builtin.assert:
     that:
       - upgrade_c1 is changed
       - upgrade_c2 is not changed
@@ -162,7 +162,7 @@
   register: exec_c0
 
 - name: Assert collection was installed using explicit executable
-  assert:
+  ansible.builtin.assert:
     that:
       - exec_c0 is changed
       - '"netbox.netbox" in exec_c0.new_collections'
@@ -178,6 +178,6 @@
   ignore_errors: true
 
 - name: Assert bad executable caused failure
-  assert:
+  ansible.builtin.assert:
     that:
       - exec_c_fail is failed

--- a/tests/integration/targets/apache2_mod_proxy/tasks/main.yml
+++ b/tests/integration/targets/apache2_mod_proxy/tasks/main.yml
@@ -79,7 +79,7 @@
     balancer_vhost: localhost:81
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.members | length == 2
@@ -101,7 +101,7 @@
     state: present
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -110,7 +110,7 @@
     balancer_vhost: localhost:81
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.members | length == 2
@@ -140,7 +140,7 @@
     state: drained
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
@@ -151,7 +151,7 @@
     balancer_vhost: localhost:81
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.members | length == 2
@@ -181,7 +181,7 @@
     state: absent
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
@@ -190,7 +190,7 @@
     balancer_vhost: localhost:81
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.members | length == 2
@@ -220,7 +220,7 @@
     state: present
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
@@ -229,7 +229,7 @@
     balancer_vhost: localhost:81
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.members | length == 2

--- a/tests/integration/targets/apache2_module/tasks/635-apache2-misleading-warning.yml
+++ b/tests/integration/targets/apache2_module/tasks/635-apache2-misleading-warning.yml
@@ -13,7 +13,7 @@
     - { module: mpm_event, state: absent }
     - { module: mpm_prefork, state: present }
 
-- assert:
+- ansible.builtin.assert:
     that:
       - "'warnings' in disable_mpm_modules"
       - disable_mpm_modules["warnings"] == [
@@ -42,6 +42,6 @@
     - { module: mpm_event, state: absent }
     - { module: mpm_prefork, state: present }
 
-- assert:
+- ansible.builtin.assert:
     that:
       - "'warnings' not in disable_mpm_modules"

--- a/tests/integration/targets/apache2_module/tasks/actualtest.yml
+++ b/tests/integration/targets/apache2_module/tasks/actualtest.yml
@@ -16,7 +16,7 @@
   register: disable
 
 - name: ensure community.general.apache2_module is idempotent
-  assert:
+  ansible.builtin.assert:
     that:
       - disable is not changed
 
@@ -27,7 +27,7 @@
   register: enable
 
 - name: ensure changed on successful enable
-  assert:
+  ansible.builtin.assert:
     that:
       - enable is changed
 
@@ -38,7 +38,7 @@
   register: enabletwo
 
 - name: ensure community.general.apache2_module is idempotent
-  assert:
+  ansible.builtin.assert:
     that:
       - 'not enabletwo.changed'
 
@@ -49,7 +49,7 @@
   register: disablefinal
 
 - name: ensure changed on successful disable
-  assert:
+  ansible.builtin.assert:
     that:
       - 'disablefinal.changed'
 
@@ -127,7 +127,7 @@
         identifier: dumpio_module
         state: absent
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - enable_dumpio_wrong is failed
           - enable_dumpio_correct_1 is changed
@@ -151,7 +151,7 @@
       register: enabledmpmevent
 
     - name: ensure changed mpm_event
-      assert:
+      ansible.builtin.assert:
         that:
           - 'enabledmpmevent.changed'
 
@@ -173,7 +173,7 @@
       register: enabledmpmworker
 
     - name: ensure mpm_worker unchanged
-      assert:
+      ansible.builtin.assert:
         that:
           - 'not enabledmpmworker.changed'
 
@@ -189,7 +189,7 @@
       register: remove_with_configcheck
 
     - name: ensure configcheck fails task with when run without mpm modules
-      assert:
+      ansible.builtin.assert:
         that:
           - item is failed
       with_items: "{{ remove_with_configcheck.results }}"

--- a/tests/integration/targets/apache2_module/tasks/main.yml
+++ b/tests/integration/targets/apache2_module/tasks/main.yml
@@ -26,7 +26,7 @@
       debug:
         var: modules_after
     - name: ensure that all test modules are disabled again
-      assert:
+      ansible.builtin.assert:
         that: modules_before.stdout == modules_after.stdout
   when: ansible_facts.os_family in ['Debian', 'Suse']
   # CentOS/RHEL does not have a2enmod/a2dismod

--- a/tests/integration/targets/archive/tasks/main.yml
+++ b/tests/integration/targets/archive/tasks/main.yml
@@ -37,7 +37,7 @@
   register: pretest_2
 
 - name: Archive - validate pre-test
-  assert:
+  ansible.builtin.assert:
     that:
       - pretest_1 is changed
       - pretest_2 is not changed

--- a/tests/integration/targets/archive/tests/core.yml
+++ b/tests/integration/targets/archive/tests/core.yml
@@ -25,7 +25,7 @@
     state: file
 
 - name: Verify that archive result is changed and includes all files - no options ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - archive_no_options is changed
       - "archive_no_options.dest_state == 'archive'"
@@ -50,7 +50,7 @@
   register: archive_file_options_stat
 
 - name: Test that the file modes were changed
-  assert:
+  ansible.builtin.assert:
     that:
       - archive_file_options_stat is not changed
       - "archive_file_options.mode == '0600'"
@@ -74,7 +74,7 @@
   register: archive_nonascii_stat
 
 - name: Test that archive exists - non-ascii ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - archive_nonascii is changed
       - archive_nonascii_stat.stat.exists == true
@@ -92,7 +92,7 @@
   register: archive_single_target
 
 - name: Assert archive has correct state - single target ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - archive_single_target.dest_state == state_map[format]
   vars:
@@ -114,7 +114,7 @@
       register: archive_single_target_contents
 
     - name: Assert that file names are preserved - single target ({{ format }})
-      assert:
+      ansible.builtin.assert:
         that:
           - "'oo.txt' not in archive_single_target_contents.files"
           - "'foo.txt' in archive_single_target_contents.files"
@@ -143,7 +143,7 @@
     state: file
 
 - name: Assert that archive contains all files - path list ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - archive_path_list is changed
       - "archive_path_list.archived | length == 3"
@@ -164,7 +164,7 @@
   register: archive_missing_paths
 
 - name: Assert that incomplete archive has incomplete state - missing paths ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - archive_missing_paths is changed
       - "archive_missing_paths.dest_state == 'incomplete'"

--- a/tests/integration/targets/archive/tests/exclusions.yml
+++ b/tests/integration/targets/archive/tests/exclusions.yml
@@ -12,7 +12,7 @@
   register: archive_exclusion_patterns
 
 - name: Assert that only included files are archived - exclusion patterns ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - archive_exclusion_patterns is changed
       - "'bar.txt' not in archive_exclusion_patterns.archived"
@@ -34,7 +34,7 @@
   register: archive_excluded_paths
 
 - name: Assert that excluded paths do not influence archive root - exclude path ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - archive_excluded_paths.arcroot != remote_tmp_dir
 

--- a/tests/integration/targets/archive/tests/idempotency.yml
+++ b/tests/integration/targets/archive/tests/idempotency.yml
@@ -24,7 +24,7 @@
   register: file_content_idempotency_after
 
 - name: Assert task status is changed - file content idempotency ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - file_content_idempotency_after is changed
   # Only ``zip`` archives are guaranteed to compare file content checksums rather than header checksums
@@ -59,7 +59,7 @@
   register: file_name_idempotency_after
 
 - name: Check task status - file name idempotency ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - file_name_idempotency_after is changed
 
@@ -92,7 +92,7 @@
   register: single_file_content_idempotency_after
 
 - name: Assert task status is changed - single file content idempotency ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - single_file_content_idempotency_after is changed
   # ``tar`` archives are not guaranteed to identify changes to file content if the file meta properties are unchanged.
@@ -130,7 +130,7 @@
 # The gz, bz2, and xz formats do not store the original file name
 # so it is not possible to identify a change in this scenario.
 - name: Check task status - single file name idempotency ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - single_file_name_idempotency_after is changed
   when: "format in ('tar', 'zip')"

--- a/tests/integration/targets/archive/tests/remove.yml
+++ b/tests/integration/targets/archive/tests/remove.yml
@@ -17,7 +17,7 @@
     state: file
 
 - name: Verify all files were archived - remove source files ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - archive_remove_source_files is changed
       - "archive_remove_source_files.archived | length == 3"
@@ -39,7 +39,7 @@
   register: remove_files
 
 - name: Assert that source files were removed - remove source files ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_files is not changed
 
@@ -80,7 +80,7 @@
     state: file
 
 - name: Verify archive contains all files - remove source directory ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - archive_remove_source_directory is changed
       - "archive_remove_source_directory.archived | length == 3"
@@ -98,7 +98,7 @@
   register: remove_dir
 
 - name: Verify source directory was removed - remove source directory ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_dir is not changed
 
@@ -131,7 +131,7 @@
     state: file
 
 - name: Verify all files except excluded are archived - remove source excluding path ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - archive_remove_source_excluding_path is changed
       - "archive_remove_source_excluding_path.archived | length == 2"
@@ -214,7 +214,7 @@
   register: archive_remove_nested_paths_status
 
 - name: Assert tasks status - remove source with nested paths ({{ format }})
-  assert:
+  ansible.builtin.assert:
     that:
       - archive_remove_nested_paths is success
       - archive_remove_nested_paths_status is not changed

--- a/tests/integration/targets/callback/tasks/main.yml
+++ b/tests/integration/targets/callback/tasks/main.yml
@@ -48,7 +48,7 @@
           {%- endfor -%}"
 
     - name: Assert test output equals expected output
-      assert:
+      ansible.builtin.assert:
         that: result.output.differences | length == 0
       loop: "{{ outputs.results | callback_results_extractor }}"
       loop_control:

--- a/tests/integration/targets/cargo/tasks/test_directory.yml
+++ b/tests/integration/targets/cargo/tasks/test_directory.yml
@@ -109,7 +109,7 @@
         state: absent
 
 - name: Check assertions
-  assert:
+  ansible.builtin.assert:
     that:
       - uninstall_absent is not changed
       - install_absent is changed

--- a/tests/integration/targets/cargo/tasks/test_general.yml
+++ b/tests/integration/targets/cargo/tasks/test_general.yml
@@ -27,7 +27,7 @@
   register: uninstall_present_helloworld
 
 - name: Check assertions helloworld
-  assert:
+  ansible.builtin.assert:
     that:
       - uninstall_absent_helloworld is not changed
       - install_absent_helloworld is changed

--- a/tests/integration/targets/cargo/tasks/test_rustup_cargo.yml
+++ b/tests/integration/targets/cargo/tasks/test_rustup_cargo.yml
@@ -17,7 +17,7 @@
   register: rustup_uninstall_present_helloworld
 
 - name: Check assertions helloworld
-  assert:
+  ansible.builtin.assert:
     that:
       - rustup_install_absent_helloworld is changed
       - rustup_uninstall_present_helloworld is changed

--- a/tests/integration/targets/cargo/tasks/test_version.yml
+++ b/tests/integration/targets/cargo/tasks/test_version.yml
@@ -40,7 +40,7 @@
   register: downgrade_helloworld_010_idem
 
 - name: Check assertions helloworld-yliu
-  assert:
+  ansible.builtin.assert:
     that:
       - install_helloworld_010 is changed
       - install_helloworld_010_idem is not changed

--- a/tests/integration/targets/cloud_init_data_facts/tasks/main.yml
+++ b/tests/integration/targets/cloud_init_data_facts/tasks/main.yml
@@ -52,7 +52,7 @@
       check_mode: true
       register: result
     - name: verify test gather cloud-init facts in check mode
-      assert:
+      ansible.builtin.assert:
         that:
           - result.cloud_init_data_facts.status.v1 is defined
           - result.cloud_init_data_facts.status.v1.stage is defined
@@ -65,7 +65,7 @@
       cloud_init_data_facts:
       register: result
     - name: verify test gather cloud-init facts
-      assert:
+      ansible.builtin.assert:
         that:
           - result.cloud_init_data_facts.status.v1 is defined
           - result.cloud_init_data_facts.status.v1.stage is defined

--- a/tests/integration/targets/connection/test_connection.yml
+++ b/tests/integration/targets/connection/test_connection.yml
@@ -14,7 +14,7 @@
       raw: echo 汉语
       register: command
     - name: check output of raw with unicode arg and output
-      assert:
+      ansible.builtin.assert:
         that:
           - "'汉语' in command.stdout"
           - command is changed # as of 2.2, raw should default to changed: true for consistency w/ shell/command/script modules

--- a/tests/integration/targets/connection_wsl/plugin-specific-tests.yml
+++ b/tests/integration/targets/connection_wsl/plugin-specific-tests.yml
@@ -19,13 +19,13 @@
       register: empty_file_stat
 
     - name: verify file without content exists
-      assert:
+      ansible.builtin.assert:
         that:
           - empty_file_stat.stat.exists
         fail_msg: "The file {{ remote_tmp }}/test_empty.txt does not exist."
 
     - name: verify file without content is empty
-      assert:
+      ansible.builtin.assert:
         that:
           - empty_file_stat.stat.size == 0
         fail_msg: "The file {{ remote_tmp }}/test_empty.txt is not empty."

--- a/tests/integration/targets/consul/tasks/consul_agent_check.yml
+++ b/tests/integration/targets/consul/tasks/consul_agent_check.yml
@@ -17,7 +17,7 @@
 - set_fact:
     nginx_service: "{{result.service}}"
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.service.ID is defined
@@ -32,7 +32,7 @@
     service_id: "{{ nginx_service.ID }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.check is defined
@@ -55,7 +55,7 @@
     service_id: "{{ nginx_service.ID }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.check is defined
@@ -72,7 +72,7 @@
     service_id: "{{ nginx_service.ID }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result is not failed
@@ -87,7 +87,7 @@
     notes: "check"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.check is defined
@@ -101,7 +101,7 @@
     notes: "check"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.check is defined

--- a/tests/integration/targets/consul/tasks/consul_agent_service.yml
+++ b/tests/integration/targets/consul/tasks/consul_agent_service.yml
@@ -17,7 +17,7 @@
 - set_fact:
     nginx_service: "{{result.service}}"
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.service.ID is defined
@@ -42,7 +42,7 @@
       nginx_version: 1.0.0
       nginx: 1.25.3
   register: result
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.service.ID is defined
@@ -71,7 +71,7 @@
       nginx: 1.25.3
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.operation is not defined
@@ -82,7 +82,7 @@
     state: absent
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result is not failed

--- a/tests/integration/targets/consul/tasks/consul_auth_method.yml
+++ b/tests/integration/targets/consul/tasks/consul_auth_method.yml
@@ -21,7 +21,7 @@
           -----END PUBLIC KEY-----
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.auth_method.Type == 'jwt'
@@ -33,7 +33,7 @@
     max_token_ttl: 30m80s
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.auth_method.Type == 'jwt'
@@ -45,7 +45,7 @@
     max_token_ttl: 30m80s
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.auth_method.Type == 'jwt'
@@ -57,7 +57,7 @@
     state: absent
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.operation == 'remove'
@@ -68,7 +68,7 @@
     state: absent
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.operation is not defined

--- a/tests/integration/targets/consul/tasks/consul_binding_rule.yml
+++ b/tests/integration/targets/consul/tasks/consul_binding_rule.yml
@@ -29,7 +29,7 @@
     bind_name: yolo
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.binding_rule.AuthMethod == 'test'
@@ -43,7 +43,7 @@
     bind_name: yolo2
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - "result.binding_rule.Description == 'test-binding: my description'"
@@ -55,7 +55,7 @@
     auth_method: test
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - "result.binding_rule.Description == 'test-binding: my description'"
@@ -67,7 +67,7 @@
     auth_method: test
     state: absent
   register: result
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.operation == 'remove'

--- a/tests/integration/targets/consul/tasks/consul_general.yml
+++ b/tests/integration/targets/consul/tasks/consul_general.yml
@@ -12,7 +12,7 @@
   register: result
   ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is failed
 
@@ -27,7 +27,7 @@
   ignore_errors: true
 
 - name: previous task should fail since certificate is not known
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
       - "'certificate verify failed' in result.msg"
@@ -43,7 +43,7 @@
   register: result
 
 - name: previous task should succeed since certificate isn't checked
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -57,7 +57,7 @@
     ca_path: '{{ remote_dir }}/cert.pem'
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
@@ -70,7 +70,7 @@
   register: result
   ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is failed
       - result.msg.startswith('Could not connect to consul agent at localhost:1234, error was')

--- a/tests/integration/targets/consul/tasks/consul_kv.yml
+++ b/tests/integration/targets/consul/tasks/consul_kv.yml
@@ -10,13 +10,13 @@
     token: "{{ consul_management_token }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.data.Value == 'somevalue'
 
 # - name: Test the lookup
-#   assert:
+#   ansible.builtin.assert:
 #     that:
 #       - lookup('community.general.consul_kv', 'somekey', token=consul_management_token) == 'somevalue'
 
@@ -27,7 +27,7 @@
     token: "{{ consul_management_token }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.data.Value == 'somevalue'
@@ -39,7 +39,7 @@
     token: "{{ consul_management_token }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.data.Value == 'somevalue'
@@ -51,7 +51,7 @@
     token: "{{ consul_management_token }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - not result.data

--- a/tests/integration/targets/consul/tasks/consul_policy.yml
+++ b/tests/integration/targets/consul/tasks/consul_policy.yml
@@ -15,7 +15,7 @@
         }
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.policy.Name == 'foo-access'
@@ -36,7 +36,7 @@
         }
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.operation == 'update'
@@ -56,7 +56,7 @@
         }
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.operation is not defined
@@ -66,7 +66,7 @@
     name: foo-access
     state: absent
   register: result
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.operation == 'remove'

--- a/tests/integration/targets/consul/tasks/consul_role.yml
+++ b/tests/integration/targets/consul/tasks/consul_role.yml
@@ -34,7 +34,7 @@
       - name: "foo-access-for-role"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.role.Name == 'foo-role-with-policy'
@@ -47,7 +47,7 @@
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.role.Description == "Testing updating description"
@@ -60,7 +60,7 @@
     description: "Role for testing policies"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.role.Description == "Role for testing policies"
@@ -75,7 +75,7 @@
       - name: "bar-access-for-role"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.role.Policies.0.Name == 'foo-access-for-role'
@@ -92,7 +92,7 @@
           - dc1
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.role.ServiceIdentities.0.ServiceName == "web"
@@ -108,7 +108,7 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.role.ServiceIdentities.0.ServiceName == "web"
@@ -121,7 +121,7 @@
       - name: "foo-access-for-role"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.role.ServiceIdentities.0.ServiceName == "web"
@@ -134,7 +134,7 @@
     policies: []
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.role.ServiceIdentities.0.ServiceName == "web"
@@ -148,7 +148,7 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.role.ServiceIdentities.0.ServiceName == "web"
@@ -162,7 +162,7 @@
     service_identities: []
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.role.ServiceIdentities is not defined # in normal mode the dictionary is removed from the result
@@ -176,7 +176,7 @@
         datacenter: dc2
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.role.NodeIdentities.0.NodeName == "node-1"
@@ -188,7 +188,7 @@
     state: absent
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.operation == 'remove'

--- a/tests/integration/targets/consul/tasks/consul_session.yml
+++ b/tests/integration/targets/consul/tasks/consul_session.yml
@@ -8,7 +8,7 @@
     state: list
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - "'sessions' in result"
@@ -19,7 +19,7 @@
     name: testsession
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result['name'] == 'testsession'
@@ -36,7 +36,7 @@
 - set_fact:
     session_count: "{{ result['sessions'] | length }}"
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - (result['sessions'] | selectattr('ID', 'match', '^' ~ session_id ~ '$') | first)['Name'] == 'testsession'
@@ -47,7 +47,7 @@
     id: '{{ session_id }}'
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
@@ -58,7 +58,7 @@
   register: result
   ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is failed
 
@@ -68,7 +68,7 @@
     id: '{{ session_id }}'
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
@@ -77,7 +77,7 @@
     state: list
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - (result['sessions'] | selectattr('ID', 'equalto', session_id) | list | length) == 0
@@ -89,7 +89,7 @@
     ttl: 180  # sec
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result['ttl'] == 180

--- a/tests/integration/targets/consul/tasks/consul_token.yml
+++ b/tests/integration/targets/consul/tasks/consul_token.yml
@@ -19,7 +19,7 @@
     state: present
   register: simple_create_result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - simple_create_result is changed
       - simple_create_result.token.AccessorID is truthy
@@ -41,7 +41,7 @@
     expiration_ttl: 1h
   register: create_result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - create_result is changed
       - create_result.token.AccessorID == "07a7de84-c9c7-448a-99cc-beaf682efd21"
@@ -57,7 +57,7 @@
     service_identities: []
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.operation == 'update'
@@ -70,7 +70,7 @@
       - name: foo-access2
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.operation is not defined
@@ -81,7 +81,7 @@
     accessor_id: 07a7de84-c9c7-448a-99cc-beaf682efd21
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.token is falsy

--- a/tests/integration/targets/consul/tasks/main.yml
+++ b/tests/integration/targets/consul/tasks/main.yml
@@ -45,7 +45,7 @@
       register: result
       until: result is success
       when: ansible_facts.distribution != "MacOSX"
-    - assert:
+    - ansible.builtin.assert:
         that: ansible_facts.architecture in ['i386', 'x86_64', 'amd64', 'arm64', 'aarch64']
     - set_fact:
         consul_arch: '386'

--- a/tests/integration/targets/copr/tasks/main.yml
+++ b/tests/integration/targets/copr/tasks/main.yml
@@ -21,7 +21,7 @@
       register: result
 
     - name: assert that the copr project was enabled
-      assert:
+      ansible.builtin.assert:
         that:
           - 'result is changed'
           - result.msg == 'enabled'
@@ -36,7 +36,7 @@
       register: result
 
     - name: assert that the copr project was enabled
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
           - result.msg == 'enabled'
@@ -91,7 +91,7 @@
       register: result
 
     - name: assert that the copr project was removed
-      assert:
+      ansible.builtin.assert:
         that:
           - 'result is changed'
           - result.msg == 'absent'
@@ -113,7 +113,7 @@
       register: result
 
     - name: assert that the copr project was disabled
-      assert:
+      ansible.builtin.assert:
         that:
           - 'result is changed'
           - result.msg == 'disabled'

--- a/tests/integration/targets/cpanm/tasks/main.yml
+++ b/tests/integration/targets/cpanm/tasks/main.yml
@@ -31,7 +31,7 @@
   register: install_perl_package_result
 
 - name: assert package is installed
-  assert:
+  ansible.builtin.assert:
     that:
       - install_perl_package_result is changed
       - install_perl_package_result is not failed
@@ -43,7 +43,7 @@
   register: install_same_perl_package_result
 
 - name: assert same package is installed
-  assert:
+  ansible.builtin.assert:
     that:
       - install_same_perl_package_result is not changed
       - install_same_perl_package_result is not failed
@@ -57,7 +57,7 @@
   register: install_perl_package_with_version_op_result
 
 - name: assert package with version operator is installed
-  assert:
+  ansible.builtin.assert:
     that:
       - install_perl_package_with_version_op_result is changed
       - install_perl_package_with_version_op_result is not failed

--- a/tests/integration/targets/cronvar/tasks/main.yml
+++ b/tests/integration/targets/cronvar/tasks/main.yml
@@ -107,7 +107,7 @@
   failed_when: custom_varcheck3.rc == 0
 
 - name: Ensure cronvar tasks did the right thing
-  assert:
+  ansible.builtin.assert:
     that:
       - create_cronvar1 is changed
       - create_cronvar2 is not changed

--- a/tests/integration/targets/decompress/tasks/core.yml
+++ b/tests/integration/targets/decompress/tasks/core.yml
@@ -21,7 +21,7 @@
   register: decompressed_file_stat
 
 - name: Check that file was decompressed correctly ({{ format }} test)
-  assert:
+  ansible.builtin.assert:
     that:
       - first_decompression.changed
       - decompressed_file_stat.stat.exists

--- a/tests/integration/targets/decompress/tasks/dest.yml
+++ b/tests/integration/targets/decompress/tasks/dest.yml
@@ -33,7 +33,7 @@
   register: result_files_stat
 
 - name: Test that file exists
-  assert:
+  ansible.builtin.assert:
     that:
       - item.stat.exists
     quiet: true

--- a/tests/integration/targets/decompress/tasks/misc.yml
+++ b/tests/integration/targets/decompress/tasks/misc.yml
@@ -31,7 +31,7 @@
   register: nonexisting_stat
 
 - name: Check mode test
-  assert:
+  ansible.builtin.assert:
     that:
       - decompressed_check_mode.changed
       - decompressed_check_mode_2.changed
@@ -63,7 +63,7 @@
   register: compressed_stat
 
 - name: Run tests
-  assert:
+  ansible.builtin.assert:
     that:
       - not compressed_stat.stat.exists
       - not decompress_non_existing_src.changed

--- a/tests/integration/targets/deploy_helper/tasks/main.yml
+++ b/tests/integration/targets/deploy_helper/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: State=query with default parameters
   deploy_helper: path={{ deploy_helper_test_root }} state=query
 - name: Assert State=query with default parameters
-  assert:
+  ansible.builtin.assert:
     that:
       - "'project_path' in deploy_helper"
       - "deploy_helper.current_path   == deploy_helper.project_path ~ '/current'"
@@ -30,7 +30,7 @@
 - name: State=query with relative overridden paths
   deploy_helper: path={{ deploy_helper_test_root }} current_path=CURRENT_PATH releases_path=RELEASES_PATH shared_path=SHARED_PATH state=query
 - name: Assert State=query with relative overridden paths
-  assert:
+  ansible.builtin.assert:
     that:
       - "deploy_helper.current_path   == deploy_helper.project_path ~ '/CURRENT_PATH'"
       - "deploy_helper.releases_path  == deploy_helper.project_path ~ '/RELEASES_PATH'"
@@ -40,7 +40,7 @@
 - name: State=query with absolute overridden paths
   deploy_helper: path={{ deploy_helper_test_root }} current_path=/CURRENT_PATH releases_path=/RELEASES_PATH shared_path=/SHARED_PATH state=query
 - name: Assert State=query with absolute overridden paths
-  assert:
+  ansible.builtin.assert:
     that:
       - "deploy_helper.current_path   == '/CURRENT_PATH'"
       - "deploy_helper.releases_path  == '/RELEASES_PATH'"
@@ -50,7 +50,7 @@
 - name: State=query with overridden unfinished_filename
   deploy_helper: path={{ deploy_helper_test_root }} unfinished_filename=UNFINISHED_DEPLOY state=query
 - name: Assert State=query with overridden unfinished_filename
-  assert:
+  ansible.builtin.assert:
     that:
       - "'UNFINISHED_DEPLOY' == deploy_helper.unfinished_filename"
 
@@ -64,7 +64,7 @@
 - stat: path={{ deploy_helper.shared_path }}
   register: shared_path
 - name: Assert State=present with default parameters
-  assert:
+  ansible.builtin.assert:
     that:
       - "releases_path.stat.exists"
       - "shared_path.stat.exists"
@@ -86,7 +86,7 @@
 - stat: path={{ deploy_helper.current_path }}/DEPLOY_UNFINISHED
   register: current_path_unfinished_filename
 - name: Assert State=finalize with default parameters
-  assert:
+  ansible.builtin.assert:
     that:
       - "current_path.stat.islnk"
       - "deploy_helper.new_release_path in current_path.stat.lnk_source"
@@ -96,13 +96,13 @@
 - shell: "ls {{ deploy_helper.releases_path }} | wc -l"
   register: releases_count
 - name: Assert State=finalize with default parameters (clean=true checks)
-  assert:
+  ansible.builtin.assert:
     that:
       - "not third_release_path.stat.exists"
       - "releases_count.stdout|trim == '6'"
 - deploy_helper: path={{ deploy_helper_test_root }} release={{ deploy_helper.new_release }} state=query
 - name: Assert State=finalize with default parameters (previous_release checks)
-  assert:
+  ansible.builtin.assert:
     that:
       - "deploy_helper.new_release == deploy_helper.previous_release"
 
@@ -111,7 +111,7 @@
 - stat: path={{ deploy_helper_test_root }}
   register: project_path
 - name: Assert State=absent with default parameters
-  assert:
+  ansible.builtin.assert:
     that:
       - "not project_path.stat.exists"
 
@@ -125,7 +125,7 @@
   register: shared_path
   when: deploy_helper.shared_path is truthy
 - name: Assert State=present with shared_path set to False
-  assert:
+  ansible.builtin.assert:
     that:
       - "releases_path.stat.exists"
       - "deploy_helper.shared_path is falsy or not shared_path.stat.exists"
@@ -149,7 +149,7 @@
 - shell: "ls {{ deploy_helper.releases_path }} | wc -l"
   register: releases_count
 - name: Assert State=finalize with default parameters (clean=true checks)
-  assert:
+  ansible.builtin.assert:
     that:
       - "not third_release_path.stat.exists"
       - "before_releases_count.stdout|trim == '6'"

--- a/tests/integration/targets/discord/tasks/main.yml
+++ b/tests/integration/targets/discord/tasks/main.yml
@@ -16,7 +16,7 @@
   register: result
 
 - name: Check result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.http_code == 204
@@ -48,7 +48,7 @@
   register: result
 
 - name: Check result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.http_code == 204
@@ -62,7 +62,7 @@
   ignore_errors: true
 
 - name: Check result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.http_code == 401

--- a/tests/integration/targets/dnf_versionlock/tasks/lock_bash.yml
+++ b/tests/integration/targets/dnf_versionlock/tasks/lock_bash.yml
@@ -8,7 +8,7 @@
     state: clean
   register: clear_locklist
 
-- assert:
+- ansible.builtin.assert:
     that:
       - clear_locklist.locklist_post | length == 0
 
@@ -18,7 +18,7 @@
     state: present
   register: lock_bash
 
-- assert:
+- ansible.builtin.assert:
     that:
       - lock_bash is changed
       - lock_bash.locklist_post | length == 1
@@ -29,7 +29,7 @@
     state: absent
   register: unlock_bash
 
-- assert:
+- ansible.builtin.assert:
     that:
       - unlock_bash is changed
       - unlock_bash.locklist_post | length == 0

--- a/tests/integration/targets/dnf_versionlock/tasks/lock_updates.yml
+++ b/tests/integration/targets/dnf_versionlock/tasks/lock_updates.yml
@@ -22,7 +22,7 @@
         state: clean
       register: clear_locklist
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - clear_locklist.locklist_post | length == 0
 
@@ -32,7 +32,7 @@
         state: present
       register: lock_packages
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - lock_packages is changed
           - (lock_packages.locklist_post | length) <= (_packages | length)
@@ -44,7 +44,7 @@
       register: update_locked_packages
       changed_when: '"Nothing to do" not in update_locked_packages.stdout'
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_locked_packages is not changed
 
@@ -54,7 +54,7 @@
         state: absent
       register: unlock_packages
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - unlock_packages is changed
           - unlock_packages.locklist_post | length == 0
@@ -66,7 +66,7 @@
       check_mode: true
       register: update_packages
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_packages is changed
 

--- a/tests/integration/targets/dpkg_divert/tasks/tests/01-basic.yml
+++ b/tests/integration/targets/dpkg_divert/tasks/tests/01-basic.yml
@@ -71,7 +71,7 @@
   register: diversion_7
 
 - name: "assert that results of test 01 are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - diversion_0 is changed
       - diversion_1 is changed
@@ -135,7 +135,7 @@
   register: diversion_5
 
 - name: "assert that results of test 02 are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - diversion_0 is changed
       - diversion_1 is changed
@@ -200,7 +200,7 @@
   register: diversion_5
 
 - name: "assert that results of test 03 are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - diversion_0 is changed
       - diversion_1 is changed
@@ -270,7 +270,7 @@
   register: diversion_5
 
 - name: "assert that results of test 04 are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - diversion_0 is changed
       - diversion_1 is changed

--- a/tests/integration/targets/dpkg_divert/tasks/tests/02-rename.yml
+++ b/tests/integration/targets/dpkg_divert/tasks/tests/02-rename.yml
@@ -47,7 +47,7 @@
   register: diversion_5
 
 - name: "assert that results of test 05 are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - diversion_0 is changed
       - diversion_1 is changed
@@ -111,7 +111,7 @@
   register: diversion_5
 
 - name: "assert that results of test 06 are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - diversion_0 is changed
       - diversion_1 is changed
@@ -197,7 +197,7 @@
   register: diversion_7
 
 - name: "assert that results of test 07 are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - diversion_0 is failed
       - diversion_1 is failed
@@ -276,7 +276,7 @@
   register: diversion_6
 
 - name: "assert that results of test 08 are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - diversion_0 is changed
       - diversion_1 is changed
@@ -369,7 +369,7 @@
   register: diversion_8
 
 - name: "assert that results of test 09 are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - diversion_0 is failed
       - diversion_1 is failed

--- a/tests/integration/targets/filter_accumulate/tasks/main.yml
+++ b/tests/integration/targets/filter_accumulate/tasks/main.yml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Filter | Accumulate | Test valid values
-  assert:
+  ansible.builtin.assert:
     that:
       - "'abc' | community.general.accumulate == ['a', 'ab', 'abc']"
       - "['a', 'b'] | community.general.accumulate == ['a', 'ab']"
@@ -27,7 +27,7 @@
   ignore_errors: true
 
 - name: Filter | Accumulate | Test invalid values | Check errors
-  assert:
+  ansible.builtin.assert:
     that:
       - integer_result is failed
       - integer_result.msg is search('Invalid value type')

--- a/tests/integration/targets/filter_counter/tasks/main.yml
+++ b/tests/integration/targets/filter_counter/tasks/main.yml
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: test counter filter
-  assert:
+  ansible.builtin.assert:
     that:
       - "('abca' | community.general.counter) == {'a': 2, 'b': 1, 'c': 1}"
       - "(['apple', 'pear', 'pear'] | community.general.counter) == {'apple': 1, 'pear': 2}"
@@ -23,7 +23,7 @@
   register: res
 
 - name: verify test fail argument not a sequence
-  assert:
+  ansible.builtin.assert:
     that:
       - res is failed
       - res.msg is search('Argument for community.general.counter must be a sequence')
@@ -35,7 +35,7 @@
   register: res
 
 - name: verify test fail element not hashable
-  assert:
+  ansible.builtin.assert:
     that:
       - res is failed
       - res.msg is search('community.general.counter needs a sequence with hashable elements')

--- a/tests/integration/targets/filter_dict/tasks/main.yml
+++ b/tests/integration/targets/filter_dict/tasks/main.yml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: "Test dict filter"
-  assert:
+  ansible.builtin.assert:
     that:
       - "[['a', 'b']] | community.general.dict == dict([['a', 'b']])"
       - "[['a', 'b'], [1, 2]] | community.general.dict == dict([['a', 'b'], [1, 2]])"

--- a/tests/integration/targets/filter_dict_kv/tasks/main.yml
+++ b/tests/integration/targets/filter_dict_kv/tasks/main.yml
@@ -9,6 +9,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: test dict_kv filter
-  assert:
+  ansible.builtin.assert:
     that:
       - "('value' | community.general.dict_kv('key')) == {'key': 'value'}"

--- a/tests/integration/targets/filter_from_csv/tasks/main.yml
+++ b/tests/integration/targets/filter_from_csv/tasks/main.yml
@@ -9,24 +9,24 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Parse valid csv input
-  assert:
+  ansible.builtin.assert:
     that:
       - "valid_comma_separated | community.general.from_csv  ==  expected_result"
 
 - name: Parse valid csv input containing spaces with/without skipinitialspace=True
-  assert:
+  ansible.builtin.assert:
     that:
       - "valid_comma_separated_spaces | community.general.from_csv(skipinitialspace=True)  ==  expected_result"
       - "valid_comma_separated_spaces | community.general.from_csv  !=  expected_result"
 
 - name: Parse valid csv input with no headers with/without specifying fieldnames
-  assert:
+  ansible.builtin.assert:
     that:
       - "valid_comma_separated_no_headers | community.general.from_csv(fieldnames=['id','name','role'])  ==  expected_result"
       - "valid_comma_separated_no_headers | community.general.from_csv  !=  expected_result"
 
 - name: Parse valid pipe-delimited csv input with/without delimiter=|
-  assert:
+  ansible.builtin.assert:
     that:
       - "valid_pipe_separated | community.general.from_csv(delimiter='|')  ==  expected_result"
       - "valid_pipe_separated | community.general.from_csv  !=  expected_result"
@@ -37,7 +37,7 @@
   register: _invalid_csv_strict_false
 
 - name: Test invalid csv input when strict=False is successful
-  assert:
+  ansible.builtin.assert:
     that:
       - _invalid_csv_strict_false is success
 
@@ -48,7 +48,7 @@
   ignore_errors: true
 
 - name: Test invalid csv input when strict=True is failed
-  assert:
+  ansible.builtin.assert:
     that:
       - _invalid_csv_strict_true is failed
       - _invalid_csv_strict_true.msg is search('Unable to process file:.*')

--- a/tests/integration/targets/filter_from_toml/tasks/main.yml
+++ b/tests/integration/targets/filter_from_toml/tasks/main.yml
@@ -7,6 +7,6 @@
   set_fact:
     actual_dict: "{{ toml_document | community.general.from_toml }}"
 
-- assert:
+- ansible.builtin.assert:
     that:
       - expected_dict == actual_dict

--- a/tests/integration/targets/filter_groupby_as_dict/tasks/main.yml
+++ b/tests/integration/targets/filter_groupby_as_dict/tasks/main.yml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Test functionality
-  assert:
+  ansible.builtin.assert:
     that:
       - list1 | community.general.groupby_as_dict('name') == dict1
 
@@ -14,7 +14,7 @@
   ignore_errors: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.msg is search('Input is not a sequence')
 
@@ -24,7 +24,7 @@
   ignore_errors: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - "result.msg is search('Sequence element #0 is not a mapping')"
 
@@ -34,7 +34,7 @@
   ignore_errors: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - "result.msg is search('Attribute not contained in element #1 of sequence')"
 
@@ -44,6 +44,6 @@
   ignore_errors: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.msg is search("Multiple sequence entries have attribute value u?'a'")

--- a/tests/integration/targets/filter_hashids/tasks/main.yml
+++ b/tests/integration/targets/filter_hashids/tasks/main.yml
@@ -9,14 +9,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Test valid hashable inputs
-  assert:
+  ansible.builtin.assert:
     that:
       - "single_int | community.general.hashids_encode | community.general.hashids_decode == [single_int]"
       - "int_list | community.general.hashids_encode | community.general.hashids_decode | list == int_list"
       - "(1,2,3) | community.general.hashids_encode | community.general.hashids_decode == [1,2,3]"
 
 - name: Test valid parameters
-  assert:
+  ansible.builtin.assert:
     that:
       - "single_int | community.general.hashids_encode(salt='test') | community.general.hashids_decode(salt='test') == [single_int]"
       - "single_int | community.general.hashids_encode(alphabet='1234567890abcdef') | community.general.hashids_decode(alphabet='1234567890abcdef') == [single_int]"
@@ -24,7 +24,7 @@
       - "single_int | community.general.hashids_encode(min_length=20) | length == 20"
 
 - name: Test valid unhashable inputs
-  assert:
+  ansible.builtin.assert:
     that:
       - "single_float | community.general.hashids_encode | community.general.hashids_decode == []"
       - "arbitrary_string | community.general.hashids_encode | community.general.hashids_decode == []"
@@ -36,7 +36,7 @@
   ignore_errors: true
 
 - name: Test invalid salt fails
-  assert:
+  ansible.builtin.assert:
     that:
       - invalid_salt_message is failed
 
@@ -47,7 +47,7 @@
   ignore_errors: true
 
 - name: Test invalid alphabet fails
-  assert:
+  ansible.builtin.assert:
     that:
       - invalid_alphabet_message is failed
 
@@ -58,6 +58,6 @@
   ignore_errors: true
 
 - name: Test invalid min_length fails
-  assert:
+  ansible.builtin.assert:
     that:
       - invalid_min_length_message is failed

--- a/tests/integration/targets/filter_jc/tasks/main.yml
+++ b/tests/integration/targets/filter_jc/tasks/main.yml
@@ -9,6 +9,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: test jc key/value parser
-  assert:
+  ansible.builtin.assert:
     that:
       - "('key1=value1\nkey2=value2' | community.general.jc('kv')) == {'key1': 'value1', 'key2': 'value2'}"

--- a/tests/integration/targets/filter_json_patch/tasks/main.yml
+++ b/tests/integration/targets/filter_json_patch/tasks/main.yml
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Test json_patch
-  assert:
+  ansible.builtin.assert:
     that:
       - > # Insert a new element into an array at a specified index
           list_input |
@@ -82,7 +82,7 @@
       bar: { two: 2 }
 
 - name: Test json_patch_recipe
-  assert:
+  ansible.builtin.assert:
     that:
       - > # List of operations
           input |
@@ -120,7 +120,7 @@
         value: [10, 20, 30]
 
 - name: Test json_diff
-  assert:
+  ansible.builtin.assert:
     that: # The order in the result array is not stable, sort by path
       - >
           input |

--- a/tests/integration/targets/filter_json_query/tasks/main.yml
+++ b/tests/integration/targets/filter_json_query/tasks/main.yml
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Test json_query filter
-  assert:
+  ansible.builtin.assert:
     that:
       - >-
         users | community.general.json_query('[*].hosts[].host') == ['host_a', 'host_b', 'host_c', 'host_d']

--- a/tests/integration/targets/filter_lists_mergeby/tasks/lists_mergeby_2-10.yml
+++ b/tests/integration/targets/filter_lists_mergeby/tasks/lists_mergeby_2-10.yml
@@ -18,7 +18,7 @@
             {{ my_list|difference(result101)|to_nice_yaml|indent(2) }}
       when: debug_test|default(false)|bool
     - name: Merge 2 lists by attribute name. list_merge='keep'. assert
-      assert:
+      ansible.builtin.assert:
         that: my_list | difference(result101) | length == 0
   tags: t101
 
@@ -37,7 +37,7 @@
             {{ my_list|difference(result102)|to_nice_yaml|indent(2) }}
       when: debug_test|default(false)|bool
     - name: Merge 2 lists by attribute name. list_merge='append'. assert
-      assert:
+      ansible.builtin.assert:
         that: my_list | difference(result102) | length == 0
   tags: t102
 
@@ -56,7 +56,7 @@
             {{ my_list|difference(result103)|to_nice_yaml|indent(2) }}
       when: debug_test|default(false)|bool
     - name: Merge 2 lists by attribute name. list_merge='prepend'. assert
-      assert:
+      ansible.builtin.assert:
         that: my_list | difference(result103) | length == 0
   tags: t103
 
@@ -75,7 +75,7 @@
             {{ my_list|difference(result104)|to_nice_yaml|indent(2) }}
       when: debug_test|default(false)|bool
     - name: Merge 2 lists by attribute name. list_merge='append_rp'. assert
-      assert:
+      ansible.builtin.assert:
         that: my_list | difference(result104) | length == 0
   tags: t104
 
@@ -94,7 +94,7 @@
             {{ my_list|difference(result105)|to_nice_yaml|indent(2) }}
       when: debug_test|default(false)|bool
     - name: Merge 2 lists by attribute name. list_merge='prepend_rp'. assert
-      assert:
+      ansible.builtin.assert:
         that: my_list | difference(result105) | length == 0
   tags: t105
 
@@ -117,7 +117,7 @@
             {{ my_list|difference(result200)|to_nice_yaml|indent(2) }}
       when: debug_test|default(false)|bool
     - name: Merge by name. recursive=True list_merge='append_rp'. assert
-      assert:
+      ansible.builtin.assert:
         that: my_list | difference(result200) | length == 0
   tags: t200
 
@@ -138,6 +138,6 @@
             {{ my_list|difference(result201)|to_nice_yaml|indent(2) }}
       when: debug_test|default(false)|bool
     - name: Merge by name. recursive=False list_merge='append_rp'. assert
-      assert:
+      ansible.builtin.assert:
         that: my_list | difference(result201) | length == 0
   tags: t201

--- a/tests/integration/targets/filter_lists_mergeby/tasks/lists_mergeby_default.yml
+++ b/tests/integration/targets/filter_lists_mergeby/tasks/lists_mergeby_default.yml
@@ -10,7 +10,7 @@
         msg: "{{ list1 | community.general.lists_mergeby(list2, 'name') }}"
       when: debug_test|default(false)|bool
     - name: Test lists merged by attribute name assert
-      assert:
+      ansible.builtin.assert:
         that:
           - "(list1 | community.general.lists_mergeby(list2, 'name') | list |
               difference(list3) | length) == 0"
@@ -23,7 +23,7 @@
         msg: "{{ [] | community.general.lists_mergeby(list2, 'name') }}"
       when: debug_test|default(false)|bool
     - name: Test list1 empty assert
-      assert:
+      ansible.builtin.assert:
         that:
           - "([] | community.general.lists_mergeby(list2, 'name') | list |
               difference(list2) | length) == 0"
@@ -36,7 +36,7 @@
         msg: "{{ [] | community.general.lists_mergeby([], 'name') }}"
       when: debug_test|default(false)|bool
     - name: Test all lists empty assert
-      assert:
+      ansible.builtin.assert:
         that:
           - "([] | community.general.lists_mergeby([], 'name') | list |
               length) == 0"
@@ -54,7 +54,7 @@
         var: my_list
       when: debug_test|default(false)|bool
     - name: First argument must be list assert
-      assert:
+      ansible.builtin.assert:
         that:
           - result is failed
           - '"All arguments before the argument index for community.general.lists_mergeby must be lists." in result.msg'
@@ -72,7 +72,7 @@
         var: my_list
       when: debug_test|default(false)|bool
     - name: Second argument must be list set assert
-      assert:
+      ansible.builtin.assert:
         that:
           - result is failed
           - '"All arguments before the argument index for community.general.lists_mergeby must be lists." in result.msg'
@@ -90,7 +90,7 @@
         var: my_list
       when: debug_test|default(false)|bool
     - name: First arguments after the lists must be string assert
-      assert:
+      ansible.builtin.assert:
         that:
           - result is failed
           - '"First argument after the lists for community.general.lists_mergeby must be string." in result.msg'
@@ -108,7 +108,7 @@
         var: my_list
       when: debug_test|default(false)|bool
     - name: Elements of list must be dictionaries assert
-      assert:
+      ansible.builtin.assert:
         that:
           - result is failed
           - '"Elements of list arguments for lists_mergeby must be dictionaries." in result.msg'
@@ -124,7 +124,7 @@
         var: my_list
       when: debug_test|default(false)|bool
     - name: Merge 3 lists by attribute name. 1 list in params. assert
-      assert:
+      ansible.builtin.assert:
         that: my_list | difference(result1) | length == 0
   tags: t8
 
@@ -138,7 +138,7 @@
         var: my_list
       when: debug_test|default(false)|bool
     - name: Merge 3 lists by attribute name. No list in the params. asset
-      assert:
+      ansible.builtin.assert:
         that: my_list | difference(result1) | length == 0
   tags: t9
 
@@ -158,6 +158,6 @@
             {{ my_list|difference(result100)|to_nice_yaml|indent(2) }}
       when: debug_test|default(false)|bool
     - name: Merge 2 lists by attribute name. list_merge='replace'. assert
-      assert:
+      ansible.builtin.assert:
         that: my_list | difference(result100) | length == 0
   tags: t100

--- a/tests/integration/targets/filter_path_join_shim/tasks/main.yml
+++ b/tests/integration/targets/filter_path_join_shim/tasks/main.yml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: "Test path_join filter"
-  assert:
+  ansible.builtin.assert:
     that:
       - "['a', 'b'] | community.general.path_join == 'a/b'"
       - "['a', '/b'] | community.general.path_join == '/b'"

--- a/tests/integration/targets/filter_random_mac/tasks/main.yml
+++ b/tests/integration/targets/filter_random_mac/tasks/main.yml
@@ -16,7 +16,7 @@
   ignore_errors: true
 
 - name: Verify random_mac filter showed a bad argument type error message
-  assert:
+  ansible.builtin.assert:
     that:
       - _bad_random_mac_filter is failed
       - "_bad_random_mac_filter.msg is search('Invalid value type (.*int.*) for random_mac .*')"
@@ -28,7 +28,7 @@
   ignore_errors: true
 
 - name: Verify random_mac filter showed a bad argument value error message
-  assert:
+  ansible.builtin.assert:
     that:
       - _bad_random_mac_filter is failed
       - "_bad_random_mac_filter.msg is search('Invalid value (.*) for random_mac: .* not hexa byte')"
@@ -40,13 +40,13 @@
   ignore_errors: true
 
 - name: Verify random_mac filter showed a prefix too big error message
-  assert:
+  ansible.builtin.assert:
     that:
       - _bad_random_mac_filter is failed
       - "_bad_random_mac_filter.msg is search('Invalid value (.*) for random_mac: 5 colon.* separated items max')"
 
 - name: Verify random_mac filter
-  assert:
+  ansible.builtin.assert:
     that:
       - "'00' | community.general.random_mac is match('^00:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]$')"
       - "'00:00' | community.general.random_mac is match('^00:00:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]$')"
@@ -56,7 +56,7 @@
       - "'00:00:00' | community.general.random_mac != '00:00:00' | community.general.random_mac"
 
 - name: Verify random_mac filter with seed
-  assert:
+  ansible.builtin.assert:
     that:
       - "'00:00:00' | community.general.random_mac(seed='test') == '00:00:00' | community.general.random_mac(seed='test')"
       - "'00:00:00' | community.general.random_mac(seed='test') != '00:00:00' | community.general.random_mac(seed='another_test')"

--- a/tests/integration/targets/filter_reveal_ansible_type/tasks/tasks.yml
+++ b/tests/integration/targets/filter_reveal_ansible_type/tasks/tasks.yml
@@ -6,7 +6,7 @@
 # -------------------------------------------------------------
 
 - name: String. AnsibleUnicode/_AnsibleTaggedStr.
-  assert:
+  ansible.builtin.assert:
     that: result in dtype
     success_msg: '"abc" is one of {{ dtype }}'
     fail_msg: '"abc" is {{ result }}, not one of {{ dtype }}'
@@ -19,7 +19,7 @@
       - '_AnsibleTaggedStr'
 
 - name: String. AnsibleUnicode/_AnsibleTaggedStr alias str.
-  assert:
+  ansible.builtin.assert:
     that: result in dtype
     success_msg: '"abc" is one of {{ dtype }}'
     fail_msg: '"abc" is {{ result }}, not one of {{ dtype }}'
@@ -32,7 +32,7 @@
       - 'str'
 
 - name: List. All items are AnsibleUnicode/_AnsibleTaggedStr.
-  assert:
+  ansible.builtin.assert:
     that: result in dtype
     success_msg: '["a", "b", "c"] is one of {{ dtype }}'
     fail_msg: '["a", "b", "c"] is {{ result }}, not one of {{ dtype }}'
@@ -45,7 +45,7 @@
       - 'list[_AnsibleTaggedStr]'
 
 - name: Dictionary. All keys and values are AnsibleUnicode/_AnsibleTaggedStr.
-  assert:
+  ansible.builtin.assert:
     that: result in dtype
     success_msg: '{"a": "foo", "b": "bar", "c": "baz"} is one of {{ dtype }}'
     fail_msg: '{"a": "foo", "b": "bar", "c": "baz"} is {{ result }}, not one of {{ dtype }}'
@@ -61,7 +61,7 @@
 # ----------------------------------------------------
 
 - name: String
-  assert:
+  ansible.builtin.assert:
     that: result == dtype
     success_msg: '"abc" is {{ dtype }}'
     fail_msg: '"abc" is {{ result }}, not {{ dtype }}'
@@ -71,7 +71,7 @@
     dtype: str
 
 - name: Integer
-  assert:
+  ansible.builtin.assert:
     that: result == dtype
     success_msg: '123 is {{ dtype }}'
     fail_msg: '123 is {{ result }}, not {{ dtype }}'
@@ -81,7 +81,7 @@
     dtype: int
 
 - name: Float
-  assert:
+  ansible.builtin.assert:
     that: result == dtype
     success_msg: '123.45 is {{ dtype }}'
     fail_msg: '123.45 is {{ result }}, not {{ dtype }}'
@@ -91,7 +91,7 @@
     dtype: float
 
 - name: Boolean
-  assert:
+  ansible.builtin.assert:
     that: result == dtype
     success_msg: 'true is {{ dtype }}'
     fail_msg: 'true is {{ result }}, not {{ dtype }}'
@@ -101,7 +101,7 @@
     dtype: bool
 
 - name: List. All items are strings.
-  assert:
+  ansible.builtin.assert:
     that: result == dtype
     success_msg: '["a", "b", "c"] is {{ dtype }}'
     fail_msg: '["a", "b", "c"] is {{ result }}, not {{ dtype }}'
@@ -111,7 +111,7 @@
     dtype: list[str]
 
 - name: List of dictionaries.
-  assert:
+  ansible.builtin.assert:
     that: result == dtype
     success_msg: '[{"a": 1}, {"b": 2}] is {{ dtype }}'
     fail_msg: '[{"a": 1}, {"b": 2}] is {{ result }}, not {{ dtype }}'
@@ -121,7 +121,7 @@
     dtype: list[dict]
 
 - name: Dictionary. All keys are strings. All values are integers.
-  assert:
+  ansible.builtin.assert:
     that: result == dtype
     success_msg: '{"a": 1} is {{ dtype }}'
     fail_msg: '{"a": 1} is {{ result }}, not {{ dtype }}'
@@ -131,7 +131,7 @@
     dtype: dict[str, int]
 
 - name: Dictionary. All keys are strings. All values are integers.
-  assert:
+  ansible.builtin.assert:
     that: result == dtype
     success_msg: '{"a": 1, "b": 2} is {{ dtype }}'
     fail_msg: '{"a": 1, "b": 2} is {{ result }}, not {{ dtype }}'
@@ -144,7 +144,7 @@
 # ----------------------------------------------------------
 
 - name: Dictionary. The keys are integers or strings. All values are strings.
-  assert:
+  ansible.builtin.assert:
     that: result == dtype
     success_msg: 'data is {{ dtype }}'
     fail_msg: 'data is {{ result }}, not {{ dtype }}'
@@ -156,7 +156,7 @@
     dtype: dict[int|str, str]
 
 - name: Dictionary. All keys are integers. All values are keys.
-  assert:
+  ansible.builtin.assert:
     that: result == dtype
     success_msg: 'data is {{ dtype }}'
     fail_msg: 'data is {{ result }}, not {{ dtype }}'
@@ -168,7 +168,7 @@
     dtype: dict[int, str]
 
 - name: Dictionary. All keys are strings. Multiple types values.
-  assert:
+  ansible.builtin.assert:
     that: result == dtype
     success_msg: 'data is {{ dtype }}'
     fail_msg: 'data is {{ result }}, not {{ dtype }}'
@@ -180,7 +180,7 @@
     dtype: dict[str, bool|dict|float|int|list|str]
 
 - name: List. Multiple types items.
-  assert:
+  ansible.builtin.assert:
     that: result == dtype
     success_msg: 'data is {{ dtype }}'
     fail_msg: 'data is {{ result }}, not {{ dtype }}'

--- a/tests/integration/targets/filter_time/tasks/main.yml
+++ b/tests/integration/targets/filter_time/tasks/main.yml
@@ -9,21 +9,21 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: test zero is 0
-  assert:
+  ansible.builtin.assert:
     that:
       - "('0' | community.general.to_milliseconds) == 0"
       - "('0' | community.general.to_seconds) == 0"
       - "('0' | community.general.to_minutes) == 0"
 
 - name: test to_milliseconds filter
-  assert:
+  ansible.builtin.assert:
     that:
       - "('1000ms' | community.general.to_milliseconds) == 1000"
       - "('1s' | community.general.to_milliseconds) == 1000"
       - "('1m' | community.general.to_milliseconds) == 60000"
 
 - name: test to_seconds filter
-  assert:
+  ansible.builtin.assert:
     that:
       - "('1000msecs' | community.general.to_seconds) == 1"
       - "('1ms' | community.general.to_seconds) == 0.001"
@@ -34,7 +34,7 @@
       - "('2d -2d -12s' | community.general.to_seconds) == -12"
 
 - name: test to_minutes filter
-  assert:
+  ansible.builtin.assert:
     that:
       - "('30s' | community.general.to_minutes) == 0.5"
       - "('12m' | community.general.to_minutes) == 12"
@@ -42,13 +42,13 @@
       - "('300s' | community.general.to_minutes) == 5"
 
 - name: test to_hours filter
-  assert:
+  ansible.builtin.assert:
     that:
       - "('30m' | community.general.to_hours) == 0.5"
       - "('3h 119m 61s' | community.general.to_hours) > 5"
 
 - name: test to_days filter
-  assert:
+  ansible.builtin.assert:
     that:
       - "('1year' | community.general.to_days) == 365"
       - "('1week' | community.general.to_days) == 7"
@@ -57,14 +57,14 @@
       - "('1mo' | community.general.to_days(month=28)) == 28"
 
 - name: test to_weeks filter
-  assert:
+  ansible.builtin.assert:
     that:
       - "('1y' | community.general.to_weeks | int) == 52"
       - "('7d' | community.general.to_weeks) == 1"
       - "('1mo' | community.general.to_weeks(month=28)) == 4"
 
 - name: test to_months filter
-  assert:
+  ansible.builtin.assert:
     that:
       - "('30d' | community.general.to_months) == 1"
       - "('1year' | community.general.to_months | int) == 12"
@@ -72,7 +72,7 @@
       - "('1years' | community.general.to_months(month=2, year=34)) == 17"
 
 - name: test to_years filter
-  assert:
+  ansible.builtin.assert:
     that:
       - "('365d' | community.general.to_years | int) == 1"
       - "('12mo' | community.general.to_years | round(0, 'ceil')) == 1"
@@ -85,7 +85,7 @@
   register: res
 
 - name: verify test fail unknown unit
-  assert:
+  ansible.builtin.assert:
     that:
       - res is failed
       - "'to_time_unit() can not convert to the following unit: lightyears' in res.msg"
@@ -97,7 +97,7 @@
   register: res
 
 - name: test fail unknown string
-  assert:
+  ansible.builtin.assert:
     that:
       - res is failed
       - "'to_time_unit() can not interpret following string' in res.msg"
@@ -109,7 +109,7 @@
   register: res
 
 - name: test fail unknown kwarg
-  assert:
+  ansible.builtin.assert:
     that:
       - res is failed
       - "'to_time_unit() got unknown keyword arguments' in res.msg"

--- a/tests/integration/targets/filter_to_prettytable/tasks/main.yml
+++ b/tests/integration/targets/filter_to_prettytable/tasks/main.yml
@@ -42,7 +42,7 @@
       +-------+-----+-------+
 
 - name: Verify basic table output
-  assert:
+  ansible.builtin.assert:
     that:
       - basic_table == expected_basic_table
 
@@ -59,7 +59,7 @@
       +-------+-------+-----+
 
 - name: Verify ordered table output
-  assert:
+  ansible.builtin.assert:
     that:
       - ordered_table == expected_ordered_table
 
@@ -76,7 +76,7 @@
       +-------+-------+
 
 - name: Verify selective column ordering
-  assert:
+  ansible.builtin.assert:
     that:
       - selective_ordered_table == expected_selective_table
 
@@ -93,7 +93,7 @@
       +-----------+----------+-----------+
 
 - name: Verify custom headers output
-  assert:
+  ansible.builtin.assert:
     that:
       - headers_table == expected_headers_table
 
@@ -110,7 +110,7 @@
       +-----------+-----------+
 
 - name: Verify selective column ordering with custom headers
-  assert:
+  ansible.builtin.assert:
     that:
       - selective_ordered_headers_table == expected_selective_headers_table
 
@@ -126,7 +126,7 @@
       +------------+-----------------+--------+
 
 - name: Verify aligned table output
-  assert:
+  ansible.builtin.assert:
     that:
       - aligned_table == expected_aligned_table
 
@@ -146,7 +146,7 @@
       +----------+-----------+-------+
 
 - name: Verify combined table output
-  assert:
+  ansible.builtin.assert:
     that:
       - combined_table == expected_combined_table
 
@@ -159,7 +159,7 @@
       ++
 
 - name: Verify empty table output
-  assert:
+  ansible.builtin.assert:
     that:
       - empty_table == expected_empty_table
 
@@ -174,7 +174,7 @@
       +------+-----+------+
 
 - name: Verify empty table with column_order
-  assert:
+  ansible.builtin.assert:
     that:
       - empty_with_columns == expected_empty_with_columns
 
@@ -189,7 +189,7 @@
       +-----------+----------+-----------+
 
 - name: Verify empty table with header_names
-  assert:
+  ansible.builtin.assert:
     that:
       - empty_with_headers == expected_empty_with_headers
 
@@ -207,7 +207,7 @@
       +----------+-----------+-------+
 
 - name: Verify empty table with combined parameters
-  assert:
+  ansible.builtin.assert:
     that:
       - empty_combined == expected_empty_combined
 
@@ -219,7 +219,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for empty data with invalid column_order
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -232,7 +232,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for empty data with invalid header_names
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -245,7 +245,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for empty data with invalid column_alignments
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -258,7 +258,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for empty data with non-string values in column_alignments
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -271,7 +271,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for empty data with invalid alignment value
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -286,7 +286,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for empty data with mismatched lengths
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -300,7 +300,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for non-list input
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -313,7 +313,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for non-dictionary items
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -326,7 +326,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for non-list column_order
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -339,7 +339,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for non-list header_names
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -352,7 +352,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for unknown parameters
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -365,7 +365,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for using both positional args and column_order
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -378,7 +378,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for non-string values in positional args
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -391,7 +391,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for non-string values in column_order
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -404,7 +404,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for non-string values in header_names
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -417,7 +417,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for mismatched sizes
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -430,7 +430,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for column_order with too many elements
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -443,7 +443,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for header_names with too many elements
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -456,7 +456,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for column_alignments with too many elements
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -469,7 +469,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for non-dictionary column_alignments
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -482,7 +482,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for non-string keys in column_alignments
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -495,7 +495,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for non-string values in column_alignments
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -508,7 +508,7 @@
       register: failure_result
       ignore_errors: true
     - name: Verify error message for invalid alignment value in column_alignments
-      assert:
+      ansible.builtin.assert:
         that:
           - failure_result is failed
           - >
@@ -539,7 +539,7 @@
       +-------+-------+-------+
 
 - name: Verify mixed key types were handled correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - mixed_key_table == expected_mixed_key_table
 
@@ -556,7 +556,7 @@
       +-------+-------+-------+
 
 - name: Verify column ordering with numeric keys
-  assert:
+  ansible.builtin.assert:
     that:
       - mixed_ordered_table == expected_ordered_numeric_table
 
@@ -573,7 +573,7 @@
       +-------+-------+-------+
 
 - name: Verify custom headers with numeric keys
-  assert:
+  ansible.builtin.assert:
     that:
       - mixed_headers_table == expected_headers_numeric_table
 
@@ -590,7 +590,7 @@
       +-------+-------+-------+
 
 - name: Verify column alignments with numeric keys
-  assert:
+  ansible.builtin.assert:
     that:
       - mixed_aligned_table == expected_aligned_numeric_table
 
@@ -619,7 +619,7 @@
       +-------+-------+------+-------+
 
 - name: Verify boolean-like keys were handled correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - bool_table == expected_bool_table
 
@@ -636,7 +636,7 @@
       +------+-------+-------+-------+
 
 - name: Verify that 'True' in column_order works with 'true' keys
-  assert:
+  ansible.builtin.assert:
     that:
       - bool_ordered_table == expected_bool_ordered_table
 
@@ -653,6 +653,6 @@
       +-------+-------+------+-------+
 
 - name: Verify column alignments with boolean-like string keys
-  assert:
+  ansible.builtin.assert:
     that:
       - bool_aligned_table == expected_bool_aligned_table

--- a/tests/integration/targets/filter_to_toml/main.yml
+++ b/tests/integration/targets/filter_to_toml/main.yml
@@ -16,7 +16,7 @@
         complex: "{{ foobar | community.general.to_toml }}"
         complex_redact: "{{ foobar | community.general.to_toml(redact_sensitive_values=true) }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - complex == exp_complex
           - complex_redact == exp_complex_redact
@@ -44,7 +44,7 @@
             - "{{ foo }}"
 
     - when: ansible_version.full is version("2.19", "<")
-      assert:
+      ansible.builtin.assert:
         that:
           - complex == exp_complex
           # With ansible-core 2.18 and before, the vaulted string is decrypted before it reaches the filter,
@@ -65,7 +65,7 @@
           bang = ["2025-01-02 03:04:05+00:00", "foobarbaz", "bar"]
 
     - when: ansible_version.full is version("2.19", ">=")
-      assert:
+      ansible.builtin.assert:
         that:
           - complex == exp_complex
           - complex_redact == exp_complex_redact

--- a/tests/integration/targets/filter_to_yaml/main.yml
+++ b/tests/integration/targets/filter_to_yaml/main.yml
@@ -29,7 +29,7 @@
         vdict: "{{ {'a': 'b', 1: 2} | community.general.to_yaml }}"
 
     - name: Check values
-      assert:
+      ansible.builtin.assert:
         that:
           - 'vstr == "foo\n"'
           - 'vvstr == "bar\n"'
@@ -54,7 +54,7 @@
         vdict: "{{ {'a': 'b', 1: 2} | community.general.to_nice_yaml }}"
 
     - name: Check values
-      assert:
+      ansible.builtin.assert:
         that:
           - 'vstr == "foo\n"'
           - 'vvstr == "bar\n"'
@@ -73,7 +73,7 @@
         complex_nice: "{{ foobar | community.general.to_nice_yaml }}"
         complex_nice_redact: "{{ foobar | community.general.to_nice_yaml(redact_sensitive_values=true) }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - complex == exp_complex
           - complex_redact == exp_complex_redact
@@ -121,7 +121,7 @@
             - "{{ foo }}"
 
     - when: ansible_version.full is version("2.19", "<")
-      assert:
+      ansible.builtin.assert:
         that:
           - complex == exp_complex
           # With ansible-core 2.18 and before, the vaulted string is decryped before it reaches the filter,
@@ -149,7 +149,7 @@
           foo: 123
 
     - when: ansible_version.full is version("2.19", ">=")
-      assert:
+      ansible.builtin.assert:
         that:
           - complex == exp_complex
           - complex_redact == exp_complex_redact

--- a/tests/integration/targets/filter_unicode_normalize/tasks/main.yml
+++ b/tests/integration/targets/filter_unicode_normalize/tasks/main.yml
@@ -9,14 +9,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Test 'NFC' normalization
-  assert:
+  ansible.builtin.assert:
     that:
       - u_umlaut != u_umlaut_combining
       - u_umlaut_combining != (u_umlaut_combining | community.general.unicode_normalize)
       - u_umlaut == (u_umlaut_combining | community.general.unicode_normalize)
 
 - name: Test 'NFKC' normalization
-  assert:
+  ansible.builtin.assert:
     that:
       - latin_capital_i != roman_numeral_one
       - latin_capital_i == (roman_numeral_one | community.general.unicode_normalize(form='NFKC'))
@@ -28,7 +28,7 @@
   register: invalid_input_type
 
 - name: Assert an invalid input type causes failure
-  assert:
+  ansible.builtin.assert:
     that:
       - invalid_input_type is failed
 
@@ -39,6 +39,6 @@
   register: invalid_form_selection
 
 - name: Assert invalid form selection causes failure
-  assert:
+  ansible.builtin.assert:
     that:
       - invalid_form_selection is failed

--- a/tests/integration/targets/filter_version_sort/tasks/main.yml
+++ b/tests/integration/targets/filter_version_sort/tasks/main.yml
@@ -9,6 +9,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: validate that versions are properly sorted in a stable way
-  assert:
+  ansible.builtin.assert:
     that:
       - "['a-1.9.rpm', 'a-1.10-1.rpm', 'a-1.09.rpm', 'b-1.01.rpm', 'a-2.1-0.rpm', 'a-1.10-0.rpm'] | community.general.version_sort == ['a-1.9.rpm', 'a-1.09.rpm', 'a-1.10-0.rpm', 'a-1.10-1.rpm', 'a-2.1-0.rpm', 'b-1.01.rpm']"

--- a/tests/integration/targets/flatpak/tasks/check_mode.yml
+++ b/tests/integration/targets/flatpak/tasks/check_mode.yml
@@ -16,7 +16,7 @@
   check_mode: true
 
 - name: Verify addition of absent flatpak test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - addition_result is changed
     msg: "Adding an absent flatpak shall mark module execution as changed"
@@ -30,7 +30,7 @@
   check_mode: true
 
 - name: Verify non-existent idempotency of addition of absent flatpak test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - double_addition_result is changed
     msg: |
@@ -47,7 +47,7 @@
   check_mode: true
 
 - name: Verify removal of absent flatpak test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - removal_result is not changed
     msg: "Removing an absent flatpak shall mark module execution as not changed"
@@ -63,7 +63,7 @@
   check_mode: true
 
 - name: Verify state=latest of absent flatpak test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - latest_result is changed
     msg: "state=latest an absent flatpak shall mark module execution as changed"
@@ -77,7 +77,7 @@
   check_mode: true
 
 - name: Verify non-existent idempotency of state=latest of absent flatpak test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - double_latest_result is changed
     msg: |
@@ -96,7 +96,7 @@
   check_mode: true
 
 - name: Verify addition of absent flatpak with from_url test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - from_url_addition_result is changed
     msg: "Adding an absent flatpak with from_url shall mark module execution as changed"
@@ -111,7 +111,7 @@
   check_mode: true
 
 - name: Verify non-existent idempotency of addition of absent flatpak with from_url test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - double_from_url_addition_result is changed
     msg: |
@@ -129,7 +129,7 @@
   check_mode: true
 
 - name: Verify addition of absent flatpak with url test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - url_addition_result is changed
     msg: "Adding an absent flatpak from URL shall mark module execution as changed"
@@ -145,7 +145,7 @@
 - name: >
       Verify non-existent idempotency of additionof absent flatpak with url test
       result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - double_url_addition_result is changed
     msg: |
@@ -162,7 +162,7 @@
   check_mode: true
 
 - name: Verify removal of absent flatpak with url test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - url_removal_result is not changed
     msg: "Removing an absent flatpak shall mark module execution as not changed"
@@ -178,7 +178,7 @@
   check_mode: true
 
 - name: Verify state=latest of absent flatpak with url test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - url_latest_result is changed
     msg: "state=latest an absent flatpak from URL shall mark module execution as changed"
@@ -194,7 +194,7 @@
 - name: >
       Verify non-existent idempotency of additionof state=latest flatpak with url test
       result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - double_url_latest_result is changed
     msg: |
@@ -214,7 +214,7 @@
   check_mode: true
 
 - name: Verify addition test result of present flatpak (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - addition_present_result is not changed
     msg: "Adding an present flatpak shall mark module execution as not changed"
@@ -229,7 +229,7 @@
   check_mode: true
 
 - name: Verify removal of present flatpak test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - removal_present_result is changed
     msg: "Removing a present flatpak shall mark module execution as changed"
@@ -242,7 +242,7 @@
   check_mode: true
 
 - name: Verify non-existent idempotency of removal (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - double_removal_present_result is changed
     msg: |
@@ -260,7 +260,7 @@
   check_mode: true
 
 - name: Verify latest test result of present flatpak (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - latest_present_result is changed
     msg: "state=latest an present flatpak shall mark module execution as changed"
@@ -277,7 +277,7 @@
   check_mode: true
 
 - name: Verify addition with from_url of present flatpak test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - from_url_addition_present_result is not changed
     msg: "Adding a present flatpak with from_url shall mark module execution as not changed"
@@ -293,7 +293,7 @@
   check_mode: true
 
 - name: Verify addition with url of present flatpak test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - url_addition_present_result is not changed
     msg: "Adding a present flatpak from URL shall mark module execution as not changed"
@@ -308,7 +308,7 @@
   check_mode: true
 
 - name: Verify removal with url of present flatpak test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - url_removal_present_result is changed
     msg: "Removing an absent flatpak shall mark module execution as not changed"
@@ -324,7 +324,7 @@
 - name: >
       Verify non-existent idempotency of installation with url of present
       flatpak test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - double_url_removal_present_result is changed
     msg: Removing an absent flatpak a second time shall still mark module execution as changed
@@ -340,7 +340,7 @@
   check_mode: true
 
 - name: Verify state=latest with url of present flatpak test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - url_latest_present_result is changed
     msg: "state=latest a present flatpak from URL shall mark module execution as changed"

--- a/tests/integration/targets/flatpak/tasks/main.yml
+++ b/tests/integration/targets/flatpak/tasks/main.yml
@@ -25,7 +25,7 @@
       register: executable_override_result
 
     - name: Verify executable override test result
-      assert:
+      ansible.builtin.assert:
         that:
           - executable_override_result is failed
           - executable_override_result is not changed

--- a/tests/integration/targets/flatpak/tasks/test.yml
+++ b/tests/integration/targets/flatpak/tasks/test.yml
@@ -15,7 +15,7 @@
   register: addition_result
 
 - name: Verify addition test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - addition_result is changed
     msg: "state=present shall add flatpak when absent"
@@ -30,7 +30,7 @@
   register: double_addition_result
 
 - name: Verify idempotency of addition test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - double_addition_result is not changed
     msg: "state=present shall not do anything when flatpak is already present"
@@ -46,7 +46,7 @@
   register: removal_result
 
 - name: Verify removal test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - removal_result is changed
     msg: "state=absent shall remove flatpak when present"
@@ -60,7 +60,7 @@
   register: double_removal_result
 
 - name: Verify idempotency of removal test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - double_removal_result is not changed
     msg: "state=absent shall not do anything when flatpak is not present"
@@ -77,7 +77,7 @@
   register: latest_result
 
 - name: Verify state=latest test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - latest_result is changed
     msg: "state=latest shall add flatpak when absent"
@@ -92,7 +92,7 @@
   register: double_latest_result
 
 - name: Verify idempotency of state=latest test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - double_latest_result is not changed
     msg: "state=latest shall not do anything when flatpak is already present"
@@ -116,7 +116,7 @@
   register: url_addition_result
 
 - name: Verify addition test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - url_addition_result is changed
     msg: "state=present with url as name shall add flatpak when absent"
@@ -131,7 +131,7 @@
   register: double_url_addition_result
 
 - name: Verify idempotency of addition with url test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - double_url_addition_result is not changed
     msg: "state=present with url as name shall not do anything when flatpak is already present"
@@ -152,7 +152,7 @@
   # the following message, which we check for. If another error happens, we fail.
   # Upstream issue: https://github.com/flatpak/flatpak/issues/4307
   # (The second message happens with Ubuntu 18.04.)
-  assert:
+  ansible.builtin.assert:
     that:
       - >-
         url_removal_result.msg in [
@@ -165,7 +165,7 @@
   block:
 
     - name: Verify removal test result - {{ method }}
-      assert:
+      ansible.builtin.assert:
         that:
           - url_removal_result is changed
         msg: "state=absent with url as name shall remove flatpak when present"
@@ -179,7 +179,7 @@
       register: double_url_removal_result
 
     - name: Verify idempotency of removal with url test result - {{ method }}
-      assert:
+      ansible.builtin.assert:
         that:
           - double_url_removal_result is not changed
         msg: "state=absent with url as name shall not do anything when flatpak is not present"
@@ -203,7 +203,7 @@
   register: url_latest_result
 
 - name: Verify state=latest test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - url_latest_result is changed
     msg: "state=present with url as name shall add flatpak when absent"
@@ -218,7 +218,7 @@
   register: double_url_latest_result
 
 - name: Verify idempotency of state=latest with url test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - double_url_latest_result is not changed
     msg: "state=present with url as name shall not do anything when flatpak is already present"
@@ -242,7 +242,7 @@
   register: from_url_addition_result
 
 - name: Verify addition with from_url test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - from_url_addition_result is changed
     msg: "state=present with from_url shall add flatpak when absent"
@@ -257,7 +257,7 @@
   register: double_from_url_addition_result
 
 - name: Verify idempotency of addition with from_url test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - double_from_url_addition_result is not changed
     msg: "state=present with from_url shall not do anything when flatpak is already present"
@@ -281,7 +281,7 @@
   ignore_errors: true
 
 - name: Verify from_url with URL in name fails - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - from_url_url_name_result is failed
       - from_url_url_name_result is not changed
@@ -299,7 +299,7 @@
   ignore_errors: true
 
 - name: Verify from_url with multiple names fails - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - from_url_multi_name_result is failed
       - from_url_multi_name_result is not changed
@@ -315,7 +315,7 @@
   ignore_errors: true
 
 - name: Verify from_url with non-http URL fails - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - from_url_non_http_result is failed
       - from_url_non_http_result is not changed
@@ -335,7 +335,7 @@
   register: addition_result
 
 - name: Verify addition with list test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - addition_result is changed
     msg: "state=present shall add flatpak when absent"
@@ -352,7 +352,7 @@
   register: double_addition_result
 
 - name: Verify idempotency of addition with list test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - double_addition_result is not changed
     msg: "state=present shall not do anything when flatpak is already present"
@@ -370,7 +370,7 @@
   register: addition_result
 
 - name: Verify addition with list partially installed test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - addition_result is changed
     msg: "state=present shall add flatpak when absent"
@@ -388,7 +388,7 @@
   register: double_addition_result
 
 - name: Verify idempotency of addition with list partially installed test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - double_addition_result is not changed
     msg: "state=present shall not do anything when flatpak is already present"
@@ -405,7 +405,7 @@
   register: removal_result
 
 - name: Verify removal with list test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - removal_result is changed
     msg: "state=absent shall remove flatpak when present"
@@ -420,7 +420,7 @@
   register: double_removal_result
 
 - name: Verify idempotency of removal with list test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - double_removal_result is not changed
     msg: "state=absent shall not do anything when flatpak is not present"
@@ -436,7 +436,7 @@
   register: removal_result
 
 - name: Verify removal with list partially removed test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - removal_result is changed
     msg: "state=absent shall remove flatpak when present"
@@ -452,7 +452,7 @@
   register: double_removal_result
 
 - name: Verify idempotency of removal with list partially removed test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - double_removal_result is not changed
     msg: "state=absent shall not do anything when flatpak is not present"
@@ -471,7 +471,7 @@
   register: latest_result
 
 - name: Verify state=latest with list test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - latest_result is changed
     msg: "state=present shall add flatpak when absent"
@@ -488,7 +488,7 @@
   register: double_latest_result
 
 - name: Verify idempotency of state=latest with list test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - double_latest_result is not changed
     msg: "state=present shall not do anything when flatpak is already present"
@@ -506,7 +506,7 @@
   register: latest_result
 
 - name: Verify state=latest with list partially installed test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - latest_result is changed
     msg: "state=present shall add flatpak when absent"
@@ -524,7 +524,7 @@
   register: double_latest_result
 
 - name: Verify idempotency of state=latest with list partially installed test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - double_latest_result is not changed
     msg: "state=present shall not do anything when flatpak is already present"

--- a/tests/integration/targets/flatpak_remote/tasks/check_mode.yml
+++ b/tests/integration/targets/flatpak_remote/tasks/check_mode.yml
@@ -16,7 +16,7 @@
   check_mode: true
 
 - name: Verify addition of absent flatpak remote test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - addition_result is changed
     msg: "Adding an absent flatpak remote shall mark module execution as changed"
@@ -32,7 +32,7 @@
 - name: >
       Verify non-existent idempotency of addition of absent flatpak remote
       test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - double_addition_result is changed
     msg: |
@@ -49,7 +49,7 @@
   check_mode: true
 
 - name: Verify removal of absent flatpak remote test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - removal_result is not changed
     msg: "Removing an absent flatpak remote shall mark module execution as not changed"
@@ -68,7 +68,7 @@
   check_mode: true
 
 - name: Verify addition of present flatpak remote test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - addition_result is not changed
     msg: "Adding a present flatpak remote shall mark module execution as not changed"
@@ -83,7 +83,7 @@
   check_mode: true
 
 - name: Verify removal of present flatpak remote test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - removal_result is changed
     msg: "Removing a present flatpak remote shall mark module execution as changed"
@@ -98,7 +98,7 @@
 - name: >
       Verify non-existent idempotency of removal of present flatpak remote
       test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - double_removal_result is changed
     msg: |
@@ -118,7 +118,7 @@
   check_mode: true
 
 - name: Verify activation of disabled flatpak remote test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - activation_result is changed
     msg: "Enabling an disabled flatpak remote shall mark module execution as changed"
@@ -133,7 +133,7 @@
 - name: >
       Verify non-existent idempotency of activation of disabled flatpak remote
       test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - double_activation_result is changed
     msg: |
@@ -150,7 +150,7 @@
   check_mode: true
 
 - name: Verify deactivation of disabled flatpak remote test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - deactivation_result is not changed
     msg: "Disabling an disabled flatpak remote shall mark module execution as not changed"
@@ -168,7 +168,7 @@
   check_mode: true
 
 - name: Verify activation of enabled flatpak remote test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - activation_result is not changed
     msg: "Enabling a enabled flatpak remote shall mark module execution as not changed"
@@ -183,7 +183,7 @@
   check_mode: true
 
 - name: Verify deactivation of enabled flatpak remote test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - deactivation_result is changed
     msg: "Disabling a enabled flatpak remote shall mark module execution as changed"
@@ -198,7 +198,7 @@
 - name: >
       Verify non-existent idempotency of deactivation of enabled flatpak remote
       test result (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - double_deactivation_result is changed
     msg: |

--- a/tests/integration/targets/flatpak_remote/tasks/main.yml
+++ b/tests/integration/targets/flatpak_remote/tasks/main.yml
@@ -26,7 +26,7 @@
       register: executable_override_result
 
     - name: Verify executable override test result
-      assert:
+      ansible.builtin.assert:
         that:
           - executable_override_result is failed
           - executable_override_result is not changed

--- a/tests/integration/targets/flatpak_remote/tasks/test.yml
+++ b/tests/integration/targets/flatpak_remote/tasks/test.yml
@@ -14,7 +14,7 @@
   register: addition_result
 
 - name: Verify addition test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - addition_result is changed
     msg: "state=present shall add flatpak when absent"
@@ -28,7 +28,7 @@
   register: double_addition_result
 
 - name: Verify idempotency of addition test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - double_addition_result is not changed
     msg: "state=present shall not do anything when flatpak is already present"
@@ -42,7 +42,7 @@
   register: url_update_result
 
 - name: Verify updating remote url does not do anything - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - url_update_result is not changed
     msg: "Trying to update the URL of an existing flatpak remote shall not do anything"
@@ -58,7 +58,7 @@
   register: deactivation_result
 
 - name: Verify deactivation test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - deactivation_result is changed
     msg: "enable=false shall disable flatpak remote when enabled"
@@ -71,7 +71,7 @@
   register: double_deactivation_result
 
 - name: Verify idempotency of deactivation test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - double_deactivation_result is not changed
     msg: "enabled=false shall not do anything when flatpak remote is already disabled"
@@ -87,7 +87,7 @@
   register: activation_result
 
 - name: Verify activation test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - activation_result is changed
     msg: "enable=true shall enable flatpak remote when disabled"
@@ -100,7 +100,7 @@
   register: double_activation_result
 
 - name: Verify idempotency of activation test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - double_activation_result is not changed
     msg: "enabled=true shall not do anything when flatpak remote is already enabled"
@@ -116,7 +116,7 @@
   register: removal_result
 
 - name: Verify removal test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - removal_result is changed
     msg: "state=absent shall remove flatpak when present"
@@ -129,7 +129,7 @@
   register: double_removal_result
 
 - name: Verify idempotency of removal test result - {{ method }}
-  assert:
+  ansible.builtin.assert:
     that:
       - double_removal_result is not changed
     msg: "state=absent shall not do anything when flatpak is not present"

--- a/tests/integration/targets/gandi_livedns/tasks/create_record.yml
+++ b/tests/integration/targets/gandi_livedns/tasks/create_record.yml
@@ -13,7 +13,7 @@
     state: absent
   register: result
 - name: verify test absent dns record
-  assert:
+  ansible.builtin.assert:
     that:
       - result is successful
 
@@ -28,7 +28,7 @@
   check_mode: true
   register: result
 - name: verify test create a dns record in check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -42,7 +42,7 @@
     type: "{{ item.type }}"
   register: result
 - name: verify test create a dns record
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.record['values'] == item['values']
@@ -60,7 +60,7 @@
     type: "{{ item.type }}"
   register: result
 - name: verify test create a dns record idempotence
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.record['values'] == item['values']

--- a/tests/integration/targets/gandi_livedns/tasks/remove_record.yml
+++ b/tests/integration/targets/gandi_livedns/tasks/remove_record.yml
@@ -14,7 +14,7 @@
   check_mode: true
   register: result
 - name: verify test remove a dns record in check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -28,7 +28,7 @@
     state: absent
   register: result
 - name: verify test remove a dns record
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -42,7 +42,7 @@
     state: absent
   register: result
 - name: verify test remove a dns record idempotence
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -56,6 +56,6 @@
     state: absent
   register: result
 - name: verify test remove a dns record idempotence
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed

--- a/tests/integration/targets/gandi_livedns/tasks/update_record.yml
+++ b/tests/integration/targets/gandi_livedns/tasks/update_record.yml
@@ -14,7 +14,7 @@
   check_mode: true
   register: result
 - name: verify test update in check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.record['values'] == (item.update_values | default(item['values']))
@@ -32,7 +32,7 @@
     type: "{{ item.type }}"
   register: result
 - name: verify test update a dns record
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.record['values'] == (item.update_values | default(item['values']))
@@ -50,7 +50,7 @@
     type: "{{ item.type }}"
   register: result
 - name: verify test update a dns record idempotence
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.record['values'] == (item.update_values | default(item['values']))

--- a/tests/integration/targets/gem/tasks/main.yml
+++ b/tests/integration/targets/gem/tasks/main.yml
@@ -44,7 +44,7 @@
           register: current_gems
 
         - name: Ensure gem was installed
-          assert:
+          ansible.builtin.assert:
             that:
               - install_gem_result is changed
               - current_gems.stdout is search('gist\s+\([0-9.]+\)')
@@ -60,7 +60,7 @@
           register: current_gems
 
         - name: Verify gem is not installed
-          assert:
+          ansible.builtin.assert:
             that:
               - remove_gem_results is changed
               - current_gems.stdout is not search('gist\s+\([0-9.]+\)')
@@ -79,7 +79,7 @@
           register: current_gems
 
         - name: Ensure gem was installed
-          assert:
+          ansible.builtin.assert:
             that:
               - install_gem_result is changed
               - current_gems.stdout is search('gist\s+\([0-9.]+\)')
@@ -96,7 +96,7 @@
           register: current_gems
 
         - name: Verify gem is not installed
-          assert:
+          ansible.builtin.assert:
             that:
               - remove_gem_results is changed
               - current_gems.stdout is not search('gist\s+\([0-9.]+\)')
@@ -116,7 +116,7 @@
       tags: debug
 
     - name: Ensure previous task failed
-      assert:
+      ansible.builtin.assert:
         that:
           - install_gem_fail_result is failed
           - install_gem_fail_result.msg == 'install_dir requires user_install=false'
@@ -137,7 +137,7 @@
       register: gem_search
 
     - name: Ensure gem was installed in custom directory
-      assert:
+      ansible.builtin.assert:
         that:
           - install_gem_result is changed
           - gem_search.files[0].path is search('gist-[0-9.]+')
@@ -159,7 +159,7 @@
       register: gem_search
 
     - name: Ensure gem was removed in custom directory
-      assert:
+      ansible.builtin.assert:
         that:
           - install_gem_result is changed
           - gem_search.files | length == 0
@@ -180,7 +180,7 @@
       register: gem_bindir_stat
 
     - name: Ensure gem executable was installed in custom directory
-      assert:
+      ansible.builtin.assert:
         that:
           - install_gem_result is changed
           - gem_bindir_stat.stat.exists and gem_bindir_stat.stat.isreg
@@ -200,7 +200,7 @@
       register: gem_bindir_stat
 
     - name: Ensure gem executable was removed from custom directory
-      assert:
+      ansible.builtin.assert:
         that:
           - install_gem_result is changed
           - not gem_bindir_stat.stat.exists
@@ -218,7 +218,7 @@
       register: current_gems
 
     - name: Ensure gem was installed with override_platform_install_dir
-      assert:
+      ansible.builtin.assert:
         that:
           - install_gem_result is changed
           - current_gems.stdout is search('gist\s+\([0-9.]+\)')
@@ -231,7 +231,7 @@
       register: install_gem_result
 
     - name: Ensure install is idempotent
-      assert:
+      ansible.builtin.assert:
         that:
           - install_gem_result is not changed
 
@@ -247,7 +247,7 @@
       register: current_gems
 
     - name: Verify gem was removed with override_platform_install_dir
-      assert:
+      ansible.builtin.assert:
         that:
           - remove_gem_result is changed
           - current_gems.stdout is not search('gist\s+\([0-9.]+\)')
@@ -262,7 +262,7 @@
 
     - name: Assert gem uninstall failed as expected
       when: ansible_facts.distribution == "Ubuntu"
-      assert:
+      ansible.builtin.assert:
         that:
           - gem_result is failed
           - gem_result.msg.startswith("Failed to uninstall gem 'json'")

--- a/tests/integration/targets/git_config/tasks/get_set_no_state.yml
+++ b/tests/integration/targets/git_config/tasks/get_set_no_state.yml
@@ -19,7 +19,7 @@
   register: get_result
 
 - name: assert set changed and value is correct
-  assert:
+  ansible.builtin.assert:
     that:
       - set_result is changed
       - set_result.diff.before == "\n"

--- a/tests/integration/targets/git_config/tasks/get_set_state_present.yml
+++ b/tests/integration/targets/git_config/tasks/get_set_state_present.yml
@@ -20,7 +20,7 @@
   register: get_result
 
 - name: assert set changed and value is correct with state=present
-  assert:
+  ansible.builtin.assert:
     that:
       - set_result is changed
       - set_result.diff.before == "\n"

--- a/tests/integration/targets/git_config/tasks/get_set_state_present_file.yml
+++ b/tests/integration/targets/git_config/tasks/get_set_state_present_file.yml
@@ -22,7 +22,7 @@
   register: get_result
 
 - name: assert set changed and value is correct with state=present
-  assert:
+  ansible.builtin.assert:
     that:
       - set_result is changed
       - set_result.diff.before == "\n"

--- a/tests/integration/targets/git_config/tasks/precedence_between_unset_and_value.yml
+++ b/tests/integration/targets/git_config/tasks/precedence_between_unset_and_value.yml
@@ -20,7 +20,7 @@
   register: get_result
 
 - name: assert unset changed and deleted value
-  assert:
+  ansible.builtin.assert:
     that:
       - unset_result is changed
       - unset_result.diff.before == option_value + "\n"

--- a/tests/integration/targets/git_config/tasks/set_multi_value.yml
+++ b/tests/integration/targets/git_config/tasks/set_multi_value.yml
@@ -47,7 +47,7 @@
   register: set_result3
 
 - name: assert set changed and value is correct
-  assert:
+  ansible.builtin.assert:
     that:
       - set_result1.results[0] is changed
       - set_result1.results[1] is changed
@@ -60,7 +60,7 @@
       - 'get_result.config_values == {"push.pushoption": ["merge_request.create", "merge_request.draft", "merge_request.target=foobar"]}'
 
 - name: assert the diffs are also right
-  assert:
+  ansible.builtin.assert:
     that:
       - set_result1.results[0].diff.before == "\n"
       - set_result1.results[0].diff.after == "merge_request.create\n"

--- a/tests/integration/targets/git_config/tasks/set_value.yml
+++ b/tests/integration/targets/git_config/tasks/set_value.yml
@@ -26,7 +26,7 @@
   register: get_result
 
 - name: assert set changed and value is correct
-  assert:
+  ansible.builtin.assert:
     that:
       - set_result1 is changed
       - set_result2 is changed

--- a/tests/integration/targets/git_config/tasks/set_value_with_tilde.yml
+++ b/tests/integration/targets/git_config/tasks/set_value_with_tilde.yml
@@ -28,7 +28,7 @@
   register: get_result
 
 - name: assert set changed and value is correct
-  assert:
+  ansible.builtin.assert:
     that:
       - set_result1 is changed
       - set_result2 is not changed

--- a/tests/integration/targets/git_config/tasks/unset_check_mode.yml
+++ b/tests/integration/targets/git_config/tasks/unset_check_mode.yml
@@ -20,7 +20,7 @@
   register: get_result
 
 - name: assert unset changed but dit not delete value
-  assert:
+  ansible.builtin.assert:
     that:
       - unset_result is changed
       - unset_result.diff.before == option_value + "\n"

--- a/tests/integration/targets/git_config/tasks/unset_multi_value.yml
+++ b/tests/integration/targets/git_config/tasks/unset_multi_value.yml
@@ -19,7 +19,7 @@
   register: get_all_result
 
 - name: assert unsetting muti-values
-  assert:
+  ansible.builtin.assert:
     that:
       - unset_result is changed
       - 'get_all_result.config_values == {"push.pushoption": []}'

--- a/tests/integration/targets/git_config/tasks/unset_no_value.yml
+++ b/tests/integration/targets/git_config/tasks/unset_no_value.yml
@@ -19,7 +19,7 @@
   register: get_result
 
 - name: assert unsetting didn't change
-  assert:
+  ansible.builtin.assert:
     that:
       - unset_result is not changed
       - unset_result.msg == 'no setting to unset'

--- a/tests/integration/targets/git_config/tasks/unset_value.yml
+++ b/tests/integration/targets/git_config/tasks/unset_value.yml
@@ -19,7 +19,7 @@
   register: get_result
 
 - name: assert unset changed and deleted value
-  assert:
+  ansible.builtin.assert:
     that:
       - unset_result is changed
       - unset_result.diff.before == option_value + "\n"
@@ -43,7 +43,7 @@
   register: get_result
 
 - name: assert unset changed and deleted value
-  assert:
+  ansible.builtin.assert:
     that:
       - unset_result is changed
       - unset_result.diff.before == option_value + "\n"

--- a/tests/integration/targets/git_config_info/tasks/error_handling.yml
+++ b/tests/integration/targets/git_config_info/tasks/error_handling.yml
@@ -17,7 +17,7 @@
   register: get_result2
 
 - name: assert value is correct
-  assert:
+  ansible.builtin.assert:
     that:
       - get_result1.config_value == ""
       - 'get_result1.config_values == {}'

--- a/tests/integration/targets/git_config_info/tasks/get_all_values.yml
+++ b/tests/integration/targets/git_config_info/tasks/get_all_values.yml
@@ -12,7 +12,7 @@
   register: get_result
 
 - name: assert value is correct
-  assert:
+  ansible.builtin.assert:
     that:
       - get_result.config_value == ""
       - 'get_result.config_values == {"credential.https://some.com.username": ["yolo"], "user.name": ["foobar"], "push.pushoption": ["merge_request.create", "merge_request.draft"]}'

--- a/tests/integration/targets/git_config_info/tasks/get_multi_value.yml
+++ b/tests/integration/targets/git_config_info/tasks/get_multi_value.yml
@@ -13,7 +13,7 @@
   register: get_result
 
 - name: assert value is correct
-  assert:
+  ansible.builtin.assert:
     that:
       - get_result.config_value == "merge_request.create"
       - 'get_result.config_values == {"push.pushoption": ["merge_request.create", "merge_request.draft"]}'

--- a/tests/integration/targets/git_config_info/tasks/get_simple_value.yml
+++ b/tests/integration/targets/git_config_info/tasks/get_simple_value.yml
@@ -27,7 +27,7 @@
   register: get_result3
 
 - name: assert value is correct
-  assert:
+  ansible.builtin.assert:
     that:
       - get_result1.config_value == "foobar"
       - 'get_result1.config_values == {"user.name": ["foobar"]}'

--- a/tests/integration/targets/github_issue/tasks/main.yml
+++ b/tests/integration/targets/github_issue/tasks/main.yml
@@ -17,7 +17,7 @@
     action: get_status
   register: get_status_0002
 
-- assert:
+- ansible.builtin.assert:
     that:
       - get_status_0002 is changed
       - get_status_0002.issue_status == 'closed'
@@ -31,7 +31,7 @@
   register: get_status_0003
   ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - get_status_0003 is not changed
       - get_status_0003 is failed

--- a/tests/integration/targets/github_key/tasks/main.yml
+++ b/tests/integration/targets/github_key/tasks/main.yml
@@ -20,7 +20,7 @@
   ignore_errors: true
 
 - name: Assert api_url parameter works with GitHub.com
-  assert:
+  ansible.builtin.assert:
     that:
       - github_api_result is failed
       - '"Unauthorized" in github_api_result.msg or "401" in github_api_result.msg'
@@ -36,7 +36,7 @@
   ignore_errors: true
 
 - name: Assert api_url parameter works with GitHub Enterprise
-  assert:
+  ansible.builtin.assert:
     that:
       - enterprise_api_result is failed
       - '"github.company.com" in enterprise_api_result.msg'
@@ -52,7 +52,7 @@
   ignore_errors: true
 
 - name: Assert trailing slash is handled correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - trailing_slash_result is failed
       - '"github.company.com" in trailing_slash_result.msg'

--- a/tests/integration/targets/gitlab_branch/tasks/main.yml
+++ b/tests/integration/targets/gitlab_branch/tasks/main.yml
@@ -42,7 +42,7 @@
   register: create_branch
 
 - name: Test module is idempotent
-  assert:
+  ansible.builtin.assert:
     that:
       - create_branch is not changed
 
@@ -56,7 +56,7 @@
   register: delete_branch
 
 - name: Test module is idempotent
-  assert:
+  ansible.builtin.assert:
     that:
       - delete_branch is changed
 

--- a/tests/integration/targets/gitlab_deploy_key/tasks/main.yml
+++ b/tests/integration/targets/gitlab_deploy_key/tasks/main.yml
@@ -41,7 +41,7 @@
     state: present
   register: deploy_key_status
 
-- assert:
+- ansible.builtin.assert:
     that:
       - deploy_key_status is changed
       - deploy_key_status.deploy_key.key == gitlab_deploy_key
@@ -57,7 +57,7 @@
     state: present
   register: deploy_key_status
 
-- assert:
+- ansible.builtin.assert:
     that:
       - deploy_key_status is changed
       - deploy_key_status.deploy_key.key == gitlab_deploy_key_new
@@ -72,7 +72,7 @@
     state: present
   register: deploy_key_status
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not deploy_key_status.changed
       - deploy_key_status.deploy_key.key == gitlab_deploy_key_new

--- a/tests/integration/targets/gitlab_group/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group/tasks/main.yml
@@ -33,7 +33,7 @@
   register: gitlab_group_state
 
 - name: Test group created
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_state is changed
 
@@ -49,7 +49,7 @@
   register: gitlab_group_state_again
 
 - name: Test module is idempotent
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_state_again is not changed
 
@@ -74,7 +74,7 @@
   register: gitlab_group_state_desc
 
 - name: Test group created with Description
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_state_desc.group.description == "My Test Group"
 
@@ -99,7 +99,7 @@
   register: gitlab_group_state_pcl
 
 - name: Test group created with project_creation_level
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_state_pcl.group.project_creation_level == "noone"
 
@@ -124,6 +124,6 @@
   register: gitlab_group_state_rtfa
 
 - name: Test group created with project_creation_level
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_state_rtfa.group.require_two_factor_authentication == true

--- a/tests/integration/targets/gitlab_group_access_token/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group_access_token/tasks/main.yml
@@ -30,7 +30,7 @@
       register: create_pfail_token_status
   always:
     - name: Assert that token creation in nonexisting group failed
-      assert:
+      ansible.builtin.assert:
         that:
           - create_pfail_token_status is failed
   ignore_errors: true
@@ -52,7 +52,7 @@
       register: create_efail_token_status
   always:
     - name: Assert that token creation with invalid expires_at failed
-      assert:
+      ansible.builtin.assert:
         that:
           - create_efail_token_status is failed
   ignore_errors: true
@@ -72,7 +72,7 @@
       - read_api
   register: create_token_status
 - name: Assert that token creation with valid arguments is successfull
-  assert:
+  ansible.builtin.assert:
     that:
       - create_token_status is changed
       - create_token_status.access_token.token is defined
@@ -92,7 +92,7 @@
       - read_api
   register: check_token_status
 - name: Assert that token creation without changes and recreate=never succeeds with status not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - check_token_status is not changed
       - check_token_status.access_token.token is not defined
@@ -113,7 +113,7 @@
     recreate: state_change
   register: check_recreate_token_status
 - name: Assert that token creation without changes and recreate=state_change succeeds with status not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - check_recreate_token_status is not changed
       - check_recreate_token_status.access_token.token is not defined
@@ -135,7 +135,7 @@
       register: change_token_status
   always:
     - name: Assert that token change with recreate=never fails
-      assert:
+      ansible.builtin.assert:
         that:
           - change_token_status is failed
   ignore_errors: true
@@ -156,7 +156,7 @@
     recreate: state_change
   register: change_recreate_token_status
 - name: Assert that token change with recreate=state_change succeeds
-  assert:
+  ansible.builtin.assert:
     that:
       - change_recreate_token_status is changed
       - change_recreate_token_status.access_token.token is defined
@@ -177,7 +177,7 @@
     recreate: always
   register: change_recreate1_token_status
 - name: Assert that token change with recreate=always succeeds
-  assert:
+  ansible.builtin.assert:
     that:
       - change_recreate1_token_status is changed
       - change_recreate1_token_status.access_token.token is defined
@@ -197,7 +197,7 @@
       - read_api
   register: revoke_token_status
 - name: Assert that token revocation succeeds
-  assert:
+  ansible.builtin.assert:
     that:
       - revoke_token_status is changed
 
@@ -216,6 +216,6 @@
       - read_api
   register: revoke_token_status
 - name: Assert that token revocation succeeds with status not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - revoke_token_status is not changed

--- a/tests/integration/targets/gitlab_group_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group_variable/tasks/main.yml
@@ -31,7 +31,7 @@
   register: gitlab_group_variable_state
 
 - name: check_mode state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is changed
 
@@ -46,7 +46,7 @@
   register: gitlab_group_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is changed
 
@@ -61,7 +61,7 @@
   register: gitlab_group_variable_state
 
 - name: state must be not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is not changed
 
@@ -77,7 +77,7 @@
   register: gitlab_group_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is changed
 
@@ -93,7 +93,7 @@
   register: gitlab_group_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is changed
 
@@ -109,7 +109,7 @@
   register: gitlab_group_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is changed
 
@@ -124,7 +124,7 @@
   register: gitlab_group_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is changed
 
@@ -139,7 +139,7 @@
   register: gitlab_group_variable_state
 
 - name: state must be not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is not changed
 
@@ -157,7 +157,7 @@
   register: gitlab_group_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is changed
 
@@ -175,7 +175,7 @@
   register: gitlab_group_variable_state
 
 - name: state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is not changed
 
@@ -191,7 +191,7 @@
   register: gitlab_group_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is changed
 
@@ -206,7 +206,7 @@
   register: gitlab_group_variable_state
 
 - name: check_mode state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is not changed
 
@@ -220,7 +220,7 @@
   register: gitlab_group_variable_state
 
 - name: state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is not changed
 
@@ -237,7 +237,7 @@
   when: gitlab_premium_tests is defined
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is changed
   when: gitlab_premium_tests is defined
@@ -255,7 +255,7 @@
   when: gitlab_premium_tests is defined
 
 - name: state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is not changed
   when: gitlab_premium_tests is defined
@@ -278,7 +278,7 @@
   register: gitlab_group_variable_state
 
 - name: set two test variables state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is changed
       - gitlab_group_variable_state.group_variable.added|length == 2
@@ -297,7 +297,7 @@
   register: gitlab_group_variable_state
 
 - name: re-set two test variables state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is not changed
       - gitlab_group_variable_state.group_variable.added|length == 0
@@ -316,7 +316,7 @@
   register: gitlab_group_variable_state
 
 - name: edit one variable state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state.changed
       - gitlab_group_variable_state.group_variable.added|length == 0
@@ -336,7 +336,7 @@
   register: gitlab_group_variable_state
 
 - name: append one variable state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state.changed
       - gitlab_group_variable_state.group_variable.added|length == 1
@@ -357,7 +357,7 @@
   register: gitlab_group_variable_state
 
 - name: re-set all variables state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - not gitlab_group_variable_state.changed
       - gitlab_group_variable_state.group_variable.added|length == 0
@@ -376,7 +376,7 @@
   register: gitlab_group_variable_state
 
 - name: set one variables and purge all others state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state.changed
       - gitlab_group_variable_state.group_variable.added|length == 0
@@ -395,7 +395,7 @@
   register: gitlab_group_variable_state
 
 - name: only one variable is left state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - not gitlab_group_variable_state.changed
       - gitlab_group_variable_state.group_variable.added|length == 0
@@ -415,7 +415,7 @@
   register: gitlab_group_variable_state
 
 - name: only one variable is left state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state.changed
       - gitlab_group_variable_state.group_variable.added|length == 0
@@ -434,7 +434,7 @@
   register: gitlab_group_variable_state
 
 - name: only one variable is left state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state.changed
       - gitlab_group_variable_state.group_variable.added|length == 0
@@ -453,7 +453,7 @@
   register: gitlab_group_variable_state
 
 - name: no variable is left state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state.changed
       - gitlab_group_variable_state.group_variable.added|length == 0
@@ -475,7 +475,7 @@
   register: gitlab_group_variable_state
 
 - name: append one variable state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state.changed
       - gitlab_group_variable_state.group_variable.added|length == 1
@@ -496,7 +496,7 @@
   register: gitlab_group_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is changed
 
@@ -512,7 +512,7 @@
   register: gitlab_group_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is changed
 
@@ -527,7 +527,7 @@
   register: gitlab_group_variable_state
 
 - name: no variable is left state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state.changed
       - gitlab_group_variable_state.group_variable.added|length == 0
@@ -566,7 +566,7 @@
   register: gitlab_group_variable_state
 
 - name: complete page added state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is changed
       - gitlab_group_variable_state.group_variable.added|length == 20
@@ -602,7 +602,7 @@
   register: gitlab_group_variable_state
 
 - name: existing page untouched state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state is changed
       - gitlab_group_variable_state.group_variable.added|length == 20
@@ -617,7 +617,7 @@
   register: gitlab_group_variable_state
 
 - name: check that no variables are untouched state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state.changed
       - gitlab_group_variable_state.group_variable.added|length == 0
@@ -648,7 +648,7 @@
   when: gitlab_premium_tests is defined
 
 - name: verify two vars
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state.changed
       - gitlab_group_variable_state.group_variable.added|length == 2
@@ -668,7 +668,7 @@
   ignore_errors: true
 
 - name: verify fail
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state.failed
       - gitlab_group_variable_state is not changed
@@ -685,7 +685,7 @@
   register: gitlab_group_variable_state
 
 - name: verify the change
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state.changed
 
@@ -700,7 +700,7 @@
   register: gitlab_group_variable_state
 
 - name: verify deletion
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_group_variable_state.changed
       - gitlab_group_variable_state.group_variable.removed|length == 1

--- a/tests/integration/targets/gitlab_hook/tasks/main.yml
+++ b/tests/integration/targets/gitlab_hook/tasks/main.yml
@@ -41,7 +41,7 @@
   register: gitlab_hook_state
 
 - name: Test group created
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_hook_state is changed
 
@@ -57,7 +57,7 @@
   register: gitlab_hook_state_again
 
 - name: Test module is idempotent
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_hook_state_again is not changed
 
@@ -72,6 +72,6 @@
   register: gitlab_hook_state_absent
 
 - name: Assert hook has been removed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_hook_state_absent is changed

--- a/tests/integration/targets/gitlab_instance_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_instance_variable/tasks/main.yml
@@ -30,7 +30,7 @@
   register: gitlab_instance_variable_state
 
 - name: check_mode state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is changed
 
@@ -44,7 +44,7 @@
   register: gitlab_instance_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is changed
 
@@ -58,7 +58,7 @@
   register: gitlab_instance_variable_state
 
 - name: state must be not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is not changed
 
@@ -73,7 +73,7 @@
   register: gitlab_instance_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is changed
 
@@ -88,7 +88,7 @@
   register: gitlab_instance_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is changed
 
@@ -103,7 +103,7 @@
   register: gitlab_instance_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is changed
 
@@ -118,7 +118,7 @@
   register: gitlab_instance_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is changed
 
@@ -132,7 +132,7 @@
   register: gitlab_instance_variable_state
 
 - name: state must be not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is not changed
 
@@ -149,7 +149,7 @@
   register: gitlab_instance_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is changed
 
@@ -166,7 +166,7 @@
   register: gitlab_instance_variable_state
 
 - name: state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is not changed
 
@@ -181,7 +181,7 @@
   register: gitlab_instance_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is changed
 
@@ -196,7 +196,7 @@
   register: gitlab_instance_variable_state
 
 - name: check_mode state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is not changed
 
@@ -210,7 +210,7 @@
   register: gitlab_instance_variable_state
 
 - name: state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is not changed
 
@@ -232,7 +232,7 @@
   register: gitlab_instance_variable_state
 
 - name: set two test variables state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is changed
       - gitlab_instance_variable_state.instance_variable.added|length == 2
@@ -252,7 +252,7 @@
   register: gitlab_instance_variable_state
 
 - name: re-set two test variables state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is not changed
       - gitlab_instance_variable_state.instance_variable.added|length == 0
@@ -271,7 +271,7 @@
   register: gitlab_instance_variable_state
 
 - name: edit one variable state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state.changed
       - gitlab_instance_variable_state.instance_variable.added|length == 0
@@ -291,7 +291,7 @@
   register: gitlab_instance_variable_state
 
 - name: append one variable state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state.changed
       - gitlab_instance_variable_state.instance_variable.added|length == 1
@@ -314,7 +314,7 @@
   register: gitlab_instance_variable_state
 
 - name: re-set all variables state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - not gitlab_instance_variable_state.changed
       - gitlab_instance_variable_state.instance_variable.added|length == 0
@@ -333,7 +333,7 @@
   register: gitlab_instance_variable_state
 
 - name: set one variables and purge all others state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state.changed
       - gitlab_instance_variable_state.instance_variable.added|length == 0
@@ -352,7 +352,7 @@
   register: gitlab_instance_variable_state
 
 - name: only one variable is left state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - not gitlab_instance_variable_state.changed
       - gitlab_instance_variable_state.instance_variable.added|length == 0
@@ -372,7 +372,7 @@
   register: gitlab_instance_variable_state
 
 - name: only one variable is left state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state.changed
       - gitlab_instance_variable_state.instance_variable.added|length == 0
@@ -391,7 +391,7 @@
   register: gitlab_instance_variable_state
 
 - name: only one variable is left state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state.changed
       - gitlab_instance_variable_state.instance_variable.added|length == 0
@@ -409,7 +409,7 @@
   register: gitlab_instance_variable_state
 
 - name: no variable is left state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state.changed
       - gitlab_instance_variable_state.instance_variable.added|length == 0
@@ -430,7 +430,7 @@
   register: gitlab_instance_variable_state
 
 - name: append one variable state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state.changed
       - gitlab_instance_variable_state.instance_variable.added|length == 1
@@ -451,7 +451,7 @@
   register: gitlab_instance_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is changed
 
@@ -466,7 +466,7 @@
   register: gitlab_instance_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is changed
 
@@ -480,7 +480,7 @@
   register: gitlab_instance_variable_state
 
 - name: no variable is left state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state.changed
       - gitlab_instance_variable_state.instance_variable.added|length == 0
@@ -538,7 +538,7 @@
   register: gitlab_instance_variable_state
 
 - name: complete page added state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state is changed
       - gitlab_instance_variable_state.instance_variable.added|length == 20
@@ -552,7 +552,7 @@
   register: gitlab_instance_variable_state
 
 - name: check that no variables are untouched state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state.changed
       - gitlab_instance_variable_state.instance_variable.added|length == 0
@@ -570,7 +570,7 @@
   ignore_errors: true
 
 - name: verify fail
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state.failed
       - gitlab_instance_variable_state is not changed
@@ -586,7 +586,7 @@
   register: gitlab_instance_variable_state
 
 - name: verify the change
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state.changed
 
@@ -600,7 +600,7 @@
   register: gitlab_instance_variable_state
 
 - name: verify deletion
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_instance_variable_state.changed
       - gitlab_instance_variable_state.instance_variable.removed|length == 1

--- a/tests/integration/targets/gitlab_issue/tasks/main.yml
+++ b/tests/integration/targets/gitlab_issue/tasks/main.yml
@@ -36,7 +36,7 @@
       register: gitlab_issue_create
 
     - name: Test Issue Created
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_issue_create is changed
 
@@ -51,7 +51,7 @@
       register: gitlab_issue_create_idempotence
 
     - name: Test Create Issue is Idempotent
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_issue_create_idempotence is not changed
 
@@ -70,7 +70,7 @@
       register: gitlab_issue_update_additions
 
     - name: Test Issue Updated ( Additions )
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_issue_update_additions.issue.labels[0] == "{{ gitlab_labels[0] }}"
           - gitlab_issue_update_additions.issue.assignees[0].username == "{{ gitlab_assignee_ids[0] }}"
@@ -90,7 +90,7 @@
       register: gitlab_issue_update_persistence
 
     - name: Test issue Not Updated ( Persistence )
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_issue_update_persistence.issue.labels[0] == "{{ gitlab_labels[0] }}"
           - gitlab_issue_update_persistence.issue.assignees[0].username == "{{ gitlab_assignee_ids[0] }}"
@@ -110,7 +110,7 @@
       register: gitlab_issue_update_removal
 
     - name: Test issue updated
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_issue_update_removal.issue.labels == []
           - gitlab_issue_update_removal.issue.assignees == []
@@ -126,7 +126,7 @@
       register: gitlab_issue_delete
 
     - name: Test issue is deleted
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_issue_delete is changed
 

--- a/tests/integration/targets/gitlab_label/tasks/main.yml
+++ b/tests/integration/targets/gitlab_label/tasks/main.yml
@@ -45,7 +45,7 @@
       register: gitlab_group_label_state
 
     - name: Group label - Check_mode state must be changed
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_group_label_state is changed
 
@@ -65,7 +65,7 @@
       register: gitlab_group_label_create
 
     - name: Group label - Test Label Created
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_group_label_create is changed
           - gitlab_group_label_create.labels.added|length == 2
@@ -89,7 +89,7 @@
       register: gitlab_group_label_create_idempotence
 
     - name: Group label - Test Create Label is Idempotent
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_group_label_create_idempotence is not changed
 
@@ -105,7 +105,7 @@
       register: gitlab_group_label_update
 
     - name: Group label - Test Label Updated
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_group_label_update.labels.added|length == 0
           - gitlab_group_label_update.labels.untouched|length == 0
@@ -125,7 +125,7 @@
       register: gitlab_group_label_new_name
 
     - name: Group label - Test Label name changed
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_group_label_new_name.labels.added|length == 0
           - gitlab_group_label_new_name.labels.untouched|length == 0
@@ -145,7 +145,7 @@
       register: gitlab_group_label_orig_name
 
     - name: Group label - Test Label name changed back
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_group_label_orig_name.labels.added|length == 0
           - gitlab_group_label_orig_name.labels.untouched|length == 0
@@ -166,7 +166,7 @@
       register: gitlab_group_label_update_additions
 
     - name: Group label - Test Label Updated ( Additions )
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_group_label_update_additions.labels.added|length == 0
           - gitlab_group_label_update_additions.labels.untouched|length == 0
@@ -185,7 +185,7 @@
       register: gitlab_group_label_delete
 
     - name: Group label - Test label is deleted
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_group_label_delete is changed
           - gitlab_group_label_delete.labels.added|length == 0
@@ -207,7 +207,7 @@
       register: gitlab_group_label_create_purging
 
     - name: Group label - Test Label Created again
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_group_label_create_purging is changed
           - gitlab_group_label_create_purging.labels.added|length == 1
@@ -251,7 +251,7 @@
       register: gitlab_first_label_state
 
     - name: Check_mode state must be changed
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_label_state is changed
 
@@ -271,7 +271,7 @@
       register: gitlab_first_label_create
 
     - name: Test Label Created
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_label_create is changed
           - gitlab_first_label_create.labels.added|length == 2
@@ -295,7 +295,7 @@
       register: gitlab_first_label_create_idempotence
 
     - name: Test Create Label is Idempotent
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_label_create_idempotence is not changed
 
@@ -311,7 +311,7 @@
       register: gitlab_first_label_update
 
     - name: Test Label Updated
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_label_update.labels.added|length == 0
           - gitlab_first_label_update.labels.untouched|length == 0
@@ -331,7 +331,7 @@
       register: gitlab_first_label_new_name
 
     - name: Test Label name changed
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_label_new_name.labels.added|length == 0
           - gitlab_first_label_new_name.labels.untouched|length == 0
@@ -351,7 +351,7 @@
       register: gitlab_first_label_orig_name
 
     - name: Test Label name changed back
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_label_orig_name.labels.added|length == 0
           - gitlab_first_label_orig_name.labels.untouched|length == 0
@@ -372,7 +372,7 @@
       register: gitlab_first_label_update_additions
 
     - name: Test Label Updated ( Additions )
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_label_update_additions.labels.added|length == 0
           - gitlab_first_label_update_additions.labels.untouched|length == 0
@@ -391,7 +391,7 @@
       register: gitlab_first_label_delete
 
     - name: Test label is deleted
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_label_delete is changed
           - gitlab_first_label_delete.labels.added|length == 0
@@ -413,7 +413,7 @@
       register: gitlab_first_label_create_purging
 
     - name: Test Label Created again
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_label_create_purging is changed
           - gitlab_first_label_create_purging.labels.added|length == 1
@@ -437,7 +437,7 @@
       register: gitlab_first_label_always_delete
 
     - name: Test label are deleted
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_label_always_delete is changed
           - gitlab_first_label_always_delete.labels.added|length == 0

--- a/tests/integration/targets/gitlab_merge_request/tasks/main.yml
+++ b/tests/integration/targets/gitlab_merge_request/tasks/main.yml
@@ -52,7 +52,7 @@
       register: gitlab_merge_request_create
 
     - name: Test Merge Request Created
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_merge_request_create is changed
 
@@ -74,7 +74,7 @@
       register: gitlab_merge_request_create_idempotence
 
     - name: Test module is idempotent
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_merge_request_create_idempotence is not changed
 
@@ -96,7 +96,7 @@
       register: gitlab_merge_request_udpate
 
     - name: Test merge request updated
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_merge_request_udpate.mr.labels[0] == "{{ gitlab_labels }}"
           - gitlab_merge_request_udpate.mr.assignees[0].username == "{{ gitlab_assignee_ids }}"
@@ -114,7 +114,7 @@
       register: gitlab_merge_request_delete
 
     - name: Test merge request is deleted
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_merge_request_delete is changed
 

--- a/tests/integration/targets/gitlab_milestone/tasks/main.yml
+++ b/tests/integration/targets/gitlab_milestone/tasks/main.yml
@@ -43,7 +43,7 @@
       register: gitlab_group_milestone_state
 
     - name: Group milestone - Check_mode state must be changed
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_group_milestone_state is changed
 
@@ -69,7 +69,7 @@
       register: gitlab_group_milestone_create
 
     - name: Group milestone - Test milestone Created
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_group_milestone_create is changed
           - gitlab_group_milestone_create.milestones.added|length == 2
@@ -92,7 +92,7 @@
       register: gitlab_group_milestone_create_idempotence
 
     - name: Group milestone - Test Create milestone is Idempotent
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_group_milestone_create_idempotence is not changed
 
@@ -109,7 +109,7 @@
       register: gitlab_group_milestone_update
 
     - name: Group milestone - Test milestone Updated
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_group_milestone_update.milestones.added|length == 0
           - gitlab_group_milestone_update.milestones.untouched|length == 0
@@ -129,7 +129,7 @@
       register: gitlab_group_milestone_update_additions
 
     - name: Group milestone - Test milestone Updated ( Additions )
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_group_milestone_update_additions.milestones.added|length == 0
           - gitlab_group_milestone_update_additions.milestones.untouched|length == 0
@@ -148,7 +148,7 @@
       register: gitlab_group_milestone_delete
 
     - name: Group milestone - Test milestone is deleted
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_group_milestone_delete is changed
           - gitlab_group_milestone_delete.milestones.added|length == 0
@@ -169,7 +169,7 @@
       register: gitlab_group_milestone_create_purging
 
     - name: Group milestone - Test milestone Created again
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_group_milestone_create_purging is changed
           - gitlab_group_milestone_create_purging.milestones.added|length == 1
@@ -220,7 +220,7 @@
       register: gitlab_first_milestone_state
 
     - name: Check_mode state must be changed
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_milestone_state is changed
 
@@ -238,7 +238,7 @@
       register: gitlab_milestones_create
 
     - name: Test milestone Created
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_milestones_create is changed
           - gitlab_milestones_create.milestones.added|length == 2
@@ -261,7 +261,7 @@
       register: gitlab_first_milestone_create_idempotence
 
     - name: Test Create milestone is Idempotent
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_milestone_create_idempotence is not changed
 
@@ -278,7 +278,7 @@
       register: gitlab_first_milestone_update
 
     - name: Test milestone Updated
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_milestone_update.milestones.added|length == 0
           - gitlab_first_milestone_update.milestones.untouched|length == 0
@@ -298,7 +298,7 @@
       register: gitlab_first_milestone_update_additions
 
     - name: Test milestone Updated ( Additions )
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_milestone_update_additions.milestones.added|length == 0
           - gitlab_first_milestone_update_additions.milestones.untouched|length == 0
@@ -317,7 +317,7 @@
       register: gitlab_first_milestone_delete
 
     - name: Test milestone is deleted
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_milestone_delete is changed
           - gitlab_first_milestone_delete.milestones.added|length == 0
@@ -338,7 +338,7 @@
       register: gitlab_first_milestone_create_purging
 
     - name: Test milestone Created again
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_milestone_create_purging is changed
           - gitlab_first_milestone_create_purging.milestones.added|length == 1
@@ -362,7 +362,7 @@
       register: gitlab_first_milestone_always_delete
 
     - name: Test milestone are deleted
-      assert:
+      ansible.builtin.assert:
         that:
           - gitlab_first_milestone_always_delete is changed
           - gitlab_first_milestone_always_delete.milestones.added|length == 0

--- a/tests/integration/targets/gitlab_project/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project/tasks/main.yml
@@ -31,7 +31,7 @@
     state: present
   register: gitlab_project_state
 
-- assert:
+- ansible.builtin.assert:
     that:
       - gitlab_project_state is changed
 
@@ -44,6 +44,6 @@
     state: present
   register: gitlab_project_state_again
 
-- assert:
+- ansible.builtin.assert:
     that:
       - gitlab_project_state_again is not changed

--- a/tests/integration/targets/gitlab_project_access_token/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_access_token/tasks/main.yml
@@ -30,7 +30,7 @@
       register: create_pfail_token_status
   always:
     - name: Assert that token creation in nonexisting project failed
-      assert:
+      ansible.builtin.assert:
         that:
           - create_pfail_token_status is failed
   ignore_errors: true
@@ -52,7 +52,7 @@
       register: create_efail_token_status
   always:
     - name: Assert that token creation with invalid expires_at failed
-      assert:
+      ansible.builtin.assert:
         that:
           - create_efail_token_status is failed
   ignore_errors: true
@@ -72,7 +72,7 @@
       - read_api
   register: create_token_status
 - name: Assert that token creation with valid arguments is successfull
-  assert:
+  ansible.builtin.assert:
     that:
       - create_token_status is changed
       - create_token_status.access_token.token is defined
@@ -92,7 +92,7 @@
       - read_api
   register: check_token_status
 - name: Assert that token creation without changes and recreate=never succeeds with status not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - check_token_status is not changed
       - check_token_status.access_token.token is not defined
@@ -113,7 +113,7 @@
     recreate: state_change
   register: check_recreate_token_status
 - name: Assert that token creation without changes and recreate=state_change succeeds with status not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - check_recreate_token_status is not changed
       - check_recreate_token_status.access_token.token is not defined
@@ -135,7 +135,7 @@
       register: change_token_status
   always:
     - name: Assert that token change with recreate=never fails
-      assert:
+      ansible.builtin.assert:
         that:
           - change_token_status is failed
   ignore_errors: true
@@ -156,7 +156,7 @@
     recreate: state_change
   register: change_recreate_token_status
 - name: Assert that token change with recreate=state_change succeeds
-  assert:
+  ansible.builtin.assert:
     that:
       - change_recreate_token_status is changed
       - change_recreate_token_status.access_token.token is defined
@@ -177,7 +177,7 @@
     recreate: always
   register: change_recreate1_token_status
 - name: Assert that token change with recreate=always succeeds
-  assert:
+  ansible.builtin.assert:
     that:
       - change_recreate1_token_status is changed
       - change_recreate1_token_status.access_token.token is defined
@@ -197,7 +197,7 @@
       - read_api
   register: revoke_token_status
 - name: Assert that token revocation succeeds
-  assert:
+  ansible.builtin.assert:
     that:
       - revoke_token_status is changed
 
@@ -216,6 +216,6 @@
       - read_api
   register: revoke_token_status
 - name: Assert that token revocation succeeds with status not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - revoke_token_status is not changed

--- a/tests/integration/targets/gitlab_project_approvals/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_approvals/tasks/main.yml
@@ -29,7 +29,7 @@
     require_reauthentication_to_approve: true
   register: approval_result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - approval_result is changed
 
@@ -49,7 +49,7 @@
     require_reauthentication_to_approve: true
   register: approval_result_idem
 
-- assert:
+- ansible.builtin.assert:
     that:
       - approval_result_idem is not changed
 
@@ -69,6 +69,6 @@
     require_reauthentication_to_approve: false
   register: approval_result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - approval_result is changed

--- a/tests/integration/targets/gitlab_project_badge/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_badge/tasks/main.yml
@@ -38,7 +38,7 @@
     var: gitlab_badge_create_check_task
 
 - name: Check module call result
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_badge_create_check_task.changed
       - not gitlab_badge_create_check_task.failed
@@ -58,7 +58,7 @@
     var: gitlab_badge_create_task
 
 - name: Check module call result
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_badge_create_task.changed
       - not gitlab_badge_create_task.failed
@@ -78,7 +78,7 @@
     var: gitlab_badge_create_confirmation_task
 
 - name: Check module call result
-  assert:
+  ansible.builtin.assert:
     that:
       - not gitlab_badge_create_confirmation_task.changed
       - not gitlab_badge_create_confirmation_task.failed
@@ -99,7 +99,7 @@
     var: gitlab_badge_update_check_task
 
 - name: Check module call result
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_badge_update_check_task.changed
       - not gitlab_badge_update_check_task.failed
@@ -119,7 +119,7 @@
     var: gitlab_badge_update_task
 
 - name: Check module call result
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_badge_update_task.changed
       - not gitlab_badge_update_task.failed
@@ -139,7 +139,7 @@
     var: gitlab_badge_update_confirmation_task
 
 - name: Check module call result
-  assert:
+  ansible.builtin.assert:
     that:
       - not gitlab_badge_update_confirmation_task.changed
       - not gitlab_badge_update_confirmation_task.failed
@@ -160,7 +160,7 @@
     var: gitlab_badge_delete_check_task
 
 - name: Check module call result
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_badge_delete_check_task.changed
       - not gitlab_badge_delete_check_task.failed
@@ -180,7 +180,7 @@
     var: gitlab_badge_delete_task
 
 - name: Check module call result
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_badge_delete_task.changed
       - not gitlab_badge_delete_task.failed
@@ -200,7 +200,7 @@
     var: gitlab_badge_delete_confirmation_task
 
 - name: Check module call result
-  assert:
+  ansible.builtin.assert:
     that:
       - not gitlab_badge_delete_confirmation_task.changed
       - not gitlab_badge_delete_confirmation_task.failed

--- a/tests/integration/targets/gitlab_project_members/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_members/tasks/main.yml
@@ -34,7 +34,7 @@
   register: gitlab_project_members_state
 
 - name: Test member added to project
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_members_state is changed
 
@@ -49,7 +49,7 @@
   register: gitlab_project_members_state_again
 
 - name: Test module is idempotent
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_members_state_again is not changed
 
@@ -64,7 +64,7 @@
   register: remove_gitlab_project_members_state
 
 - name: Test member removed from project
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_gitlab_project_members_state is changed
 
@@ -79,7 +79,7 @@
   register: remove_gitlab_project_members_state_again
 
 - name: Test module is idempotent
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_gitlab_project_members_state_again is not changed
 

--- a/tests/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -31,7 +31,7 @@
   register: gitlab_project_variable_state
 
 - name: check_mode state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is changed
 
@@ -46,7 +46,7 @@
   register: gitlab_project_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is changed
 
@@ -61,7 +61,7 @@
   register: gitlab_project_variable_state
 
 - name: state must be not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is not changed
 
@@ -77,7 +77,7 @@
   register: gitlab_project_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is changed
 
@@ -93,7 +93,7 @@
   register: gitlab_project_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is changed
 
@@ -109,7 +109,7 @@
   register: gitlab_project_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is changed
 
@@ -124,7 +124,7 @@
   register: gitlab_project_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is changed
 
@@ -139,7 +139,7 @@
   register: gitlab_project_variable_state
 
 - name: state must be not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is not changed
 
@@ -157,7 +157,7 @@
   register: gitlab_project_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is changed
 
@@ -175,7 +175,7 @@
   register: gitlab_project_variable_state
 
 - name: state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is not changed
 
@@ -191,7 +191,7 @@
   register: gitlab_project_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is changed
 
@@ -206,7 +206,7 @@
   register: gitlab_project_variable_state
 
 - name: check_mode state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is not changed
 
@@ -220,7 +220,7 @@
   register: gitlab_project_variable_state
 
 - name: state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is not changed
 
@@ -236,7 +236,7 @@
   register: gitlab_project_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is changed
 
@@ -252,7 +252,7 @@
   register: gitlab_project_variable_state
 
 - name: state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is not changed
 
@@ -274,7 +274,7 @@
   register: gitlab_project_variable_state
 
 - name: set two test variables state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is changed
       - gitlab_project_variable_state.project_variable.added|length == 2
@@ -293,7 +293,7 @@
   register: gitlab_project_variable_state
 
 - name: re-set two test variables state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is not changed
       - gitlab_project_variable_state.project_variable.added|length == 0
@@ -312,7 +312,7 @@
   register: gitlab_project_variable_state
 
 - name: edit one variable state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state.changed
       - gitlab_project_variable_state.project_variable.added|length == 0
@@ -332,7 +332,7 @@
   register: gitlab_project_variable_state
 
 - name: append one variable state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state.changed
       - gitlab_project_variable_state.project_variable.added|length == 1
@@ -353,7 +353,7 @@
   register: gitlab_project_variable_state
 
 - name: re-set all variables state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - not gitlab_project_variable_state.changed
       - gitlab_project_variable_state.project_variable.added|length == 0
@@ -372,7 +372,7 @@
   register: gitlab_project_variable_state
 
 - name: set one variables and purge all others state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state.changed
       - gitlab_project_variable_state.project_variable.added|length == 0
@@ -391,7 +391,7 @@
   register: gitlab_project_variable_state
 
 - name: only one variable is left state must not be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - not gitlab_project_variable_state.changed
       - gitlab_project_variable_state.project_variable.added|length == 0
@@ -411,7 +411,7 @@
   register: gitlab_project_variable_state
 
 - name: only one variable is left state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state.changed
       - gitlab_project_variable_state.project_variable.added|length == 0
@@ -430,7 +430,7 @@
   register: gitlab_project_variable_state
 
 - name: only one variable is left state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state.changed
       - gitlab_project_variable_state.project_variable.added|length == 0
@@ -449,7 +449,7 @@
   register: gitlab_project_variable_state
 
 - name: no variable is left state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state.changed
       - gitlab_project_variable_state.project_variable.added|length == 0
@@ -471,7 +471,7 @@
   register: gitlab_project_variable_state
 
 - name: append one variable state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state.changed
       - gitlab_project_variable_state.project_variable.added|length == 1
@@ -493,7 +493,7 @@
   register: gitlab_project_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is changed
 
@@ -509,7 +509,7 @@
   register: gitlab_project_variable_state
 
 - name: state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is changed
 
@@ -524,7 +524,7 @@
   register: gitlab_project_variable_state
 
 - name: no variable is left state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state.changed
       - gitlab_project_variable_state.project_variable.added|length == 0
@@ -563,7 +563,7 @@
   register: gitlab_project_variable_state
 
 - name: complete page added state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is changed
       - gitlab_project_variable_state.project_variable.added|length == 20
@@ -599,7 +599,7 @@
   register: gitlab_project_variable_state
 
 - name: existing page untouched state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state is changed
       - gitlab_project_variable_state.project_variable.added|length == 20
@@ -614,7 +614,7 @@
   register: gitlab_project_variable_state
 
 - name: check that no variables are untouched state must be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state.changed
       - gitlab_project_variable_state.project_variable.added|length == 0
@@ -644,7 +644,7 @@
   register: gitlab_project_variable_state
 
 - name: verify two vars
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state.changed
       - gitlab_project_variable_state.project_variable.added|length == 2
@@ -663,7 +663,7 @@
   ignore_errors: true
 
 - name: verify fail
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state.failed
       - gitlab_project_variable_state is not changed
@@ -680,7 +680,7 @@
   register: gitlab_project_variable_state
 
 - name: verify the change
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state.changed
 
@@ -695,7 +695,7 @@
   register: gitlab_project_variable_state
 
 - name: verify deletion
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_project_variable_state.changed
       - gitlab_project_variable_state.project_variable.removed|length == 1

--- a/tests/integration/targets/gitlab_runner/tasks/main.yml
+++ b/tests/integration/targets/gitlab_runner/tasks/main.yml
@@ -41,7 +41,7 @@
   register: gitlab_runner_state
 
 - name: Test group created
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_runner_state is changed
 
@@ -58,7 +58,7 @@
 #   register: gitlab_runner_state_again
 
 # - name: Test module is idempotent
-#   assert:
+#   ansible.builtin.assert:
 #     that:
 #       - gitlab_runner_state_again is not changed
 
@@ -73,6 +73,6 @@
   register: gitlab_runner_state_absent
 
 - name: Assert runner has been removed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_runner_state_absent is changed

--- a/tests/integration/targets/gitlab_user/tasks/main.yml
+++ b/tests/integration/targets/gitlab_user/tasks/main.yml
@@ -38,7 +38,7 @@
   register: gitlab_user_state
 
 - name: Check user has been created correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_state is changed
 
@@ -55,7 +55,7 @@
   register: gitlab_user_state_again
 
 - name: Check state is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_state_again is not changed
       - gitlab_user_state_again.user.is_admin == False
@@ -74,7 +74,7 @@
   register: gitlab_user_state
 
 - name: Check if user is admin now
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_state is changed
       - gitlab_user_state.user.is_admin == True
@@ -92,7 +92,7 @@
   register: gitlab_user_state
 
 - name: Check state is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_state is not changed
       - gitlab_user_state.user.is_admin == True
@@ -110,7 +110,7 @@
   register: gitlab_user_state
 
 - name: Check if user is not admin anymore
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_state is changed
       - gitlab_user_state.user.is_admin == False
@@ -129,7 +129,7 @@
   register: gitlab_user_state
 
 - name: Check that eMail is unchanged (Only works with confirmation skipping)
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_state is changed
       - gitlab_user_state.user.email == gitlab_user_email
@@ -147,7 +147,7 @@
   register: gitlab_user_state
 
 - name: Check that mail has changed now
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_state is changed
       - gitlab_user_state.user.email == 'foo@bar.baz'
@@ -165,7 +165,7 @@
   register: gitlab_user_state
 
 - name: Check state is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_state is not changed
       - gitlab_user_state.user.email == 'foo@bar.baz'
@@ -183,7 +183,7 @@
   register: gitlab_user_state
 
 - name: Check that reverting mail back to original has worked
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_state is changed
       - gitlab_user_state.user.email == gitlab_user_email
@@ -208,7 +208,7 @@
   register: gitlab_user_state
 
 - name: Check PW setting return state
-  assert:
+  ansible.builtin.assert:
     that:
         # note: there is no way to determine if a password has changed or
         #   not, so it can only be always yellow or always green, we
@@ -231,7 +231,7 @@
   register: gitlab_user_state
 
 - name: Check PW setting return state (Again)
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_state is not changed
 
@@ -250,7 +250,7 @@
   register: gitlab_user_state
 
 - name: Check PW setting return state (Reset)
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_state is not changed
 

--- a/tests/integration/targets/gitlab_user/tasks/sshkey.yml
+++ b/tests/integration/targets/gitlab_user/tasks/sshkey.yml
@@ -23,7 +23,7 @@
   register: gitlab_user_sshkey
 
 - name: Check user has been created correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_sshkey is changed
 
@@ -42,7 +42,7 @@
   register: gitlab_user_sshkey_again
 
 - name: Check state is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_sshkey_again is not changed
 
@@ -62,7 +62,7 @@
   register: gitlab_user_sshkey_updated
 
 - name: Check ssh key has been updated
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_sshkey_updated is changed
 
@@ -82,7 +82,7 @@
   register: gitlab_user_sshkey_updated_again
 
 - name: Check updated ssh key is idempotent
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_sshkey_updated_again is not changed
 
@@ -103,7 +103,7 @@
   register: gitlab_user_created_user_sshkey_expires_at
 
 - name: Check expires_at will not be added to a present ssh key
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_created_user_sshkey_expires_at is not changed
 
@@ -119,7 +119,7 @@
   register: gitlab_user_sshkey_remove
 
 - name: Check user has been removed correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_sshkey_remove is changed
 
@@ -139,7 +139,7 @@
   register: gitlab_user_sshkey_expires_at
 
 - name: Check user has been created correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_sshkey_expires_at is changed
 
@@ -159,7 +159,7 @@
   register: gitlab_user_sshkey_expires_at_again
 
 - name: Check state is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_sshkey_expires_at_again is not changed
 
@@ -175,6 +175,6 @@
   register: gitlab_user_sshkey_expires_at_remove
 
 - name: Check user has been removed correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - gitlab_user_sshkey_expires_at_remove is changed

--- a/tests/integration/targets/golang_package/tasks/test_general.yml
+++ b/tests/integration/targets/golang_package/tasks/test_general.yml
@@ -37,7 +37,7 @@
   register: uninstall_idem
 
 - name: Check assertions
-  assert:
+  ansible.builtin.assert:
     that:
       - uninstall_absent is not changed
       - install_result is changed

--- a/tests/integration/targets/golang_package/tasks/test_version.yml
+++ b/tests/integration/targets/golang_package/tasks/test_version.yml
@@ -39,7 +39,7 @@
     state: absent
 
 - name: Check assertions
-  assert:
+  ansible.builtin.assert:
     that:
       - install_version is changed
       - install_version_idem is not changed

--- a/tests/integration/targets/hg/tasks/install.yml
+++ b/tests/integration/targets/hg/tasks/install.yml
@@ -79,6 +79,6 @@
   register: current_python_version
 
 - name: verify the python version has not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - default_python_version.stdout == current_python_version.stdout

--- a/tests/integration/targets/hg/tasks/run-tests.yml
+++ b/tests/integration/targets/hg/tasks/run-tests.yml
@@ -24,7 +24,7 @@
 - shell: ls {{ checkout_dir }}
 
 - name: verify information about the initial clone
-  assert:
+  ansible.builtin.assert:
     that:
       - "'before' in hg_result"
       - "'after' in hg_result"
@@ -50,13 +50,13 @@
   register: branches
 
 - name: assert presence of tags/trunk/branches
-  assert:
+  ansible.builtin.assert:
     that:
       - "hg_tags.stat.isreg"
       - "branches.stat.isreg"
 
 - name: verify on a re-clone things are marked unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - "not hg_result2.changed"
 
@@ -69,7 +69,7 @@
   ignore_errors: true
 
 - name: Verify result of non-existent repo clone
-  assert:
+  ansible.builtin.assert:
     that:
       - "'abort: HTTP Error' in hg_result3.msg"
       - "not hg_result3.changed"

--- a/tests/integration/targets/homebrew/tasks/casks.yml
+++ b/tests/integration/targets/homebrew/tasks/casks.yml
@@ -28,7 +28,7 @@
 #   environment:
 #     HOMEBREW_NO_AUTO_UPDATE: True
 
-# - assert:
+# - ansible.builtin.assert:
 #     that:
 #       - upgrade_option_result.changed
 
@@ -53,7 +53,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is changed
 
@@ -66,7 +66,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is not changed
 
@@ -79,7 +79,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is changed
 
@@ -92,6 +92,6 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is not changed

--- a/tests/integration/targets/homebrew/tasks/formulae.yml
+++ b/tests/integration/targets/homebrew/tasks/formulae.yml
@@ -28,7 +28,7 @@
 #   environment:
 #     HOMEBREW_NO_AUTO_UPDATE: True
 
-# - assert:
+# - ansible.builtin.assert:
 #     that:
 #       - upgrade_option_result.changed
 
@@ -51,7 +51,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is changed
           - "package_result.msg == 'Package installed: gnu-tar'"
@@ -66,7 +66,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is not changed
           - "package_result.msg == 'Package already installed: gnu-tar'"
@@ -81,7 +81,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is changed
           - "package_result.msg == 'Package unlinked: gnu-tar'"
@@ -96,7 +96,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is changed
           - "package_result.msg == 'Package linked: gnu-tar'"
@@ -111,7 +111,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is changed
           - "package_result.msg == 'Package uninstalled: gnu-tar'"
@@ -126,7 +126,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is not changed
           - "package_result.msg == 'Package already uninstalled: gnu-tar'"
@@ -141,7 +141,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is changed
           - "package_result.msg == 'Package upgraded: gnu-tar'"
@@ -156,7 +156,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is not changed
           - "package_result.msg == 'Package already upgraded: gnu-tar'"
@@ -191,7 +191,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is changed
           - "package_result.msg == 'Changed: 1, Unchanged: 1'"
@@ -206,7 +206,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is not changed
           - "package_result.msg == 'Changed: 0, Unchanged: 2'"
@@ -221,7 +221,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is changed
           - "package_result.msg == 'Changed: 2, Unchanged: 0'"
@@ -236,7 +236,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is changed
           - "package_result.msg == 'Changed: 2, Unchanged: 0'"
@@ -251,7 +251,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is changed
           - "package_result.msg == 'Changed: 2, Unchanged: 0'"
@@ -266,7 +266,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is not changed
           - "package_result.msg == 'Changed: 0, Unchanged: 2'"
@@ -281,7 +281,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is changed
           - "package_result.msg == 'Changed: 2, Unchanged: 0'"
@@ -296,7 +296,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is not changed
           - "package_result.msg == 'Changed: 0, Unchanged: 2'"
@@ -325,7 +325,7 @@
       become: true
       become_user: "{{ brew_stat.stat.pw_name }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - terraform_install_result is changed
           - "terraform_install_result.msg == 'Package upgraded: hashicorp/tap/terraform'"
@@ -349,7 +349,7 @@
       become: true
       become_user: "{{ brew_stat.stat.pw_name }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - terraform_install_result is changed
           - "terraform_install_result.msg == 'Package upgraded: hashicorp/tap/terraform'"
@@ -378,7 +378,7 @@
       become: true
       become_user: "{{ brew_stat.stat.pw_name }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - ascii_install_result is changed
           - "ascii_install_result.msg == 'Package upgraded: thezoraiz/ascii-image-converter/ascii-image-converter'"
@@ -393,7 +393,7 @@
       become: true
       become_user: "{{ brew_stat.stat.pw_name }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - ascii_reinstall_result is not changed
           - "ascii_reinstall_result.msg == 'Package already upgraded: thezoraiz/ascii-image-converter/ascii-image-converter'"
@@ -408,7 +408,7 @@
       become: true
       become_user: "{{ brew_stat.stat.pw_name }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - ascii_uninstall_result is changed
           - "ascii_uninstall_result.msg == 'Package uninstalled: thezoraiz/ascii-image-converter/ascii-image-converter'"
@@ -424,7 +424,7 @@
       become: true
       become_user: "{{ brew_stat.stat.pw_name }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - ascii_again_uninstall_result is not changed
           - "ascii_again_uninstall_result.msg == 'Package already uninstalled: thezoraiz/ascii-image-converter/ascii-image-converter'"
@@ -439,7 +439,7 @@
       become: true
       become_user: "{{ brew_stat.stat.pw_name }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - ascii_install_result is changed
           - "ascii_install_result.msg == 'Package upgraded: ascii-image-converter'"

--- a/tests/integration/targets/homebrew/tasks/package_names_item.yml
+++ b/tests/integration/targets/homebrew/tasks/package_names_item.yml
@@ -26,7 +26,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is changed
           - package_result.changed_pkgs[0] == package[1]
@@ -42,7 +42,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is not changed
           - 'package_result.msg == "Package already installed: " ~ package[1]'
@@ -56,7 +56,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: package_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - package_result is changed
           - 'package_result.msg == "Package uninstalled: " ~ package[1]'

--- a/tests/integration/targets/homebrew_cask/tasks/main.yml
+++ b/tests/integration/targets/homebrew_cask/tasks/main.yml
@@ -29,7 +29,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: cask_install_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - cask_install_result is changed
           - "'Cask installed' in cask_install_result.msg"
@@ -42,7 +42,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: cask_install_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - cask_install_result is not changed
           - "'Cask installed' not in cask_install_result.msg"
@@ -57,7 +57,7 @@
       become_user: "{{ brew_stat.stat.pw_name }}"
       register: cask_install_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - cask_install_result is changed
           - "'Cask installed' in cask_install_result.msg"

--- a/tests/integration/targets/homebrew_services/tasks/main.yml
+++ b/tests/integration/targets/homebrew_services/tasks/main.yml
@@ -29,7 +29,7 @@
         - uninstall black
 
     - name: Check the black service is installed
-      assert:
+      ansible.builtin.assert:
         that:
           - install_result is success
 
@@ -42,7 +42,7 @@
         HOMEBREW_NO_ENV_HINTS: "1"
 
     - name: Check the black service is running
-      assert:
+      ansible.builtin.assert:
         that:
           - start_result is success
 
@@ -55,7 +55,7 @@
         HOMEBREW_NO_ENV_HINTS: "1"
 
     - name: Check for idempotency
-      assert:
+      ansible.builtin.assert:
         that:
           - start_result.changed == 0
 
@@ -68,7 +68,7 @@
         HOMEBREW_NO_ENV_HINTS: "1"
 
     - name: Check the black service is restarted
-      assert:
+      ansible.builtin.assert:
         that:
           - restart_result is success
 
@@ -81,6 +81,6 @@
         HOMEBREW_NO_ENV_HINTS: "1"
 
     - name: Check the black service is stopped
-      assert:
+      ansible.builtin.assert:
         that:
           - stop_result is success

--- a/tests/integration/targets/homectl/tasks/main.yml
+++ b/tests/integration/targets/homectl/tasks/main.yml
@@ -169,7 +169,7 @@
       ignore_errors: true
       register: jake_incorrect_pass_out
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - james_info.rc == 0
           - tom_userinfo.data['gid'] == 1000 and tom_userinfo.data['uid'] == 1000

--- a/tests/integration/targets/hwc_ecs_instance/tasks/main.yml
+++ b/tests/integration/targets/hwc_ecs_instance/tasks/main.yml
@@ -87,7 +87,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------
@@ -114,7 +114,7 @@
     state: present
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       result is changed
 # ----------------------------------------------------------
@@ -142,7 +142,7 @@
   check_mode: true
   register: result
 - name: idemponent
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.changed
 # ----------------------------------------------------------------------------
@@ -169,7 +169,7 @@
     state: present
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed
@@ -198,7 +198,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------
@@ -225,7 +225,7 @@
     state: absent
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       result is changed
 # ----------------------------------------------------------
@@ -252,7 +252,7 @@
     state: absent
   register: result
 - name: idemponent
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.changed
 # ----------------------------------------------------------------------------
@@ -279,7 +279,7 @@
     state: absent
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed

--- a/tests/integration/targets/hwc_evs_disk/tasks/main.yml
+++ b/tests/integration/targets/hwc_evs_disk/tasks/main.yml
@@ -25,7 +25,7 @@
     state: present
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       result is changed
 # ------------------------------------------------------------
@@ -39,7 +39,7 @@
   register: result
   check_mode: true
 - name: verify results of test create a disk in check mode
-  assert:
+  ansible.builtin.assert:
     that:
       result is changed
 # ----------------------------------------------------------------------------
@@ -52,7 +52,7 @@
     state: present
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed
@@ -67,7 +67,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       result is changed
 # ----------------------------------------------------------
@@ -80,7 +80,7 @@
     state: absent
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       result is changed
 # ----------------------------------------------------------------------------
@@ -94,7 +94,7 @@
   check_mode: true
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 # ----------------------------------------------------------------------------
@@ -107,7 +107,7 @@
     state: absent
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed

--- a/tests/integration/targets/hwc_network_vpc/tasks/main.yml
+++ b/tests/integration/targets/hwc_network_vpc/tasks/main.yml
@@ -47,7 +47,7 @@
     state: present
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------------------------
@@ -64,7 +64,7 @@
     state: present
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed
@@ -82,7 +82,7 @@
     state: absent
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------------------------
@@ -99,7 +99,7 @@
     state: absent
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed

--- a/tests/integration/targets/hwc_smn_topic/tasks/main.yml
+++ b/tests/integration/targets/hwc_smn_topic/tasks/main.yml
@@ -31,7 +31,7 @@
     state: present
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------------------------
@@ -47,7 +47,7 @@
     state: present
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed
@@ -64,7 +64,7 @@
     state: absent
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------------------------
@@ -80,7 +80,7 @@
     state: absent
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed

--- a/tests/integration/targets/hwc_vpc_eip/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_eip/tasks/main.yml
@@ -52,7 +52,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------
@@ -67,7 +67,7 @@
     state: present
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       result is changed
 # ----------------------------------------------------------
@@ -83,7 +83,7 @@
   check_mode: true
   register: result
 - name: idemponent
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.changed
 # ----------------------------------------------------------------------------
@@ -98,7 +98,7 @@
     state: present
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed
@@ -115,7 +115,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------
@@ -130,7 +130,7 @@
     state: absent
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------
@@ -146,7 +146,7 @@
   check_mode: true
   register: result
 - name: idemponent
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.changed
 # ----------------------------------------------------------------------------
@@ -161,7 +161,7 @@
     state: absent
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed

--- a/tests/integration/targets/hwc_vpc_peering_connect/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_peering_connect/tasks/main.yml
@@ -39,7 +39,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.id
       - result.changed
@@ -53,7 +53,7 @@
     state: present
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       result is changed
 # ----------------------------------------------------------
@@ -67,7 +67,7 @@
   check_mode: true
   register: result
 - name: idemponent
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.changed
 # ----------------------------------------------------------------------------
@@ -80,7 +80,7 @@
     state: present
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed
@@ -95,7 +95,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       result is changed
 # ----------------------------------------------------------
@@ -108,7 +108,7 @@
     state: absent
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       result is changed
 # ----------------------------------------------------------
@@ -122,7 +122,7 @@
   check_mode: true
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.changed
 # ----------------------------------------------------------------------------
@@ -135,7 +135,7 @@
     state: absent
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed

--- a/tests/integration/targets/hwc_vpc_port/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_port/tasks/main.yml
@@ -38,7 +38,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------
@@ -49,7 +49,7 @@
     state: present
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------
@@ -60,7 +60,7 @@
     state: present
   register: result
 - name: idemponent
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.changed
 # ----------------------------------------------------------------------------
@@ -71,7 +71,7 @@
     state: present
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed
@@ -84,7 +84,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------
@@ -95,7 +95,7 @@
     state: absent
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------
@@ -107,7 +107,7 @@
   check_mode: true
   register: result
 - name: idemponent
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.changed
 # ----------------------------------------------------------------------------
@@ -118,7 +118,7 @@
     state: absent
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed

--- a/tests/integration/targets/hwc_vpc_private_ip/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_private_ip/tasks/main.yml
@@ -38,7 +38,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------
@@ -49,7 +49,7 @@
     state: present
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------
@@ -61,7 +61,7 @@
   check_mode: true
   register: result
 - name: idemponent
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.changed
 # ----------------------------------------------------------------------------
@@ -72,7 +72,7 @@
     state: present
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed
@@ -85,7 +85,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------
@@ -96,7 +96,7 @@
     state: absent
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------
@@ -108,7 +108,7 @@
   check_mode: true
   register: result
 - name: idemponent
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.changed
 # ----------------------------------------------------------------------------
@@ -119,7 +119,7 @@
     state: absent
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed

--- a/tests/integration/targets/hwc_vpc_route/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_route/tasks/main.yml
@@ -45,7 +45,7 @@
     next_hop: "{{ connect.id }}"
   check_mode: true
   register: result
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.id
       - result.changed
@@ -58,7 +58,7 @@
     state: present
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       result is changed
 # ----------------------------------------------------------
@@ -71,7 +71,7 @@
   check_mode: true
   register: result
 - name: idemponent
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.changed
 # -----------------------------------------------------------
@@ -83,7 +83,7 @@
     state: present
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed
@@ -104,7 +104,7 @@
     state: absent
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       result is changed
 # ----------------------------------------------------------
@@ -117,7 +117,7 @@
   check_mode: true
   register: result
 - name: not changed
-  assert:
+  ansible.builtin.assert:
     that:
       not result.changed
 # ----------------------------------------------------------------------------
@@ -129,7 +129,7 @@
     state: absent
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed

--- a/tests/integration/targets/hwc_vpc_security_group/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_security_group/tasks/main.yml
@@ -21,7 +21,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.id
       - result.changed
@@ -32,7 +32,7 @@
     state: present
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       result is changed
 # ----------------------------------------------------------
@@ -43,7 +43,7 @@
   check_mode: true
   register: idemponent
 - name: idemponent
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.changed
 # ----------------------------------------------------------------------------
@@ -53,7 +53,7 @@
     state: present
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed
@@ -65,7 +65,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       result is changed
 # ----------------------------------------------------------
@@ -75,7 +75,7 @@
     state: absent
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       result is changed
 # ----------------------------------------------------------------------------
@@ -85,7 +85,7 @@
     state: absent
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed

--- a/tests/integration/targets/hwc_vpc_security_group_rule/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_security_group_rule/tasks/main.yml
@@ -38,7 +38,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.id
       - result.changed
@@ -55,7 +55,7 @@
     state: present
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------
@@ -71,7 +71,7 @@
     state: present
   register: result
 - name: idemponent
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.changed
 # ----------------------------------------------------------------------------
@@ -87,7 +87,7 @@
     state: present
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed
@@ -105,7 +105,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------
@@ -121,7 +121,7 @@
     state: absent
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ----------------------------------------------------------
@@ -137,7 +137,7 @@
     state: absent
   register: result
 - name: idemponent
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.changed
 # ----------------------------------------------------------------------------
@@ -153,7 +153,7 @@
     state: absent
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed

--- a/tests/integration/targets/hwc_vpc_subnet/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_subnet/tasks/main.yml
@@ -35,7 +35,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.id
       - result.changed
@@ -50,7 +50,7 @@
     state: present
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       result is changed
 # ---------------------------------------------------------
@@ -65,7 +65,7 @@
   check_mode: true
   register: result
 - name: idemponent
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.changed
 # ----------------------------------------------------------------------------
@@ -79,7 +79,7 @@
     state: present
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed
@@ -95,7 +95,7 @@
   check_mode: true
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ---------------------------------------------------------
@@ -109,7 +109,7 @@
     state: absent
   register: result
 - name: assert changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 # ---------------------------------------------------------
@@ -124,7 +124,7 @@
   check_mode: true
   register: result
 - name: idemponent
-  assert:
+  ansible.builtin.assert:
     that:
       - not result.changed
 # ----------------------------------------------------------------------------
@@ -138,7 +138,7 @@
     state: absent
   register: result
 - name: assert changed is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed

--- a/tests/integration/targets/influxdb_user/tasks/tests.yml
+++ b/tests/integration/targets/influxdb_user/tasks/tests.yml
@@ -14,7 +14,7 @@
       register: add_admin_user
 
     - name: Check that admin user adding succeeds with a change
-      assert:
+      ansible.builtin.assert:
         that:
           - add_admin_user is changed
 
@@ -25,7 +25,7 @@
       register: add_admin_user
 
     - name: Check that admin user adding succeeds with a change
-      assert:
+      ansible.builtin.assert:
         that:
           - add_admin_user is changed
 
@@ -36,7 +36,7 @@
       register: add_admin_user
 
     - name: Check that admin user adding succeeds without a change
-      assert:
+      ansible.builtin.assert:
         that:
           - add_admin_user is not changed
 
@@ -59,7 +59,7 @@
       register: add_user_with_auth_enabled
 
     - name: Check that adding user with enabled authentication succeeds with a change
-      assert:
+      ansible.builtin.assert:
         that:
           - add_user_with_auth_enabled is changed
 
@@ -70,7 +70,7 @@
       register: add_user_with_auth_enabled
 
     - name: Check that adding user with enabled authentication succeeds with a change
-      assert:
+      ansible.builtin.assert:
         that:
           - add_user_with_auth_enabled is changed
 
@@ -81,7 +81,7 @@
       register: same_user
 
     - name: Check that adding same user succeeds without a change
-      assert:
+      ansible.builtin.assert:
         that:
           - same_user is not changed
 
@@ -93,7 +93,7 @@
       register: change_password
 
     - name: Check that password changing succeeds with a change
-      assert:
+      ansible.builtin.assert:
         that:
           - change_password is changed
 
@@ -104,7 +104,7 @@
       register: change_password
 
     - name: Check that password changing succeeds with a change
-      assert:
+      ansible.builtin.assert:
         that:
           - change_password is changed
 
@@ -116,7 +116,7 @@
       register: remove_user
 
     - name: Check that removing user succeeds with a change
-      assert:
+      ansible.builtin.assert:
         that:
           - remove_user is changed
 
@@ -127,7 +127,7 @@
       register: remove_user
 
     - name: Check that removing user succeeds with a change
-      assert:
+      ansible.builtin.assert:
         that:
           - remove_user is changed
 
@@ -138,6 +138,6 @@
       register: remove_user
 
     - name: Check that removing user succeeds without a change
-      assert:
+      ansible.builtin.assert:
         that:
           - remove_user is not changed

--- a/tests/integration/targets/ini_file/tasks/tests/00-basic.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/00-basic.yml
@@ -18,7 +18,7 @@
   ignore_errors: true
 
 - name: test-basic 1 - verify error message
-  assert:
+  ansible.builtin.assert:
     that:
       - result_basic_1 is not changed
       - result_basic_1 is failed
@@ -35,7 +35,7 @@
   ignore_errors: true
 
 - name: test-basic 2 - verify error message
-  assert:
+  ansible.builtin.assert:
     that:
       - result_basic_2 is not changed
       - result_basic_2 is failed

--- a/tests/integration/targets/ini_file/tasks/tests/01-value.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/01-value.yml
@@ -16,7 +16,7 @@
   ignore_errors: true
 
 - name: test-value 1 - verify error message
-  assert:
+  ansible.builtin.assert:
     that:
       - result_value_1 is not changed
       - result_value_1 is failed
@@ -33,7 +33,7 @@
   ignore_errors: true
 
 - name: test-value 2 - verify error message
-  assert:
+  ansible.builtin.assert:
     that:
       - result_value_2 is not changed
       - result_value_2 is failed
@@ -62,7 +62,7 @@
     content3: "{{ output_content.content | b64decode }}"
 
 - name: test-value 3 - Verify content of ini file is as expected and ini_file 'changed' is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result3 is changed
       - result3.msg == 'section and option added'
@@ -78,7 +78,7 @@
   register: result4
 
 - name: test-value 4 - Ensure unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result4 is not changed
       - result4.msg == 'OK'
@@ -107,7 +107,7 @@
     content5: "{{ output_content.content | b64decode }}"
 
 - name: test-value 5 - assert 'changed' is true and content is OK
-  assert:
+  ansible.builtin.assert:
     that:
       - result5 is changed
       - result5.msg == 'option added'
@@ -136,7 +136,7 @@
     content6: "{{ output_content.content | b64decode }}"
 
 - name: test-value 6 - assert 'changed' is true and content is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - result6 is changed
       - result6.msg == 'option changed'
@@ -160,7 +160,7 @@
     content7: "{{ output_content.content | b64decode }}"
 
 - name: test-value 7 - assert 'changed' is true and content is empty
-  assert:
+  ansible.builtin.assert:
     that:
       - result7 is changed
       - result7.msg == 'section removed'
@@ -191,7 +191,7 @@
       skip-name
 
 - name: test-value 8 - assert 'changed' is true and section and option added
-  assert:
+  ansible.builtin.assert:
     that:
       - result8 is changed
       - result8.msg == 'section and option added'
@@ -207,7 +207,7 @@
   register: result9
 
 - name: test-value 9 - assert 'changed' is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result9 is not changed
       - result9.msg == 'OK'
@@ -221,7 +221,7 @@
   register: result10
 
 - name: test-value 10 - assert 'changed' is true and section added
-  assert:
+  ansible.builtin.assert:
     that:
       - result10 is changed
       - result10.msg == 'only section added'
@@ -235,7 +235,7 @@
   register: result11
 
 - name: test-value 11 - assert 'changed' is false
-  assert:
+  ansible.builtin.assert:
     that:
       - result11 is not changed
       - result11.msg == 'OK'
@@ -275,7 +275,7 @@
       max_connections = 500
 
 - name: test-value 12 - Verify content of ini file is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - content12 == expected12
 
@@ -304,7 +304,7 @@
       max_connections = 500
 
 - name: test-value 13 - assert 'changed' and msg 'option changed' and content is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - result13 is changed
       - result13.msg == 'option changed'
@@ -335,7 +335,7 @@
       max_connections = 500
 
 - name: test-value 14 - assert 'changed' is true and msg 'option changed' and content is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - result14 is changed
       - result14.msg == 'option changed'
@@ -365,7 +365,7 @@
       max_connections = 500
 
 - name: test-value 15 - assert 'changed' is true and msg 'option changed' and content is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - result15 is changed
       - result15.msg == 'option changed'
@@ -399,7 +399,7 @@
     content16: "{{ output_content.content | b64decode }}"
 
 - name: test-value 16 - assert 'changed' is true and content is OK (no section)
-  assert:
+  ansible.builtin.assert:
     that:
       - result16 is changed
       - result16.msg == 'option added'
@@ -427,7 +427,7 @@
     content17: "{{ output_content.content | b64decode }}"
 
 - name: test-value 17 - assert 'changed' is true and content is OK (no section)
-  assert:
+  ansible.builtin.assert:
     that:
       - result17 is changed
       - result17.msg == 'option changed'
@@ -452,7 +452,7 @@
     content18: "{{ output_content.content | b64decode }}"
 
 - name: test-value 18 - assert 'changed' is true and option is removed (no section)
-  assert:
+  ansible.builtin.assert:
     that:
       - result18 is changed
       - result18.msg == 'option changed'
@@ -489,7 +489,7 @@
     content19: "{{ output_content.content | b64decode }}"
 
 - name: test-value 19 - Verify content of ini file is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - content19 == expected19
 
@@ -536,7 +536,7 @@
     content20: "{{ output_content.content | b64decode }}"
 
 - name: test-value 20 - Verify content of ini file is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - content20 == expected20
 
@@ -578,7 +578,7 @@
     content21: "{{ output_content.content | b64decode }}"
 
 - name: test-value 21 - Verify content of ini file is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - result21 is changed
       - result21.msg == 'option added'

--- a/tests/integration/targets/ini_file/tasks/tests/02-values.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/02-values.yml
@@ -16,7 +16,7 @@
   ignore_errors: true
 
 - name: test-values 1 - verify error message
-  assert:
+  ansible.builtin.assert:
     that:
       - result1 is not changed
       - result1 is failed
@@ -33,7 +33,7 @@
   ignore_errors: true
 
 - name: test-values 2 - verify error message
-  assert:
+  ansible.builtin.assert:
     that:
       - result2 is not changed
       - result2 is failed
@@ -66,7 +66,7 @@
     content3: "{{ output_content.content | b64decode }}"
 
 - name: test-values 3 - Verify content of ini file is as expected and ini_file 'changed' is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result3 is changed
       - result3.msg == 'section and option added'
@@ -98,7 +98,7 @@
     content4: "{{ output_content.content | b64decode }}"
 
 - name: test-values 4 - Verify content of ini file is as expected and ini_file 'changed' is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result4 is changed
       - result4.msg == 'option changed'
@@ -131,7 +131,7 @@
     content5: "{{ output_content.content | b64decode }}"
 
 - name: test-values 5 - Verify content of ini file is as expected and ini_file 'changed' is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result5 is changed
       - result5.msg == 'option added'
@@ -150,7 +150,7 @@
   register: result6
 
 - name: test-values 6 - Ensure unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result6 is not changed
       - result6.msg == 'OK'
@@ -168,7 +168,7 @@
   register: result7
 
 - name: test-values 7 - Ensure unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result7 is not changed
       - result7.msg == 'OK'
@@ -186,7 +186,7 @@
   register: result8
 
 - name: test-values 8 - Ensure unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result8 is not changed
       - result8.msg == 'OK'
@@ -216,7 +216,7 @@
     content9: "{{ output_content.content | b64decode }}"
 
 - name: test-values 9 - Verify content of ini file is as expected and ini_file 'changed' is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result9 is changed
       - result9.msg == 'option changed'
@@ -247,7 +247,7 @@
 
 
 - name: test-values 10 - Ensure unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result10 is changed
       - result10.msg == 'option changed'
@@ -289,7 +289,7 @@
     content11: "{{ output_content.content | b64decode }}"
 
 - name: test-values 11 - assert 'changed' is true and content is OK
-  assert:
+  ansible.builtin.assert:
     that:
       - result11 is changed
       - result11.msg == 'option added'
@@ -308,7 +308,7 @@
   register: result12
 
 - name: test-values 12 - Ensure unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result12 is not changed
       - result12.msg == 'OK'
@@ -341,7 +341,7 @@
     content13: "{{ output_content.content | b64decode }}"
 
 - name: test-values 13 - Verify content of ini file is as expected and ini_file 'changed' is true
-  assert:
+  ansible.builtin.assert:
     that:
       - result13 is changed
       - result13.msg == 'option added'
@@ -379,7 +379,7 @@
     content14: "{{ output_content.content | b64decode }}"
 
 - name: test-values 14 - assert 'changed' is true and content is OK
-  assert:
+  ansible.builtin.assert:
     that:
       - result14 is changed
       - result14.msg == 'option added'
@@ -398,7 +398,7 @@
   register: result15
 
 - name: test-values 15 - Ensure unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result15 is not changed
       - result15.msg == 'OK'
@@ -416,7 +416,7 @@
   register: result16
 
 - name: test-values 16 - Ensure unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result16 is not changed
       - result16.msg == 'OK'
@@ -446,7 +446,7 @@
     content17: "{{ output_content.content | b64decode }}"
 
 - name: test-values 17 - assert 'changed' is true and content is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - result17 is changed
       - result17.msg == 'option changed'
@@ -476,7 +476,7 @@
     content18: "{{ output_content.content | b64decode }}"
 
 - name: test-values 18 - assert 'changed' is true and content is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - result18 is changed
       - result18.msg == 'option changed'
@@ -494,7 +494,7 @@
   register: result19
 
 - name: test-values 19 - Ensure unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result19 is not changed
       - result19.msg == 'OK'
@@ -524,7 +524,7 @@
     content20: "{{ output_content.content | b64decode }}"
 
 - name: test-values 20 - assert 'changed' is true and content is empty
-  assert:
+  ansible.builtin.assert:
     that:
       - result20 is changed
       - result20_remove_again is not changed
@@ -561,7 +561,7 @@
     content21: "{{ output_content.content | b64decode }}"
 
 - name: test-values 21 - assert 'changed' is true and content is OK
-  assert:
+  ansible.builtin.assert:
     that:
       - result21 is changed
       - result21.msg == 'section and option added'
@@ -622,7 +622,7 @@
     content22: "{{ output_content.content | b64decode }}"
 
 - name: test-values 22 - assert 'changed' is true and content is OK and option added
-  assert:
+  ansible.builtin.assert:
     that:
       - result22 is changed
       - result22.msg == 'option added'
@@ -665,7 +665,7 @@
     content23: "{{ output_content.content | b64decode }}"
 
 - name: test-values 23 - assert 'changed' and msg 'option changed' and content is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - result23 is changed
       - result23.msg == 'option changed'
@@ -710,7 +710,7 @@
     content24: "{{ output_content.content | b64decode }}"
 
 - name: test-values 24 - assert 'changed' and msg 'option added' and content is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - result24 is changed
       - result24.msg == 'option added'
@@ -748,7 +748,7 @@
     content25: "{{ output_content.content | b64decode }}"
 
 - name: test-values 25 - assert 'changed' is true and content is OK (no section)
-  assert:
+  ansible.builtin.assert:
     that:
       - result25 is changed
       - result25.msg == 'option added'
@@ -781,7 +781,7 @@
     content26: "{{ output_content.content | b64decode }}"
 
 - name: test-values 26 - assert 'changed' is true and content is OK (no section)
-  assert:
+  ansible.builtin.assert:
     that:
       - result26 is changed
       - result26.msg == 'option changed'
@@ -806,7 +806,7 @@
     content27: "{{ output_content.content | b64decode }}"
 
 - name: test-values 27 - assert changed (no section)
-  assert:
+  ansible.builtin.assert:
     that:
       - result27 is changed
       - result27.msg == 'option changed'
@@ -852,7 +852,7 @@
     content28: "{{ output_content.content | b64decode }}"
 
 - name: test-values 28 - Verify content of ini file is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - content28 == expected28
 
@@ -891,7 +891,7 @@
     content29: "{{ output_content.content | b64decode }}"
 
 - name: test-value 29 - Verify content of ini file is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - result29 is changed
       - result29.msg == 'option changed'
@@ -934,7 +934,7 @@
     content30: "{{ output_content.content | b64decode }}"
 
 - name: test-value 30 - Verify content of ini file is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - result30 is changed
       - result30.msg == 'option changed'
@@ -973,7 +973,7 @@
     content31: "{{ output_content.content | b64decode }}"
 
 - name: test-value 31 - Verify content of ini file is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - result31 is changed
       - result31.msg == 'option changed'
@@ -1016,7 +1016,7 @@
     content32: "{{ output_content.content | b64decode }}"
 
 - name: test-value 32 - Verify content of ini file is as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - result32 is not changed
       - result32.msg == 'OK'

--- a/tests/integration/targets/ini_file/tasks/tests/05-ignore_spaces.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/05-ignore_spaces.yml
@@ -28,7 +28,7 @@
   vars:
     actual_content: "{{ output_content.content | b64decode }}"
     expected_content: "[foo]\nbar = frelt\n"
-  assert:
+  ansible.builtin.assert:
     that:
       - actual_content == expected_content
       - result is changed
@@ -57,7 +57,7 @@
   vars:
     actual_content: "{{ output_content.content | b64decode }}"
     expected_content: "[foo]\nbar = frelt\n"
-  assert:
+  ansible.builtin.assert:
     that:
       - actual_content == expected_content
       - result is changed
@@ -86,7 +86,7 @@
   vars:
     actual_content: "{{ output_content.content | b64decode }}"
     expected_content: "[foo]\nbar=baz\n"
-  assert:
+  ansible.builtin.assert:
     that:
       - actual_content == expected_content
       - result is not changed
@@ -116,7 +116,7 @@
   vars:
     actual_content: "{{ output_content.content | b64decode }}"
     expected_content: "[foo]\nbar = baz\n"
-  assert:
+  ansible.builtin.assert:
     that:
       - actual_content == expected_content
       - result is not changed

--- a/tests/integration/targets/ini_file/tasks/tests/06-modify_inactive_option.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/06-modify_inactive_option.yml
@@ -40,7 +40,7 @@
     content1: "{{ output_content.content | b64decode }}"
 
 - name: test-modify_inactive_option 1 - assert 'changed' is true, content is OK and option changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result1 is changed
       - result1.msg == 'option changed'
@@ -83,7 +83,7 @@
     content2: "{{ output_content.content | b64decode }}"
 
 - name: test-modify_inactive_option 2 - assert 'changed' is true and content is OK and option added
-  assert:
+  ansible.builtin.assert:
     that:
       - result2 is changed
       - result2.msg == 'option added'
@@ -116,7 +116,7 @@
     content3: "{{ output_content.content | b64decode }}"
 
 - name: test-modify_inactive_option 3 - assert 'changed' is true and content is OK and active option removed
-  assert:
+  ansible.builtin.assert:
     that:
       - result3 is changed
       - result3.msg == 'option changed'
@@ -158,7 +158,7 @@
     content4: "{{ output_content.content | b64decode }}"
 
 - name: test-modify_inactive_option 4 - assert 'changed' is true and content is OK and option changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result4 is changed
       - result4.msg == 'option changed'

--- a/tests/integration/targets/ini_file/tasks/tests/08-section.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/08-section.yml
@@ -46,7 +46,7 @@
     output1: "{{ output_content.content | b64decode }}"
 
 - name: test-section 1 - Option was added to first section
-  assert:
+  ansible.builtin.assert:
     that:
       - result1 is changed
       - result1.msg == 'option added'
@@ -98,7 +98,7 @@
     output1: "{{ output_content.content | b64decode }}"
 
 - name: test-section 2 - Option added to second section specified with section_has_values
-  assert:
+  ansible.builtin.assert:
     that:
       - result1 is changed
       - result1.msg == 'option added'
@@ -148,7 +148,7 @@
     output1: "{{ output_content.content | b64decode }}"
 
 - name: test-section 3 - Option was removed from specified section
-  assert:
+  ansible.builtin.assert:
     that:
       - result1 is changed
       - result1.msg == 'option changed'
@@ -202,7 +202,7 @@
     output1: "{{ output_content.content | b64decode }}"
 
 - name: test-section 4 - New section created, including required values
-  assert:
+  ansible.builtin.assert:
     that:
       - result1 is changed
       - result1.msg == 'section and option added'
@@ -240,7 +240,7 @@
     output1: "{{ output_content.content | b64decode }}"
 
 - name: test-section 5 - Section removed as specified
-  assert:
+  ansible.builtin.assert:
     that:
       - result1 is changed
       - result1.msg == 'section removed'
@@ -292,7 +292,7 @@
     output1: "{{ output_content.content | b64decode }}"
 
 - name: test-section 6 - New section added
-  assert:
+  ansible.builtin.assert:
     that:
       - result1 is changed
       - result1.msg == 'section and option added'
@@ -334,7 +334,7 @@
     output1: "{{ output_content.content | b64decode }}"
 
 - name: test-section 7 - Option changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result1 is changed
       - result1.msg == 'option changed'

--- a/tests/integration/targets/interfaces_file/tasks/main.yml
+++ b/tests/integration/targets/interfaces_file/tasks/main.yml
@@ -22,7 +22,7 @@
     value: 1.2.3.5
   register: ifile_1
 
-- assert:
+- ansible.builtin.assert:
     that:
       - ifile_1 is changed
 
@@ -34,7 +34,7 @@
     value: 1.2.3.5
   register: ifile_2
 
-- assert:
+- ansible.builtin.assert:
     that:
       - ifile_2 is not changed
 
@@ -62,7 +62,7 @@
   register: ifile_3841_b
 
 - name: 3841 - check assertions
-  assert:
+  ansible.builtin.assert:
     that:
       - ifile_3841_a is changed
       - ifile_3841_b is not changed
@@ -93,7 +93,7 @@
   register: content_7610
 
 - name: 7610 - check assertions
-  assert:
+  ansible.builtin.assert:
     that:
       - content_7610.content | b64decode == expected_content
   vars:
@@ -115,7 +115,7 @@
   register: content_7610
 
 - name: 7610 - check assertions
-  assert:
+  ansible.builtin.assert:
     that:
       - content_7610.content | b64decode == expected_content
   vars:

--- a/tests/integration/targets/ipify_facts/tasks/main.yml
+++ b/tests/integration/targets/ipify_facts/tasks/main.yml
@@ -28,7 +28,7 @@
   delay: 10
 
 - name: check if task was successful
-  assert:
+  ansible.builtin.assert:
     that:
       - external_ip is not changed
       - external_ip.ansible_facts is defined

--- a/tests/integration/targets/iptables_state/tasks/tests/00-basic.yml
+++ b/tests/integration/targets/iptables_state/tasks/tests/00-basic.yml
@@ -25,7 +25,7 @@
   ignore_errors: true
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is failed
       - iptables_state.msg is match("Invalid options")
@@ -39,7 +39,7 @@
   ignore_errors: true
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is failed
       - iptables_state.msg is match("missing required arguments")
@@ -53,7 +53,7 @@
   ignore_errors: true
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is failed
       - iptables_state.msg is match("missing required arguments")
@@ -68,7 +68,7 @@
   ignore_errors: true
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is failed
       - iptables_state.msg is match("value of state must be one of")
@@ -89,7 +89,7 @@
   check_mode: true
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is changed
       - iptables_state.initial_state == iptables_state.saved
@@ -103,7 +103,7 @@
   register: iptables_state
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is changed
       - iptables_state.initial_state == iptables_state.saved
@@ -117,7 +117,7 @@
   register: iptables_state
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is not changed
       - iptables_state.initial_state == iptables_state.saved
@@ -132,7 +132,7 @@
   check_mode: true
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is not changed
       - iptables_state.initial_state == iptables_state.saved
@@ -153,7 +153,7 @@
       check_mode: true
 
     - name: "assert that results are as expected"
-      assert:
+      ansible.builtin.assert:
         that:
           - iptables_state is not changed
           - iptables_state.initial_state == iptables_state.restored
@@ -161,7 +161,7 @@
 
   rescue:
     - name: "assert that results are not as expected for only one reason (xtables lock)"
-      assert:
+      ansible.builtin.assert:
         that:
           - iptables_state is failed
           - iptables_state.stderr is search('xtables lock')
@@ -178,7 +178,7 @@
       register: iptables_state
 
     - name: "assert that results are as expected"
-      assert:
+      ansible.builtin.assert:
         that:
           - iptables_state is not changed
           - iptables_state.initial_state == iptables_state.restored
@@ -186,7 +186,7 @@
 
   rescue:
     - name: "assert that results are not as expected for only one reason (xtables lock)"
-      assert:
+      ansible.builtin.assert:
         that:
           - iptables_state is failed
           - iptables_state.stderr is search('xtables lock')
@@ -210,7 +210,7 @@
       check_mode: true
 
     - name: "assert that results are as expected"
-      assert:
+      ansible.builtin.assert:
         that:
           - iptables_state is changed
           - iptables_state.initial_state != iptables_state.restored
@@ -218,7 +218,7 @@
 
   rescue:
     - name: "assert that results are not as expected for only one reason (xtables lock)"
-      assert:
+      ansible.builtin.assert:
         that:
           - iptables_state is failed
           - iptables_state.stderr is search('xtables lock')
@@ -237,7 +237,7 @@
       poll: 0
 
     - name: "assert that results are as expected"
-      assert:
+      ansible.builtin.assert:
         that:
           - iptables_state is changed
           - iptables_state.initial_state != iptables_state.restored
@@ -246,7 +246,7 @@
 
   rescue:
     - name: "assert that results are not as expected for only one reason (xtables lock)"
-      assert:
+      ansible.builtin.assert:
         that:
           - iptables_state is failed
           - iptables_state.stderr is search('xtables lock')
@@ -265,7 +265,7 @@
       poll: 0
 
     - name: "assert that results are as expected"
-      assert:
+      ansible.builtin.assert:
         that:
           - iptables_state is not changed
           - iptables_state.initial_state == iptables_state.restored
@@ -273,7 +273,7 @@
 
   rescue:
     - name: "assert that results are not as expected for only one reason (xtables lock)"
-      assert:
+      ansible.builtin.assert:
         that:
           - iptables_state is failed
           - iptables_state.stderr is search('xtables lock')
@@ -291,7 +291,7 @@
       check_mode: true
 
     - name: "assert that results are as expected"
-      assert:
+      ansible.builtin.assert:
         that:
           - iptables_state is not changed
           - iptables_state.initial_state == iptables_state.restored
@@ -299,7 +299,7 @@
 
   rescue:
     - name: "assert that results are not as expected for only one reason (xtables lock)"
-      assert:
+      ansible.builtin.assert:
         that:
           - iptables_state is failed
           - iptables_state.stderr is search('xtables lock')

--- a/tests/integration/targets/iptables_state/tasks/tests/01-tables.yml
+++ b/tests/integration/targets/iptables_state/tasks/tests/01-tables.yml
@@ -20,7 +20,7 @@
   check_mode: true
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'*filter' in iptables_state.initial_state"
       - iptables_state.tables.filter is defined
@@ -38,7 +38,7 @@
   check_mode: true
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'*nat' in iptables_state.initial_state"
       - "'*filter' in iptables_state.initial_state"
@@ -55,7 +55,7 @@
   register: iptables_state
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'*filter' in iptables_state.initial_state"
       - "'*filter' in iptables_state.saved"
@@ -74,7 +74,7 @@
   register: iptables_state
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is changed
       - "'*nat' in iptables_state.initial_state"
@@ -93,7 +93,7 @@
   register: iptables_state
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is changed
       - "'*filter' in iptables_state.initial_state"
@@ -115,7 +115,7 @@
   poll: 0
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'*nat' in iptables_state.initial_state"
       - "'*nat' in iptables_state.restored"
@@ -145,7 +145,7 @@
   poll: 0
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'*nat' in iptables_state.initial_state"
       - "'*nat' in iptables_state.restored"
@@ -178,7 +178,7 @@
   register: iptables_state
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'filter' in iptables_state.tables"
       - "'*filter' in iptables_state.saved"
@@ -213,7 +213,7 @@
   poll: 0
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'*filter' in iptables_state.initial_state"
       - "'*mangle' in iptables_state.initial_state"
@@ -240,7 +240,7 @@
   poll: 0
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'*filter' in iptables_state.initial_state"
       - "'*mangle' in iptables_state.initial_state"
@@ -269,7 +269,7 @@
   ignore_errors: true
 
 - name: "explain expected failure"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is failed
       - "iptables_state.msg == ('Table mangle to restore not defined in ' ~ iptables_tests)"

--- a/tests/integration/targets/iptables_state/tasks/tests/02-partial-restore.yml
+++ b/tests/integration/targets/iptables_state/tasks/tests/02-partial-restore.yml
@@ -48,7 +48,7 @@
 
 
 - name: "assert that no changes are detected in check mode"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is not changed
 
@@ -61,6 +61,6 @@
   poll: 0
 
 - name: "assert that no changes are made"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is not changed

--- a/tests/integration/targets/iptables_state/tasks/tests/10-rollback.yml
+++ b/tests/integration/targets/iptables_state/tasks/tests/10-rollback.yml
@@ -20,7 +20,7 @@
   check_mode: true
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is changed
 
@@ -37,7 +37,7 @@
 
   rescue:
     - name: "explain expected failure"
-      assert:
+      ansible.builtin.assert:
         that:
           - iptables_state is not changed
           - not iptables_state.applied
@@ -52,7 +52,7 @@
           expected.
 
 - name: "check that the expected failure happened"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is failed
 
@@ -71,7 +71,7 @@
 
   rescue:
     - name: "explain expected failure"
-      assert:
+      ansible.builtin.assert:
         that:
           - iptables_state is not changed
           - not iptables_state.applied
@@ -86,7 +86,7 @@
           expected.
 
 - name: "check that the expected failure happened"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is failed
 
@@ -100,7 +100,7 @@
   poll: 0
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is not changed
 
@@ -115,7 +115,7 @@
   poll: 0
 
 - name: "assert that results are as expected"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is not changed
 
@@ -141,7 +141,7 @@
 
   rescue:
     - name: "explain expected failure"
-      assert:
+      ansible.builtin.assert:
         that:
           - iptables_state is not changed
           - not iptables_state.applied
@@ -156,7 +156,7 @@
           expected.
 
 - name: "check that the expected failure happened"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is failed
 
@@ -175,7 +175,7 @@
 
   rescue:
     - name: "explain expected failure"
-      assert:
+      ansible.builtin.assert:
         that:
           - iptables_state is not changed
           - not iptables_state.applied
@@ -190,6 +190,6 @@
           expected.
 
 - name: "check that the expected failure happened"
-  assert:
+  ansible.builtin.assert:
     that:
       - iptables_state is failed

--- a/tests/integration/targets/ipwcli_dns/tasks/main.yml
+++ b/tests/integration/targets/ipwcli_dns/tasks/main.yml
@@ -26,7 +26,7 @@
   register: result
 
 - name: assert the new A record is added
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is changed
@@ -45,7 +45,7 @@
   register: result
 
 - name: assert the new A record is deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is changed
@@ -64,7 +64,7 @@
   register: result
 
 - name: assert the new a record
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is not changed
@@ -86,7 +86,7 @@
   ignore_errors: true
 
 - name: assert the failure of the new SRV record
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
       - result is not changed
@@ -109,7 +109,7 @@
   register: result
 
 - name: assert the NAPTR check_mode
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not failed
       - result is changed

--- a/tests/integration/targets/iso_create/tasks/main.yml
+++ b/tests/integration/targets/iso_create/tasks/main.yml
@@ -42,7 +42,7 @@
     path: "{{ output_test_dir }}/test.iso"
   register: iso_file
 - debug: var=iso_file
-- assert:
+- ansible.builtin.assert:
     that:
       - iso_result is changed
       - iso_file.stat.exists == False
@@ -61,7 +61,7 @@
     path: "{{ output_test_dir }}/test.iso"
   register: iso_file
 
-- assert:
+- ansible.builtin.assert:
     that:
       - iso_result is changed
       - iso_file.stat.exists == True
@@ -81,7 +81,7 @@
     path: "{{ output_test_dir }}/test1.iso"
   register: iso_file
 
-- assert:
+- ansible.builtin.assert:
     that:
       - iso_result is changed
       - iso_file.stat.exists == True
@@ -100,7 +100,7 @@
     path: "{{ output_test_dir }}/test2.iso"
   register: iso_file
 
-- assert:
+- ansible.builtin.assert:
     that:
       - iso_result is changed
       - iso_file.stat.exists == True
@@ -119,7 +119,7 @@
     path: "{{ output_test_dir }}/test3.iso"
   register: iso_file
 
-- assert:
+- ansible.builtin.assert:
     that:
       - iso_result is changed
       - iso_file.stat.exists == True
@@ -138,7 +138,7 @@
     path: "{{ output_test_dir }}/test4.iso"
   register: iso_file
 
-- assert:
+- ansible.builtin.assert:
     that:
       - iso_result is changed
       - iso_file.stat.exists == True
@@ -157,7 +157,7 @@
     path: "{{ output_test_dir }}/test5.iso"
   register: iso_file
 
-- assert:
+- ansible.builtin.assert:
     that:
       - iso_result is changed
       - iso_file.stat.exists == True

--- a/tests/integration/targets/iso_customize/tasks/iso_customize.yml
+++ b/tests/integration/targets/iso_customize/tasks/iso_customize.yml
@@ -32,7 +32,7 @@
     path: "{{ mount_root_dir }}/test01.cfg"
   register: check_file
 
-- assert:
+- ansible.builtin.assert:
     that:
       - check_file.stat.exists == False
 
@@ -41,7 +41,7 @@
     path: "{{ mount_root_dir }}/preseed/ubuntu.seed"
   register: check_file
 
-- assert:
+- ansible.builtin.assert:
     that:
       - check_file.stat.exists == True
 

--- a/tests/integration/targets/iso_customize/tasks/iso_customize_add_files.yml
+++ b/tests/integration/targets/iso_customize/tasks/iso_customize_add_files.yml
@@ -23,7 +23,7 @@
     path: "{{ mount_root_dir }}/preseed/ubuntu.seed"
   register: check_file
 
-- assert:
+- ansible.builtin.assert:
     that:
       - check_file.stat.exists == True
 

--- a/tests/integration/targets/iso_customize/tasks/iso_customize_delete_files.yml
+++ b/tests/integration/targets/iso_customize/tasks/iso_customize_delete_files.yml
@@ -23,7 +23,7 @@
     path: "{{ mount_root_dir }}/test01.cfg"
   register: check_file
 
-- assert:
+- ansible.builtin.assert:
     that:
       - check_file.stat.exists == False
 

--- a/tests/integration/targets/iso_extract/tasks/tests.yml
+++ b/tests/integration/targets/iso_extract/tasks/tests.yml
@@ -15,7 +15,7 @@
     executable: '{{ iso_extract_7zip_executable | default(omit) }}'
   register: iso_extract_test0
 
-- assert:
+- ansible.builtin.assert:
     that:
       - iso_extract_test0 is changed
 
@@ -30,13 +30,13 @@
   register: iso_extract_test0_again
 
 - name: Test iso_extract_test0_again (normal mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - iso_extract_test0_again is not changed
   when: not in_check_mode
 
 - name: Test iso_extract_test0_again (check-mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - iso_extract_test0_again is changed
   when: in_check_mode
@@ -53,7 +53,7 @@
   register: iso_extract_leading_slash
 
 - name: Test iso_extract with leading slash succeeds (normal mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - iso_extract_leading_slash is not failed
   when: not in_check_mode

--- a/tests/integration/targets/java_keystore/tasks/tests.yml
+++ b/tests/integration/targets/java_keystore/tasks/tests.yml
@@ -277,7 +277,7 @@
   when: remote_cert
 
 - name: Validate results
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result_check is changed

--- a/tests/integration/targets/jboss/tasks/jboss.yml
+++ b/tests/integration/targets/jboss/tasks/jboss.yml
@@ -69,7 +69,7 @@
         src: '{{ war_file_1_path }}'
       check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
@@ -80,7 +80,7 @@
         path: '{{ deploy_dir }}/{{ war_file_1 }}.deployed'
       ignore_errors: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - "'is absent' in result.msg"
 
@@ -92,7 +92,7 @@
         deploy_path: '{{ deploy_dir }}'
         src: '{{ war_file_1_path }}'
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
@@ -102,7 +102,7 @@
       file:
         path: '{{ deploy_dir }}/{{ war_file_1 }}.deployed'
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result.state == 'file'
 
@@ -115,7 +115,7 @@
         deploy_path: '{{ deploy_dir }}'
       check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
 
@@ -127,7 +127,7 @@
         src: '{{ war_file_1_path }}'
         deploy_path: '{{ deploy_dir }}'
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
 
@@ -137,7 +137,7 @@
       file:
         path: '{{ deploy_dir }}/{{ war_file_1 }}.deployed'
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result.state == 'file'
 
@@ -150,7 +150,7 @@
         state: absent
       check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
@@ -159,7 +159,7 @@
       file:
         path: '{{ deploy_dir }}/{{ war_file_1 }}.deployed'
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result.state == 'file'
 
@@ -171,7 +171,7 @@
         deploy_path: '{{ deploy_dir }}'
         state: absent
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
@@ -180,7 +180,7 @@
       file:
         path: '{{ deploy_dir }}/{{ war_file_1 }}.undeployed'
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result.state == 'file'
 
@@ -193,7 +193,7 @@
         state: absent
       check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
 
@@ -205,7 +205,7 @@
         deploy_path: '{{ deploy_dir }}'
         state: absent
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
 
@@ -219,7 +219,7 @@
         state: present
       ignore_errors: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is failed
           - "'Source file {{ fake_src_path }} does not exist.' in result.msg"
@@ -232,7 +232,7 @@
         state: present
       ignore_errors: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is failed
           - "'state is present but all of the following are missing: src' in result.msg"

--- a/tests/integration/targets/jenkins_credential/tasks/add.yml
+++ b/tests/integration/targets/jenkins_credential/tasks/add.yml
@@ -33,7 +33,7 @@
   register: custom_scope
 
 - name: Assert CUSTOM scope changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - custom_scope.changed == (run_number == 1)
     fail_msg: "CUSTOM scope changed status incorrect on run {{ run_number }}"
@@ -51,7 +51,7 @@
   register: userpass_cred
 
 - name: Assert user_and_pass changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - userpass_cred.changed == (run_number == 1)
     fail_msg: "user_and_pass credential changed status incorrect on run {{ run_number }}"
@@ -69,7 +69,7 @@
   register: file_cred
 
 - name: Assert file credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - file_cred.changed == (run_number == 1)
     fail_msg: "file credential changed status incorrect on run {{ run_number }}"
@@ -88,7 +88,7 @@
   register: text_cred
 
 - name: Assert text credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - text_cred.changed == (run_number == 1)
     fail_msg: "text credential changed status incorrect on run {{ run_number }}"
@@ -107,7 +107,7 @@
   register: githubapp_cred
 
 - name: Assert githubApp credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - githubapp_cred.changed == (run_number == 1)
     fail_msg: "githubApp credential changed status incorrect on run {{ run_number }}"
@@ -126,7 +126,7 @@
   register: sshkey_cred
 
 - name: Assert sshKey credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - sshkey_cred.changed == (run_number == 1)
     fail_msg: "sshKey credential changed status incorrect on run {{ run_number }}"
@@ -144,7 +144,7 @@
   register: cert_p12_cred
 
 - name: Assert certificate (p12) credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - cert_p12_cred.changed == (run_number == 1)
     fail_msg: "certificate (p12) credential changed status incorrect on run {{ run_number }}"
@@ -162,7 +162,7 @@
   register: cert_pem_cred
 
 - name: Assert certificate (pem) credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - cert_pem_cred.changed == (run_number == 1)
     fail_msg: "certificate (pem) credential changed status incorrect on run {{ run_number }}"

--- a/tests/integration/targets/jenkins_credential/tasks/del.yml
+++ b/tests/integration/targets/jenkins_credential/tasks/del.yml
@@ -11,7 +11,7 @@
   register: userpass_cred
 
 - name: Assert user_and_pass changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - userpass_cred.changed == (run_number == 1)
     fail_msg: "user_and_pass credential changed status incorrect on run {{ run_number }}"
@@ -27,7 +27,7 @@
   register: file_cred
 
 - name: Assert file credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - file_cred.changed == (run_number == 1)
     fail_msg: "file credential changed status incorrect on run {{ run_number }}"
@@ -43,7 +43,7 @@
   register: custom_scope
 
 - name: Assert CUSTOM scope changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - custom_scope.changed == (run_number == 1)
     fail_msg: "CUSTOM scope changed status incorrect on run {{ run_number }}"
@@ -60,7 +60,7 @@
   register: text_cred
 
 - name: Assert text credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - text_cred.changed == (run_number == 1)
     fail_msg: "text credential changed status incorrect on run {{ run_number }}"
@@ -75,7 +75,7 @@
   register: githubapp_cred
 
 - name: Assert githubApp credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - githubapp_cred.changed == (run_number == 1)
     fail_msg: "githubApp credential changed status incorrect on run {{ run_number }}"
@@ -91,7 +91,7 @@
   register: sshkey_cred
 
 - name: Assert sshKey credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - sshkey_cred.changed == (run_number == 1)
     fail_msg: "sshKey credential changed status incorrect on run {{ run_number }}"
@@ -106,7 +106,7 @@
   register: cert_p12_cred
 
 - name: Assert certificate (p12) credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - cert_p12_cred.changed == (run_number == 1)
     fail_msg: "certificate (p12) credential changed status incorrect on run {{ run_number }}"
@@ -121,7 +121,7 @@
   register: cert_pem_cred
 
 - name: Assert certificate (pem) credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - cert_pem_cred.changed == (run_number == 1)
     fail_msg: "certificate (pem) credential changed status incorrect on run {{ run_number }}"

--- a/tests/integration/targets/jenkins_credential/tasks/edit.yml
+++ b/tests/integration/targets/jenkins_credential/tasks/edit.yml
@@ -49,7 +49,7 @@
   register: custom_scope
 
 - name: Assert CUSTOM scope changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - custom_scope.changed == true
     fail_msg: "CUSTOM scope changed status when it shouldn't"
@@ -68,7 +68,7 @@
   register: userpass_cred
 
 - name: Assert user_and_pass changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - userpass_cred.changed == true
     fail_msg: "user_and_pass credential changed status incorrect"
@@ -87,7 +87,7 @@
   register: file_cred
 
 - name: Assert file credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - file_cred.changed == true
     fail_msg: "file credential changed status incorrect"
@@ -107,7 +107,7 @@
   register: text_cred
 
 - name: Assert text credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - text_cred.changed == true
     fail_msg: "text credential changed status incorrect"
@@ -127,7 +127,7 @@
   register: githubapp_cred
 
 - name: Assert githubApp credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - githubapp_cred.changed == true
     fail_msg: "githubApp credential changed status incorrect"
@@ -147,7 +147,7 @@
   register: sshkey_cred
 
 - name: Assert sshKey credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - sshkey_cred.changed == true
     fail_msg: "sshKey credential changed status incorrect"
@@ -166,7 +166,7 @@
   register: cert_p12_cred
 
 - name: Assert certificate (p12) credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - cert_p12_cred.changed == true
     fail_msg: "certificate (p12) credential changed status incorrect"
@@ -185,7 +185,7 @@
   register: cert_pem_cred
 
 - name: Assert certificate (pem) credential changed value
-  assert:
+  ansible.builtin.assert:
     that:
       - cert_pem_cred.changed == true
     fail_msg: "certificate (pem) credential changed status incorrect"

--- a/tests/integration/targets/jenkins_credential/tasks/main.yml
+++ b/tests/integration/targets/jenkins_credential/tasks/main.yml
@@ -17,7 +17,7 @@
   register: token_result
 
 - name: Assert token and tokenUuid are returned
-  assert:
+  ansible.builtin.assert:
     that:
       - token_result.token is defined
       - token_result.token_uuid is defined
@@ -67,7 +67,7 @@
   register: delete_token_result
 
 - name: Assert token deletion
-  assert:
+  ansible.builtin.assert:
     that:
       - delete_token_result.changed is true
     fail_msg: "Token deletion failed"

--- a/tests/integration/targets/jira/tasks/main.yml
+++ b/tests/integration/targets/jira/tasks/main.yml
@@ -17,7 +17,7 @@
 - debug:
     msg: Issue={{ issue }}
 - name: assert test ticket
-  assert:
+  ansible.builtin.assert:
     that:
       - issue is changed
       - issue.meta.key.startswith(proj)
@@ -32,7 +32,7 @@
     comment: bleep bleep!
   register: comment_bleep_bleep
 - name: assert comment bleep bleep
-  assert:
+  ansible.builtin.assert:
     that:
       - comment_bleep_bleep is changed
       - comment_bleep_bleep.meta.body == "bleep bleep!"
@@ -49,7 +49,7 @@
     comment: -> in progress
   register: transition_inprog
 - name: assert transition -> In Progress with comment
-  assert:
+  ansible.builtin.assert:
     that:
       - transition_inprog is changed
 
@@ -63,7 +63,7 @@
     account_id: "{{ user2 }}"
   register: assign
 - name: assert change assignee
-  assert:
+  ansible.builtin.assert:
     that:
       - assign is changed
 
@@ -79,7 +79,7 @@
       timeSpentSeconds: 1200
   register: worklog
 - name: assert worklog -> with comment
-  assert:
+  ansible.builtin.assert:
     that:
       - worklog is changed
       - worklog.meta.comment == 'Worklog'
@@ -101,7 +101,7 @@
       description: wakawakawakawaka
   register: transition_resolved
 - name: assert transition -> Resolved with comment
-  assert:
+  ansible.builtin.assert:
     that:
       - transition_resolved is changed
 

--- a/tests/integration/targets/kdeconfig/tasks/main.yml
+++ b/tests/integration/targets/kdeconfig/tasks/main.yml
@@ -31,7 +31,7 @@
   ignore_errors: true
 
 - name: Simple test - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_simple is changed
       - result_simple is not failed
@@ -48,7 +48,7 @@
   ignore_errors: true
 
 - name: Simple test - idempotence - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_simple_idem is not changed
       - result_simple_idem is not failed
@@ -71,7 +71,7 @@
   ignore_errors: true
 
 - name: Group and groups are mutually exclusive - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_group_mutex is not changed
       - result_group_mutex is failed
@@ -90,7 +90,7 @@
   ignore_errors: true
 
 - name: value and bool_value are mutually exclusive - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_val_mutex is not changed
       - result_val_mutex is failed
@@ -108,7 +108,7 @@
   ignore_errors: true
 
 - name: bool_value must be bool - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_val_bool is not changed
       - result_val_bool is failed
@@ -129,7 +129,7 @@
   ignore_errors: true
 
 - name: Multiple groups test - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_groups is changed
       - result_groups is not failed
@@ -149,7 +149,7 @@
   ignore_errors: true
 
 - name: Multiple groups test - idempotence - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_groups_idem is not changed
       - result_groups_idem is not failed
@@ -171,7 +171,7 @@
   ignore_errors: true
 
 - name: Simple test - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_bool is changed
       - result_bool is not failed
@@ -188,7 +188,7 @@
   ignore_errors: true
 
 - name: Bool test - idempotence - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_bool_idem is not changed
       - result_bool_idem is not failed
@@ -221,7 +221,7 @@
   ignore_errors: true
 
 - name: check_mode test - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_checkmode is changed
       - result_checkmode is not failed
@@ -244,7 +244,7 @@
   diff: true
 
 - name: check_mode test - apply - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_checkmode_apply is changed
       - result_checkmode_apply is not failed
@@ -267,7 +267,7 @@
   check_mode: true
 
 - name: check_mode test - idempotence - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_checkmode2 is not changed
       - result_checkmode2 is not failed
@@ -289,7 +289,7 @@
   ignore_errors: true
 
 - name: Unicode test - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_unicode is changed
       - result_unicode is not failed
@@ -310,7 +310,7 @@
   ignore_errors: true
 
 - name: Missing groups - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_mgroup is not changed
       - result_mgroup is failed
@@ -327,7 +327,7 @@
   ignore_errors: true
 
 - name: Missing key - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_mkey is not changed
       - result_mkey is failed
@@ -344,7 +344,7 @@
   ignore_errors: true
 
 - name: Missing value - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_mvalue is not changed
       - result_mvalue is failed
@@ -362,7 +362,7 @@
   ignore_errors: true
 
 - name: Empty key - checks
-  assert:
+  ansible.builtin.assert:
     that:
       - result_ekey is not changed
       - result_ekey is failed

--- a/tests/integration/targets/kernel_blacklist/tasks/main.yml
+++ b/tests/integration/targets/kernel_blacklist/tasks/main.yml
@@ -44,7 +44,7 @@
     # q('ansible.builtin.subelements', bl_test_1, 'deprecations', {'skip_missing': True}) }}"
 
 - name: assert file is unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - bl_test_1 is not changed
       - bl_test_1a is not changed
@@ -63,7 +63,7 @@
       blacklist cccc
 
 - name: test deprecation
-  assert:
+  ansible.builtin.assert:
     that:
       - "'deprecations' not in bl_test_1"
 
@@ -80,7 +80,7 @@
   register: slurp_test_2
 
 - name: assert element is added
-  assert:
+  ansible.builtin.assert:
     that:
       - bl_test_2 is changed
       - slurp_test_2.content|b64decode == (content | trim + '\n')
@@ -108,7 +108,7 @@
   register: slurp_test_3
 
 - name: assert element is removed
-  assert:
+  ansible.builtin.assert:
     that:
       - bl_test_3 is changed
       - slurp_test_3.content|b64decode == (content | trim + '\n')

--- a/tests/integration/targets/keycloak_authz_authorization_scope/tasks/main.yml
+++ b/tests/integration/targets/keycloak_authz_authorization_scope/tasks/main.yml
@@ -43,7 +43,7 @@
   register: result
 
 - name: Assert that authorization scope was not created in check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -68,7 +68,7 @@
   register: result
 
 - name: Assert that authorization scope was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -91,7 +91,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state != {}
@@ -114,7 +114,7 @@
   register: result
 
 - name: Assert that authorization scope was not updated in check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.msg == 'Authorization scope would be updated'
@@ -136,7 +136,7 @@
   register: result
 
 - name: Assert that optional parameters have been removed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -157,7 +157,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state != {}
@@ -180,7 +180,7 @@
   register: result
 
 - name: Assert that authorization scope has not been removed in check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.msg == 'Authorization scope would be removed'
@@ -200,7 +200,7 @@
   register: result
 
 - name: Assert that authorization scope has been removed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -218,7 +218,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state == {}

--- a/tests/integration/targets/keycloak_authz_custom_policy/tasks/main.yml
+++ b/tests/integration/targets/keycloak_authz_custom_policy/tasks/main.yml
@@ -41,7 +41,7 @@
   register: result
 
 - name: Assert that first custom policy was not created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -63,7 +63,7 @@
   register: result
 
 - name: Assert that first custom policy was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -85,7 +85,7 @@
   register: result
 
 - name: Assert that first custom policy was not modified
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state != {}
@@ -108,7 +108,7 @@
   register: result
 
 - name: Assert that second instance of the custom policy was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -131,7 +131,7 @@
   register: result
 
 - name: Assert that second custom policy was not removed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -151,7 +151,7 @@
   register: result
 
 - name: Assert that second custom policy was removed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}

--- a/tests/integration/targets/keycloak_authz_permission/tasks/main.yml
+++ b/tests/integration/targets/keycloak_authz_permission/tasks/main.yml
@@ -141,7 +141,7 @@
   register: result
 
 - name: Assert that scope permission was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -164,7 +164,7 @@
   register: result
 
 - name: Assert that queried state matches desired end state
-  assert:
+  ansible.builtin.assert:
     that:
       - result.queried_state.name == "ScopePermission"
       - result.queried_state.description == "Scope permission"
@@ -188,7 +188,7 @@
   register: result
 
 - name: Assert that nothing changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result.end_state != {}
       - result.end_state.name == "ScopePermission"
@@ -210,7 +210,7 @@
   register: result
 
 - name: Assert that queried state matches desired end state
-  assert:
+  ansible.builtin.assert:
     that:
       - result.queried_state.name == "ScopePermission"
       - result.queried_state.description == "Scope permission"
@@ -235,7 +235,7 @@
   register: result
 
 - name: Assert that scope permission was updated correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - result.changed == True
       - result.end_state != {}
@@ -257,7 +257,7 @@
   register: result
 
 - name: Assert that queried state matches desired end state
-  assert:
+  ansible.builtin.assert:
     that:
       - result.queried_state.name == "ScopePermission"
       - result.queried_state.description == "Scope permission changed"
@@ -282,7 +282,7 @@
   register: result
 
 - name: Assert that nothing changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result.changed == True
       - result.end_state != {}
@@ -304,7 +304,7 @@
   register: result
 
 - name: Assert that queried state matches desired end state
-  assert:
+  ansible.builtin.assert:
     that:
       - result.queried_state.name == "ScopePermission"
       - result.queried_state.description == "Scope permission changed"
@@ -323,7 +323,7 @@
   register: result
 
 - name: Assert that scope permission was removed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -342,7 +342,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state == {}
@@ -404,7 +404,7 @@
   register: result
 
 - name: Assert that resource permission was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -425,7 +425,7 @@
   register: result
 
 - name: Assert that queried state matches desired end state
-  assert:
+  ansible.builtin.assert:
     that:
       - result.queried_state.name == "ResourcePermission"
       - result.queried_state.description == "Resource permission"
@@ -449,7 +449,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result.end_state != {}
       - result.end_state.policies|length == 1
@@ -469,7 +469,7 @@
   register: result
 
 - name: Assert that queried state matches desired end state
-  assert:
+  ansible.builtin.assert:
     that:
       - result.queried_state.name == "ResourcePermission"
       - result.queried_state.description == "Resource permission"
@@ -492,7 +492,7 @@
   register: result
 
 - name: Assert that resource permission was updated correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - result.changed == True
       - result.end_state != {}
@@ -513,7 +513,7 @@
   register: result
 
 - name: Assert that queried state matches desired end state
-  assert:
+  ansible.builtin.assert:
     that:
       - result.queried_state.name == "ResourcePermission"
       - result.queried_state.description == "Resource permission changed"
@@ -532,7 +532,7 @@
   register: result
 
 - name: Assert that resource permission was removed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -551,7 +551,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state == {}

--- a/tests/integration/targets/keycloak_client/tasks/main.yml
+++ b/tests/integration/targets/keycloak_client/tasks/main.yml
@@ -84,7 +84,7 @@
   register: check_client_when_present_and_same
 
 - name: Assert changes not detected in last two tasks (desire when same, and check)
-  assert:
+  ansible.builtin.assert:
     that:
       - desire_client_when_present_and_same is not changed
       - check_client_when_present_and_same is not changed
@@ -107,7 +107,7 @@
   register: check_client_when_present_and_changed
 
 - name: Assert changes detected in last tasks
-  assert:
+  ansible.builtin.assert:
     that:
       - check_client_when_present_and_changed is changed
 
@@ -128,7 +128,7 @@
   register: check_client_protocol_mappers_idempotence
 
 - name: Assert idempotence changes to protocol_mappers
-  assert:
+  ansible.builtin.assert:
     that:
       - check_client_protocol_mappers_idempotence is changed
       - end_state.protocolMappers | length == 3
@@ -160,7 +160,7 @@
   register: desire_client_with_flow_binding_overrides
 
 - name: Assert flows are set
-  assert:
+  ansible.builtin.assert:
     that:
       - desire_client_with_flow_binding_overrides is changed
       - "'authenticationFlowBindingOverrides' in desire_client_with_flow_binding_overrides.end_state"
@@ -189,7 +189,7 @@
   register: desire_client_with_flow_binding_overrides
 
 - name: Assert flows are updated
-  assert:
+  ansible.builtin.assert:
     that:
       - desire_client_with_flow_binding_overrides is changed
       - "'authenticationFlowBindingOverrides' in desire_client_with_flow_binding_overrides.end_state"
@@ -213,7 +213,7 @@
   register: desire_client_with_flow_binding_overrides
 
 - name: Assert flows are updated
-  assert:
+  ansible.builtin.assert:
     that:
       - desire_client_with_flow_binding_overrides is changed
       - "'authenticationFlowBindingOverrides' in desire_client_with_flow_binding_overrides.end_state"
@@ -238,7 +238,7 @@
   register: desire_client_with_flow_binding_overrides
 
 - name: Assert flows are updated
-  assert:
+  ansible.builtin.assert:
     that:
       - desire_client_with_flow_binding_overrides is changed
       - "'authenticationFlowBindingOverrides' in desire_client_with_flow_binding_overrides.end_state"
@@ -263,7 +263,7 @@
   register: desire_client_with_flow_binding_overrides
 
 - name: Assert flows are removed
-  assert:
+  ansible.builtin.assert:
     that:
       - desire_client_with_flow_binding_overrides is changed
       - "'authenticationFlowBindingOverrides' in desire_client_with_flow_binding_overrides.end_state"
@@ -318,7 +318,7 @@
   register: desire_client_with_default_client_scopes
 
 - name: Assert default_client_scopes and optional_client_scopes are set correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - desire_client_with_default_client_scopes is changed
       - '"scope1" in end_state.defaultClientScopes'
@@ -343,7 +343,7 @@
   register: desire_client_with_default_client_scopes
 
 - name: Assert client scopes remain unchanged with ignore behavior
-  assert:
+  ansible.builtin.assert:
     that:
       - desire_client_with_default_client_scopes is not changed
       - end_state.defaultClientScopes | length == 1
@@ -369,7 +369,7 @@
   register: desire_client_with_default_client_scopes
 
 - name: Assert patch behavior fails when scope is both default and optional
-  assert:
+  ansible.builtin.assert:
     that:
       - desire_client_with_default_client_scopes is failed
       - "'scope3' in desire_client_with_default_client_scopes.msg"
@@ -389,7 +389,7 @@
   register: desire_client_with_default_client_scopes
 
 - name: Assert client scopes are patched correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - desire_client_with_default_client_scopes is changed
       - end_state.defaultClientScopes | length == 2
@@ -415,7 +415,7 @@
   register: desire_client_with_default_client_scopes
 
 - name: Assert idempotent behavior with empty default_client_scopes
-  assert:
+  ansible.builtin.assert:
     that:
       - desire_client_with_default_client_scopes is changed
       - end_state.defaultClientScopes | length == 0
@@ -449,7 +449,7 @@
   register: check_client_when_present_and_attributes_modified
 
 - name: Assert client attributes are updated
-  assert:
+  ansible.builtin.assert:
     that:
       - check_client_when_present_and_attributes_modified is changed
       - end_state.attributes["backchannel.logout.revoke.offline.tokens"] == 'false'
@@ -474,7 +474,7 @@
   register: result_create_logout_client
 
 - name: Assert logout client is created with correct attributes
-  assert:
+  ansible.builtin.assert:
     that:
       - result_create_logout_client is changed
       - result_create_logout_client.end_state.attributes["post.logout.redirect.uris"] is defined
@@ -494,7 +494,7 @@
   register: result_idempotent_logout_client
 
 - name: Assert logout client is idempotent
-  assert:
+  ansible.builtin.assert:
     that:
       - result_idempotent_logout_client is not changed
 
@@ -513,7 +513,7 @@
   register: result_update_logout_client
 
 - name: Assert logout client fields are updated
-  assert:
+  ansible.builtin.assert:
     that:
       - result_update_logout_client is changed
       - result_update_logout_client.end_state.attributes["backchannel.logout.url"] == "https://example.com/new-backchannel"

--- a/tests/integration/targets/keycloak_client_rolescope/tasks/main.yml
+++ b/tests/integration/targets/keycloak_client_rolescope/tasks/main.yml
@@ -101,7 +101,7 @@
   register: result
 
 - name: Assert mapping created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | length == 2
@@ -120,7 +120,7 @@
   register: result
 
 - name: Assert mapping created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state | length == 2
@@ -140,7 +140,7 @@
   register: result
 
 - name: Assert mapping deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | length == 1
@@ -162,7 +162,7 @@
   register: result
 
 - name: Assert failed mapping missing role
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
 
@@ -181,7 +181,7 @@
   register: result
 
 - name: Assert result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | length == 2
@@ -200,7 +200,7 @@
   register: result
 
 - name: Assert failed mapping role to full scope client
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
 
@@ -217,7 +217,7 @@
   register: result
 
 - name: Assert result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | length == 1
@@ -236,7 +236,7 @@
   register: result
 
 - name: Assert result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | length == 2
@@ -256,7 +256,7 @@
   register: result
 
 - name: Assert result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | length == 0
@@ -275,7 +275,7 @@
   register: result
 
 - name: Assert failed mapping missing realm role
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
 
@@ -294,7 +294,7 @@
   register: result
 
 - name: Assert result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | length == 2
@@ -311,7 +311,7 @@
   register: result
 
 - name: Assert result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state | length == 0

--- a/tests/integration/targets/keycloak_clientscope_rolemappings/tasks/main.yml
+++ b/tests/integration/targets/keycloak_clientscope_rolemappings/tasks/main.yml
@@ -122,7 +122,7 @@
   register: result
 
 - name: Assert mapping created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | length == 2
@@ -141,7 +141,7 @@
   register: result
 
 - name: Assert no change
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state | length == 2
@@ -161,7 +161,7 @@
   register: result
 
 - name: Assert mapping deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | length == 1
@@ -183,7 +183,7 @@
   register: result
 
 - name: Assert failed mapping missing role
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
       - "result.msg == 'Failed to retrieve role \\'myrealm.backend-client.client-role-missing\\''"
@@ -203,7 +203,7 @@
   register: result
 
 - name: Assert result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | length == 2
@@ -223,7 +223,7 @@
   register: result
 
 - name: Assert failed mapping role to full scope client
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
       - "result.msg == 'FullScopeAllowed is active for Client \\'myrealm.full-scope-client\\''"
@@ -241,7 +241,7 @@
   register: result
 
 - name: Assert result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | length == 1
@@ -260,7 +260,7 @@
   register: result
 
 - name: Assert result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | length == 2
@@ -280,7 +280,7 @@
   register: result
 
 - name: Assert result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | length == 0
@@ -299,7 +299,7 @@
   register: result
 
 - name: Assert failed mapping missing realm role
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
       - "result.msg == 'Failed to retrieve role \\'myrealm.client-role-missing\\''"
@@ -319,7 +319,7 @@
   register: result
 
 - name: Assert result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | length == 2
@@ -336,7 +336,7 @@
   register: result
 
 - name: Assert result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state | length == 0

--- a/tests/integration/targets/keycloak_clientscope_type/tasks/main.yml
+++ b/tests/integration/targets/keycloak_clientscope_type/tasks/main.yml
@@ -63,7 +63,7 @@
   register: result
 
 - name: Assert that client scope types are set
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -96,7 +96,7 @@
   register: result
 
 - name: Assert that client scope types are set
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -119,7 +119,7 @@
   register: result
 
 - name: Assert that client scope types are set
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -154,7 +154,7 @@
   register: result
 
 - name: Assert that client scope types are set
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}

--- a/tests/integration/targets/keycloak_clientsecret_info/tasks/main.yml
+++ b/tests/integration/targets/keycloak_clientsecret_info/tasks/main.yml
@@ -29,7 +29,7 @@
   register: fetch_by_client_id_result
 
 - name: Assert that the client secret was retrieved
-  assert:
+  ansible.builtin.assert:
     that:
       - fetch_by_client_id_result.clientsecret_info.type == "secret"
       - fetch_by_client_id_result.clientsecret_info.value | length >= 32
@@ -43,6 +43,6 @@
   register: fetch_by_id_result
 
 - name: Assert that the same client secret was retrieved both times
-  assert:
+  ansible.builtin.assert:
     that:
       - fetch_by_id_result.clientsecret_info.value == fetch_by_client_id_result.clientsecret_info.value

--- a/tests/integration/targets/keycloak_clientsecret_regenerate/tasks/main.yml
+++ b/tests/integration/targets/keycloak_clientsecret_regenerate/tasks/main.yml
@@ -29,7 +29,7 @@
   register: regenerate_by_client_id
 
 - name: Assert that the client secret was retrieved
-  assert:
+  ansible.builtin.assert:
     that:
       - regenerate_by_client_id.end_state.type == "secret"
       - regenerate_by_client_id.end_state.value | length >= 32
@@ -43,7 +43,7 @@
   register: regenerate_by_id
 
 - name: Assert that client secret was regenerated
-  assert:
+  ansible.builtin.assert:
     that:
       - regenerate_by_id.end_state.value | length >= 32
       - regenerate_by_id.end_state.value != regenerate_by_client_id.end_state.value

--- a/tests/integration/targets/keycloak_component_info/tasks/main.yml
+++ b/tests/integration/targets/keycloak_component_info/tasks/main.yml
@@ -43,7 +43,7 @@
   register: result
 
 - name: Assert ldap is missing
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.components | length == 0
@@ -101,7 +101,7 @@
   register: result
 
 - name: Assert ldap exists
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.components | length == 1
@@ -122,7 +122,7 @@
   register: result
 
 - name: Assert components exists
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.components | length > 0
@@ -139,7 +139,7 @@
   register: result
 
 - name: Assert sub component with name "email" exists
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.components | length == 1
@@ -157,7 +157,7 @@
   register: result
 
 - name: Assert ldap sub components filter by type
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.components | length > 0
@@ -175,7 +175,7 @@
   register: result
 
 - name: Assert key is missing
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.components | length == 0
@@ -209,7 +209,7 @@
   register: result
 
 - name: Assert key exists
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.components | length == 1
@@ -224,7 +224,7 @@
   register: result
 
 - name: Assert key exists
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.components | length > 0
@@ -240,7 +240,7 @@
   register: result
 
 - name: Assert key exists
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.components | length == 1
@@ -258,7 +258,7 @@
   register: result
 
 - name: Assert key exists
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.components | length == 1

--- a/tests/integration/targets/keycloak_group/tasks/main.yml
+++ b/tests/integration/targets/keycloak_group/tasks/main.yml
@@ -41,7 +41,7 @@
   until: result is not failed
 
 - name: Assert group was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -67,7 +67,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state != {}
@@ -91,7 +91,7 @@
   register: result
 
 - name: Assert that group name was updated
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -114,7 +114,7 @@
   register: result
 
 - name: Assert that group was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -131,7 +131,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state == {}
@@ -153,7 +153,7 @@
   register: result
 
 - name: Assert that group was correctly created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -179,7 +179,7 @@
   register: result
 
 - name: Assert that group was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -209,7 +209,7 @@
   register: result
 
 - name: Assert that subgroup was correctly created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -233,7 +233,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state != {}
@@ -258,7 +258,7 @@
   register: result
 
 - name: Assert that subgroup name has changed correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -282,7 +282,7 @@
   register: result
 
 - name: Assert that subgroup was correctly created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -306,7 +306,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state != {}
@@ -332,7 +332,7 @@
   register: result
 
 - name: Assert subgroup of subgroup was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -357,7 +357,7 @@
   register: result_subsubgrp
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result_subsubgrp is not changed
       - result_subsubgrp.end_state != {}
@@ -381,7 +381,7 @@
   register: result
 
 - name: Assert subgroup of subgroup was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -405,7 +405,7 @@
   register: result_subsubsubgrp
 
 - name: Assert that nothing changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result_subsubsubgrp is not changed
       - result_subsubsubgrp.end_state != {}
@@ -432,7 +432,7 @@
   register: result
 
 - name: Assert that subgroup was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -449,7 +449,7 @@
   register: result
 
 - name: Assert that nothing changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state == {}
@@ -468,7 +468,7 @@
   register: result
 
 - name: Assert that subgroup was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -487,7 +487,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state == {}
@@ -504,7 +504,7 @@
   register: result
 
 - name: Assert that group was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -521,7 +521,7 @@
   register: result
 
 - name: Assert that group was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state == {}

--- a/tests/integration/targets/keycloak_identity_provider/tasks/main.yml
+++ b/tests/integration/targets/keycloak_identity_provider/tasks/main.yml
@@ -65,7 +65,7 @@
     var: result
 
 - name: Assert identity provider created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.existing == {}
@@ -115,7 +115,7 @@
     var: result
 
 - name: Assert identity provider unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -136,7 +136,7 @@
     var: result
 
 - name: Assert identity provider updated
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.existing.enabled == true
@@ -166,7 +166,7 @@
     var: result
 
 - name: Assert identity provider updated
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.existing.mappers | length == 2
@@ -204,7 +204,7 @@
     var: result
 
 - name: Assert identity provider updated
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.existing.mappers | length == 1
@@ -241,7 +241,7 @@
     var: result
 
 - name: Assert identity provider updated
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -261,7 +261,7 @@
     var: result
 
 - name: Assert identity provider deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -282,7 +282,7 @@
     var: result
 
 - name: Assert identity provider unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state == {}
@@ -322,7 +322,7 @@
     var: result
 
 - name: Assert identity provider created with IDP endpoints
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state.config.authorizationUrl == "{{ url }}/realms/{{ idp_realm }}/protocol/openid-connect/auth"
@@ -357,7 +357,7 @@
   ignore_errors: true
 
 - name: Check failure of identity provider creation with fromUrl and userInfoUrl
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result is failed

--- a/tests/integration/targets/keycloak_realm/tasks/main.yml
+++ b/tests/integration/targets/keycloak_realm/tasks/main.yml
@@ -50,7 +50,7 @@
   register: result
 
 - name: Assert result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state.clientSessionIdleTimeout == 240
@@ -87,7 +87,7 @@
   register: result
 
 - name: Assert result
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state.clientSessionIdleTimeout == 240

--- a/tests/integration/targets/keycloak_realm_key/tasks/main.yml
+++ b/tests/integration/targets/keycloak_realm_key/tasks/main.yml
@@ -41,7 +41,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -74,7 +74,7 @@
   register: result
 
 - name: Assert that realm key was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -106,7 +106,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state != {}
@@ -139,7 +139,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -173,7 +173,7 @@
   register: result
 
 - name: Assert that realm key was updated
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -206,7 +206,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state != {}
@@ -239,7 +239,7 @@
   register: result
 
 - name: Assert that forced update ran correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -270,7 +270,7 @@
   register: result
 
 - name: Assert that realm key was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -292,7 +292,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state == {}
@@ -317,7 +317,7 @@
   register: result
 
 - name: Assert that realm key with custom certificate was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -350,7 +350,7 @@
   register: result
 
 - name: Assert that nothing has changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state != {}
@@ -388,7 +388,7 @@
   register: result
 
 - name: Assert HMAC key would be created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -417,7 +417,7 @@
   register: result
 
 - name: Assert HMAC key was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -447,7 +447,7 @@
   register: result
 
 - name: Assert HMAC key is in sync
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.msg == "Realm key hmac-test-key was in sync"
@@ -471,7 +471,7 @@
   register: result
 
 - name: Assert HMAC key was updated
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state.config.priority == ["110"]
@@ -492,7 +492,7 @@
   register: result
 
 - name: Assert HMAC key was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -520,7 +520,7 @@
   register: result
 
 - name: Assert AES key was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -547,7 +547,7 @@
   register: result
 
 - name: Assert AES key is in sync
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.msg == "Realm key aes-test-key was in sync"
@@ -567,7 +567,7 @@
   register: result
 
 - name: Assert AES key was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.msg == "Realm key aes-test-key deleted"
@@ -595,7 +595,7 @@
   register: result
 
 - name: Assert ECDSA key was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -624,7 +624,7 @@
   register: result
 
 - name: Assert ECDSA key is in sync
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.msg == "Realm key ecdsa-test-key was in sync"
@@ -644,7 +644,7 @@
   register: result
 
 - name: Assert ECDSA key was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.msg == "Realm key ecdsa-test-key deleted"
@@ -672,7 +672,7 @@
   register: result
 
 - name: Assert RSA generated key was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -701,7 +701,7 @@
   register: result
 
 - name: Assert RSA generated key is in sync
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.msg == "Realm key rsa-gen-test-key was in sync"
@@ -721,7 +721,7 @@
   register: result
 
 - name: Assert RSA generated key was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.msg == "Realm key rsa-gen-test-key deleted"
@@ -747,7 +747,7 @@
   register: result
 
 - name: Assert default hmac-generated key was updated
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state.config.priority == ["150"]
@@ -767,7 +767,7 @@
   register: result
 
 - name: Assert default hmac-generated key was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -796,7 +796,7 @@
   register: result
 
 - name: Assert RSA encryption key was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -825,7 +825,7 @@
   register: result
 
 - name: Assert RSA encryption key is in sync
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.msg == "Realm key rsa-enc-gen-test-key was in sync"
@@ -845,7 +845,7 @@
   register: result
 
 - name: Assert RSA encryption key was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.msg == "Realm key rsa-enc-gen-test-key deleted"
@@ -873,7 +873,7 @@
   register: result
 
 - name: Assert ECDH key was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -902,7 +902,7 @@
   register: result
 
 - name: Assert ECDH key is in sync
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.msg == "Realm key ecdh-test-key was in sync"
@@ -922,7 +922,7 @@
   register: result
 
 - name: Assert ECDH key was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.msg == "Realm key ecdh-test-key deleted"
@@ -949,7 +949,7 @@
   register: result
 
 - name: Assert EdDSA key was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -976,7 +976,7 @@
   register: result
 
 - name: Assert EdDSA key is in sync
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.msg == "Realm key eddsa-test-key was in sync"
@@ -996,7 +996,7 @@
   register: result
 
 - name: Assert EdDSA key was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.msg == "Realm key eddsa-test-key deleted"
@@ -1030,7 +1030,7 @@
   when: test_keystore_path is defined
 
 - name: Assert java-keystore key would be created (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -1064,7 +1064,7 @@
   when: test_keystore_path is defined
 
 - name: Assert java-keystore key was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -1101,7 +1101,7 @@
   when: test_keystore_path is defined
 
 - name: Assert java-keystore key is in sync
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.msg == "Realm key jks-test-key was in sync"
@@ -1129,7 +1129,7 @@
   when: test_keystore_path is defined
 
 - name: Assert java-keystore key was updated
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state.config.priority == ["110"]
@@ -1152,7 +1152,7 @@
   when: test_keystore_path is defined
 
 - name: Assert java-keystore key was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -1186,7 +1186,7 @@
   when: test_keystore_path is defined
 
 - name: Assert java-keystore key was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -1221,7 +1221,7 @@
 # for the config comparison (passwords are excluded from comparison).
 # The key difference is: always sends real passwords, on_create sends masked values.
 - name: Assert java-keystore key is in sync (no config changes detected)
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.msg == "Realm key jks-update-pw-test was in sync"
@@ -1265,7 +1265,7 @@
   when: test_keystore_path is defined
 
 - name: Assert java-keystore key was created with on_create mode
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -1296,7 +1296,7 @@
   when: test_keystore_path is defined
 
 - name: Assert java-keystore key is idempotent with on_create mode
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.msg == "Realm key jks-update-pw-test was in sync"
@@ -1325,7 +1325,7 @@
   when: test_keystore_path is defined
 
 - name: Assert priority was updated but passwords preserved
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state.config.priority == ["110"]
@@ -1348,7 +1348,7 @@
   when: test_keystore_path is defined
 
 - name: Assert java-keystore update_password test key was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}

--- a/tests/integration/targets/keycloak_realm_users_info/tasks/main.yml
+++ b/tests/integration/targets/keycloak_realm_users_info/tasks/main.yml
@@ -58,7 +58,7 @@
   register: create_result
 
 - name: Assert user is created
-  assert:
+  ansible.builtin.assert:
     that:
       - create_result.changed
       - create_result.end_state.username == 'test'
@@ -96,7 +96,7 @@
     user_info_with_groups: "{{ [user_infos.users[0] | combine({'groups': ['test', 'test2']}), user_infos.users[1] | combine({'groups': []}) ] }}"
 
 - name: Assert user info is returned correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - not user_infos.changed
       - " user_info_with_groups == [create_result.end_state, create_result2.end_state]"

--- a/tests/integration/targets/keycloak_role/tasks/main.yml
+++ b/tests/integration/targets/keycloak_role/tasks/main.yml
@@ -50,7 +50,7 @@
     var: result
 
 - name: Assert realm role created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.existing == {}
@@ -74,7 +74,7 @@
     var: result
 
 - name: Assert realm role unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -95,7 +95,7 @@
     var: result
 
 - name: Assert realm role updated
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.existing.description == description_1
@@ -117,7 +117,7 @@
     var: result
 
 - name: Assert realm role deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -138,7 +138,7 @@
     var: result
 
 - name: Assert realm role unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state == {}
@@ -161,7 +161,7 @@
     var: result
 
 - name: Assert client role created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.existing == {}
@@ -186,7 +186,7 @@
     var: result
 
 - name: Assert client role unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -208,7 +208,7 @@
     var: result
 
 - name: Assert client role updated
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.existing.description == description_1
@@ -231,7 +231,7 @@
     var: result
 
 - name: Assert client role deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -253,7 +253,7 @@
     var: result
 
 - name: Assert client role unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state == {}
@@ -277,7 +277,7 @@
     var: result
 
 - name: Assert realm role is created with composites
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state.composites | length == 3
@@ -301,7 +301,7 @@
     var: result
 
 - name: Assert realm role with composites have not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state.composites | length == 3
@@ -325,7 +325,7 @@
     var: result
 
 - name: Assert realm role with composites using aliases have not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -348,7 +348,7 @@
     var: result
 
 - name: Assert composite was removed from realm role with composites
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state.composites | length == 2
@@ -369,7 +369,7 @@
     var: result
 
 - name: Assert realm role deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -390,7 +390,7 @@
     var: result
 
 - name: Assert not changed and realm role absent
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state == {}
@@ -415,7 +415,7 @@
     var: result
 
 - name: Assert client role is created with composites
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state.composites | length == 3
@@ -440,7 +440,7 @@
     var: result
 
 - name: Assert client role with composites have not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state.composites | length == 3
@@ -465,7 +465,7 @@
     var: result
 
 - name: Assert composite was removed from client role with composites
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state.composites | length == 2
@@ -487,7 +487,7 @@
     var: result
 
 - name: Assert client role deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -509,7 +509,7 @@
     var: result
 
 - name: Assert not changed and client role absent
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state == {}

--- a/tests/integration/targets/keycloak_user_federation/tasks/main.yml
+++ b/tests/integration/targets/keycloak_user_federation/tasks/main.yml
@@ -60,7 +60,7 @@
     var: result
 
 - name: Assert user federation created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.existing == {}
@@ -113,7 +113,7 @@
     var: result
 
 - name: Assert user federation created (admin realm)
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.existing == {}
@@ -166,7 +166,7 @@
     var: result
 
 - name: Assert user federation unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.existing != {}
@@ -221,7 +221,7 @@
     var: result
 
 - name: Assert user federation unchanged (admin realm)
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.existing != {}
@@ -292,7 +292,7 @@
     var: result
 
 - name: Assert user federation created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.existing != {}
@@ -316,7 +316,7 @@
     var: result
 
 - name: Assert user federation deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.existing != {}
@@ -338,7 +338,7 @@
     var: result
 
 - name: Assert user federation unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.existing == {}
@@ -407,7 +407,7 @@
     var: result
 
 - name: Assert user federation created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.existing == {}

--- a/tests/integration/targets/keycloak_user_rolemapping/tasks/main.yml
+++ b/tests/integration/targets/keycloak_user_rolemapping/tasks/main.yml
@@ -51,7 +51,7 @@
   register: result
 
 - name: Assert realm role is assigned
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | selectattr("clientRole", "eq", false) | selectattr("name", "eq", role) | list | count > 0
@@ -72,7 +72,7 @@
   register: result
 
 - name: Assert realm role is unassigned
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - (result.end_state | length) == (result.existing | length) - 1
@@ -130,7 +130,7 @@
   register: result
 
 - name: Assert client role is assigned to user with no prior roles
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | selectattr("clientRole", "eq", true) | selectattr("name", "eq", role) | list | count > 0
@@ -152,7 +152,7 @@
   register: result
 
 - name: Assert cross-client role mapping is removed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == []
@@ -174,7 +174,7 @@
   register: result
 
 - name: Assert client role is assigned
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state | selectattr("clientRole", "eq", true) | selectattr("name", "eq", role) | list | count > 0
@@ -196,7 +196,7 @@
   register: result
 
 - name: Assert client role is unassigned
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == []

--- a/tests/integration/targets/keycloak_userprofile/tasks/main.yml
+++ b/tests/integration/targets/keycloak_userprofile/tasks/main.yml
@@ -57,7 +57,7 @@
   register: result
 
 - name: Assert that User Profile would be created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -78,7 +78,7 @@
   register: result
 
 - name: Assert that User Profile was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -98,7 +98,7 @@
   register: result
 
 - name: Assert that User Profile was in sync
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state != {}
@@ -119,7 +119,7 @@
   register: result
 
 - name: Assert that User Profile would be changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -140,7 +140,7 @@
   register: result
 
 - name: Assert that User Profile changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -160,7 +160,7 @@
   register: result
 
 - name: Assert that User Profile was in sync
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state != {}
@@ -182,7 +182,7 @@
 #   register: result
 #
 # - name: Assert that forced update ran correctly
-#   assert:
+#   ansible.builtin.assert:
 #     that:
 #       - result is changed
 #       - result.end_state != {}
@@ -203,7 +203,7 @@
   register: result
 
 - name: Assert that User Profile was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state == {}
@@ -221,7 +221,7 @@
   register: result
 
 - name: Assert that User Profile not present
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result.end_state == {}
@@ -240,7 +240,7 @@
   register: result
 
 - name: Assert that User Profile was created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -261,7 +261,7 @@
   register: result
 
 - name: Assert that User Profile was changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}
@@ -282,7 +282,7 @@
   register: result
 
 - name: Assert that User Profile was changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result.end_state != {}

--- a/tests/integration/targets/launchd/tasks/teardown.yml
+++ b/tests/integration/targets/launchd/tasks/teardown.yml
@@ -11,7 +11,7 @@
   register: launchd_unloaded_result
 
 - name: "[{{ item }}] Validation"
-  assert:
+  ansible.builtin.assert:
     that:
       - launchd_unloaded_result is success
       - launchd_unloaded_result.status.current_state == 'unloaded'

--- a/tests/integration/targets/launchd/tasks/tests/test_reload.yml
+++ b/tests/integration/targets/launchd/tasks/tests/test_reload.yml
@@ -14,7 +14,7 @@
   check_mode: true
 
 - name: "[{{ item }}] Assert that everything work in check mode"
-  assert:
+  ansible.builtin.assert:
     that:
       - test_1_launchd_start_result_check_mode is success
       - test_1_launchd_start_result_check_mode is changed
@@ -47,7 +47,7 @@
   register: "test_1_launchd_reload_result"
 
 - name: "[{{ item }}] Validate that service was reloaded"
-  assert:
+  ansible.builtin.assert:
     that:
       - test_1_launchd_reload_result is success
       - test_1_launchd_reload_result is changed

--- a/tests/integration/targets/launchd/tasks/tests/test_restart.yml
+++ b/tests/integration/targets/launchd/tasks/tests/test_restart.yml
@@ -22,7 +22,7 @@
   check_mode: true
 
 - name: "[{{ item }}] Validate that service was restarted in check mode"
-  assert:
+  ansible.builtin.assert:
     that:
       - test_1_launchd_restart_result_check_mode is success
       - test_1_launchd_restart_result_check_mode is changed
@@ -35,7 +35,7 @@
   register: "test_1_launchd_restart_result"
 
 - name: "[{{ item }}] Validate that service was restarted"
-  assert:
+  ansible.builtin.assert:
     that:
       - test_1_launchd_restart_result is success
       - test_1_launchd_restart_result is changed

--- a/tests/integration/targets/launchd/tasks/tests/test_runatload.yml
+++ b/tests/integration/targets/launchd/tasks/tests/test_runatload.yml
@@ -14,7 +14,7 @@
   register: test_1_launchd_start_result
 
 - name: "[{{ item }}] Validate that service was started"
-  assert:
+  ansible.builtin.assert:
     that:
       - test_1_launchd_start_result is success
       - test_1_launchd_start_result is changed

--- a/tests/integration/targets/launchd/tasks/tests/test_start_stop.yml
+++ b/tests/integration/targets/launchd/tasks/tests/test_start_stop.yml
@@ -15,7 +15,7 @@
 
 
 - name: "[{{ item }}] Validate that service was started in check mode"
-  assert:
+  ansible.builtin.assert:
     that:
       - test_1_launchd_start_result_check_mode is success
       - test_1_launchd_start_result_check_mode is changed
@@ -30,7 +30,7 @@
 
 
 - name: "[{{ item }}] Validate that service was started"
-  assert:
+  ansible.builtin.assert:
     that:
       - test_1_launchd_start_result is success
       - test_1_launchd_start_result is changed
@@ -50,7 +50,7 @@
   register: "test_2_launchd_stop_result"
 
 - name: "[{{ item }}] Validate that service was stopped after it was started"
-  assert:
+  ansible.builtin.assert:
     that:
       - test_2_launchd_stop_result is success
       - test_2_launchd_stop_result is changed
@@ -69,7 +69,7 @@
   register: "test_3_launchd_stop_result"
 
 - name: "[{{ item }}] Validate that service can be stopped after being already stopped"
-  assert:
+  ansible.builtin.assert:
     that:
       - test_3_launchd_stop_result is success
       - not test_3_launchd_stop_result is changed
@@ -88,7 +88,7 @@
   register: "test_4_launchd_start_result"
 
 - name: "[{{ item }}] Validate that service was started..."
-  assert:
+  ansible.builtin.assert:
     that:
       - test_4_launchd_start_result is success
       - test_4_launchd_start_result is changed
@@ -106,7 +106,7 @@
   register: "test_5_launchd_start_result"
 
 - name: "[{{ item }}] Validate that service is still in the same state as before"
-  assert:
+  ansible.builtin.assert:
     that:
       - test_5_launchd_start_result is success
       - not test_5_launchd_start_result is changed

--- a/tests/integration/targets/launchd/tasks/tests/test_unload.yml
+++ b/tests/integration/targets/launchd/tasks/tests/test_unload.yml
@@ -22,7 +22,7 @@
   check_mode: true
 
 - name: "[{{ item }}] Validate that service was unloaded in check mode"
-  assert:
+  ansible.builtin.assert:
     that:
       - test_1_launchd_unloaded_result_check_mode is success
       - test_1_launchd_unloaded_result_check_mode is changed
@@ -36,7 +36,7 @@
   register: "test_1_launchd_unloaded_result"
 
 - name: "[{{ item }}] Validate that service was unloaded"
-  assert:
+  ansible.builtin.assert:
     that:
       - test_1_launchd_unloaded_result is success
       - test_1_launchd_unloaded_result is changed
@@ -55,7 +55,7 @@
   register: "test_2_launchd_unloaded_result"
 
 - name: "[{{ item }}] Validate that service did not change and is still unloaded"
-  assert:
+  ansible.builtin.assert:
     that:
       - test_2_launchd_unloaded_result is success
       - not test_2_launchd_unloaded_result is changed

--- a/tests/integration/targets/ldap_inc/tasks/tests/basic.yml
+++ b/tests/integration/targets/ldap_inc/tasks/tests/basic.yml
@@ -19,7 +19,7 @@
   register: output
 
 - name: assert that test increment by default
-  assert:
+  ansible.builtin.assert:
     that:
       - output is not failed
       - output.incremented
@@ -37,7 +37,7 @@
   register: output
 
 - name: assert that test increment by default
-  assert:
+  ansible.builtin.assert:
     that:
       - output is not failed
       - output.incremented
@@ -55,7 +55,7 @@
   register: output
 
 - name: assert that test defined increment by 0
-  assert:
+  ansible.builtin.assert:
     that:
       - output is not failed
       - output.incremented == false
@@ -72,7 +72,7 @@
   register: output
 
 - name: assert that test defined negative increment
-  assert:
+  ansible.builtin.assert:
     that:
       - output is not failed
       - output.incremented
@@ -91,7 +91,7 @@
   register: output
 
 - name: assert that test defined negative increment
-  assert:
+  ansible.builtin.assert:
     that:
       - output is not failed
       - output.incremented

--- a/tests/integration/targets/ldap_search/tasks/tests/auth.yml
+++ b/tests/integration/targets/ldap_search/tasks/tests/auth.yml
@@ -20,7 +20,7 @@
   register: output
 
 - name: assert that test LDAP user can read its password
-  assert:
+  ansible.builtin.assert:
     that:
       - output is not failed
       - output.results | length == 1
@@ -40,7 +40,7 @@
   register: output
 
 - name: assert that test LDAP user can read its password
-  assert:
+  ansible.builtin.assert:
     that:
       - output is not failed
       - output.results | length == 1

--- a/tests/integration/targets/ldap_search/tasks/tests/basic.yml
+++ b/tests/integration/targets/ldap_search/tasks/tests/basic.yml
@@ -18,7 +18,7 @@
   register: output
 
 - name: assert that test LDAP user can be found
-  assert:
+  ansible.builtin.assert:
     that:
       - output is not failed
       - output.results | length == 1
@@ -33,7 +33,7 @@
   register: output
 
 - name: assert that the output is empty
-  assert:
+  ansible.builtin.assert:
     that:
       - output is not failed
       - output.results | length == 0

--- a/tests/integration/targets/ldap_search/tasks/tests/pages.yml
+++ b/tests/integration/targets/ldap_search/tasks/tests/pages.yml
@@ -18,7 +18,7 @@
   register: output
 
 - name: assert that the right number of results are returned
-  assert:
+  ansible.builtin.assert:
     that:
       - output is not failed
       - output.results | length == 2

--- a/tests/integration/targets/ldap_search/tasks/tests/schema.yml
+++ b/tests/integration/targets/ldap_search/tasks/tests/schema.yml
@@ -18,7 +18,7 @@
   register: output
 
 - name: Assert that the schema output is correct
-  assert:
+  ansible.builtin.assert:
     that:
       - output is not failed
       - output.results | length >= 1

--- a/tests/integration/targets/listen_ports_facts/tasks/main.yml
+++ b/tests/integration/targets/listen_ports_facts/tasks/main.yml
@@ -60,7 +60,7 @@
   when: ansible_facts.os_family == "RedHat" or ansible_facts.os_family == "Debian"
 
 - name: check that the include_non_listening parameters ('state' and 'foreign_address') are not active in default setting
-  assert:
+  ansible.builtin.assert:
     that:
       - ansible_facts.tcp_listen | selectattr('state', 'defined') | list | length == 0
       - ansible_facts.tcp_listen | selectattr('foreign_address', 'defined') | list | length == 0
@@ -79,29 +79,29 @@
   when: ansible_facts.os_family == "RedHat" and ansible_facts.distribution_major_version|int >= 7
 
 - name: check for ansible_facts.udp_listen exists
-  assert:
+  ansible.builtin.assert:
     that: ansible_facts.udp_listen is defined
   when: ansible_facts.os_family == "RedHat" or ansible_facts.os_family == "Debian"
 
 - name: check for ansible_facts.tcp_listen exists
-  assert:
+  ansible.builtin.assert:
     that: ansible_facts.tcp_listen is defined
   when: ansible_facts.os_family == "RedHat" or ansible_facts.os_family == "Debian"
 
 - name: check that the include_non_listening parameter 'state' and 'foreign_address' exists
-  assert:
+  ansible.builtin.assert:
     that:
       - ansible_facts.tcp_listen | selectattr('state', 'defined') | list | length > 0
       - ansible_facts.tcp_listen | selectattr('foreign_address', 'defined') | list | length > 0
   when: ansible_facts.os_family == "RedHat" or ansible_facts.os_family == "Debian"
 
 - name: check TCP 5556 is in listening ports
-  assert:
+  ansible.builtin.assert:
     that: 5556 in ansible_facts.tcp_listen | map(attribute='port') | sort | list
   when: (ansible_facts.os_family == "RedHat" and ansible_facts.distribution_major_version|int >= 7) or ansible_facts.os_family == "Debian"
 
 - name: check UDP 5555 is in listening ports
-  assert:
+  ansible.builtin.assert:
     that: 5555 in ansible_facts.udp_listen | map(attribute='port') | sort | list
   when: (ansible_facts.os_family == "RedHat" and ansible_facts.distribution_major_version|int >= 7) or ansible_facts.os_family == "Debian"
 

--- a/tests/integration/targets/locale_gen/tasks/basic.yml
+++ b/tests/integration/targets/locale_gen/tasks/basic.yml
@@ -19,7 +19,7 @@
   ignore_errors: true
 
 - name: Make sure the locale is not present {{ locale_basic.localegen }}
-  assert:
+  ansible.builtin.assert:
     that:
       - locale_basic.skip_removal or locale_basic.locales | intersect(cleaned.stdout_lines) == []
 
@@ -35,7 +35,7 @@
   ignore_errors: true
 
 - name: Make sure the locale is present and we say we installed it {{ locale_basic.localegen }}
-  assert:
+  ansible.builtin.assert:
     that:
       - locale_basic.locales | intersect(post_check_output_present.stdout_lines) != []
       - locale_basic.skip_removal or output_present is changed
@@ -52,7 +52,7 @@
   ignore_errors: true
 
 - name: Make sure the locale is present and we reported no change {{ locale_basic.localegen }}
-  assert:
+  ansible.builtin.assert:
     that:
       - locale_basic.locales | intersect(post_check_output_present_idempotent.stdout_lines) != []
       - output_present_idempotent is not changed
@@ -72,7 +72,7 @@
       ignore_errors: true
 
     - name: Make sure the locale is absent and we reported a change {{ locale_basic.localegen }}
-      assert:
+      ansible.builtin.assert:
         that:
           - locale_basic.locales | intersect(post_check_output_absent.stdout_lines) == []
           - output_absent is changed
@@ -89,7 +89,7 @@
       ignore_errors: true
 
     - name: Make sure the locale is absent and we reported no change {{ locale_basic.localegen }}
-      assert:
+      ansible.builtin.assert:
         that:
           - locale_basic.locales | intersect(post_check_output_absent_idempotent.stdout_lines) == []
           - output_absent_idempotent is not changed

--- a/tests/integration/targets/lookup_cartesian/tasks/main.yml
+++ b/tests/integration/targets/lookup_cartesian/tasks/main.yml
@@ -19,7 +19,7 @@
       - '2'
       - '3'
 - name: Verify cartesian lookup
-  assert:
+  ansible.builtin.assert:
     that:
       - product.results[0]['item'] == ["A", "1"]
       - product.results[1]['item'] == ["A", "2"]

--- a/tests/integration/targets/lookup_collection_version/runme.yml
+++ b/tests/integration/targets/lookup_collection_version/runme.yml
@@ -6,7 +6,7 @@
 - hosts: localhost
   tasks:
     - name: Test collection_version
-      assert:
+      ansible.builtin.assert:
         that:
           # Collection that does not exist
           - query('community.general.collection_version', 'foo.bar') == [none]
@@ -34,7 +34,7 @@
       register: invalid_fqcn
 
     - name: Validate error message
-      assert:
+      ansible.builtin.assert:
         that:
           - >
             '"foo.bar.baz" is not a FQCN' in invalid_fqcn.msg

--- a/tests/integration/targets/lookup_dependent/tasks/main.yml
+++ b/tests/integration/targets/lookup_dependent/tasks/main.yml
@@ -14,7 +14,7 @@
       }}
 
 - name: Check result of Test 1
-  assert:
+  ansible.builtin.assert:
     that:
       - loop_result == expected_result
   vars:
@@ -41,7 +41,7 @@
     # The last expression could have been `range(item.a, 5)`, but that's not supported by all Jinja2 versions used in CI
 
 - name: Check result of Test 2
-  assert:
+  ansible.builtin.assert:
     that:
       - loop_result == expected_result
   vars:
@@ -96,7 +96,7 @@
         - G
 
 - name: Check result of Test 3
-  assert:
+  ansible.builtin.assert:
     that:
       - (dependent.results | length) == 7
       - dependent.results[0].item.var1.key == "a"
@@ -133,7 +133,7 @@
   register: eval_error
 
 - name: Check result of Test 4
-  assert:
+  ansible.builtin.assert:
     that:
       - eval_error is failed
       - >-
@@ -149,7 +149,7 @@
   register: eval_error
 
 - name: Check result of Test 5
-  assert:
+  ansible.builtin.assert:
     that:
       - eval_error is failed
       - >-
@@ -165,7 +165,7 @@
   register: eval_error
 
 - name: Check result of Test 6
-  assert:
+  ansible.builtin.assert:
     that:
       - eval_error is failed
       - >-
@@ -180,7 +180,7 @@
   register: eval_error
 
 - name: Check result of Test 7
-  assert:
+  ansible.builtin.assert:
     that:
       - eval_error is failed
       - >-

--- a/tests/integration/targets/lookup_dig/tasks/main.yml
+++ b/tests/integration/targets/lookup_dig/tasks/main.yml
@@ -23,7 +23,7 @@
     dig_nonexisting_fail_no: "{{ lookup('community.general.dig', 'non-existing.domain.', 'fail_on_error=no') }}"
 
 - name: Verify that NXDOMAIN was returned
-  assert:
+  ansible.builtin.assert:
     that: dig_nonexisting_fail_no == 'NXDOMAIN'
 
 - name: Test dig lookup with non-existing domain and fail_on_error=yes
@@ -33,5 +33,5 @@
   register: dig_nonexisting_fail_yes_result
 
 - name: Verify that the task failed
-  assert:
+  ansible.builtin.assert:
     that: dig_nonexisting_fail_yes_result is failed

--- a/tests/integration/targets/lookup_etcd3/tasks/tests.yml
+++ b/tests/integration/targets/lookup_etcd3/tasks/tests.yml
@@ -12,7 +12,7 @@
         key_inexistent: "{{ lookup('community.general.etcd3', 'inexistent_key') }}"
 
     - name: 'Check etcd values'
-      assert:
+      ansible.builtin.assert:
         msg: 'unexpected etcd3 values'
         that:
           - etcdoutkey1 is sequence

--- a/tests/integration/targets/lookup_flattened/tasks/main.yml
+++ b/tests/integration/targets/lookup_flattened/tasks/main.yml
@@ -16,7 +16,7 @@
       - - c__
         - d__
 - name: verify with_flattened results
-  assert:
+  ansible.builtin.assert:
     that:
       - a__ == 'flattened'
       - b__ == 'flattened'

--- a/tests/integration/targets/lookup_github_app_access_token/tasks/main.yml
+++ b/tests/integration/targets/lookup_github_app_access_token/tasks/main.yml
@@ -24,7 +24,7 @@
   ansible.builtin.set_fact:
     github_app_token: "{{ lookup('community.general.github_app_access_token', app_id=github_app_id, installation_id=github_app_installation_id, private_key=github_app_private_key) }}"
 
-- assert:
+- ansible.builtin.assert:
     that:
       - github_app_access_token is failed
       - '"Github return error" in github_app_access_token.msg'

--- a/tests/integration/targets/lookup_lmdb_kv/test.yml
+++ b/tests/integration/targets/lookup_lmdb_kv/test.yml
@@ -10,11 +10,11 @@
     - debug:
         var: item.1
       loop: '{{ query("community.general.lmdb_kv", db="jp.mdb") }}'
-    - assert:
+    - ansible.builtin.assert:
         that:
           - query('community.general.lmdb_kv', 'nl', 'be', 'lu', db='jp.mdb') == ['Netherlands', 'Belgium', 'Luxembourg']
           - query('community.general.lmdb_kv', db='jp.mdb')|length == 5
-    - assert:
+    - ansible.builtin.assert:
         that:
           - item.0 == 'nl'
           - item.1 == 'Netherlands'
@@ -22,7 +22,7 @@
         lmdb_kv_db: jp.mdb
       with_community.general.lmdb_kv:
         - n*
-    - assert:
+    - ansible.builtin.assert:
         that:
           - item == 'Belgium'
       vars:

--- a/tests/integration/targets/lookup_merge_variables/test.yml
+++ b/tests/integration/targets/lookup_merge_variables/test.yml
@@ -18,7 +18,7 @@
             msg: "{{ merged_list }}"
 
         - name: Validate that the list is complete
-          assert:
+          ansible.builtin.assert:
             that:
               - "(merged_list | length) == 2"
               - "'item1' in merged_list"
@@ -33,7 +33,7 @@
             msg: "{{ merged_dict }}"
 
         - name: Validate that dict is complete
-          assert:
+          ansible.builtin.assert:
             that:
               - "'item1' in merged_dict"
               - "'item2' in merged_dict"
@@ -107,7 +107,7 @@
             msg: "{{ not_found }}"
         - name: Validate that the variable defaults to an empty list
           vars:
-          assert:
+          ansible.builtin.assert:
             that:
               - "(not_found | default('default-used', True)) == 'default-used'"
       vars:
@@ -121,7 +121,7 @@
             msg: "{{ merged_list }}"
 
         - name: Validate that the list is complete
-          assert:
+          ansible.builtin.assert:
             that:
               - "(merged_list | length) == 4"
               - "'item1' in merged_list"
@@ -138,7 +138,7 @@
             msg: "{{ merged_list }}"
 
         - name: Validate that the list is complete
-          assert:
+          ansible.builtin.assert:
             that:
               - "(merged_list | length) == 2"
               - "'item1' in merged_list"
@@ -153,7 +153,7 @@
             msg: "{{ merged_list }}"
 
         - name: Validate that the list is complete
-          assert:
+          ansible.builtin.assert:
             that:
               - "(merged_list | length) == 3"
               - "'item1' in merged_list"
@@ -171,7 +171,7 @@
 
         - name: Validate that the variable only contains the initial value
           vars:
-          assert:
+          ansible.builtin.assert:
             that:
               - "(not_found_initial_value | count) == 1"
               - "(not_found_initial_value | first) == 'item2'"
@@ -185,7 +185,7 @@
             msg: "{{ merged_list_with_initial_value }}"
 
         - name: Validate that the list is complete
-          assert:
+          ansible.builtin.assert:
             that:
               - "(merged_list_with_initial_value | length) == 3"
               - "'item1' in merged_list_with_initial_value"
@@ -202,7 +202,7 @@
             msg: "{{ merged_with_override_warn }}"
 
         - name: Validate that the dict is complete and the warning is printed
-          assert:
+          ansible.builtin.assert:
             that:
               - "'key_to_override' in merged_with_override_warn"
               - "merged_with_override_warn.key_to_override == 'Override value'"
@@ -224,7 +224,7 @@
             msg: "{{ _override_error_result }}"
 
         - name: Validate that the error is reported
-          assert:
+          ansible.builtin.assert:
             that:
               - "_override_error_result.failed"
               - "'key_to_override' in _override_error_result.msg"

--- a/tests/integration/targets/lookup_merge_variables/test_with_env.yml
+++ b/tests/integration/targets/lookup_merge_variables/test_with_env.yml
@@ -18,7 +18,7 @@
             msg: "{{ merged_list }}"
 
         - name: Validate that the list is complete
-          assert:
+          ansible.builtin.assert:
             that:
               - "(merged_list | length) == 2"
               - "'item1' in merged_list"
@@ -34,7 +34,7 @@
             msg: "{{ merged_list }}"
 
         - name: Validate that the list is complete
-          assert:
+          ansible.builtin.assert:
             that:
               - "(merged_list | length) == 3"
               - "'item1' in merged_list"

--- a/tests/integration/targets/lookup_passwordstore/tasks/password_tests.yml
+++ b/tests/integration/targets/lookup_passwordstore/tasks/password_tests.yml
@@ -12,7 +12,7 @@
     readpass: "{{ lookup('community.general.passwordstore', 'test-pass', backend=backend) }}"
 
 - name: Verify password ({{ backend }})
-  assert:
+  ansible.builtin.assert:
     that:
       - readpass == newpass
 
@@ -25,7 +25,7 @@
     readpass: "{{ lookup('community.general.passwordstore', 'test-pass-equal', backend=backend) }}"
 
 - name: Verify password ({{ backend }})
-  assert:
+  ansible.builtin.assert:
     that:
       - readpass == newpass
 
@@ -38,7 +38,7 @@
     readpass: "{{ lookup('community.general.passwordstore', 'test-missing-create', backend=backend) }}"
 
 - name: Verify password ({{ backend }})
-  assert:
+  ansible.builtin.assert:
     that:
       - readpass == newpass
 
@@ -47,7 +47,7 @@
     readpass: "{{ lookup('community.general.passwordstore', 'test-missing-create', missing='empty', backend=backend) }}"
 
 - name: Verify password ({{ backend }})
-  assert:
+  ansible.builtin.assert:
     that:
       - readpass == newpass
 
@@ -56,7 +56,7 @@
     readpass: "{{ query('community.general.passwordstore', 'test-missing-pass', missing='empty', backend=backend) }}"
 
 - name: Verify password ({{ backend }})
-  assert:
+  ansible.builtin.assert:
     that:
       - readpass == [ none ]
 
@@ -74,7 +74,7 @@
     readyamlpass: "{{ lookup('community.general.passwordstore', 'test-yaml-pass', subkey='key', backend=backend) }}"
 
 - name: Read a yaml subkey ({{ backend }})
-  assert:
+  ansible.builtin.assert:
     that:
       - readyamlpass == 'multi\nline\n'
 
@@ -90,7 +90,7 @@
     readyamlpass: "{{ lookup('community.general.passwordstore', 'test-multiline-pass', backend=backend) }}"
 
 - name: Multiline pass only returns first line ({{ backend }})
-  assert:
+  ansible.builtin.assert:
     that:
       - readyamlpass == 'testpassword'
 
@@ -99,7 +99,7 @@
     readyamlpass: "{{ lookup('community.general.passwordstore', 'test-multiline-pass', returnall='yes', backend=backend) }}"
 
 - name: Multiline pass returnall returns everything in the file ({{ backend }})
-  assert:
+  ansible.builtin.assert:
     that:
       - readyamlpass == 'testpassword\nrandom additional line\n'
 
@@ -112,7 +112,7 @@
     readpass: "{{ lookup('community.general.passwordstore', 'folder/test-pass', backend=backend) }}"
 
 - name: Verify password from folder ({{ backend }})
-  assert:
+  ansible.builtin.assert:
     that:
       - readpass == newpass
 
@@ -123,7 +123,7 @@
   register: eval_error
 
 - name: Make sure reading folder as passname failed ({{ backend }})
-  assert:
+  ansible.builtin.assert:
     that:
       - eval_error is failed
       - '"passname folder not found" in eval_error.msg'

--- a/tests/integration/targets/lookup_passwordstore/tasks/tests.yml
+++ b/tests/integration/targets/lookup_passwordstore/tasks/tests.yml
@@ -121,7 +121,7 @@
   register: eval_error
 
 - name: Make sure reading from non-existent passwordstore location failed
-  assert:
+  ansible.builtin.assert:
     that:
       - eval_error is failed
       - >-
@@ -155,7 +155,7 @@
         PATH: "/tmp"
 
     - name: Verify password received from shim
-      assert:
+      ansible.builtin.assert:
         that:
           - newpass == "shim_ok"
 
@@ -164,7 +164,7 @@
         newpass: "{{ lookup('community.general.passwordstore', 'folder') }}"
 
     - name: Verify password received from shim
-      assert:
+      ansible.builtin.assert:
         that:
           - newpass == "shim_ok"
 
@@ -218,7 +218,7 @@
         newpass: "{{ lookup('community.general.passwordstore', 'folder') }}"
 
     - name: Verify password received from gopass mock
-      assert:
+      ansible.builtin.assert:
         that:
           - newpass == "gopass_ok"
 

--- a/tests/integration/targets/lookup_random_pet/test.yml
+++ b/tests/integration/targets/lookup_random_pet/test.yml
@@ -15,7 +15,7 @@
         result5: "{{ query('community.general.random_pet', words=2, length=6, prefix='kubernetes', separator='_') }}"
 
     - name: Check results
-      assert:
+      ansible.builtin.assert:
         that:
           - result1 | length == 1
           - result1[0].split('-') | length == 3

--- a/tests/integration/targets/lookup_random_string/test.yml
+++ b/tests/integration/targets/lookup_random_string/test.yml
@@ -31,7 +31,7 @@
       register: impossible_result
 
     - name: Check results
-      assert:
+      ansible.builtin.assert:
         that:
           - result1[0] | length == 8
           - result2[0] | length == 0

--- a/tests/integration/targets/lookup_random_words/test.yml
+++ b/tests/integration/targets/lookup_random_words/test.yml
@@ -15,7 +15,7 @@
         result5: "{{ query('community.general.random_words', min_length=5, max_length=5, numwords=3, delimiter='') }}"
 
     - name: Check results
-      assert:
+      ansible.builtin.assert:
         that:
           - result1 | length == 1
           - result1[0] | length >= 35

--- a/tests/integration/targets/lvg/tasks/test_active_change.yml
+++ b/tests/integration/targets/lvg/tasks/test_active_change.yml
@@ -33,7 +33,7 @@
 
 - name: Assert all lv in testvg are active
   loop: "{{ initial_lv_status_result.stdout_lines }}"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'active' == item"
 
@@ -48,7 +48,7 @@
   register: deactivated_lv_status_result
 
 - name: Do all assertions to verify expected results
-  assert:
+  ansible.builtin.assert:
     that:
       - vg_deactivate_result is changed
       - "'active' not in deactivated_lv_status_result.stdout"
@@ -60,7 +60,7 @@
   register: repeated_vg_deactivate_result
 
 - name: Verify vg deactivation idempontency
-  assert:
+  ansible.builtin.assert:
     that:
       - repeated_vg_deactivate_result is not changed
 
@@ -76,7 +76,7 @@
   register: check_mode_activate_lv_status_result
 
 - name: Verify VG activation in check mode changed without activating LVs
-  assert:
+  ansible.builtin.assert:
     that:
       - check_mode_vg_activate_result is changed
       - "'active' not in check_mode_activate_lv_status_result.stdout"
@@ -92,13 +92,13 @@
   register: activate_lv_status_result
 
 - name: Verify vg activation
-  assert:
+  ansible.builtin.assert:
     that:
       - vg_activate_result is changed
 
 - name: Assert all lv in testvg are active
   loop: "{{ activate_lv_status_result.stdout_lines }}"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'active' == item"
 
@@ -109,7 +109,7 @@
   register: repeated_vg_activate_result
 
 - name: Verify vg activation idempontency
-  assert:
+  ansible.builtin.assert:
     that:
       - repeated_vg_activate_result is not changed
 
@@ -126,7 +126,7 @@
   register: partial_vg_activate_result
 
 - name: Verify partially activated vg activation
-  assert:
+  ansible.builtin.assert:
     that:
       - partial_vg_activate_result is changed
 
@@ -136,7 +136,7 @@
 
 - name: Assert all lv in testvg are active
   loop: "{{ activate_partial_lv_status_result.stdout_lines }}"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'active' == item"
 
@@ -152,12 +152,12 @@
   register: check_mode_deactivate_lv_status_result
 
 - name: Verify check mode vg deactivation changed
-  assert:
+  ansible.builtin.assert:
     that:
       - check_mode_vg_deactivate_result is changed
 
 - name: Assert all lv in testvg are still active
   loop: "{{ check_mode_deactivate_lv_status_result.stdout_lines }}"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'active' == item"

--- a/tests/integration/targets/lvg/tasks/test_active_create.yml
+++ b/tests/integration/targets/lvg/tasks/test_active_create.yml
@@ -20,7 +20,7 @@
       register: active_vg_autoact_status_result
 
     - name: Assert vg autoactivation is set for vg_autoact_test
-      assert:
+      ansible.builtin.assert:
         that: "'enabled' == active_vg_autoact_status_result.stdout"
 
     - name: Remove vg_autoact_test for the next test
@@ -40,7 +40,7 @@
       register: inactive_vg_autoact_status_result
 
     - name: Assert vg autoactivation disabled for vg_autoact_test
-      assert:
+      ansible.builtin.assert:
         that: "inactive_vg_autoact_status_result.stdout | length == 0"
 
     - name: Remove vg_autoact_test for the next test
@@ -61,7 +61,7 @@
       register: inactive_by_option_vg_autoact_status_result
 
     - name: Assert vg autoactivation disabled by option for vg_autoact_test
-      assert:
+      ansible.builtin.assert:
         that: "inactive_by_option_vg_autoact_status_result.stdout | length == 0"
   always:
     - name: Cleanup vg_autoact_test

--- a/tests/integration/targets/lvg/tasks/test_grow_reduce.yml
+++ b/tests/integration/targets/lvg/tasks/test_grow_reduce.yml
@@ -14,7 +14,7 @@
 - debug: var=ansible_facts.lvm
 
 - name: "Assert the testvg span only on first disk"
-  assert:
+  ansible.builtin.assert:
     that:
       - ansible_facts.lvm.pvs[loop_device1].vg == "testvg"
       - 'loop_device2 not in ansible_facts.lvm.pvs or
@@ -31,7 +31,7 @@
 - debug: var=ansible_facts.lvm
 
 - name: "Assert the testvg span only on first disk"
-  assert:
+  ansible.builtin.assert:
     that:
       - 'loop_device1 not in ansible_facts.lvm.pvs or
          ansible_facts.lvm.pvs[loop_device1].vg == ""'

--- a/tests/integration/targets/lvg/tasks/test_indempotency.yml
+++ b/tests/integration/targets/lvg/tasks/test_indempotency.yml
@@ -15,6 +15,6 @@
   register: repeat_vg_create
 
 - name: Do all assertions to verify expected results
-  assert:
+  ansible.builtin.assert:
     that:
       - repeat_vg_create is not changed

--- a/tests/integration/targets/lvg/tasks/test_pvresize.yml
+++ b/tests/integration/targets/lvg/tasks/test_pvresize.yml
@@ -13,7 +13,7 @@
   register: cmd_result
 
 - name: Assert the testvg size is 33554432B
-  assert:
+  ansible.builtin.assert:
     that:
       - "'33554432B' == cmd_result.stdout"
 
@@ -30,7 +30,7 @@
     pvresize: false
   register: cmd_result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - cmd_result is not changed
 
@@ -39,7 +39,7 @@
   register: cmd_result
 
 - name: Assert the testvg size is still 33554432B
-  assert:
+  ansible.builtin.assert:
     that:
       - "'33554432B' == cmd_result.stdout"
 
@@ -52,7 +52,7 @@
   register: cmd_result
 
 - name: Assert that the module returned the state was changed
-  assert:
+  ansible.builtin.assert:
     that:
       - cmd_result is changed
 
@@ -61,7 +61,7 @@
   register: cmd_result
 
 - name: Assert the testvg size is still 33554432B
-  assert:
+  ansible.builtin.assert:
     that:
       - "'33554432B' == cmd_result.stdout"
 
@@ -76,6 +76,6 @@
   register: cmd_result
 
 - name: Assert the testvg size is now 41943040B
-  assert:
+  ansible.builtin.assert:
     that:
       - "'41943040B' == cmd_result.stdout"

--- a/tests/integration/targets/lvg/tasks/test_remove_extra_pvs.yml
+++ b/tests/integration/targets/lvg/tasks/test_remove_extra_pvs.yml
@@ -16,7 +16,7 @@
 - debug: var=ansible_facts.lvm
 
 - name: "Assert the testvg span only on first disk"
-  assert:
+  ansible.builtin.assert:
     that:
       - ansible_facts.lvm.pvs[loop_device1].vg == "testvg"
       - 'loop_device2 not in ansible_facts.lvm.pvs or
@@ -34,7 +34,7 @@
 - debug: var=ansible_facts.lvm
 
 - name: "Assert the testvg spans on both disks"
-  assert:
+  ansible.builtin.assert:
     that:
       - ansible_facts.lvm.pvs[loop_device1].vg == "testvg"
       - ansible_facts.lvm.pvs[loop_device2].vg == "testvg"

--- a/tests/integration/targets/lvg/tasks/test_uuid_reset.yml
+++ b/tests/integration/targets/lvg/tasks/test_uuid_reset.yml
@@ -34,7 +34,7 @@
   register: new_pv_uuid_cmd_result
 
 - name: Do all assertions to verify expected results
-  assert:
+  ansible.builtin.assert:
     that:
       - vg_uuid_reset is changed
       - orig_vg_uuid_cmd_result.stdout != new_vg_uuid_cmd_result.stdout
@@ -62,7 +62,7 @@
   register: repeat_pv_uuid_cmd_result
 
 - name: Do all assertions to verify expected results
-  assert:
+  ansible.builtin.assert:
     that:
       - repeat_vg_uuid_reset is changed
       - repeat_pv_uuid_reset is changed
@@ -93,7 +93,7 @@
   register: check_mode_pv_uuid_cmd_result
 
 - name: Do all assertions to verify expected results
-  assert:
+  ansible.builtin.assert:
     that:
       - check_mode_vg_uuid_reset is changed
       - check_mode_pv_uuid_reset is changed

--- a/tests/integration/targets/lvg_rename/tasks/test.yml
+++ b/tests/integration/targets/lvg_rename/tasks/test.yml
@@ -16,7 +16,7 @@
   changed_when: false
 
 - name: Assert that renaming a VG is changed - check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - check_mode_vg_rename is changed
 
@@ -27,7 +27,7 @@
   register: vg_renamed
 
 - name: Assert that renaming a VG is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - vg_renamed is changed
 
@@ -57,7 +57,7 @@
   register: vg_renamed_again
 
 - name: Assert that renaming a VG again is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - check_mode_vg_renamed_again is not changed
       - vg_renamed_again is not changed
@@ -78,7 +78,7 @@
   register: ne_vg_rename
 
 - name: Assert that renaming a no-existing VG failed
-  assert:
+  ansible.builtin.assert:
     that:
       - check_mode_ne_vg_rename is failed
       - ne_vg_rename is failed
@@ -99,7 +99,7 @@
   register: vg_rename_collision
 
 - name: Assert that renaming to an existing VG name failed
-  assert:
+  ansible.builtin.assert:
     that:
       - check_mode_vg_rename_collision is failed
       - vg_rename_collision is failed

--- a/tests/integration/targets/lvol/tasks/test_pvs.yml
+++ b/tests/integration/targets/lvol/tasks/test_pvs.yml
@@ -12,7 +12,7 @@
   register: css_pvs_create_testlv1_result
 
 - name: Assert logical volume (testlv1) created with pvs set as comma separated string
-  assert:
+  ansible.builtin.assert:
     that:
       - css_pvs_create_testlv1_result is success
       - css_pvs_create_testlv1_result is changed
@@ -28,7 +28,7 @@
   register: list_pvs_create_testlv1_result
 
 - name: Assert logical volume (testlv1) creation idempotency with pvs set as list on second execution
-  assert:
+  ansible.builtin.assert:
     that:
       - list_pvs_create_testlv1_result is success
       - list_pvs_create_testlv1_result is not changed
@@ -44,7 +44,7 @@
   register: list_pvs_create_testlv2_result
 
 - name: Assert logical volume (testlv2) created with pvs set as list
-  assert:
+  ansible.builtin.assert:
     that:
       - list_pvs_create_testlv2_result is success
       - list_pvs_create_testlv2_result is changed
@@ -58,7 +58,7 @@
   register: css_pvs_create_testlv2_result
 
 - name: Assert logical volume (testlv2) creation idempotency with pvs set as comma separated string on second execution
-  assert:
+  ansible.builtin.assert:
     that:
       - css_pvs_create_testlv2_result is success
       - css_pvs_create_testlv2_result is not changed

--- a/tests/integration/targets/lvol/tasks/test_thinpool.yml
+++ b/tests/integration/targets/lvol/tasks/test_thinpool.yml
@@ -13,7 +13,7 @@
   register: thinpool_pct_vg_create
 
 - name: Assert thin pool with percentage of VG created
-  assert:
+  ansible.builtin.assert:
     that:
       - thinpool_pct_vg_create is success
       - thinpool_pct_vg_create is changed
@@ -26,7 +26,7 @@
   register: thinpool_pct_vg_idempotent
 
 - name: Assert thin pool with percentage of VG creation is idempotent
-  assert:
+  ansible.builtin.assert:
     that:
       - thinpool_pct_vg_idempotent is success
       - thinpool_pct_vg_idempotent is not changed
@@ -39,7 +39,7 @@
   register: thinpool_pct_free_create
 
 - name: Assert thin pool with percentage of free space created
-  assert:
+  ansible.builtin.assert:
     that:
       - thinpool_pct_free_create is success
       - thinpool_pct_free_create is changed
@@ -52,7 +52,7 @@
   register: thinpool_abs_create
 
 - name: Assert thin pool with absolute size created
-  assert:
+  ansible.builtin.assert:
     that:
       - thinpool_abs_create is success
       - thinpool_abs_create is changed
@@ -66,7 +66,7 @@
   register: thinpool_abs_idempotent
 
 - name: Assert thin pool with absolute size creation is idempotent
-  assert:
+  ansible.builtin.assert:
     that:
       - thinpool_abs_idempotent is success
       - thinpool_abs_idempotent is not changed
@@ -80,7 +80,7 @@
   register: thinvol_create
 
 - name: Assert thin volume created
-  assert:
+  ansible.builtin.assert:
     that:
       - thinvol_create is success
       - thinvol_create is changed
@@ -95,7 +95,7 @@
   register: thinvol_idempotent
 
 - name: Assert thin volume creation is idempotent
-  assert:
+  ansible.builtin.assert:
     that:
       - thinvol_idempotent is success
       - thinvol_idempotent is not changed

--- a/tests/integration/targets/lxd_project/tasks/main.yml
+++ b/tests/integration/targets/lxd_project/tasks/main.yml
@@ -29,7 +29,7 @@
   register: results
 
 - name: Check project has been created correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - results is changed
       - results.actions is defined
@@ -48,7 +48,7 @@
   register: results
 
 - name: Check state is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - results is not changed
       - "{{ results.actions | length }} == 0"
@@ -66,7 +66,7 @@
   register: results
 
 - name: Check state is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - results is changed
       - "'apply_projects_configs' in results.actions"
@@ -85,7 +85,7 @@
   register: results
 
 - name: Check state is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - results is changed
       - "'apply_projects_configs' in results.actions"
@@ -104,7 +104,7 @@
   register: results
 
 - name: Check state is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - results is changed
       - "'apply_projects_configs' in results.actions"
@@ -124,7 +124,7 @@
   register: results
 
 - name: Check state is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - results is changed
       - "'rename' in results.actions"
@@ -136,7 +136,7 @@
   register: results
 
 - name: Check project is deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - results is changed
       - "'delete' in results.actions"

--- a/tests/integration/targets/lxd_storage_pool_info/tasks/main.yaml
+++ b/tests/integration/targets/lxd_storage_pool_info/tasks/main.yaml
@@ -12,7 +12,7 @@
   register: pool_info_all
 
 - name: Verify pools information was retrieved
-  assert:
+  ansible.builtin.assert:
     that:
       - pool_info_all is not changed
       - pool_info_all is success
@@ -25,7 +25,7 @@
   register: pool_info_default
 
 - name: Verify default pool information
-  assert:
+  ansible.builtin.assert:
     that:
       - pool_info_default is not changed
       - pool_info_default is success
@@ -39,7 +39,7 @@
   register: pool_info_dir
 
 - name: Verify type filtering works
-  assert:
+  ansible.builtin.assert:
     that:
       - pool_info_dir is not changed
       - pool_info_dir is success
@@ -52,7 +52,7 @@
   ignore_errors: true
 
 - name: Verify error handling for non-existent pool
-  assert:
+  ansible.builtin.assert:
     that:
       - pool_info_nonexistent is failed
 
@@ -62,7 +62,7 @@
   register: pool_info_check
 
 - name: Verify check mode works
-  assert:
+  ansible.builtin.assert:
     that:
       - pool_info_check is not changed
       - pool_info_check is success

--- a/tests/integration/targets/lxd_storage_volume_info/tasks/main.yaml
+++ b/tests/integration/targets/lxd_storage_volume_info/tasks/main.yaml
@@ -13,7 +13,7 @@
   register: volume_info_all
 
 - name: Verify volumes information was retrieved
-  assert:
+  ansible.builtin.assert:
     that:
       - volume_info_all is not changed
       - volume_info_all is success
@@ -27,7 +27,7 @@
   register: volume_info_custom
 
 - name: Verify type filtering works
-  assert:
+  ansible.builtin.assert:
     that:
       - volume_info_custom is not changed
       - volume_info_custom is success
@@ -41,7 +41,7 @@
   register: volume_info_container
 
 - name: Verify container type filtering works
-  assert:
+  ansible.builtin.assert:
     that:
       - volume_info_container is not changed
       - volume_info_container is success
@@ -55,7 +55,7 @@
   when: volume_info_all.storage_volumes | length > 0
 
 - name: Verify specific volume retrieval
-  assert:
+  ansible.builtin.assert:
     that:
       - volume_info_specific is not changed
       - volume_info_specific is success
@@ -70,7 +70,7 @@
   ignore_errors: true
 
 - name: Verify error handling for non-existent pool
-  assert:
+  ansible.builtin.assert:
     that:
       - volume_info_nonexistent_pool is failed
 
@@ -82,7 +82,7 @@
   ignore_errors: true
 
 - name: Verify error handling for non-existent volume
-  assert:
+  ansible.builtin.assert:
     that:
       - volume_info_nonexistent_volume is failed
   when: volume_info_nonexistent_volume is defined
@@ -94,7 +94,7 @@
   register: volume_info_check
 
 - name: Verify check mode works
-  assert:
+  ansible.builtin.assert:
     that:
       - volume_info_check is not changed
       - volume_info_check is success

--- a/tests/integration/targets/mas/tasks/main.yml
+++ b/tests/integration/targets/mas/tasks/main.yml
@@ -22,7 +22,7 @@
   register: install_status
 
 - name: Ensure the app is uninstalled
-  assert:
+  ansible.builtin.assert:
     that:
       - install_status.stat.exists == false
 
@@ -39,7 +39,7 @@
   check_mode: true
 
 - name: Ensure that the status would have changed
-  assert:
+  ansible.builtin.assert:
     that:
       - install_check is changed
       - install_check.msg == "Installed 1 app(s)"
@@ -50,7 +50,7 @@
   register: install_status
 
 - name: Ensure the app is not yet installed
-  assert:
+  ansible.builtin.assert:
     that:
       - install_status.stat.exists == false
 
@@ -61,7 +61,7 @@
   register: install
 
 - name: Ensure that the status changed
-  assert:
+  ansible.builtin.assert:
     that:
       - install is changed
       - install.msg == "Installed 1 app(s)"
@@ -72,7 +72,7 @@
   register: install_status
 
 - name: Ensure the app is installed
-  assert:
+  ansible.builtin.assert:
     that:
       - install_status.stat.exists == true
 
@@ -87,7 +87,7 @@
   register: install_again
 
 - name: Ensure that the status is unchanged (already installed)
-  assert:
+  ansible.builtin.assert:
     that:
       - install_again is not changed
       - "'msg' not in install_again"
@@ -102,7 +102,7 @@
   check_mode: true
 
 - name: Ensure that the status would have changed
-  assert:
+  ansible.builtin.assert:
     that:
       - uninstall_check is changed
       - uninstall_check.msg == "Uninstalled 1 app(s)"
@@ -113,7 +113,7 @@
   register: install_status
 
 - name: Ensure the app is not yet uninstalled
-  assert:
+  ansible.builtin.assert:
     that:
       - install_status.stat.exists == true
 
@@ -125,7 +125,7 @@
   become: true
 
 - name: Ensure that the status changed
-  assert:
+  ansible.builtin.assert:
     that:
       - uninstall is changed
       - uninstall.msg == "Uninstalled 1 app(s)"
@@ -136,7 +136,7 @@
   register: uninstall_status
 
 - name: Ensure the app is uninstalled
-  assert:
+  ansible.builtin.assert:
     that:
       - uninstall_status.stat.exists == false
 
@@ -152,7 +152,7 @@
   become: true
 
 - name: Ensure that the status is unchanged (already uninstalled)
-  assert:
+  ansible.builtin.assert:
     that:
       - uninstall_again is not changed
       - "'msg' not in uninstall_again"

--- a/tests/integration/targets/memset_dns_reload/tasks/main.yml
+++ b/tests/integration/targets/memset_dns_reload/tasks/main.yml
@@ -15,7 +15,7 @@
   register: result
 
 - name: check API response with invalid API key
-  assert:
+  ansible.builtin.assert:
     that:
       - "'Memset API returned a 403 response (ApiErrorForbidden, Bad api_key)' in result.msg"
       - result is not successful
@@ -27,7 +27,7 @@
   register: result
 
 - name: check reload succeeded
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result is successful

--- a/tests/integration/targets/memset_memstore_info/tasks/main.yml
+++ b/tests/integration/targets/memset_memstore_info/tasks/main.yml
@@ -16,7 +16,7 @@
   register: result
 
 - name: check API response with invalid API key
-  assert:
+  ansible.builtin.assert:
     that:
       - "'Memset API returned a 403 response (ApiErrorForbidden, Bad api_key)' in result.msg"
       - result is not successful
@@ -28,7 +28,7 @@
   register: result
 
 - name: check the request succeeded
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result is successful

--- a/tests/integration/targets/memset_server_info/tasks/main.yml
+++ b/tests/integration/targets/memset_server_info/tasks/main.yml
@@ -16,7 +16,7 @@
   register: result
 
 - name: check API response with invalid API key
-  assert:
+  ansible.builtin.assert:
     that:
       - "'Memset API returned a 403 response (ApiErrorForbidden, Bad api_key)' in result.msg"
       - result is not successful
@@ -28,7 +28,7 @@
   register: result
 
 - name: check the request succeeded
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
       - result is successful

--- a/tests/integration/targets/memset_zone/tasks/main.yml
+++ b/tests/integration/targets/memset_zone/tasks/main.yml
@@ -22,7 +22,7 @@
   register: result
 
 - name: check API response with invalid API key
-  assert:
+  ansible.builtin.assert:
     that:
       - "'Memset API returned a 403 response (ApiErrorForbidden, Bad api_key)' in result.msg"
       - result is not successful
@@ -37,7 +37,7 @@
   register: result
 
 - name: check if the zone would be created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result is successful
@@ -51,7 +51,7 @@
   register: result
 
 - name: create the zone
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result is successful
@@ -65,7 +65,7 @@
   register: result
 
 - name: ensure we can't create duplicate zones
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -78,7 +78,7 @@
   register: result
 
 - name: check if the zone would be deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result is successful
@@ -92,7 +92,7 @@
   register: result
 
 - name: delete the zone
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result is successful
@@ -105,7 +105,7 @@
   register: result
 
 - name: ensure we can't create duplicate zones
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result is successful
@@ -119,7 +119,7 @@
   register: result
 
 - name: ensure force is respected
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result is successful

--- a/tests/integration/targets/memset_zone_domain/tasks/main.yml
+++ b/tests/integration/targets/memset_zone_domain/tasks/main.yml
@@ -18,7 +18,7 @@
   register: result
 
 - name: check API response with invalid API key
-  assert:
+  ansible.builtin.assert:
     that:
       - "'Memset API returned a 403 response (ApiErrorForbidden, Bad api_key)' in result.msg"
       - result is not successful
@@ -33,7 +33,7 @@
   register: result
 
 - name: test domain length is validated
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
       - "'Zone domain must be less than 250 characters in length' in result.stderr"
@@ -48,7 +48,7 @@
   register: result
 
 - name: fail if zone does not exist
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
       - "'does not exist, cannot create domain.' in result.stderr"
@@ -63,7 +63,7 @@
   register: result
 
 - name: fail if the zone is not unique
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
       - "'matches multiple zones, cannot create domain' in result.stderr"
@@ -78,7 +78,7 @@
   register: result
 
 - name: create domain with check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result is successful
@@ -92,7 +92,7 @@
   register: result
 
 - name: create domain
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result is successful
@@ -106,7 +106,7 @@
   register: result
 
 - name: create existing domain
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -120,7 +120,7 @@
   register: result
 
 - name: delete domain with check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result is successful
@@ -134,7 +134,7 @@
   register: result
 
 - name: delete domain
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -147,6 +147,6 @@
   register: result
 
 - name: delete absent domain
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed

--- a/tests/integration/targets/memset_zone_record/tasks/main.yml
+++ b/tests/integration/targets/memset_zone_record/tasks/main.yml
@@ -18,7 +18,7 @@
   ignore_errors: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - "'Memset API returned a 403 response (ApiErrorForbidden, Bad api_key)' in result.msg"
       - result is not successful
@@ -34,7 +34,7 @@
   register: result
 
 - name: assert that record is not created
-  assert:
+  ansible.builtin.assert:
     that:
       - "'DNS zone a-non-existent-zone does not exist.' in result.msg"
       - result is not successful
@@ -50,7 +50,7 @@
   register: result
 
 - name: assert that record is not created
-  assert:
+  ansible.builtin.assert:
     that:
       - "'ansible-dns-zone-dupe matches multiple zones.' in result.msg"
       - result is not successful
@@ -68,7 +68,7 @@
   register: result
 
 - name: assert that priority was out of range
-  assert:
+  ansible.builtin.assert:
     that:
       - "'Priority must be in the range 0 > 999 (inclusive).' in result.msg"
       - result is not successful
@@ -85,7 +85,7 @@
   register: result
 
 - name: assert that address was longer than allowed
-  assert:
+  ansible.builtin.assert:
     that:
       - "'Address must be less than 250 characters in length.' in result.msg"
       - result is not successful
@@ -102,7 +102,7 @@
   register: result
 
 - name: assert that record was longer than allowed
-  assert:
+  ansible.builtin.assert:
     that:
       - "'Record must be less than 63 characters in length.' in result.msg"
       - result is not successful
@@ -119,7 +119,7 @@
   register: result
 
 - name: assert that setting relative failed
-  assert:
+  ansible.builtin.assert:
     that:
       - "'Relative is only valid for CNAME, MX, NS and SRV record types' in result.msg"
       - result is not successful
@@ -136,7 +136,7 @@
   register: result
 
 - name: assert that result would have changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result is successful
@@ -152,7 +152,7 @@
   register: result
 
 - name: assert that result changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result is successful
@@ -167,7 +167,7 @@
   register: result
 
 - name: assert that result changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result is successful
@@ -184,7 +184,7 @@
   register: result
 
 - name: assert that result changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result is successful
@@ -200,7 +200,7 @@
   register: result
 
 - name: assert that result changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result is successful
@@ -215,7 +215,7 @@
   register: result
 
 - name: assert that result changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
       - result is successful
@@ -230,6 +230,6 @@
   register: result
 
 - name: assert that result changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed

--- a/tests/integration/targets/module_helper/tasks/mdepfail.yml
+++ b/tests/integration/targets/module_helper/tasks/mdepfail.yml
@@ -13,7 +13,7 @@
     var: result
 
 - name: assert failing dependency
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
       - '"Failed to import" in result.msg'

--- a/tests/integration/targets/module_helper/tasks/msimple.yml
+++ b/tests/integration/targets/module_helper/tasks/msimple.yml
@@ -8,7 +8,7 @@
   register: simple1
 
 - name: assert simple1
-  assert:
+  ansible.builtin.assert:
     that:
       - simple1.a == 80
       - simple1.abc == "abc"
@@ -22,7 +22,7 @@
   register: simple2
 
 - name: assert simple2
-  assert:
+  ansible.builtin.assert:
     that:
       - simple2.a == 101
       - 'simple2.msg == "Module failed with exception: a >= 100"'
@@ -38,7 +38,7 @@
   register: simple3
 
 - name: assert simple3
-  assert:
+  ansible.builtin.assert:
     that:
       - simple3.a == 2
       - simple3.b == "potatoespotatoes"
@@ -51,7 +51,7 @@
   register: simple4
 
 - name: assert simple4
-  assert:
+  ansible.builtin.assert:
     that:
       - simple4.c == "abc change"
       - simple4.abc == "changed abc"
@@ -73,7 +73,7 @@
   register: simple5b
 
 - name: assert simple5
-  assert:
+  ansible.builtin.assert:
     that:
       - simple5a.a == 3
       - simple5a.b == "ohohoh"

--- a/tests/integration/targets/module_helper/tasks/msimple_output_conflict.yml
+++ b/tests/integration/targets/module_helper/tasks/msimple_output_conflict.yml
@@ -8,7 +8,7 @@
   register: simple1
 
 - name: assert simple1
-  assert:
+  ansible.builtin.assert:
     that:
       - simple1.a == 80
       - simple1.abc == "abc"
@@ -22,7 +22,7 @@
   register: simple2
 
 - name: assert simple2
-  assert:
+  ansible.builtin.assert:
     that:
       - simple1.a == 80
       - simple1.abc == "abc"
@@ -41,7 +41,7 @@
   register: simple3
 
 - name: assert simple3
-  assert:
+  ansible.builtin.assert:
     that:
       - simple3.a == 101
       - >

--- a/tests/integration/targets/module_helper/tasks/msimpleda.yml
+++ b/tests/integration/targets/module_helper/tasks/msimpleda.yml
@@ -30,7 +30,7 @@
   register: simple1
 
 - name: assert simple1
-  assert:
+  ansible.builtin.assert:
     that:
       - simple1.a == 1
       - simple1.attr1 == "abc"
@@ -51,7 +51,7 @@
     var: simple2
 
 - name: assert simple2
-  assert:
+  ansible.builtin.assert:
     that:
       - simple2.a == 2
       - simple2.attr2 == "def"

--- a/tests/integration/targets/module_helper/tasks/mstate.yml
+++ b/tests/integration/targets/module_helper/tasks/mstate.yml
@@ -11,7 +11,7 @@
   register: state1
 
 - name: assert state1
-  assert:
+  ansible.builtin.assert:
     that:
       - state1.a == 80
       - state1.b == "banana"
@@ -27,7 +27,7 @@
   register: state2
 
 - name: assert state2
-  assert:
+  ansible.builtin.assert:
     that:
       - state2.a == 80
       - state2.b == "banana"
@@ -43,7 +43,7 @@
   register: state3
 
 - name: assert state3
-  assert:
+  ansible.builtin.assert:
     that:
       - state3.a == 3
       - state3.b == "banana"
@@ -58,7 +58,7 @@
   register: state4
 
 - name: assert state4
-  assert:
+  ansible.builtin.assert:
     that:
       - state4.a == 4
       - state4.c == "cashew"
@@ -74,7 +74,7 @@
   register: state5
 
 - name: assert state5
-  assert:
+  ansible.builtin.assert:
     that:
       - state5.a == 5
       - state5.b == "foo"

--- a/tests/integration/targets/monit/tasks/test_reload_present.yml
+++ b/tests/integration/targets/monit/tasks/test_reload_present.yml
@@ -10,7 +10,7 @@
   register: result
 
 - name: check that state is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is success
       - result is changed
@@ -67,7 +67,7 @@
   register: result
 
 - name: check that state is unchanged
-  assert:
+  ansible.builtin.assert:
     that:
       - result is success
       - result is not changed

--- a/tests/integration/targets/monit/tasks/test_state.yml
+++ b/tests/integration/targets/monit/tasks/test_state.yml
@@ -15,7 +15,7 @@
   register: result
 
 - name: check that state changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is success
       - result is changed
@@ -32,7 +32,7 @@
   register: result
 
 - name: check that state is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is success
       - result is not changed

--- a/tests/integration/targets/mqtt/tasks/ubuntu.yml
+++ b/tests/integration/targets/mqtt/tasks/ubuntu.yml
@@ -16,7 +16,7 @@
     client_id: me001
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is success
 
@@ -32,7 +32,7 @@
     port: 8883
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is success
 
@@ -48,7 +48,7 @@
     port: 8884
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is success
 
@@ -66,7 +66,7 @@
 #    port: 8885
 #  register: result
 
-# - assert:
+# - ansible.builtin.assert:
 #     that:
 #       - result is success
 
@@ -84,7 +84,7 @@
   register: result
   failed_when: result is success
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is success
 
@@ -104,7 +104,7 @@
 #  register: result
 #  failed_when: result is success
 
-# - assert:
+# - ansible.builtin.assert:
 #    that:
 #      - result is success
 
@@ -122,7 +122,7 @@
   register: result
   failed_when: result is success
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is success
 
@@ -142,6 +142,6 @@
 #  register: result
 #  failed_when: result is success
 
-# - assert:
+# - ansible.builtin.assert:
 #    that:
 #      - result is success

--- a/tests/integration/targets/mssql_script/tasks/main.yml
+++ b/tests/integration/targets/mssql_script/tasks/main.yml
@@ -58,7 +58,7 @@
     script: "SELCT 1"
   failed_when: false
   register: bad_query
-- assert:
+- ansible.builtin.assert:
     that:
       - bad_query.error.startswith('ProgrammingError')
 
@@ -97,7 +97,7 @@
 #     ]
 # ]
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result_batches.query_results | length == 2  # two batch results
       - result_batches.query_results[0] | length == 2  # two selects in first batch
@@ -141,7 +141,7 @@
 #         ]
 #     ]
 # ]
-- assert:
+- ansible.builtin.assert:
     that:
       - result_batches_dict.query_results_dict | length == 2  # two batch results
       - result_batches_dict.query_results_dict[0] | length == 2  # two selects in first batch
@@ -165,7 +165,7 @@
       GO
       DROP TABLE #integration56yH2
   register: empty_batches
-- assert:
+- ansible.builtin.assert:
     that:
       - empty_batches.query_results | length == 5  # five batch results
       - empty_batches.query_results[3][0] | length == 1  # one row in select
@@ -181,7 +181,7 @@
     script: sp_spaceused
     output: dict
   register: result_spaceused
-- assert:
+- ansible.builtin.assert:
     that:
       - result_spaceused.query_results_dict | length == 1  # one batch
       - result_spaceused.query_results_dict[0] | length == 2  # stored procedure returns two result sets
@@ -197,7 +197,7 @@
     output: dict
     db: msdb
   register: result_db
-- assert:
+- ansible.builtin.assert:
     that:
       - result_db.query_results_dict[0][0][0]['database_name'] == 'msdb'
 
@@ -212,7 +212,7 @@
     params:
       dbname: msdb
   register: result_params
-- assert:
+- ansible.builtin.assert:
     that:
       - result_params.query_results[0][0][0][0] == 'msdb'
       - result_params.query_results[0][0][0][1] == 'ONLINE'
@@ -226,7 +226,7 @@
     script: SELECT Invalid_Column FROM Does_Not_Exist WITH Invalid Syntax
   check_mode: true
   register: check_mode
-- assert:
+- ansible.builtin.assert:
     that: check_mode.query_results is undefined
 
 - name: "Test: Value of unknown type: <class 'uuid.UUID'>"
@@ -241,7 +241,7 @@
 - debug:
     var: result_databases
 - name: check types
-  assert:
+  ansible.builtin.assert:
     that:
       - result_databases.query_results[0][0][0][0] == '00000000-0000-0000-0000-000000000000'  # guid
       - result_databases.query_results[0][0][0][1] == 'master'  # string
@@ -274,7 +274,7 @@
     params:
       dbname: msdb
   register: empty_result
-- assert:
+- ansible.builtin.assert:
     that:
       - empty_result.query_results[0] | length == 3  # == 1 ; issue: only first result is returned
       - empty_result.query_results[0][0][0][0] == 'msdb'

--- a/tests/integration/targets/nomad/tasks/nomad_job.yml
+++ b/tests/integration/targets/nomad/tasks/nomad_job.yml
@@ -35,7 +35,7 @@
   register: list_nomad_jobs
 
 - name: assert job is deployed and tasks is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - job_check_deployed is changed
       - job_deployed is changed
@@ -102,7 +102,7 @@
     msg: "{{ list_nomad_jobs }}"
 
 - name: assert idempotence
-  assert:
+  ansible.builtin.assert:
     that:
       - job_check_deployed_idempotence is not changed
       - job_deployed_idempotence is not changed

--- a/tests/integration/targets/npm/tasks/no_bin_links.yml
+++ b/tests/integration/targets/npm/tasks/no_bin_links.yml
@@ -58,7 +58,7 @@
         path: "{{ remote_dir }}/node_modules/.bin"
       register: npm_dotbin_folder_enabled
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - npm_install_no_bin_links_disabled is success
           - npm_install_no_bin_links_disabled is changed

--- a/tests/integration/targets/npm/tasks/test.yml
+++ b/tests/integration/targets/npm/tasks/test.yml
@@ -28,7 +28,7 @@
         name: '{{ package }}'
       register: npm_install
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - npm_install is success
           - npm_install is changed
@@ -41,7 +41,7 @@
       register: npm_reinstall
 
     - name: Check there is no change
-      assert:
+      ansible.builtin.assert:
         that:
           - npm_reinstall is success
           - not (npm_reinstall is changed)
@@ -59,7 +59,7 @@
       register: npm_fix_install
 
     - name: Check result is changed and successful
-      assert:
+      ansible.builtin.assert:
         that:
           - npm_fix_install is success
           - npm_fix_install is changed

--- a/tests/integration/targets/odbc/tasks/main.yml
+++ b/tests/integration/targets/odbc/tasks/main.yml
@@ -85,7 +85,7 @@
       become: true
       register: results
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - results is changed
 
@@ -100,7 +100,7 @@
       become: true
       register: results
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - results is changed
 
@@ -119,7 +119,7 @@
       become: true
       register: results
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - results is changed
           - results['row_count'] == -1
@@ -135,7 +135,7 @@
         query: "SELECT * FROM films WHERE code='asdfg'"
       register: results
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - results is changed
           - results is successful
@@ -151,7 +151,7 @@
       register: results
       changed_when: false
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - results is not changed
           - results is successful
@@ -163,7 +163,7 @@
         query: "DROP TABLE films"
       register: results
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - results is successful
           - results is changed

--- a/tests/integration/targets/odbc/tasks/negative_tests.yml
+++ b/tests/integration/targets/odbc/tasks/negative_tests.yml
@@ -18,7 +18,7 @@
   register: results
   ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - results is failed
       - "'Failed to connect to DSN' in results.msg"

--- a/tests/integration/targets/odbc/tasks/no_pyodbc.yml
+++ b/tests/integration/targets/odbc/tasks/no_pyodbc.yml
@@ -10,7 +10,7 @@
   ignore_errors: true
   register: results
 
-- assert:
+- ansible.builtin.assert:
     that:
       - results is failed
       - "'Failed to import the required Python library (pyodbc) on' in results.msg"

--- a/tests/integration/targets/one_host/tasks/main.yml
+++ b/tests/integration/targets/one_host/tasks/main.yml
@@ -67,7 +67,7 @@
     - offline
 
 - name: "assert test_{{test_number}} failed"
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
       - result.results[0].msg == 'invalid host state ERROR'
@@ -92,7 +92,7 @@
   register: result
 
 - name: "assert test_{{test_number}} worked"
-  assert:
+  ansible.builtin.assert:
     that:
       - result.changed
 
@@ -118,7 +118,7 @@
   register: result
 
 - name: "assert test_{{test_number}} worked"
-  assert:
+  ansible.builtin.assert:
     that:
       - result.changed
 
@@ -148,7 +148,7 @@
   register: result
 
 - name: "assert test_{{test_number}} worked"
-  assert:
+  ansible.builtin.assert:
     that:
       - result.changed
 
@@ -178,7 +178,7 @@
   register: result
 
 - name: "assert test_{{test_number}} worked"
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -203,7 +203,7 @@
   register: result
 
 - name: "assert test_{{test_number}} worked"
-  assert:
+  ansible.builtin.assert:
     that:
       - result.changed
 
@@ -228,7 +228,7 @@
   register: result
 
 - name: "assert test_{{test_number}} worked"
-  assert:
+  ansible.builtin.assert:
     that:
       - result.changed
 

--- a/tests/integration/targets/one_image/tasks/main.yml
+++ b/tests/integration/targets/one_image/tasks/main.yml
@@ -19,7 +19,7 @@
   register: result
 
 - name: Assert that image is present
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -33,7 +33,7 @@
   register: result
 
 - name: Assert that image is present
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -48,7 +48,7 @@
   register: result
 
 - name: Assert that image is cloned
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -63,7 +63,7 @@
   register: result
 
 - name: Assert that image is cloned
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -77,7 +77,7 @@
   register: result
 
 - name: Assert that network is disabled
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -91,7 +91,7 @@
   register: result
 
 - name: Assert that network is enabled
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -105,7 +105,7 @@
   register: result
 
 - name: Assert that network is persistent
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -119,7 +119,7 @@
   register: result
 
 - name: Assert that network is non-persistent
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -135,7 +135,7 @@
   register: result
 
 - name: Assert that network not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -150,7 +150,7 @@
   register: result
 
 - name: Assert that network not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -164,7 +164,7 @@
   register: result
 
 - name: Assert that image was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -180,7 +180,7 @@
   ignore_errors: true
 
 - name: Assert that task failed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
 
@@ -195,7 +195,7 @@
   ignore_errors: true
 
 - name: Assert that task failed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
 

--- a/tests/integration/targets/one_image_info/tasks/main.yml
+++ b/tests/integration/targets/one_image_info/tasks/main.yml
@@ -18,7 +18,7 @@
   register: result
 
 - name: Assert that image is present
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -34,7 +34,7 @@
   register: result
 
 - name: Assert that image is present
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -47,7 +47,7 @@
   register: result
 
 - name: Assert that image is present
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -59,7 +59,7 @@
   register: result
 
 - name: Assert that images are present
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -72,7 +72,7 @@
   register: result
 
 - name: Assert that images are present
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -85,7 +85,7 @@
   register: result
 
 - name: Assert that images are present
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -100,7 +100,7 @@
   register: result
 
 - name: Assert that image is cloned
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -115,7 +115,7 @@
   register: result
 
 - name: Assert that image is cloned
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -129,7 +129,7 @@
   register: result
 
 - name: Assert that network is disabled
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -143,7 +143,7 @@
   register: result
 
 - name: Assert that network is enabled
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -157,7 +157,7 @@
   register: result
 
 - name: Assert that network is persistent
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -171,7 +171,7 @@
   register: result
 
 - name: Assert that network is non-persistent
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -187,6 +187,6 @@
   ignore_errors: true
 
 - name: Assert that network not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed

--- a/tests/integration/targets/one_template/tasks/main.yml
+++ b/tests/integration/targets/one_template/tasks/main.yml
@@ -68,7 +68,7 @@
   register: result
 
 - name: "assert that creation worked"
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -121,7 +121,7 @@
   register: result
 
 - name: "assert that it updated the template"
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -171,7 +171,7 @@
   register: result
 
 - name: "assert that there was no change"
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -193,7 +193,7 @@
   register: result
 
 - name: "assert that there was no change"
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -212,7 +212,7 @@
   register: result
 
 - name: "assert that there was a change"
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -230,7 +230,7 @@
   ignore_errors: true
 
 - name: "assert that it failed because template is missing"
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
 

--- a/tests/integration/targets/one_vnet/tasks/main.yml
+++ b/tests/integration/targets/one_vnet/tasks/main.yml
@@ -29,7 +29,7 @@
   register: result
 
 - name: Assert that network is created
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -55,7 +55,7 @@
   register: result
 
 - name: Assert that network is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -80,7 +80,7 @@
   register: result
 
 - name: Assert that network is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -96,7 +96,7 @@
   register: result
 
 - name: Assert that network is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - result is not changed
 
@@ -110,7 +110,7 @@
   register: result
 
 - name: Assert that network was deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - result is changed
 
@@ -126,7 +126,7 @@
   ignore_errors: true
 
 - name: Assert that it failed because network is missing
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
 
@@ -152,7 +152,7 @@
   ignore_errors: true
 
 - name: Assert that it failed because name is required for initial creation
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
 
@@ -168,6 +168,6 @@
   ignore_errors: true
 
 - name: Assert that it failed because you can use only one at the time
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed

--- a/tests/integration/targets/osx_defaults/tasks/main.yml
+++ b/tests/integration/targets/osx_defaults/tasks/main.yml
@@ -19,7 +19,7 @@
   ignore_errors: true
 
 - name: Test if state and value are required together
-  assert:
+  ansible.builtin.assert:
     that:
       - "'following are missing: value' in missing_value['msg']"
 
@@ -34,7 +34,7 @@
   check_mode: true
 
 - name: Test if AppleMeasurementUnits value is changed to Centimeters in check_mode
-  assert:
+  ansible.builtin.assert:
     that:
       - measure_task_check_mode.changed
 
@@ -66,7 +66,7 @@
   register: change_value
 
 - name: Test if AppleMeasurementUnits value is changed to {{ new_value }}
-  assert:
+  ansible.builtin.assert:
     that:
       - change_value.changed
 
@@ -80,7 +80,7 @@
   register: change_value
 
 - name: Again test if AppleMeasurementUnits value is not changed to {{ new_value }}
-  assert:
+  ansible.builtin.assert:
     that:
       - not change_value.changed
 
@@ -95,7 +95,7 @@
     msg: "{{ list_fake_value }}"
 
 - name: Check if fake value is listed
-  assert:
+  ansible.builtin.assert:
     that:
       - not list_fake_value.changed
 
@@ -111,7 +111,7 @@
     msg: "{{ present_fake_value }}"
 
 - name: Check if fake is created
-  assert:
+  ansible.builtin.assert:
     that:
       - present_fake_value.changed
   when: present_fake_value.changed
@@ -137,7 +137,7 @@
     msg: "{{ absent_task }}"
 
 - name: Check if fake setting is deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - absent_task.changed
   when: present_fake_value.changed
@@ -153,7 +153,7 @@
     msg: "{{ absent_task }}"
 
 - name: Check if fake setting is not deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - not absent_task.changed
 
@@ -169,7 +169,7 @@
     msg: "{{ absent_check_mode_task }}"
 
 - name: Check delete operation with check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - not absent_check_mode_task.changed
 
@@ -193,7 +193,7 @@
     - { type: 'array', value: ['1', '2'], key: 'sample_array'}
   register: test_data_types
 
-- assert:
+- ansible.builtin.assert:
     that: "item is changed"
   with_items: "{{ test_data_types.results }}"
 
@@ -207,7 +207,7 @@
   with_items: *data_type
   register: test_data_types
 
-- assert:
+- ansible.builtin.assert:
     that: "item is changed"
   with_items: "{{ test_data_types.results }}"
 
@@ -228,7 +228,7 @@
     array_add: true
   register: test_array_add
 
-- assert:
+- ansible.builtin.assert:
     that: test_array_add.changed
 
 - name: add for the second time, should be skipped
@@ -241,7 +241,7 @@
     array_add: true
   register: test_array_add
 
-- assert:
+- ansible.builtin.assert:
     that: not test_array_add.changed
 
 - name: Clean up test key
@@ -251,7 +251,7 @@
     state: absent
   register: test_array_add
 
-- assert:
+- ansible.builtin.assert:
     that: test_array_add.changed
 
 
@@ -271,7 +271,7 @@
       OpenWith: true
   register: test_dict_write
 
-- assert:
+- ansible.builtin.assert:
     that: test_dict_write.changed
 
 - name: Write same dict value again, should not change
@@ -284,7 +284,7 @@
       OpenWith: true
   register: test_dict_write
 
-- assert:
+- ansible.builtin.assert:
     that: not test_dict_write.changed
 
 - name: Write different dict value, should change
@@ -297,7 +297,7 @@
       OpenWith: false
   register: test_dict_write
 
-- assert:
+- ansible.builtin.assert:
     that: test_dict_write.changed
 
 - name: Add new key via dict_add
@@ -310,7 +310,7 @@
       Privileges: true
   register: test_dict_add
 
-- assert:
+- ansible.builtin.assert:
     that: test_dict_add.changed
 
 - name: Add same key via dict_add again, should not change
@@ -323,7 +323,7 @@
       Privileges: true
   register: test_dict_add
 
-- assert:
+- ansible.builtin.assert:
     that: not test_dict_add.changed
 
 - name: Use dict_add on non-existent key, should create it
@@ -336,7 +336,7 @@
       Alpha: true
   register: test_dict_add_new
 
-- assert:
+- ansible.builtin.assert:
     that: test_dict_add_new.changed
 
 - name: Clean up dict test keys

--- a/tests/integration/targets/pacman/tasks/basic.yml
+++ b/tests/integration/targets/pacman/tasks/basic.yml
@@ -37,7 +37,7 @@
         state: present
       register: install_4
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - install_1 is changed
           - install_1.msg == 'Would have installed 1 packages'
@@ -74,7 +74,7 @@
         state: absent
       register: uninstall_4
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - uninstall_1 is changed
           - uninstall_1.msg == 'Would have removed 1 packages'

--- a/tests/integration/targets/pacman/tasks/locally_installed_package.yml
+++ b/tests/integration/targets/pacman/tasks/locally_installed_package.yml
@@ -72,7 +72,7 @@
       register: remove_3
 
     - name: Check conditions
-      assert:
+      ansible.builtin.assert:
         that:
           - remove_1 is changed
           - remove_2 is changed

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -184,7 +184,7 @@
           - '{{url_pkg_url}}'
       register: uninstall_3c
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - install_1 is changed
           - install_1.msg == 'Would have installed 3 packages'

--- a/tests/integration/targets/pacman/tasks/reason.yml
+++ b/tests/integration/targets/pacman/tasks/reason.yml
@@ -83,7 +83,7 @@
         reason_for: all
       register: install_5
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - install_1 is changed
           - install_1.msg == 'Would have installed 3 packages'

--- a/tests/integration/targets/pacman/tasks/remove_nosave.yml
+++ b/tests/integration/targets/pacman/tasks/remove_nosave.yml
@@ -39,7 +39,7 @@
         path: '{{config_file}}.pacsave'
       register: pacsave_st_1
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - pacsave_st_1.stat.exists
 
@@ -71,6 +71,6 @@
         path: '{{config_file}}.pacsave'
       register: pacsave_st_2
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not pacsave_st_2.stat.exists

--- a/tests/integration/targets/pacman/tasks/update_cache.yml
+++ b/tests/integration/targets/pacman/tasks/update_cache.yml
@@ -19,7 +19,7 @@
   register: update_cache_force
 
 - name: Check conditions
-  assert:
+  ansible.builtin.assert:
     that:
       - update_cache_idem is not changed
       - update_cache_idem.cache_updated == false

--- a/tests/integration/targets/pam_limits/tasks/main.yml
+++ b/tests/integration/targets/pam_limits/tasks/main.yml
@@ -23,7 +23,7 @@
   register: check_mode_test
 
 - name: Test that check mode is working
-  assert:
+  ansible.builtin.assert:
     that:
       - check_mode_test is changed
 
@@ -37,7 +37,7 @@
   register: soft_limit_test
 
 - name: Check if changes are made
-  assert:
+  ansible.builtin.assert:
     that:
       - soft_limit_test is changed
 
@@ -51,7 +51,7 @@
   register: soft_limit_test
 
 - name: Check if changes are not made idempotency
-  assert:
+  ansible.builtin.assert:
     that:
       - not soft_limit_test.changed
 
@@ -70,7 +70,7 @@
     msg: "{{ hard_limit_test }}"
 
 - name: Check if changes made
-  assert:
+  ansible.builtin.assert:
     that:
       - hard_limit_test is changed
       - hard_limit_test.diff.after is defined
@@ -87,6 +87,6 @@
   register: comment_test
 
 - name: Check if changes made
-  assert:
+  ansible.builtin.assert:
     that:
       - comment_test is changed

--- a/tests/integration/targets/pamd/tasks/main.yml
+++ b/tests/integration/targets/pamd/tasks/main.yml
@@ -21,7 +21,7 @@
     state: args_absent
   register: pamd_file_output
 - name: Check if changes made
-  assert:
+  ansible.builtin.assert:
     that:
       - pamd_file_output is changed
 
@@ -42,7 +42,7 @@
 - name: Check if changes made (3260)
   vars:
     line_array: "{{ (pamd_file_slurp_noargs.content|b64decode).split('\n')[2].split() }}"
-  assert:
+  ansible.builtin.assert:
     that:
       - pamd_file_output_noargs is changed
       - line_array == ['session', 'required', 'pam_lastlog.so']
@@ -68,7 +68,7 @@
     src: "{{ test_pamd_file }}"
   register: pamd_file_slurp
 - name: Check if changes made
-  assert:
+  ansible.builtin.assert:
     that:
       - pamd_file_output_empty is not changed
       - pamd_file_slurp.content|b64decode == ''

--- a/tests/integration/targets/parted/tasks/main.yml
+++ b/tests/integration/targets/parted/tasks/main.yml
@@ -73,7 +73,7 @@
   register: partition_rem1
 
 - name: Assert results
-  assert:
+  ansible.builtin.assert:
     that:
       - partition1 is changed
       - fs1_succ is changed
@@ -102,7 +102,7 @@
   register: info_preserve_false
 
 - name: Assert unit_preserve_case results
-  assert:
+  ansible.builtin.assert:
     that:
       - info_preserve_true.disk.unit == "KiB"
       - info_preserve_true.partitions[0].unit == "KiB"
@@ -118,6 +118,6 @@
   register: info_roundtrip
 
 - name: Assert round-trip succeeds and unit is consistent
-  assert:
+  ansible.builtin.assert:
     that:
       - info_roundtrip.disk.unit == info_preserve_true.disk.unit

--- a/tests/integration/targets/pids/tasks/main.yml
+++ b/tests/integration/targets/pids/tasks/main.yml
@@ -25,7 +25,7 @@
   register: emptypids
 
 - name: "Verify that the list of Process IDs (PIDs) returned is empty"
-  assert:
+  ansible.builtin.assert:
     that:
       - emptypids is not changed
       - emptypids.pids == []
@@ -99,7 +99,7 @@
     var: result.stdout_lines
 
 - name: "Verify that the Process IDs (PIDs) returned is not empty and also equal to the PIDs obtained in console"
-  assert:
+  ansible.builtin.assert:
     that:
       - "pids.pids | join(' ')  == newpid.content | b64decode | trim"
       - "pids.pids | length > 0"
@@ -115,6 +115,6 @@
   ignore_errors: true
 
 - name: "Verify that bad input pattern result is failed"
-  assert:
+  ansible.builtin.assert:
     that:
       - bad_pattern_result is failed

--- a/tests/integration/targets/pipx/tasks/main.yml
+++ b/tests/integration/targets/pipx/tasks/main.yml
@@ -61,7 +61,7 @@
   register: uninstall_tox
 
 - name: check assertions tox
-  assert:
+  ansible.builtin.assert:
     that:
       - install_tox is changed
       - "'version' in install_tox"
@@ -90,7 +90,7 @@
   register: uninstall_tox
 
 - name: check assertions tox
-  assert:
+  ansible.builtin.assert:
     that:
       - install_tox is changed
       - "'tox' in install_tox.application"
@@ -132,7 +132,7 @@
   register: uninstall_tox_324
 
 - name: check assertions tox 3.24.0
-  assert:
+  ansible.builtin.assert:
     that:
       - install_tox_324 is changed
       - "'tox' in install_tox_324.application"
@@ -224,7 +224,7 @@
   register: uninstall_tox_3
 
 - name: check assertions tox latest
-  assert:
+  ansible.builtin.assert:
     that:
       - install_tox_latest is changed
       - "'tox' in install_tox_latest.application"

--- a/tests/integration/targets/pipx/tasks/testcase-10031-version-specs.yml
+++ b/tests/integration/targets/pipx/tasks/testcase-10031-version-specs.yml
@@ -51,7 +51,7 @@
   register: uninstall_tox_final
 
 - name: Check version specifier assertions
-  assert:
+  ansible.builtin.assert:
     that:
       - install_tox_version is changed
       - "'tox' in install_tox_version.application"
@@ -77,7 +77,7 @@
       ignore_errors: true
 
     - name: Check version specifier assertions
-      assert:
+      ansible.builtin.assert:
         that:
           - install_tox_invalid is failed
           - "'Invalid package specification' in install_tox_invalid.msg"

--- a/tests/integration/targets/pipx/tasks/testcase-7497.yml
+++ b/tests/integration/targets/pipx/tasks/testcase-7497.yml
@@ -22,6 +22,6 @@
     state: absent
 
 - name: check assertions
-  assert:
+  ansible.builtin.assert:
     that:
       - install_conan is changed

--- a/tests/integration/targets/pipx/tasks/testcase-8656.yml
+++ b/tests/integration/targets/pipx/tasks/testcase-8656.yml
@@ -28,7 +28,7 @@
     state: absent
 
 - name: check assertions
-  assert:
+  ansible.builtin.assert:
     that:
       - install_conan2 is changed
       - "'    - conan2' in install_conan2.stdout"

--- a/tests/integration/targets/pipx/tasks/testcase-injectpkg.yml
+++ b/tests/integration/targets/pipx/tasks/testcase-injectpkg.yml
@@ -37,7 +37,7 @@
   register: uninstall_pylint
 
 - name: Check assertions inject_packages
-  assert:
+  ansible.builtin.assert:
     that:
       - install_pylint is changed
       - inject_pkgs_pylint is changed

--- a/tests/integration/targets/pipx/tasks/testcase-jupyter.yml
+++ b/tests/integration/targets/pipx/tasks/testcase-jupyter.yml
@@ -22,7 +22,7 @@
         name: mkdocs
 
     - name: check assertions
-      assert:
+      ansible.builtin.assert:
         that:
           - install_mkdocs is changed
           - '"markdown_py" in install_mkdocs.stdout'

--- a/tests/integration/targets/pkgng/tasks/create-outofdate-pkg.yml
+++ b/tests/integration/targets/pkgng/tasks/create-outofdate-pkg.yml
@@ -36,7 +36,7 @@
   register: pkgng_test_outofdate_pkg_tempfile
 
 - name: There should be only one package
-  assert:
+  ansible.builtin.assert:
     that:
       - pkgng_test_outofdate_pkg_tempfile.files | count == 1
 

--- a/tests/integration/targets/pkgng/tasks/freebsd.yml
+++ b/tests/integration/targets/pkgng/tasks/freebsd.yml
@@ -27,7 +27,7 @@
   register: pkgng_example2
 
 - name: Ensure pkgng does not upgrade up-to-date package
-  assert:
+  ansible.builtin.assert:
     that:
       - not pkgng_example2.changed
 
@@ -69,7 +69,7 @@
   register: pkgng_example3_stat_after
 
 - name: Ensure pkgng installs package correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - pkgng_example3_stat_before.stat.exists
       - pkgng_example3_stat_before.stat.executable
@@ -132,7 +132,7 @@
         state: absent
 
     - name: Ensure pkgng upgrades package correctly
-      assert:
+      ansible.builtin.assert:
         that:
           - not pkgng_example4_prepare.failed
           - pkgng_example4_wildcard_checkmode.changed
@@ -171,7 +171,7 @@
         state: absent
 
     - name: Ensure pkgng upgrades package correctly
-      assert:
+      ansible.builtin.assert:
         that:
           - not pkgng_example4_nopower_prepare.failed
           - pkgng_example4_nopower_wildcard.failed
@@ -204,7 +204,7 @@
   register: pkgng_example5_cleanup
 
 - name: Ensure pkgng installs multiple packages with one command
-  assert:
+  ansible.builtin.assert:
     that:
       - not pkgng_example5_prepare.changed
       - pkgng_example5.changed
@@ -246,7 +246,7 @@
   register: pkgng_example6_cleanup
 
 - name: Ensure pkgng installs multiple packages with one command
-  assert:
+  ansible.builtin.assert:
     that:
       - not pkgng_example6_check.changed
       - not pkgng_example6_prepare.failed
@@ -293,7 +293,7 @@
       register: pkgng_example7_cleanup
 
     - name: Ensure pkgng autoremove works correctly
-      assert:
+      ansible.builtin.assert:
         that:
           - pkgng_example7_prepare_install is changed
           - "'autoremoved' is in(pkgng_example7.msg)"
@@ -365,7 +365,7 @@
   register: pkgng_example8_remove_annotation_verify
 
 - name: Ensure pkgng annotations on single packages work correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - pkgng_example8_add_annotation.changed
       - pkgng_example8_add_annotation_failure.failed
@@ -433,7 +433,7 @@
   # ```
 
 - name: Ensure multiple annotations work correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - pkgng_example9_add_annotation.changed
       - '(pkgng_example9_add_annotation_verify.stdout_lines | select("match",  "ansibletest_example9_[12]\s*:\s*added") | list | count) == 2'
@@ -463,7 +463,7 @@
   register: pkgng_example8_invalid_annotation_verify
 
 - name: Ensure invalid annotate strings fail safely
-  assert:
+  ansible.builtin.assert:
     that:
       # Invalid strings should not change anything
       - '(pkgng_example8_invalid_annotation_failure.results | selectattr("changed") | list | count) == 0'
@@ -489,7 +489,7 @@
   register: pkgng_example10_invalid_pkgsite_failure
 
 - name: Ensure invalid pkgsite fails as expected
-  assert:
+  ansible.builtin.assert:
     that:
       - pkgng_example10_invalid_pkgsite_failure.failed
       - 'pkgng_example10_invalid_pkgsite_failure.stdout is search("^No repositories are enabled.", multiline=True)'

--- a/tests/integration/targets/pkgng/tasks/install_single_package.yml
+++ b/tests/integration/targets/pkgng/tasks/install_single_package.yml
@@ -57,7 +57,7 @@
   when: 'pkgng_test_install_cleanup | default(False)'
 
 - name: Ensure pkgng installs package correctly
-  assert:
+  ansible.builtin.assert:
     that:
       - not pkgng_install_stat_before.stat.exists
       - pkgng_install.changed

--- a/tests/integration/targets/pkgutil/tasks/main.yml
+++ b/tests/integration/targets/pkgutil/tasks/main.yml
@@ -22,7 +22,7 @@
   register: cm_add_package
 
 - name: Verify cm_add_package
-  assert:
+  ansible.builtin.assert:
     that:
       - cm_add_package is changed
 
@@ -33,7 +33,7 @@
   register: nm_add_package
 
 - name: Verify nm_add_package
-  assert:
+  ansible.builtin.assert:
     that:
       - nm_add_package is changed
 
@@ -45,7 +45,7 @@
   register: cm_add_package_again
 
 - name: Verify cm_add_package_again
-  assert:
+  ansible.builtin.assert:
     that:
       - cm_add_package_again is not changed
 
@@ -56,7 +56,7 @@
   register: nm_add_package_again
 
 - name: Verify nm_add_package_again
-  assert:
+  ansible.builtin.assert:
     that:
       - nm_add_package_again is not changed
 
@@ -70,7 +70,7 @@
   register: cm_remove_package
 
 - name: Verify cm_remove_package
-  assert:
+  ansible.builtin.assert:
     that:
       - cm_remove_package is changed
 
@@ -81,7 +81,7 @@
   register: nm_remove_package
 
 - name: Verify nm_remove_package
-  assert:
+  ansible.builtin.assert:
     that:
       - nm_remove_package is changed
 
@@ -93,7 +93,7 @@
   register: cm_remove_package_again
 
 - name: Verify cm_remove_package_again
-  assert:
+  ansible.builtin.assert:
     that:
       - cm_remove_package_again is not changed
 
@@ -104,7 +104,7 @@
   register: nm_remove_package_again
 
 - name: Verify nm_remove_package_again
-  assert:
+  ansible.builtin.assert:
     that:
       - nm_remove_package_again is not changed
 

--- a/tests/integration/targets/python_requirements_info/tasks/main.yml
+++ b/tests/integration/targets/python_requirements_info/tasks/main.yml
@@ -19,7 +19,7 @@
   register: basic_info
 
 - name: ensure python_requirements_info returns desired info
-  assert:
+  ansible.builtin.assert:
     that:
       - "'python' in basic_info"
       - "'python_version' in basic_info"
@@ -33,7 +33,7 @@
   register: dep_info
 
 - name: ensure python_requirements_info returns desired info
-  assert:
+  ansible.builtin.assert:
     that:
       - "'installed' in dep_info.valid.pip"
       - "'notreal' in dep_info.not_found"
@@ -46,6 +46,6 @@
   ignore_errors: true
 
 - name: ensure wrong specs return error
-  assert:
+  ansible.builtin.assert:
     that:
       - wrong_spec1 is failed

--- a/tests/integration/targets/read_csv/tasks/main.yml
+++ b/tests/integration/targets/read_csv/tasks/main.yml
@@ -24,7 +24,7 @@
     key: name
   register: users_unique
 
-- assert:
+- ansible.builtin.assert:
     that:
       - users_unique.dict.dag.name == 'dag'
       - users_unique.dict.dag.gecos == 'Dag Wieërs'
@@ -41,7 +41,7 @@
     path: "{{ remote_tmp_dir }}/users_unique.csv"
   register: users_unique
 
-- assert:
+- ansible.builtin.assert:
     that:
       - users_unique.list.0.name == 'dag'
       - users_unique.list.0.gecos == 'Dag Wieërs'
@@ -72,7 +72,7 @@
     delimiter: ';'
   register: users_nonunique
 
-- assert:
+- ansible.builtin.assert:
     that:
       - users_nonunique.dict.dag.name == 'dag'
       - users_nonunique.dict.dag.gecos == 'Dag Wieers'
@@ -92,7 +92,7 @@
   register: users_placebo
   ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - users_placebo is failed
       - users_placebo.msg == "Dialect 'placebo' is not supported by your version of python."
@@ -114,7 +114,7 @@
     fieldnames: name,uid,gid,gecos
   register: users_noheader
 
-- assert:
+- ansible.builtin.assert:
     that:
       - users_noheader.dict.dag.name == 'dag'
       - users_noheader.dict.dag.gecos == 'Dag Wieërs'
@@ -144,7 +144,7 @@
   register: users_broken
   ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - users_broken is failed
       - "'Unable to process file' in users_broken.msg"
@@ -164,7 +164,7 @@
     path: "{{ remote_tmp_dir }}/users_bom.csv"
   register: users_bom
 
-- assert:
+- ansible.builtin.assert:
     that:
       - users_bom.list.0.name == 'dag'
       - users_bom.list.0.gecos == 'Dag Wieërs'

--- a/tests/integration/targets/redis_info/tasks/main.yml
+++ b/tests/integration/targets/redis_info/tasks/main.yml
@@ -12,7 +12,7 @@
     login_password: "{{ redis_password }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.info is defined
@@ -27,7 +27,7 @@
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.info is defined
@@ -40,7 +40,7 @@
     login_password: "{{ redis_password }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.info is defined

--- a/tests/integration/targets/scaleway_compute/tasks/ip.yml
+++ b/tests/integration/targets/scaleway_compute/tasks/ip.yml
@@ -18,7 +18,7 @@
 
 - debug: var=server_creation_absent_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_creation_absent_check_task is success
       - server_creation_absent_check_task is changed
@@ -38,7 +38,7 @@
 
 - debug: var=server_creation_absent_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_creation_absent_task is success
       - server_creation_absent_task is changed
@@ -58,7 +58,7 @@
 
 - debug: var=server_creation_absent_confirmation_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_creation_absent_confirmation_task is success
       - server_creation_absent_confirmation_task is not changed
@@ -80,7 +80,7 @@
 
 - debug: var=ip_patching_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - ip_patching_check_task is success
       - ip_patching_check_task is changed
@@ -99,7 +99,7 @@
 
 - debug: var=ip_patching_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - ip_patching_task is success
       - ip_patching_task is changed
@@ -119,7 +119,7 @@
 
 - debug: var=ip_patching_confirmation_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - ip_patching_confirmation_task is success
       - ip_patching_confirmation_task is not changed
@@ -141,7 +141,7 @@
 
 - debug: var=remove_ip_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - remove_ip_check_task is success
       - remove_ip_check_task is changed
@@ -161,7 +161,7 @@
 
 - debug: var=remove_ip_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - remove_ip_task is success
       - remove_ip_task is changed
@@ -181,7 +181,7 @@
 
 - debug: var=remove_ip_confirmation_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - remove_ip_confirmation_task is success
       - remove_ip_confirmation_task is not changed
@@ -200,7 +200,7 @@
 
 - debug: var=server_destroy_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_destroy_task is success
       - server_destroy_task is changed

--- a/tests/integration/targets/scaleway_compute/tasks/pagination.yml
+++ b/tests/integration/targets/scaleway_compute/tasks/pagination.yml
@@ -33,7 +33,7 @@
 
 - debug: var=first_page
 
-- assert:
+- ansible.builtin.assert:
     that:
       - first_page is success
 
@@ -47,11 +47,11 @@
 
 - debug: var=second_page
 
-- assert:
+- ansible.builtin.assert:
     that:
       - second_page is success
 
-- assert:
+- ansible.builtin.assert:
     that:
       - first_page.scaleway_server_info[0].id != second_page.scaleway_server_info[0].id
 

--- a/tests/integration/targets/scaleway_compute/tasks/security_group.yml
+++ b/tests/integration/targets/scaleway_compute/tasks/security_group.yml
@@ -34,7 +34,7 @@
 
     - debug: var=server_creation_check_task
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - server_creation_check_task is success
           - server_creation_check_task is changed
@@ -54,7 +54,7 @@
 
     - debug: var=server_creation_task
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - server_creation_task is success
           - server_creation_task is changed
@@ -74,7 +74,7 @@
 
     - debug: var=server_creation_confirmation_task
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - server_creation_confirmation_task is success
           - server_creation_confirmation_task is not changed
@@ -95,7 +95,7 @@
 
     - debug: var=server_creation_confirmation_task
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - server_creation_confirmation_task is success
           - server_creation_confirmation_task is not changed
@@ -114,7 +114,7 @@
 
     - debug: var=server_creation_confirmation_task
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - server_creation_confirmation_task is success
           - server_creation_confirmation_task is not changed
@@ -134,7 +134,7 @@
 
     - debug: var=server_destroy_task
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - server_destroy_task is success
           - server_destroy_task is changed

--- a/tests/integration/targets/scaleway_compute/tasks/state.yml
+++ b/tests/integration/targets/scaleway_compute/tasks/state.yml
@@ -17,7 +17,7 @@
 
 - debug: var=server_creation_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_creation_check_task is success
       - server_creation_check_task is changed
@@ -36,7 +36,7 @@
 
 - debug: var=server_creation_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_creation_task is success
       - server_creation_task is changed
@@ -55,7 +55,7 @@
 
 - debug: var=server_creation_confirmation_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_creation_confirmation_task is success
       - server_creation_confirmation_task is not changed
@@ -76,7 +76,7 @@
 
 - debug: var=server_patching_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_patching_check_task is success
       - server_patching_check_task is changed
@@ -97,7 +97,7 @@
 
 - debug: var=server_patching_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_patching_task is success
       - server_patching_task is changed
@@ -118,7 +118,7 @@
 
 - debug: var=server_patching_confirmation_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_patching_confirmation_task is success
       - server_patching_confirmation_task is not changed
@@ -139,7 +139,7 @@
 
 - debug: var=server_run_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_run_check_task is success
       - server_run_check_task is changed
@@ -160,7 +160,7 @@
 
 - debug: var=server_run_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_run_task is success
       - server_run_task is changed
@@ -181,7 +181,7 @@
 
 - debug: var=server_run_confirmation_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_run_confirmation_task is success
       - server_run_confirmation_task is not changed
@@ -202,7 +202,7 @@
 
 - debug: var=server_reboot_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_reboot_check_task is success
       - server_reboot_check_task is changed
@@ -223,7 +223,7 @@
 
 - debug: var=server_reboot_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_reboot_task is success
       - server_reboot_task is changed
@@ -244,7 +244,7 @@
 
 - debug: var=server_stop_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_stop_check_task is success
       - server_stop_check_task is changed
@@ -265,7 +265,7 @@
 
 - debug: var=server_stop_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_stop_task is success
       - server_stop_task is changed
@@ -286,7 +286,7 @@
 
 - debug: var=server_stop_confirmation_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_stop_confirmation_task is success
       - server_stop_confirmation_task is not changed
@@ -307,7 +307,7 @@
 
 - debug: var=server_destroy_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_destroy_check_task is success
       - server_destroy_check_task is changed
@@ -328,7 +328,7 @@
 
 - debug: var=server_destroy_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_destroy_task is success
       - server_destroy_task is changed
@@ -349,7 +349,7 @@
 
 - debug: var=server_destroy_confirmation_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_destroy_confirmation_task is success
       - server_destroy_confirmation_task is not changed
@@ -367,7 +367,7 @@
 
 - debug: var=unauthorized_organization_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - unauthorized_organization_task is not success
       - unauthorized_organization_task is not changed
@@ -385,7 +385,7 @@
 
 - debug: var=unexisting_image_check
 
-- assert:
+- ansible.builtin.assert:
     that:
       - unexisting_image_check is not success
       - unexisting_image_check is not changed

--- a/tests/integration/targets/scaleway_database_backup/tasks/main.yml
+++ b/tests/integration/targets/scaleway_database_backup/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - debug: var=backup_creation_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - backup_creation_check_task is success
       - backup_creation_check_task is changed
@@ -39,7 +39,7 @@
 
 - debug: var=backup_creation_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - backup_creation_task is success
       - backup_creation_task is changed
@@ -57,7 +57,7 @@
 
 - debug: var=backup_creation_confirmation_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - backup_creation_confirmation_task is success
       - backup_creation_confirmation_task is not changed
@@ -75,7 +75,7 @@
 
 - debug: var=backup_patching_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - backup_patching_check_task is success
       - backup_patching_check_task is changed
@@ -92,7 +92,7 @@
 
 - debug: var=backup_patching_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - backup_patching_task is success
       - backup_patching_task is changed
@@ -109,7 +109,7 @@
 
 - debug: var=backup_patching_confirmation_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - backup_patching_confirmation_task is success
       - backup_patching_confirmation_task is not changed
@@ -124,7 +124,7 @@
 
 - debug: var=backup_export_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - backup_export_check_task is success
       - backup_export_check_task is changed
@@ -139,7 +139,7 @@
 
 - debug: var=backup_export_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - backup_export_task is success
       - backup_export_task is changed
@@ -154,7 +154,7 @@
 
 - debug: var=backup_export_confirmation_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - backup_export_confirmation_task is success
       - backup_export_confirmation_task is not changed
@@ -172,7 +172,7 @@
 
 - debug: var=backup_restore_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - backup_restore_check_task is success
       - backup_restore_check_task is changed
@@ -189,7 +189,7 @@
 
 - debug: var=backup_restore_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - backup_restore_task is success
       - backup_restore_task is changed
@@ -204,7 +204,7 @@
 
 - debug: var=backup_delete_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - backup_delete_check_task is success
       - backup_delete_check_task is changed
@@ -218,7 +218,7 @@
 
 - debug: var=backup_delete_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - backup_delete_task is success
       - backup_delete_task is changed
@@ -232,7 +232,7 @@
 
 - debug: var=backup_delete_confirmation_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - backup_delete_confirmation_task is success
       - backup_delete_confirmation_task is not changed

--- a/tests/integration/targets/scaleway_image_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_image_info/tasks/main.yml
@@ -18,7 +18,7 @@
     var: images
 
 - name: Ensure retrieval of images info is success
-  assert:
+  ansible.builtin.assert:
     that:
       - images is success
 
@@ -32,6 +32,6 @@
     var: images_ams1
 
 - name: Ensure retrieval of images info is success
-  assert:
+  ansible.builtin.assert:
     that:
       - images_ams1 is success

--- a/tests/integration/targets/scaleway_ip/tasks/main.yml
+++ b/tests/integration/targets/scaleway_ip/tasks/main.yml
@@ -19,12 +19,12 @@
 - debug: var=ip_creation_check_task
 
 - name: ip_creation_check_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_creation_check_task is success
 
 - name: ip_creation_check_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_creation_check_task is changed
 
@@ -38,17 +38,17 @@
 - debug: var=ip_creation_task
 
 - name: ip_creation_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_creation_task is success
 
 - name: ip_creation_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_creation_task is changed
 
 - name: ip_creation_task.scaleway_ip.server is none
-  assert:
+  ansible.builtin.assert:
     that:
       - '{{ ip_creation_task.scaleway_ip.server is none }}'
 
@@ -63,17 +63,17 @@
 - debug: var=ip_creation_confirmation_task
 
 - name: ip_creation_confirmation_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_creation_confirmation_task is success
 
 - name: ip_creation_confirmation_task is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_creation_confirmation_task is not changed
 
 - name: ip_creation_confirmation_task.scaleway_ip.server is none
-  assert:
+  ansible.builtin.assert:
     that:
       - '{{ ip_creation_task.scaleway_ip.server is none }}'
 
@@ -90,12 +90,12 @@
 - debug: var=ip_reverse_assignation_check_task
 
 - name: ip_reverse_assignation_check_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_reverse_assignation_check_task is success
 
 - name: ip_reverse_assignation_check_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_reverse_assignation_check_task is success
 
@@ -111,12 +111,12 @@
 - debug: var=ip_reverse_assignation_task
 
 - name: ip_reverse_assignation_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_reverse_assignation_task is success
 
 - name: ip_reverse_assignation_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_reverse_assignation_task is changed
 
@@ -132,12 +132,12 @@
 - debug: var=ip_reverse_assignation_confirmation_task
 
 - name: ip_reverse_assignation_confirmation_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_reverse_assignation_confirmation_task is success
 
 - name: ip_reverse_assignation_confirmation_task is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_reverse_assignation_confirmation_task is not changed
 
@@ -157,7 +157,7 @@
 - debug: var=server_creation_task
 
 - name: server_creation_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - server_creation_task is success
 
@@ -175,12 +175,12 @@
 - debug: var=ip_assignation_check_task
 
 - name: ip_assignation_check_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_assignation_check_task is success
 
 - name: ip_assignation_check_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_assignation_check_task is success
 
@@ -197,12 +197,12 @@
 - debug: var=ip_assignation_task
 
 - name: ip_assignation_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_assignation_task is success
 
 - name: ip_assignation_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_assignation_task is changed
 
@@ -219,12 +219,12 @@
 - debug: var=ip_assignation_confirmation_task
 
 - name: ip_assignation_confirmation_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_assignation_confirmation_task is success
 
 - name: ip_assignation_confirmation_task is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_assignation_confirmation_task is not changed
 
@@ -241,12 +241,12 @@
 - debug: var=ip_unassignation_check_task
 
 - name: ip_unassignation_check_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_unassignation_check_task is success
 
 - name: ip_unassignation_check_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_unassignation_check_task is changed
 
@@ -262,17 +262,17 @@
 - debug: var=ip_unassignation_task
 
 - name: ip_unassignation_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_unassignation_task is success
 
 - name: ip_unassignation_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_unassignation_task is changed
 
 - name: ip_unassignation_task.scaleway_ip.server is none
-  assert:
+  ansible.builtin.assert:
     that:
       - '{{ ip_unassignation_task.scaleway_ip.server is none }}'
 
@@ -288,17 +288,17 @@
 - debug: var=ip_unassignation_confirmation_task
 
 - name: ip_unassignation_confirmation_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_unassignation_confirmation_task is success
 
 - name: ip_unassignation_confirmation_task is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_unassignation_confirmation_task is not changed
 
 - name: ip_unassignation_confirmation_task.scaleway_ip.server is none
-  assert:
+  ansible.builtin.assert:
     that:
       - '{{ ip_unassignation_task.scaleway_ip.server is none }}'
 
@@ -314,12 +314,12 @@
 - debug: var=ip_reverse_unassignation_check_task
 
 - name: ip_reverse_unassignation_check_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_reverse_unassignation_check_task is success
 
 - name: ip_reverse_unassignation_check_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_reverse_unassignation_check_task is changed
 
@@ -334,17 +334,17 @@
 - debug: var=ip_reverse_unassignation_task
 
 - name: ip_reverse_unassignation_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_reverse_unassignation_task is success
 
 - name: ip_reverse_unassignation_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_reverse_unassignation_task is changed
 
 - name: ip_reverse_unassignation_task.scaleway_ip.reverse is none
-  assert:
+  ansible.builtin.assert:
     that:
       - '{{ ip_reverse_unassignation_task.scaleway_ip.reverse is none }}'
 
@@ -359,17 +359,17 @@
 - debug: var=ip_reverse_unassignation_confirmation_task
 
 - name: ip_reverse_unassignation_confirmation_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_reverse_unassignation_confirmation_task is success
 
 - name: ip_reverse_unassignation_confirmation_task is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_reverse_unassignation_confirmation_task is not changed
 
 - name: ip_reverse_unassignation_confirmation_task.scaleway_ip.server is none
-  assert:
+  ansible.builtin.assert:
     that:
       - '{{ ip_reverse_unassignation_confirmation_task.scaleway_ip.reverse is none }}'
 
@@ -387,12 +387,12 @@
 - debug: var=server_destroy_task
 
 - name: server_destroy_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - server_destroy_task is success
 
 - name: server_destroy_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - server_destroy_task is changed
 
@@ -405,12 +405,12 @@
   register: ip_deletion_check_task
 
 - name: ip_deletion_check_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_deletion_check_task is success
 
 - name: ip_deletion_check_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_deletion_check_task is changed
 
@@ -422,12 +422,12 @@
   register: ip_deletion_task
 
 - name: ip_deletion_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_deletion_task is success
 
 - name: ip_deletion_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_deletion_task is changed
 
@@ -439,11 +439,11 @@
   register: ip_deletion_confirmation_task
 
 - name: ip_deletion_confirmation_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_deletion_confirmation_task is success
 
 - name: ip_deletion_confirmation_task is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_deletion_confirmation_task is not changed

--- a/tests/integration/targets/scaleway_ip_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_ip_info/tasks/main.yml
@@ -18,7 +18,7 @@
     var: ips
 
 - name: Ensure retrieval of ips info is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ips is success
 
@@ -32,6 +32,6 @@
     var: ips_ams1
 
 - name: Ensure retrieval of ips info is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ips_ams1 is success

--- a/tests/integration/targets/scaleway_lb/tasks/main.yml
+++ b/tests/integration/targets/scaleway_lb/tasks/main.yml
@@ -22,12 +22,12 @@
 - debug: var=lb_creation_check_task
 
 - name: lb_creation_check_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_creation_check_task is success
 
 - name: lb_creation_check_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_creation_check_task is changed
 
@@ -45,17 +45,17 @@
 - debug: var=lb_creation_task
 
 - name: lb_creation_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_creation_task is success
 
 - name: lb_creation_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_creation_task is changed
 
 - name: Assert that the load-balancer is in a valid state
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_creation_task.scaleway_lb.status == "ready"
 
@@ -72,17 +72,17 @@
 - debug: var=lb_creation_confirmation_task
 
 - name: lb_creation_confirmation_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_creation_confirmation_task is success
 
 - name: lb_creation_confirmation_task is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_creation_confirmation_task is not changed
 
 - name: Assert that the load-balancer is in a valid state
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_creation_confirmation_task.scaleway_lb.status == "ready"
 
@@ -100,12 +100,12 @@
 - debug: var=lb_update_check_task
 
 - name: lb_update_check_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_update_check_task is success
 
 - name: lb_update_check_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_update_check_task is changed
 
@@ -123,17 +123,17 @@
 - debug: var=lb_update_task
 
 - name: lb_update_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_update_task is success
 
 - name: lb_update_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_update_task is changed
 
 - name: Assert that the load-balancer is in a valid state
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_update_task.scaleway_lb.status == "ready"
 
@@ -150,17 +150,17 @@
 - debug: var=lb_update_confirmation_task
 
 - name: lb_update_confirmation_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_update_confirmation_task is success
 
 - name: lb_update_confirmation_task is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_update_confirmation_task is not changed
 
 - name: Assert that the load-balancer is in a valid state
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_update_confirmation_task.scaleway_lb.status == "ready"
 
@@ -175,12 +175,12 @@
   register: lb_deletion_check_task
 
 - name: lb_deletion_check_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_deletion_check_task is success
 
 - name: lb_deletion_check_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_deletion_check_task is changed
 
@@ -195,12 +195,12 @@
   register: lb_deletion_task
 
 - name: lb_deletion_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_deletion_task is success
 
 - name: lb_deletion_task is changed
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_deletion_task is changed
 
@@ -214,11 +214,11 @@
   register: lb_deletion_confirmation_task
 
 - name: lb_deletion_confirmation_task is success
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_deletion_confirmation_task is success
 
 - name: lb_deletion_confirmation_task is not changed
-  assert:
+  ansible.builtin.assert:
     that:
       - lb_deletion_confirmation_task is not changed

--- a/tests/integration/targets/scaleway_organization_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_organization_info/tasks/main.yml
@@ -17,6 +17,6 @@
     var: organizations
 
 - name: Ensure retrieval of organizations info is success
-  assert:
+  ansible.builtin.assert:
     that:
       - organizations is success

--- a/tests/integration/targets/scaleway_security_group/tasks/main.yml
+++ b/tests/integration/targets/scaleway_security_group/tasks/main.yml
@@ -25,7 +25,7 @@
 - debug: var=security_group_creation
 
 - name: Ensure security groups check facts is success
-  assert:
+  ansible.builtin.assert:
     that:
       - security_group_creation is success
       - security_group_creation is changed
@@ -47,7 +47,7 @@
     - debug: var=security_group_creation
 
     - name: Ensure security groups facts is success
-      assert:
+      ansible.builtin.assert:
         that:
           - security_group_creation is success
           - security_group_creation is changed
@@ -68,7 +68,7 @@
     - debug: var=security_group_creation
 
     - name: Ensure security groups duplicate facts is success
-      assert:
+      ansible.builtin.assert:
         that:
           - security_group_creation is success
           - security_group_creation is not changed
@@ -90,7 +90,7 @@
     - debug: var=security_group_deletion
 
     - name: Ensure security groups delete check facts is success
-      assert:
+      ansible.builtin.assert:
         that:
           - security_group_deletion is success
           - security_group_deletion is changed
@@ -112,7 +112,7 @@
     - debug: var=security_group_deletion
 
     - name: Ensure security groups delete facts is success
-      assert:
+      ansible.builtin.assert:
         that:
           - security_group_deletion is success
           - security_group_deletion is changed
@@ -133,7 +133,7 @@
 - debug: var=security_group_deletion
 
 - name: Ensure security groups delete duplicate facts is success
-  assert:
+  ansible.builtin.assert:
     that:
       - security_group_deletion is success
       - security_group_deletion is not changed

--- a/tests/integration/targets/scaleway_security_group_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_security_group_info/tasks/main.yml
@@ -18,7 +18,7 @@
     var: security_groups
 
 - name: Ensure retrieval of security groups info is success
-  assert:
+  ansible.builtin.assert:
     that:
       - security_groups is success
 
@@ -32,6 +32,6 @@
     var: ams1_security_groups
 
 - name: Ensure retrieval of security groups info is success (AMS1)
-  assert:
+  ansible.builtin.assert:
     that:
       - ams1_security_groups is success

--- a/tests/integration/targets/scaleway_security_group_rule/tasks/main.yml
+++ b/tests/integration/targets/scaleway_security_group_rule/tasks/main.yml
@@ -38,7 +38,7 @@
 
 - debug: var=security_group_rule_creation_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - security_group_rule_creation_task is success
       - security_group_rule_creation_task is changed
@@ -58,7 +58,7 @@
 
     - debug: var=security_group_rule_creation_task
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - security_group_rule_creation_task is success
           - security_group_rule_creation_task is changed
@@ -77,7 +77,7 @@
 
     - debug: var=security_group_rule_creation_task
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - security_group_rule_creation_task is success
           - security_group_rule_creation_task is not changed
@@ -97,7 +97,7 @@
 
     - debug: var=security_group_rule_deletion_task
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - security_group_rule_deletion_task is success
           - security_group_rule_deletion_task is changed
@@ -117,7 +117,7 @@
 
     - debug: var=security_group_rule_deletion_task
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - security_group_rule_deletion_task is success
           - security_group_rule_deletion_task is changed
@@ -136,7 +136,7 @@
 
 - debug: var=security_group_rule_deletion_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - security_group_rule_deletion_task is success
       - security_group_rule_deletion_task is not changed
@@ -156,7 +156,7 @@
 
     - debug: var=security_group_rule_creation_task
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - security_group_rule_creation_task is success
           - security_group_rule_creation_task is changed
@@ -175,7 +175,7 @@
 
     - debug: var=security_group_rule_creation_task
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - security_group_rule_creation_task is success
           - security_group_rule_creation_task is not changed
@@ -195,7 +195,7 @@
 
     - debug: var=security_group_rule_deletion_task
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - security_group_rule_deletion_task is success
           - security_group_rule_deletion_task is changed
@@ -215,7 +215,7 @@
 
     - debug: var=security_group_rule_deletion_task
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - security_group_rule_deletion_task is success
           - security_group_rule_deletion_task is changed
@@ -234,7 +234,7 @@
 
 - debug: var=security_group_rule_deletion_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - security_group_rule_deletion_task is success
       - security_group_rule_deletion_task is not changed

--- a/tests/integration/targets/scaleway_server_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_server_info/tasks/main.yml
@@ -18,7 +18,7 @@
     var: servers
 
 - name: Ensure retrieval of servers info is success
-  assert:
+  ansible.builtin.assert:
     that:
       - servers is success
 
@@ -32,6 +32,6 @@
     var: ams1_servers
 
 - name: Ensure retrieval of servers info is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ams1_servers is success

--- a/tests/integration/targets/scaleway_snapshot_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_snapshot_info/tasks/main.yml
@@ -18,7 +18,7 @@
     var: snapshots
 
 - name: Ensure retrieval of snapshots info is success
-  assert:
+  ansible.builtin.assert:
     that:
       - snapshots is success
 
@@ -32,6 +32,6 @@
     var: ams1_snapshots
 
 - name: Ensure retrieval of snapshots info is success (AMS1)
-  assert:
+  ansible.builtin.assert:
     that:
       - ams1_snapshots is success

--- a/tests/integration/targets/scaleway_sshkey/tasks/main.yml
+++ b/tests/integration/targets/scaleway_sshkey/tasks/main.yml
@@ -23,7 +23,7 @@
     state: present
   register: result2
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result1 is success and result1 is changed
       - result2 is success and result2 is not changed
@@ -43,7 +43,7 @@
     state: absent
   register: result2
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result1 is success and result1 is changed
       - result2 is success and result2 is not changed

--- a/tests/integration/targets/scaleway_user_data/tasks/main.yml
+++ b/tests/integration/targets/scaleway_user_data/tasks/main.yml
@@ -38,7 +38,7 @@
 
 - debug: var=user_data_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - user_data_check_task is success
       - user_data_check_task is changed
@@ -53,7 +53,7 @@
 
 - debug: var=user_data_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - user_data_task is success
       - user_data_task is changed
@@ -68,7 +68,7 @@
 
 - debug: var=user_data_confirmation_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - user_data_confirmation_task is success
       - user_data_confirmation_task is not changed

--- a/tests/integration/targets/scaleway_volume/tasks/main.yml
+++ b/tests/integration/targets/scaleway_volume/tasks/main.yml
@@ -16,7 +16,7 @@
     organization: '{{ scaleway_organization }}'
   register: server_creation_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_creation_check_task is success
 
@@ -32,7 +32,7 @@
 
 - debug: var=server_creation_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_creation_check_task is success
       - server_creation_check_task is changed
@@ -45,7 +45,7 @@
     organization: '{{ scaleway_organization }}'
   register: server_creation_check_task
 
-- assert:
+- ansible.builtin.assert:
     that:
       - server_creation_check_task is success
       - server_creation_check_task is changed

--- a/tests/integration/targets/scaleway_volume_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_volume_info/tasks/main.yml
@@ -18,7 +18,7 @@
     var: volumes
 
 - name: Ensure retrieval of volumes info is success
-  assert:
+  ansible.builtin.assert:
     that:
       - volumes is success
 
@@ -32,6 +32,6 @@
     var: ams1_volumes
 
 - name: Ensure retrieval of volumes info is success
-  assert:
+  ansible.builtin.assert:
     that:
       - ams1_volumes is success

--- a/tests/integration/targets/sefcontext/tasks/sefcontext.yml
+++ b/tests/integration/targets/sefcontext/tasks/sefcontext.yml
@@ -36,7 +36,7 @@
     reload: false
   register: first
 
-- assert:
+- ansible.builtin.assert:
     that:
       - first is changed
       - first.setype == 'httpd_sys_content_t'
@@ -49,7 +49,7 @@
     reload: false
   register: second
 
-- assert:
+- ansible.builtin.assert:
     that:
       - second is not changed
       - second.setype == 'httpd_sys_content_t'
@@ -62,7 +62,7 @@
     reload: false
   register: third
 
-- assert:
+- ansible.builtin.assert:
     that:
       - third is changed
       - third.setype == 'unlabeled_t'
@@ -75,7 +75,7 @@
     reload: false
   register: fourth
 
-- assert:
+- ansible.builtin.assert:
     that:
       - fourth is not changed
       - fourth.setype == 'unlabeled_t'
@@ -88,7 +88,7 @@
     reload: false
   register: fifth
 
-- assert:
+- ansible.builtin.assert:
     that:
       - fifth is changed
       - fifth.setype == 'httpd_sys_content_t'
@@ -101,7 +101,7 @@
     reload: false
   register: sixth
 
-- assert:
+- ansible.builtin.assert:
     that:
       - sixth is not changed
       - sixth.setype == 'unlabeled_t'
@@ -114,7 +114,7 @@
     reload: false
   register: subst_first
 
-- assert:
+- ansible.builtin.assert:
     that:
       - subst_first is changed
       - subst_first.substitute == '/home'
@@ -127,7 +127,7 @@
     reload: false
   register: subst_second
 
-- assert:
+- ansible.builtin.assert:
     that:
       - subst_second is not changed
       - subst_second.substitute == '/home'
@@ -140,7 +140,7 @@
     reload: false
   register: subst_third
 
-- assert:
+- ansible.builtin.assert:
     that:
       - subst_third is changed
       - subst_third.substitute == '/boot'
@@ -153,7 +153,7 @@
     reload: false
   register: subst_fourth
 
-- assert:
+- ansible.builtin.assert:
     that:
       - subst_fourth is not changed
       - subst_fourth.substitute == '/boot'
@@ -166,7 +166,7 @@
     reload: false
   register: subst_fifth
 
-- assert:
+- ansible.builtin.assert:
     that:
       - subst_fifth is not changed
       - subst_fifth.substitute == '/dev'
@@ -179,7 +179,7 @@
     reload: false
   register: subst_sixth
 
-- assert:
+- ansible.builtin.assert:
     that:
       - subst_sixth is changed
       - subst_sixth.substitute == '/boot'
@@ -192,7 +192,7 @@
     reload: false
   register: subst_seventh
 
-- assert:
+- ansible.builtin.assert:
     that:
       - subst_seventh is not changed
       - subst_seventh.substitute == '/boot'
@@ -205,7 +205,7 @@
     reload: false
   register: subst_eighth
 
-- assert:
+- ansible.builtin.assert:
     that:
       - subst_eighth is changed
       - subst_eighth.substitute == '/home'
@@ -217,7 +217,7 @@
     reload: false
   register: subst_ninth
 
-- assert:
+- ansible.builtin.assert:
     that:
       - subst_ninth is changed
 
@@ -228,6 +228,6 @@
     reload: false
   register: subst_tenth
 
-- assert:
+- ansible.builtin.assert:
     that:
       - subst_tenth is not changed

--- a/tests/integration/targets/shutdown/tasks/main.yml
+++ b/tests/integration/targets/shutdown/tasks/main.yml
@@ -23,7 +23,7 @@
   check_mode: true
 
 - name: Verify Custom Message except Alpine, AIX
-  assert:
+  ansible.builtin.assert:
     that:
       - '"Custom Message" in shutdown_result["shutdown_command"]'
       - '"Shut down initiated by Ansible" in shutdown_result_minus["shutdown_command"]'
@@ -34,7 +34,7 @@
     - '"systemctl" not in shutdown_result_minus["shutdown_command"]'
 
 - name: Verify shutdown command is present except Alpine or AIX or systemd
-  assert:
+  ansible.builtin.assert:
     that: '"shutdown" in shutdown_result["shutdown_command"]'
   when:
     - "ansible_facts.os_family != 'Alpine'"
@@ -42,7 +42,7 @@
     - '"systemctl" not in shutdown_result["shutdown_command"]'
 
 - name: Verify shutdown command is present in Alpine except systemd
-  assert:
+  ansible.builtin.assert:
     that: '"poweroff" in shutdown_result["shutdown_command"]'
   when:
     - "ansible_facts.os_family == 'Alpine'"
@@ -50,14 +50,14 @@
 
 
 - name: Verify shutdown command is present in VMKernel except systemd
-  assert:
+  ansible.builtin.assert:
     that: '"halt" in shutdown_result["shutdown_command"]'
   when:
     - "ansible_facts.system == 'VMKernel'"
     - '"systemctl" not in shutdown_result["shutdown_command"]'
 
 - name: Verify shutdown delay is present in minutes in Linux except systemd
-  assert:
+  ansible.builtin.assert:
     that:
       - '"-h 1" in shutdown_result["shutdown_command"]'
       - '"-h 0" in shutdown_result_minus["shutdown_command"]'
@@ -68,28 +68,28 @@
     - '"systemctl" not in shutdown_result_minus["shutdown_command"]'
 
 - name: Verify shutdown delay is present in minutes in Void, MacOSX, OpenBSD
-  assert:
+  ansible.builtin.assert:
     that:
       - '"-h +1" in shutdown_result["shutdown_command"]'
       - '"-h +0" in shutdown_result_minus["shutdown_command"]'
   when: ansible_facts.system in ['Void', 'Darwin', 'OpenBSD']
 
 - name: Verify shutdown delay is present in seconds in FreeBSD
-  assert:
+  ansible.builtin.assert:
     that:
       - '"-p +100s" in shutdown_result["shutdown_command"]'
       - '"-p +0s" in shutdown_result_minus["shutdown_command"]'
   when: ansible_facts.system == 'FreeBSD'
 
 - name: Verify shutdown delay is present in seconds in Solaris, SunOS
-  assert:
+  ansible.builtin.assert:
     that:
       - '"-g 100" in shutdown_result["shutdown_command"]'
       - '"-g 0" in shutdown_result_minus["shutdown_command"]'
   when: ansible_facts.system in ['Solaris', 'SunOS']
 
 - name: Verify shutdown delay is present in seconds, VMKernel
-  assert:
+  ansible.builtin.assert:
     that:
       - '"-d 100" in shutdown_result["shutdown_command"]'
       - '"-d 0" in shutdown_result_minus["shutdown_command"]'

--- a/tests/integration/targets/snap/tasks/test.yml
+++ b/tests/integration/targets/snap/tasks/test.yml
@@ -35,7 +35,7 @@
   register: install_again
 
 - name: Assert package has been installed just once (hello-world)
-  assert:
+  ansible.builtin.assert:
     that:
       - install is changed
       - install_check is changed
@@ -74,7 +74,7 @@
   register: remove_again
 
 - name: Assert package has been removed just once (hello-world)
-  assert:
+  ansible.builtin.assert:
     that:
       - remove is changed
       - remove_check is changed
@@ -102,7 +102,7 @@
   register: classic_install_again
 
 - name: Assert package has been installed just once (nvim)
-  assert:
+  ansible.builtin.assert:
     that:
       - classic_install is changed
       - classic_install_again is not changed
@@ -123,7 +123,7 @@
   register: classic_remove_with_true_classic
 
 - name: Assert package has been removed without setting classic to true (nvim)
-  assert:
+  ansible.builtin.assert:
     that:
       - classic_remove_without_true_classic is changed
       - classic_remove_with_true_classic is not changed
@@ -172,7 +172,7 @@
   register: remove
 
 - name: Assert package has been installed with options just once and only changed options trigger a change (uhttpd)
-  assert:
+  ansible.builtin.assert:
     that:
       - install is changed
       - install_with_option is changed
@@ -217,7 +217,7 @@
   register: install_two_remove_again
 
 - name: Assert installation of two packages
-  assert:
+  ansible.builtin.assert:
     that:
       - install_two is changed
       - "'hello-world' in install_two.snaps_installed"

--- a/tests/integration/targets/snap/tasks/test_3dash.yml
+++ b/tests/integration/targets/snap/tasks/test_3dash.yml
@@ -26,6 +26,6 @@
       - shellcheck
     state: absent
 
-- assert:
+- ansible.builtin.assert:
     that:
       - install_3dash_check is changed

--- a/tests/integration/targets/snap/tasks/test_channel.yml
+++ b/tests/integration/targets/snap/tasks/test_channel.yml
@@ -37,7 +37,7 @@
     state: absent
   register: remove_wisdom
 
-- assert:
+- ansible.builtin.assert:
     that:
       - install_wisdom is changed
       - install_wisdom_chan is changed
@@ -70,7 +70,7 @@
     state: absent
   register: remove_shellcheck
 
-- assert:
+- ansible.builtin.assert:
     that:
       - install_shellcheck is changed
       - install_shellcheck_chan is changed

--- a/tests/integration/targets/snap/tasks/test_dangerous.yml
+++ b/tests/integration/targets/snap/tasks/test_dangerous.yml
@@ -50,7 +50,7 @@
     state: absent
   register: remove_dangerous
 
-- assert:
+- ansible.builtin.assert:
     that:
       - install_dangerous_check is changed
       - install_dangerous is changed

--- a/tests/integration/targets/snap/tasks/test_revision.yml
+++ b/tests/integration/targets/snap/tasks/test_revision.yml
@@ -23,7 +23,7 @@
   register: install_revision_again
 
 - name: Assert revision install behavior
-  assert:
+  ansible.builtin.assert:
     that:
       - install_revision is changed
       - install_revision_again is not changed
@@ -34,7 +34,7 @@
   changed_when: false
 
 - name: Assert snap is held
-  assert:
+  ansible.builtin.assert:
     that:
       - "'held' in snap_list_after_install.stdout"
 
@@ -46,7 +46,7 @@
   register: install_different_revision
 
 - name: Assert switching to a different revision triggers change
-  assert:
+  ansible.builtin.assert:
     that:
       - install_different_revision is changed
 
@@ -56,7 +56,7 @@
   changed_when: false
 
 - name: Assert snap is still held
-  assert:
+  ansible.builtin.assert:
     that:
       - "'held' in snap_list_after_switch.stdout"
 
@@ -72,7 +72,7 @@
   changed_when: false
 
 - name: Assert snap did not update past the held revision
-  assert:
+  ansible.builtin.assert:
     that:
       - "'45' in snap_list_after_bare_refresh.stdout"
       - "'held' in snap_list_after_bare_refresh.stdout"
@@ -92,6 +92,6 @@
   ignore_errors: true
 
 - name: Assert channel and revision are mutually exclusive
-  assert:
+  ansible.builtin.assert:
     that:
       - install_channel_and_revision is failed

--- a/tests/integration/targets/snap_alias/tasks/test.yml
+++ b/tests/integration/targets/snap_alias/tasks/test.yml
@@ -41,7 +41,7 @@
   register: alias_single_3
 
 - name: assert single alias
-  assert:
+  ansible.builtin.assert:
     that:
       - alias_single_0 is changed
       - alias_single_1 is changed
@@ -77,7 +77,7 @@
   register: alias_multi_3
 
 - name: assert multi alias
-  assert:
+  ansible.builtin.assert:
     that:
       - alias_multi_0 is changed
       - alias_multi_1 is changed
@@ -113,7 +113,7 @@
   register: alias_remove_3
 
 - name: assert remove alias
-  assert:
+  ansible.builtin.assert:
     that:
       - alias_remove_0 is changed
       - alias_remove_1 is changed
@@ -149,7 +149,7 @@
   register: alias_remove_all_3
 
 - name: assert remove_all alias
-  assert:
+  ansible.builtin.assert:
     that:
       - alias_remove_all_0 is changed
       - alias_remove_all_1 is changed

--- a/tests/integration/targets/snap_connect/tasks/test.yml
+++ b/tests/integration/targets/snap_connect/tasks/test.yml
@@ -51,7 +51,7 @@
   register: connect_3
 
 - name: Assert connect results
-  assert:
+  ansible.builtin.assert:
     that:
       - connect_0 is changed
       - connect_1 is changed
@@ -91,7 +91,7 @@
   register: disconnect_3
 
 - name: Assert disconnect results
-  assert:
+  ansible.builtin.assert:
     that:
       - disconnect_0 is changed
       - disconnect_1 is changed

--- a/tests/integration/targets/spectrum_model_attrs/tasks/main.yml
+++ b/tests/integration/targets/spectrum_model_attrs/tasks/main.yml
@@ -31,12 +31,12 @@
       register: mm_enabled_check_mode
 
     - name: "001: assert that changes were made"
-      assert:
+      ansible.builtin.assert:
         that:
           - mm_enabled_check_mode is changed
 
     - name: "001: assert that changed_attrs is properly set"
-      assert:
+      ansible.builtin.assert:
         that:
           - mm_enabled_check_mode.changed_attrs.Notes == note_mm_enabled
           - mm_enabled_check_mode.changed_attrs.isManaged == "false"
@@ -48,12 +48,12 @@
       check_mode: false
 
     - name: "002: assert that changes were made"
-      assert:
+      ansible.builtin.assert:
         that:
           - mm_enabled is changed
 
     - name: "002: assert that changed_attrs is properly set"
-      assert:
+      ansible.builtin.assert:
         that:
           - mm_enabled.changed_attrs.Notes == note_mm_enabled
           - mm_enabled.changed_attrs.isManaged == "false"
@@ -65,12 +65,12 @@
       check_mode: false
 
     - name: "003: assert that changes were not made"
-      assert:
+      ansible.builtin.assert:
         that:
           - mm_enabled_idp is not changed
 
     - name: "003: assert that changed_attrs is not set"
-      assert:
+      ansible.builtin.assert:
         that:
           - mm_enabled_idp.changed_attrs == {}
 

--- a/tests/integration/targets/ssh_config/tasks/main.yml
+++ b/tests/integration/targets/ssh_config/tasks/main.yml
@@ -32,7 +32,7 @@
   register: host_required
 
 - name: Check if ssh_config fails for required parameter host
-  assert:
+  ansible.builtin.assert:
     that:
       - not host_required.changed
 
@@ -48,7 +48,7 @@
   check_mode: true
 
 - name: Check if changes are made in check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - host_add.changed
       - "'example.com' in host_add.hosts_added"
@@ -66,7 +66,7 @@
   register: host_add
 
 - name: Check if changes are made
-  assert:
+  ansible.builtin.assert:
     that:
       - host_add.changed
       - "'example.com' in host_add.hosts_added"
@@ -84,7 +84,7 @@
   register: host_add_again
 
 - name: Check for idempotency
-  assert:
+  ansible.builtin.assert:
     that:
       - not host_add_again.changed
       - host_add.hosts_changed is defined
@@ -102,7 +102,7 @@
   register: host_update
 
 - name: Check for update operation
-  assert:
+  ansible.builtin.assert:
     that:
       - host_update.changed
       - host_update.hosts_changed is defined
@@ -122,7 +122,7 @@
   register: host_update
 
 - name: Check update operation for idempotency
-  assert:
+  ansible.builtin.assert:
     that:
       - not host_update.changed
       - host_update.hosts_changed is defined
@@ -138,7 +138,7 @@
   register: host_delete
 
 - name: Check if changes are made
-  assert:
+  ansible.builtin.assert:
     that:
       - host_delete.changed
       - "'example.com' in host_delete.hosts_removed"
@@ -154,7 +154,7 @@
   register: host_delete_again
 
 - name: Check for idempotency
-  assert:
+  ansible.builtin.assert:
     that:
       - not host_delete_again.changed
       - host_delete_again.hosts_changed is defined
@@ -174,7 +174,7 @@
   ignore_errors: true
 
 - name: Check mutual exclusive test - user and ssh_config_file
-  assert:
+  ansible.builtin.assert:
     that:
       - not mut_ex.changed
       - "'parameters are mutually exclusive' in mut_ex.msg"
@@ -193,7 +193,7 @@
   ignore_errors: true
 
 - name: Check mutual exclusive test - proxycommand and proxyjump
-  assert:
+  ansible.builtin.assert:
     that:
       - not proxy_mut_ex.changed
       - "'parameters are mutually exclusive' in proxy_mut_ex.msg"
@@ -209,7 +209,7 @@
   register: full_name
 
 - name: Check if changes are made
-  assert:
+  ansible.builtin.assert:
     that:
       - full_name is changed
       - full_name.hosts_added == ["full_name"]
@@ -227,7 +227,7 @@
   register: short_name
 
 - name: Check that short name host is added and full name host is not updated
-  assert:
+  ansible.builtin.assert:
     that:
       - short_name is changed
       - short_name.hosts_added == ["full"]

--- a/tests/integration/targets/ssh_config/tasks/options.yml
+++ b/tests/integration/targets/ssh_config/tasks/options.yml
@@ -30,7 +30,7 @@
   check_mode: true
 
 - name: Options - Check if changes are made in check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - options_add.changed
       - "'options.example.com' in options_add.hosts_added"
@@ -43,7 +43,7 @@
   register: slurp_ssh_config
 
 - name: "Options - Verify that nothing was added to {{ ssh_config_test }} during change mode"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'options.example.com' not in slurp_ssh_config['content'] | b64decode"
 
@@ -67,7 +67,7 @@
   register: options_add
 
 - name: Options - Check if changes are made
-  assert:
+  ansible.builtin.assert:
     that:
       - options_add.changed
       - "'options.example.com' in options_add.hosts_added"
@@ -94,7 +94,7 @@
   register: options_add_again
 
 - name: Options - Check for idempotency
-  assert:
+  ansible.builtin.assert:
     that:
       - not options_add_again.changed
       - options_add.hosts_changed is defined
@@ -107,7 +107,7 @@
   register: slurp_ssh_config
 
 - name: "Verify that {{ ssh_config_test }} contains added options"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'proxycommand ssh jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent yes' in slurp_ssh_config['content'] | b64decode"
@@ -141,7 +141,7 @@
   register: options_update
 
 - name: Options - Check for update operation
-  assert:
+  ansible.builtin.assert:
     that:
       - options_update.changed
       - options_update.hosts_changed is defined
@@ -170,7 +170,7 @@
   register: options_update
 
 - name: Options - Check update operation for idempotency
-  assert:
+  ansible.builtin.assert:
     that:
       - not options_update.changed
       - options_update.hosts_changed is defined
@@ -184,7 +184,7 @@
   register: slurp_ssh_config
 
 - name: "Verify that {{ ssh_config_test }} contains changed options"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
@@ -206,7 +206,7 @@
   register: options_no_update
 
 - name: Options - Check that no update took place
-  assert:
+  ansible.builtin.assert:
     that:
       - not options_update.changed
       - options_update.hosts_changed is defined
@@ -220,7 +220,7 @@
   register: slurp_ssh_config
 
 - name: "Verify that {{ ssh_config_test }} wasn't changed"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
@@ -246,7 +246,7 @@
   register: options_delete
 
 - name: Options - Check if host was removed
-  assert:
+  ansible.builtin.assert:
     that:
       - options_delete.changed
       - "'options.example.com' in options_delete.hosts_removed"
@@ -261,7 +261,7 @@
   register: options_delete_again
 
 - name: Options - Check delete operation for idempotency
-  assert:
+  ansible.builtin.assert:
     that:
       - not options_delete_again.changed
       - options_delete_again.hosts_changed is defined
@@ -274,7 +274,7 @@
   register: slurp_ssh_config
 
 - name: "Verify that {{ ssh_config_test }} does not contains deleted options"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' not in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' not in slurp_ssh_config['content'] | b64decode"
@@ -317,7 +317,7 @@
   check_mode: true
 
 - name: Options - Check if changes are made in check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - options_add.changed
       - "'options.example.com' in options_add.hosts_added"
@@ -330,7 +330,7 @@
   register: slurp_ssh_config
 
 - name: "Options - Verify that nothing was added to {{ ssh_config_test }} during change mode"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'options.example.com' not in slurp_ssh_config['content'] | b64decode"
 
@@ -354,7 +354,7 @@
   register: options_add
 
 - name: Options - Check if changes are made
-  assert:
+  ansible.builtin.assert:
     that:
       - options_add.changed
       - "'options.example.com' in options_add.hosts_added"
@@ -381,7 +381,7 @@
   register: options_add_again
 
 - name: Options - Check for idempotency
-  assert:
+  ansible.builtin.assert:
     that:
       - not options_add_again.changed
       - options_add.hosts_changed is defined
@@ -394,7 +394,7 @@
   register: slurp_ssh_config
 
 - name: "Verify that {{ ssh_config_test }} contains added options"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'proxyjump jumphost.example.com' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent yes' in slurp_ssh_config['content'] | b64decode"
@@ -428,7 +428,7 @@
   register: options_update
 
 - name: Options - Check for update operation
-  assert:
+  ansible.builtin.assert:
     that:
       - options_update.changed
       - options_update.hosts_changed is defined
@@ -457,7 +457,7 @@
   register: options_update
 
 - name: Options - Check update operation for idempotency
-  assert:
+  ansible.builtin.assert:
     that:
       - not options_update.changed
       - options_update.hosts_changed is defined
@@ -471,7 +471,7 @@
   register: slurp_ssh_config
 
 - name: "Verify that {{ ssh_config_test }} contains changed options"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'proxyjump new-jumphost.example.com' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
@@ -493,7 +493,7 @@
   register: options_no_update
 
 - name: Options - Check that no update took place
-  assert:
+  ansible.builtin.assert:
     that:
       - not options_update.changed
       - options_update.hosts_changed is defined
@@ -507,7 +507,7 @@
   register: slurp_ssh_config
 
 - name: "Verify that {{ ssh_config_test }} wasn't changed"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'proxyjump new-jumphost.example.com' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
@@ -533,7 +533,7 @@
   register: options_delete
 
 - name: Options - Check if host was removed
-  assert:
+  ansible.builtin.assert:
     that:
       - options_delete.changed
       - "'options.example.com' in options_delete.hosts_removed"
@@ -548,7 +548,7 @@
   register: options_delete_again
 
 - name: Options - Check delete operation for idempotency
-  assert:
+  ansible.builtin.assert:
     that:
       - not options_delete_again.changed
       - options_delete_again.hosts_changed is defined
@@ -561,7 +561,7 @@
   register: slurp_ssh_config
 
 - name: "Verify that {{ ssh_config_test }} does not contains deleted options"
-  assert:
+  ansible.builtin.assert:
     that:
       - "'proxyjump new-jumphost.example.com' not in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' not in slurp_ssh_config['content'] | b64decode"

--- a/tests/integration/targets/supervisorctl/tasks/test_start.yml
+++ b/tests/integration/targets/supervisorctl/tasks/test_start.yml
@@ -26,7 +26,7 @@
   failed_when: result_cmd.rc not in [0, 3]
 
 - name: check that service is started
-  assert:
+  ansible.builtin.assert:
     that:
       - (result is success and result_with_auth is skip) or (result is skip and result_with_auth is changed)
       - (result is changed and result_with_auth is skip) or (result is skip and result_with_auth is changed)
@@ -55,7 +55,7 @@
   when: credentials.username != ''
 
 - name: check that service is already running
-  assert:
+  ansible.builtin.assert:
     that:
       - (result is success and result_with_auth is skip) or (result is skip and result_with_auth is success)
       - (result is not changed and result_with_auth is skip) or (result is skip and result_with_auth is not changed)
@@ -88,7 +88,7 @@
   when: credentials.username != ''
 
 - name: check that service is started
-  assert:
+  ansible.builtin.assert:
     that:
       - (result is success and result_with_auth is skip) or (result is skip and result_with_auth is changed)
       - (result is changed and result_with_auth is skip) or (result is skip and result_with_auth is changed)

--- a/tests/integration/targets/supervisorctl/tasks/test_stop.yml
+++ b/tests/integration/targets/supervisorctl/tasks/test_stop.yml
@@ -28,7 +28,7 @@
   failed_when: result_cmd.rc not in [0, 3]
 
 - name: check that service is stopped
-  assert:
+  ansible.builtin.assert:
     that:
       - (result is success and result_with_auth is skip) or (result is skip and result_with_auth is success)
       - (result is changed and result_with_auth is skip) or (result is skip and result_with_auth is changed)
@@ -61,7 +61,7 @@
   when: credentials.username != ''
 
 - name: check that service is already stopped
-  assert:
+  ansible.builtin.assert:
     that:
       - (result is success and result_with_auth is skip) or (result is skip and result_with_auth is success)
       - (result is not changed and result_with_auth is skip) or (result is skip and result_with_auth is not changed)

--- a/tests/integration/targets/sysrc/tasks/main.yml
+++ b/tests/integration/targets/sysrc/tasks/main.yml
@@ -43,7 +43,7 @@
       register: sysrc_example1_content
 
     - name: Ensure sysrc updates rc.conf properly
-      assert:
+      ansible.builtin.assert:
         that:
           - sysrc_example1.changed
           - sysrc_example1_checkmode.changed
@@ -84,7 +84,7 @@
       register: sysrc_example2_content
 
     - name: Ensure sysrc did not change the file, but marked as changed
-      assert:
+      ansible.builtin.assert:
         that:
           - sysrc_example2.changed
           - sysrc_example2_checkmode.changed
@@ -127,7 +127,7 @@
       register: sysrc_example3_content
 
     - name: Ensure sysrc did not change the file, but marked as changed
-      assert:
+      ansible.builtin.assert:
         that:
           - sysrc_example3.changed
           - sysrc_example3_checkmode.changed
@@ -176,7 +176,7 @@
           register: sysrc_example4_content
 
         - name: Ensure sysrc worked in testjail
-          assert:
+          ansible.builtin.assert:
             that:
               - sysrc_example4.changed
               - sysrc_example4_checkmode.changed
@@ -220,7 +220,7 @@
       register: sysrc_absent_content
 
     - name: Ensure sysrc did as intended
-      assert:
+      ansible.builtin.assert:
         that:
           - sysrc_absent_checkmode.changed
           - sysrc_absent.changed
@@ -273,7 +273,7 @@
       register: sysrc_delim_content
 
     - name: Ensure sysrc did as intended
-      assert:
+      ansible.builtin.assert:
         that:
           - sysrc_delim_create.changed
           - sysrc_delim.changed
@@ -323,7 +323,7 @@
       register: sysrc_delim_content
 
     - name: Ensure sysrc did as intended with value_absent
-      assert:
+      ansible.builtin.assert:
         that:
           - not sysrc_value_absent_ignored.changed
           - sysrc_value_absent.changed
@@ -360,7 +360,7 @@
         - name: Ensure sysrc did as intended with values that contains equals sign
           vars:
             conf: "{{ sysrc_content.stdout | from_yaml }}"
-          assert:
+          ansible.builtin.assert:
             that:
               - "value_1 == sysrc_equals_sign_1.value"
               - sysrc_equals_sign_2.changed
@@ -413,7 +413,7 @@
       register: sysrc_10394_content
 
     - name: Ensure sysrc changed k1 from v1 to v2
-      assert:
+      ansible.builtin.assert:
         that:
           - sysrc_10394_changed.changed
           - >

--- a/tests/integration/targets/terraform/tasks/complex_variables.yml
+++ b/tests/integration/targets/terraform/tasks/complex_variables.yml
@@ -56,5 +56,5 @@
     state: present
   register: terraform_init_result
 
-- assert:
+- ansible.builtin.assert:
     that: terraform_init_result is not failed

--- a/tests/integration/targets/terraform/tasks/test_provider_upgrade.yml
+++ b/tests/integration/targets/terraform/tasks/test_provider_upgrade.yml
@@ -31,5 +31,5 @@
     state: present
   register: terraform_init_result
 
-- assert:
+- ansible.builtin.assert:
     that: terraform_init_result is not failed

--- a/tests/integration/targets/test_a_module/runme.yml
+++ b/tests/integration/targets/test_a_module/runme.yml
@@ -6,7 +6,7 @@
 - hosts: localhost
   tasks:
     - name: Test a_module
-      assert:
+      ansible.builtin.assert:
         that:
           # Modules/actions that do not exist
           - "'foo_bar' is not community.general.a_module"
@@ -30,7 +30,7 @@
           - "'testns.testcoll.foobar' is not community.general.a_module"
 
     - name: Test a_module in case of routing
-      assert:
+      ansible.builtin.assert:
         that:
           # Redirected module
           - "'ufw' is community.general.a_module"

--- a/tests/integration/targets/test_ansible_type/tasks/tasks.yml
+++ b/tests/integration/targets/test_ansible_type/tasks/tasks.yml
@@ -6,7 +6,7 @@
 # -------------------------------------------
 
 - name: String. AnsibleUnicode.
-  assert:
+  ansible.builtin.assert:
     that: data is community.general.ansible_type(dtype)
     success_msg: '"abc" is {{ dtype }}'
     fail_msg: '"abc" is {{ result }}'
@@ -19,7 +19,7 @@
       - '_AnsibleTaggedStr'
 
 - name: String. AnsibleUnicode alias str.
-  assert:
+  ansible.builtin.assert:
     that: data is community.general.ansible_type(dtype, alias)
     success_msg: '"abc" is {{ dtype }}'
     fail_msg: '"abc" is {{ result }}'
@@ -31,7 +31,7 @@
     dtype: 'str'
 
 - name: List. All items are AnsibleUnicode.
-  assert:
+  ansible.builtin.assert:
     that: data is community.general.ansible_type(dtype)
     success_msg: '["a", "b", "c"] is {{ dtype }}'
     fail_msg: '["a", "b", "c"] is {{ result }}'
@@ -44,7 +44,7 @@
       - 'list[_AnsibleTaggedStr]'
 
 - name: Dictionary. All keys are AnsibleUnicode. All values are AnsibleUnicode.
-  assert:
+  ansible.builtin.assert:
     that: data is community.general.ansible_type(dtype)
     success_msg: '{"a": "foo", "b": "bar", "c": "baz"} is {{ dtype }}'
     fail_msg: '{"a": "foo", "b": "bar", "c": "baz"} is {{ result }}'
@@ -60,7 +60,7 @@
 # ----------------------------------------------------
 
 - name: String
-  assert:
+  ansible.builtin.assert:
     that: '"abc" is community.general.ansible_type(dtype)'
     success_msg: '"abc" is {{ dtype }}'
     fail_msg: '"abc" is {{ result }}'
@@ -70,7 +70,7 @@
     dtype: str
 
 - name: Integer
-  assert:
+  ansible.builtin.assert:
     that: '123 is community.general.ansible_type(dtype)'
     success_msg: '123 is {{ dtype }}'
     fail_msg: '123 is {{ result }}'
@@ -80,7 +80,7 @@
     dtype: int
 
 - name: Float
-  assert:
+  ansible.builtin.assert:
     that: '123.45 is community.general.ansible_type(dtype)'
     success_msg: '123.45 is {{ dtype }}'
     fail_msg: '123.45 is {{ result }}'
@@ -90,7 +90,7 @@
     dtype: float
 
 - name: Boolean
-  assert:
+  ansible.builtin.assert:
     that: 'true is community.general.ansible_type(dtype)'
     success_msg: 'true is {{ dtype }}'
     fail_msg: 'true is {{ result }}'
@@ -100,7 +100,7 @@
     dtype: bool
 
 - name: List. All items are strings.
-  assert:
+  ansible.builtin.assert:
     that: '["a", "b", "c"] is community.general.ansible_type(dtype)'
     success_msg: '["a", "b", "c"] is {{ dtype }}'
     fail_msg: '["a", "b", "c"] is {{ result }}'
@@ -110,7 +110,7 @@
     dtype: list[str]
 
 - name: List of dictionaries.
-  assert:
+  ansible.builtin.assert:
     that: '[{"a": 1}, {"b": 2}] is community.general.ansible_type(dtype)'
     success_msg: '[{"a": 1}, {"b": 2}] is {{ dtype }}'
     fail_msg: '[{"a": 1}, {"b": 2}] is {{ result }}'
@@ -120,7 +120,7 @@
     dtype: list[dict]
 
 - name: Dictionary. All keys are strings. All values are integers.
-  assert:
+  ansible.builtin.assert:
     that: '{"a": 1} is community.general.ansible_type(dtype)'
     success_msg: '{"a": 1} is {{ dtype }}'
     fail_msg: '{"a": 1} is {{ result }}'
@@ -130,7 +130,7 @@
     dtype: dict[str, int]
 
 - name: Dictionary. All keys are strings. All values are integers.
-  assert:
+  ansible.builtin.assert:
     that: '{"a": 1, "b": 2} is community.general.ansible_type(dtype)'
     success_msg: '{"a": 1, "b": 2} is {{ dtype }}'
     fail_msg: '{"a": 1, "b": 2} is {{ result }}'
@@ -143,7 +143,7 @@
 # ----------------------------------------
 
 - name: Dictionary. The keys are integers or strings. All values are strings.
-  assert:
+  ansible.builtin.assert:
     that: data is community.general.ansible_type(dtype, alias)
     success_msg: '{"1": "a", "b": "b"} is {{ dtype }}'
     fail_msg: '{"1": "a", "b": "b"} is {{ result }}'
@@ -158,7 +158,7 @@
     dtype: dict[int|str, str]
 
 - name: Dictionary. All keys are integers. All values are keys.
-  assert:
+  ansible.builtin.assert:
     that: data is community.general.ansible_type(dtype, alias)
     success_msg: '{"1": "a", "2": "b"} is {{ dtype }}'
     fail_msg: '{"1": "a", "2": "b"} is {{ result }}'
@@ -173,7 +173,7 @@
     dtype: dict[int, str]
 
 - name: Dictionary. All keys are strings. Multiple types values.
-  assert:
+  ansible.builtin.assert:
     that: data is community.general.ansible_type(dtype, alias)
     success_msg: '{"a": 1, "b": 1.1, "c": "abc", "d": true, "e": ["x", "y", "z"], "f": {"x": 1, "y": 2}} is {{ dtype }}'
     fail_msg: '{"a": 1, "b": 1.1, "c": "abc", "d": true, "e": ["x", "y", "z"], "f": {"x": 1, "y": 2}} is {{ result }}'
@@ -189,7 +189,7 @@
     dtype: dict[str, bool|dict|float|int|list|str]
 
 - name: List. Multiple types items.
-  assert:
+  ansible.builtin.assert:
     that: data is community.general.ansible_type(dtype, alias)
     success_msg: '[1, 2, 1.1, "abc", true, ["x", "y", "z"], {"x": 1, "y": 2}] is {{ dtype }}'
     fail_msg: '[1, 2, 1.1, "abc", true, ["x", "y", "z"], {"x": 1, "y": 2}] is {{ result }}'
@@ -208,7 +208,7 @@
 # --------------------
 
 - name: AnsibleUnicode or str
-  assert:
+  ansible.builtin.assert:
     that: data is community.general.ansible_type(dtype)
     success_msg: '"abc" is {{ dtype }}'
     fail_msg: '"abc" is {{ result }}'
@@ -222,7 +222,7 @@
       - 'str'
 
 - name: float or int
-  assert:
+  ansible.builtin.assert:
     that: data is community.general.ansible_type(dtype)
     success_msg: '123 is {{ dtype }}'
     fail_msg: '123 is {{ result }}'
@@ -237,7 +237,7 @@
       - '_AnsibleTaggedFloat'
 
 - name: float or int
-  assert:
+  ansible.builtin.assert:
     that: data is community.general.ansible_type(dtype)
     success_msg: '123.45 is {{ dtype }}'
     fail_msg: '123.45 is {{ result }}'
@@ -255,7 +255,7 @@
 # --------------
 
 - name: int alias number
-  assert:
+  ansible.builtin.assert:
     that: data is community.general.ansible_type(dtype, alias)
     success_msg: '123 is {{ dtype }}'
     fail_msg: '123 is {{ result }}'
@@ -271,7 +271,7 @@
     dtype: number
 
 - name: float alias number
-  assert:
+  ansible.builtin.assert:
     that: data is community.general.ansible_type(dtype, alias)
     success_msg: '123.45 is {{ dtype }}'
     fail_msg: '123.45 is {{ result }}'

--- a/tests/integration/targets/timezone/tasks/test.yml
+++ b/tests/integration/targets/timezone/tasks/test.yml
@@ -14,7 +14,7 @@
   register: timezone_set_checkmode
 
 - name: ensure timezone reported as changed in checkmode
-  assert:
+  ansible.builtin.assert:
     that:
       - timezone_set_checkmode.changed
       - timezone_set_checkmode.diff.after.name == 'Australia/Brisbane'
@@ -44,7 +44,7 @@
   register: timezone_set
 
 - name: ensure timezone changed
-  assert:
+  ansible.builtin.assert:
     that:
       - timezone_set.changed
       - timezone_set.diff.after.name == 'Australia/Brisbane'
@@ -72,7 +72,7 @@
   register: timezone_again
 
 - name: ensure timezone idempotency
-  assert:
+  ansible.builtin.assert:
     that:
       - not timezone_again.changed
 
@@ -82,7 +82,7 @@
   register: timezone_again_checkmode
 
 - name: set timezone idempotency (checkmode)
-  assert:
+  ansible.builtin.assert:
     that:
       - not timezone_again_checkmode.changed
 
@@ -113,7 +113,7 @@
       register: timezone_etcutc_to_utc
 
     - name: check timezone changed from Etc/UTC to UTC
-      assert:
+      ansible.builtin.assert:
         that:
           - timezone_etcutc_to_utc.changed
           - timezone_etcutc_to_utc.diff.before.name == 'Etc/UTC'
@@ -125,7 +125,7 @@
       register: timezone_utc_to_etcutc
 
     - name: check timezone changed from UTC to Etc/UTC
-      assert:
+      ansible.builtin.assert:
         that:
           - timezone_utc_to_etcutc.changed
           - timezone_utc_to_etcutc.diff.before.name == 'UTC'
@@ -153,7 +153,7 @@
       register: timezone_empty_conf
 
     - name: check if timezone set (empty config file)
-      assert:
+      ansible.builtin.assert:
         that:
           - timezone_empty_conf.changed
           - timezone_empty_conf.diff.after.name == 'Europe/Belgrade'
@@ -179,7 +179,7 @@
       register: timezone_missing_conf
 
     - name: check if timezone set (no config file)
-      assert:
+      ansible.builtin.assert:
         that:
           - timezone_missing_conf.changed
           - timezone_missing_conf.diff.after.name == 'Europe/Belgrade'
@@ -207,7 +207,7 @@
       register: timezone_symllink
 
     - name: check if timezone set (over symlink)
-      assert:
+      ansible.builtin.assert:
         that:
           - timezone_symllink.changed
           - timezone_symllink.diff.after.name == 'Europe/Belgrade'
@@ -235,7 +235,7 @@
       register: timezone_symllink_broken
 
     - name: check if timezone set (over broken symlink)
-      assert:
+      ansible.builtin.assert:
         that:
           - timezone_symllink_broken.changed
           - timezone_symllink_broken.diff.after.name == 'Europe/Belgrade'
@@ -262,7 +262,7 @@
       register: timezone_copied
 
     - name: check if timezone set (over copied file)
-      assert:
+      ansible.builtin.assert:
         that:
           - timezone_copied.changed
           - timezone_copied.diff.after.name == 'Europe/Belgrade'
@@ -309,7 +309,7 @@
       register: hwclock_set_checkmode
 
     - name: ensure hwclock reported as changed (checkmode)
-      assert:
+      ansible.builtin.assert:
         that:
           - hwclock_set_checkmode.changed
           - hwclock_set_checkmode.diff.after.hwclock == 'UTC'
@@ -331,7 +331,7 @@
       register: hwclock_set
 
     - name: ensure hwclock changed
-      assert:
+      ansible.builtin.assert:
         that:
           - hwclock_set.changed
           - hwclock_set.diff.after.hwclock == 'UTC'
@@ -351,7 +351,7 @@
       register: hwclock_again
 
     - name: set hwclock idempotency
-      assert:
+      ansible.builtin.assert:
         that:
           - not hwclock_again.changed
 
@@ -362,7 +362,7 @@
       register: hwclock_again_checkmode
 
     - name: set hwclock idempotency (checkmode)
-      assert:
+      ansible.builtin.assert:
         that:
           - not hwclock_again_checkmode.changed
 
@@ -390,7 +390,7 @@
           register: hwclock_set_utc_deleted_adjtime_and_conf
 
         - name: ensure hwclock changed with deleted /etc/adjtime and conf
-          assert:
+          ansible.builtin.assert:
             that:
               - hwclock_set_utc_deleted_adjtime_and_conf.changed
               - hwclock_set_utc_deleted_adjtime_and_conf.diff.after.hwclock == 'UTC'
@@ -414,7 +414,7 @@
           register: hwclock_set_utc_deleted_adjtime_utc
 
         - name: ensure hwclock changed with deleted /etc/adjtime
-          assert:
+          ansible.builtin.assert:
             that:
               - not hwclock_set_utc_deleted_adjtime_utc.changed
               - hwclock_set_utc_deleted_adjtime_utc.diff.after.hwclock == 'UTC'
@@ -426,7 +426,7 @@
           register: hwclock_set_local_deleted_adjtime_local
 
         - name: ensure hwclock changed to LOCAL with deleted /etc/adjtime
-          assert:
+          ansible.builtin.assert:
             that:
               - hwclock_set_local_deleted_adjtime_local.changed
               - hwclock_set_local_deleted_adjtime_local.diff.after.hwclock == 'local'
@@ -450,7 +450,7 @@
           register: hwclock_set_utc_deleted_conf
 
         - name: ensure hwclock changed with deleted /etc/adjtime
-          assert:
+          ansible.builtin.assert:
             that:
               - hwclock_set_utc_deleted_conf.changed
               - hwclock_set_utc_deleted_conf.diff.after.hwclock == 'UTC'
@@ -472,7 +472,7 @@
           register: hwclock_set_utc_broken_adjtime
 
         - name: ensure hwclock doesn't report changed with broken /etc/adjtime
-          assert:
+          ansible.builtin.assert:
             that:
               - not hwclock_set_utc_broken_adjtime.changed
               - hwclock_set_utc_broken_adjtime.diff.after.hwclock == 'UTC'
@@ -484,7 +484,7 @@
           register: hwclock_set_local_broken_adjtime
 
         - name: ensure hwclock changed to LOCAL with broken /etc/adjtime
-          assert:
+          ansible.builtin.assert:
             that:
               - hwclock_set_local_broken_adjtime.changed
               - hwclock_set_local_broken_adjtime.diff.after.hwclock == 'local'
@@ -514,7 +514,7 @@
       register: tzclock_set_checkmode
 
     - name: ensure timezone and hwclock reported as changed in checkmode
-      assert:
+      ansible.builtin.assert:
         that:
           - tzclock_set_checkmode.changed
           - tzclock_set_checkmode.diff.after.name == 'Europe/Belgrade'
@@ -555,7 +555,7 @@
       register: tzclock_set
 
     - name: ensure timezone and hwclock changed
-      assert:
+      ansible.builtin.assert:
         that:
           - tzclock_set.changed
           - tzclock_set.diff.after.name == 'Europe/Belgrade'
@@ -592,7 +592,7 @@
       register: tzclock_set_again
 
     - name: set timezone and hwclock idempotency
-      assert:
+      ansible.builtin.assert:
         that:
           - not tzclock_set_again.changed
 
@@ -603,7 +603,7 @@
       register: tzclock_set_again_checkmode
 
     - name: set timezone and hwclock idempotency in checkmode
-      assert:
+      ansible.builtin.assert:
         that:
           - not tzclock_set_again_checkmode.changed
 

--- a/tests/integration/targets/ufw/tasks/tests/basic.yml
+++ b/tests/integration/targets/ufw/tasks/tests/basic.yml
@@ -25,7 +25,7 @@
     state: enabled
   check_mode: true
   register: enable_idem_check
-- assert:
+- ansible.builtin.assert:
     that:
       - enable_check is changed
       - enable is changed
@@ -59,7 +59,7 @@
     to_ip: 0.0.0.0
   check_mode: true
   register: ipv4_allow_idem_check
-- assert:
+- ansible.builtin.assert:
     that:
       - ipv4_allow_check is changed
       - ipv4_allow is changed
@@ -97,7 +97,7 @@
     delete: true
   check_mode: true
   register: delete_ipv4_allow_idem_check
-- assert:
+- ansible.builtin.assert:
     that:
       - delete_ipv4_allow_check is changed
       - delete_ipv4_allow is changed
@@ -131,7 +131,7 @@
     to_ip: "::"
   check_mode: true
   register: ipv6_allow_idem_check
-- assert:
+- ansible.builtin.assert:
     that:
       - ipv6_allow_check is changed
       - ipv6_allow is changed
@@ -169,7 +169,7 @@
     delete: true
   check_mode: true
   register: delete_ipv6_allow_idem_check
-- assert:
+- ansible.builtin.assert:
     that:
       - delete_ipv6_allow_check is changed
       - delete_ipv6_allow is changed
@@ -204,7 +204,7 @@
     to_ip: 0.0.0.0
   check_mode: true
   register: ipv4_allow_idem_check
-- assert:
+- ansible.builtin.assert:
     that:
       - ipv4_allow_check is changed
       - ipv4_allow is changed
@@ -242,7 +242,7 @@
     delete: true
   check_mode: true
   register: delete_ipv4_allow_idem_check
-- assert:
+- ansible.builtin.assert:
     that:
       - delete_ipv4_allow_check is changed
       - delete_ipv4_allow is changed
@@ -276,7 +276,7 @@
     to_ip: "::"
   check_mode: true
   register: ipv6_allow_idem_check
-- assert:
+- ansible.builtin.assert:
     that:
       - ipv6_allow_check is changed
       - ipv6_allow is changed
@@ -314,7 +314,7 @@
     delete: true
   check_mode: true
   register: delete_ipv6_allow_idem_check
-- assert:
+- ansible.builtin.assert:
     that:
       - delete_ipv6_allow_check is changed
       - delete_ipv6_allow is changed
@@ -331,7 +331,7 @@
     state: reloaded
   check_mode: true
   register: reload_check
-- assert:
+- ansible.builtin.assert:
     that:
       - reload is changed
       - reload_check is changed
@@ -355,7 +355,7 @@
     state: disabled
   check_mode: true
   register: disable_idem_check
-- assert:
+- ansible.builtin.assert:
     that:
       - disable_check is changed
       - disable is changed
@@ -398,7 +398,7 @@
     state: reset
   check_mode: true
   register: reset_idem_check
-- assert:
+- ansible.builtin.assert:
     that:
       - reset_check is changed
       - reset is changed

--- a/tests/integration/targets/ufw/tasks/tests/global-state.yml
+++ b/tests/integration/targets/ufw/tasks/tests/global-state.yml
@@ -50,7 +50,7 @@
   register: ufw_logging_change
   environment:
     LC_ALL: C
-- assert:
+- ansible.builtin.assert:
     that:
       - logging_check is changed
       - logging is changed
@@ -136,7 +136,7 @@
   ufw:
     default: allow
   register: default_change_implicit_idem
-- assert:
+- ansible.builtin.assert:
     that:
       - default_check is changed
       - default is changed

--- a/tests/integration/targets/ufw/tasks/tests/insert_relative_to.yml
+++ b/tests/integration/targets/ufw/tasks/tests/insert_relative_to.yml
@@ -69,7 +69,7 @@
   # to ignore these, the extra filtering (grepping for DENY and the regex) makes
   # sure to remove all rules not added here.
   register: ufw_status
-- assert:
+- ansible.builtin.assert:
     that:
       - ufw_status.stdout_lines == expected_stdout
   vars:

--- a/tests/integration/targets/ufw/tasks/tests/interface.yml
+++ b/tests/integration/targets/ufw/tasks/tests/interface.yml
@@ -57,7 +57,7 @@
   shell: ufw status |grep -E '(ALLOW|DENY|REJECT|LIMIT)' |sed -E 's/[ \t]+/ /g'
   register: ufw_status
 
-- assert:
+- ansible.builtin.assert:
     that:
       - '"8.8.8.8 2222/tcp on bar ALLOW FWD 1.1.1.1 1111/tcp on foo " in stdout'
       - '"Anywhere ALLOW FWD 1.1.1.1 1111/tcp on foo " in stdout'
@@ -80,7 +80,7 @@
   ignore_errors: true
   register: ufw_non_route_iface
 
-- assert:
+- ansible.builtin.assert:
     that:
       - ufw_non_route_iface is failed
       - '"Only route rules" in ufw_non_route_iface.msg'

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -35,7 +35,7 @@
   register: install_check_mode
 
 - name: Verify Python 3.14 installation in check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - (install_check_mode is changed) == (check_python_314_exists is failed)
       - install_check_mode is not failed
@@ -48,7 +48,7 @@
   register: install_python
 
 - name: Verify Python 3.14 installation
-  assert:
+  ansible.builtin.assert:
     that:
       - install_python.changed == check_python_314_exists.failed
       - install_python.failed is false
@@ -73,7 +73,7 @@
   register: reinstall_python
 
 - name: Verify Python 3.14 re-installation
-  assert:
+  ansible.builtin.assert:
     that:
       - reinstall_python is not changed
       - reinstall_python is not failed
@@ -92,7 +92,7 @@
   register: install_python_3135
 
 - name: Verify Python 3.13.5 installation
-  assert:
+  ansible.builtin.assert:
     that:
       - install_python_3135.changed == check_python_3135_exists.failed
       - install_python_3135.failed is false
@@ -106,7 +106,7 @@
   register: reinstall_python
 
 - name: Verify Python 3.13.5 installation
-  assert:
+  ansible.builtin.assert:
     that:
       - reinstall_python.changed is false
       - reinstall_python.failed is false
@@ -119,7 +119,7 @@
   register: remove_python
 
 - name: Verify Python 3.10 deletion
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_python.changed is false
       - remove_python.failed is false
@@ -133,14 +133,14 @@
   register: remove_python_in_check_mode
 
 - name: Verify Python 3.13.5 deletion in check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_python_in_check_mode.changed == install_python_3135.changed
       - remove_python_in_check_mode.failed is false
 
 - name: Additional check for Python 3.13.5 deletion in check mode
   when: install_python_3135.changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - '"3.13.5" in remove_python_in_check_mode.python_versions'
       - remove_python_in_check_mode.python_paths | length >= 1
@@ -152,14 +152,14 @@
   register: remove_python
 
 - name: Verify Python 3.13.5 deletion
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_python.changed == install_python_3135.changed
       - remove_python.failed is false
 
 - name: Additional check for Python 3.13.5 deletion
   when: install_python_3135.changed is true
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_python.python_paths | length >= 1
       - '"3.13.5" in remove_python.python_versions'
@@ -171,7 +171,7 @@
   register: remove_python
 
 - name: Verify Python 3.13.5 deletion again
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_python.changed is false
       - remove_python.failed is false
@@ -185,7 +185,7 @@
   register: upgrade_python
 
 - name: Verify Python 3.13 upgrade
-  assert:
+  ansible.builtin.assert:
     that:
       - upgrade_python.changed is true
       - upgrade_python.failed is false
@@ -200,7 +200,7 @@
   register: upgrade_python
 
 - name: Verify Python 3.13 upgrade in check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - upgrade_python.changed is false
       - upgrade_python.failed is false
@@ -214,7 +214,7 @@
   register: upgrade_python
 
 - name: Verify Python 3.13 upgrade again
-  assert:
+  ansible.builtin.assert:
     that:
       - upgrade_python.changed is false
       - upgrade_python.failed is false
@@ -229,7 +229,7 @@
   check_mode: true
 
 - name: Verify unsupported Python 2.0 install in check mode
-  assert:
+  ansible.builtin.assert:
     that:
       - unsupported_python_check_mode.changed is false
       - unsupported_python_check_mode.failed is true
@@ -243,7 +243,7 @@
   ignore_errors: true
 
 - name: Verify unsupported Python 2.0 install
-  assert:
+  ansible.builtin.assert:
     that:
       - unsupported_python.changed is false
       - unsupported_python.failed is true
@@ -256,7 +256,7 @@
   ignore_errors: true
 
 - name: Verify Python 2.0 install with latest state
-  assert:
+  ansible.builtin.assert:
     that:
       - unsupported_python.changed is false
       - unsupported_python.failed is true
@@ -268,7 +268,7 @@
   register: uninstall_result
 
 - name: Verify Python 3.13 deletion
-  assert:
+  ansible.builtin.assert:
     that:
       - uninstall_result.changed is true
       - uninstall_result.failed is false
@@ -283,7 +283,7 @@
   register: no_version
 
 - name: Verify failure when no version is specified
-  assert:
+  ansible.builtin.assert:
     that:
       - no_version.failed is true
       - '"Unsupported version format" in no_version.msg'
@@ -296,7 +296,7 @@
   register: wrong_version
 
 - name: Verify failure when unsupported version format is specified
-  assert:
+  ansible.builtin.assert:
     that:
       - wrong_version.failed is true
       - '"Unsupported version format" in wrong_version.msg'

--- a/tests/integration/targets/wakeonlan/tasks/main.yml
+++ b/tests/integration/targets/wakeonlan/tasks/main.yml
@@ -26,7 +26,7 @@
   register: incorrect_mac_length
 
 - name: Check error message
-  assert:
+  ansible.builtin.assert:
     that:
       - incorrect_mac_length is failed
       - incorrect_mac_length.msg is search('Incorrect MAC address length')
@@ -39,7 +39,7 @@
   register: incorrect_mac_format
 
 - name: Check error message
-  assert:
+  ansible.builtin.assert:
     that:
       - incorrect_mac_format is failed
       - incorrect_mac_format.msg is search('Incorrect MAC address format')
@@ -52,7 +52,7 @@
   register: incorrect_broadcast_address
 
 - name: Check error message
-  assert:
+  ansible.builtin.assert:
     that:
       - incorrect_broadcast_address is failed
       - incorrect_broadcast_address.msg is search('not known|Name does not resolve')

--- a/tests/integration/targets/xattr/tasks/test.yml
+++ b/tests/integration/targets/xattr/tasks/test.yml
@@ -21,7 +21,7 @@
     key: foo
   register: xattr_get_specific_result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - "xattr_set_result.changed"
       - "xattr_get_all_result['xattr']['user.foo'] == 'bar'"
@@ -37,7 +37,7 @@
     value: bar
   register: xattr_set_again_result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - "not xattr_set_again_result.changed"
 
@@ -53,7 +53,7 @@
     path: "{{ test_file }}"
   register: xattr_get_after_unset_result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - "xattr_unset_result.changed"
       - "xattr_get_after_unset_result['xattr'] == {}"
@@ -67,6 +67,6 @@
     state: absent
   register: xattr_unset_result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - "not xattr_set_again_result.changed"

--- a/tests/integration/targets/xfs_quota/tasks/gquota.yml
+++ b/tests/integration/targets/xfs_quota/tasks/gquota.yml
@@ -34,7 +34,7 @@
       become: true
       register: test_gquota_default_before
     - name: Assert default group limits results
-      assert:
+      ansible.builtin.assert:
         that:
           - test_gquota_default_before.changed
           - test_gquota_default_before.bsoft == gquota_default_bsoft|human_to_bytes
@@ -57,7 +57,7 @@
       become: true
       register: test_gquota_group_before
     - name: Assert group limits results for xfsquotauser
-      assert:
+      ansible.builtin.assert:
         that:
           - test_gquota_group_before.changed
           - test_gquota_group_before.bsoft == gquota_group_bsoft|human_to_bytes
@@ -79,7 +79,7 @@
       become: true
       register: test_gquota_default_after
     - name: Assert default group limits results after re-apply
-      assert:
+      ansible.builtin.assert:
         that:
           - not test_gquota_default_after.changed
     - name: Re-apply group limits
@@ -96,7 +96,7 @@
       become: true
       register: test_gquota_group_after
     - name: Assert group limits results for xfsquotauser after re-apply
-      assert:
+      ansible.builtin.assert:
         that:
           - not test_gquota_group_after.changed
     - name: Reset default group limits
@@ -107,7 +107,7 @@
       become: true
       register: test_reset_gquota_default
     - name: Assert reset of default group limits results
-      assert:
+      ansible.builtin.assert:
         that:
           - test_reset_gquota_default.changed
           - test_reset_gquota_default.bsoft == 0
@@ -125,7 +125,7 @@
       become: true
       register: test_reset_gquota_group
     - name: Assert reset of default group limits results
-      assert:
+      ansible.builtin.assert:
         that:
           - test_reset_gquota_group.changed
           - test_reset_gquota_group.bsoft == 0

--- a/tests/integration/targets/xfs_quota/tasks/pquota.yml
+++ b/tests/integration/targets/xfs_quota/tasks/pquota.yml
@@ -59,7 +59,7 @@
       become: true
       register: test_pquota_default_before
     - name: Assert default project limits results
-      assert:
+      ansible.builtin.assert:
         that:
           - test_pquota_default_before.changed
           - test_pquota_default_before.bsoft == pquota_default_bsoft|human_to_bytes
@@ -82,7 +82,7 @@
       become: true
       register: test_pquota_project_before
     - name: Assert project limits results for xft_quotaval
-      assert:
+      ansible.builtin.assert:
         that:
           - test_pquota_project_before.changed
           - test_pquota_project_before.bsoft == pquota_project_bsoft|human_to_bytes
@@ -104,7 +104,7 @@
       become: true
       register: test_pquota_default_after
     - name: Assert default project limits results after re-apply
-      assert:
+      ansible.builtin.assert:
         that:
           - not test_pquota_default_after.changed
     - name: Re-apply project limits
@@ -121,7 +121,7 @@
       become: true
       register: test_pquota_project_after
     - name: Assert project limits results for xft_quotaval after re-apply
-      assert:
+      ansible.builtin.assert:
         that:
           - test_pquota_project_after is not changed
     - name: Reset default project limits
@@ -132,7 +132,7 @@
       become: true
       register: test_reset_pquota_default
     - name: Assert reset of default projecy limits results
-      assert:
+      ansible.builtin.assert:
         that:
           - test_reset_pquota_default.changed
           - test_reset_pquota_default.bsoft == 0
@@ -150,7 +150,7 @@
       become: true
       register: test_reset_pquota_project
     - name: Assert reset of project limits results for xft_quotaval
-      assert:
+      ansible.builtin.assert:
         that:
           - test_reset_pquota_project.changed
           - test_reset_pquota_project.bsoft == 0

--- a/tests/integration/targets/xfs_quota/tasks/uquota.yml
+++ b/tests/integration/targets/xfs_quota/tasks/uquota.yml
@@ -34,7 +34,7 @@
       become: true
       register: test_uquota_default_before
     - name: Assert default user limits results
-      assert:
+      ansible.builtin.assert:
         that:
           - test_uquota_default_before.changed
           - test_uquota_default_before.bsoft == uquota_default_bsoft|human_to_bytes
@@ -57,7 +57,7 @@
       become: true
       register: test_uquota_user_before
     - name: Assert user limits results
-      assert:
+      ansible.builtin.assert:
         that:
           - test_uquota_user_before.changed
           - test_uquota_user_before.bsoft == uquota_user_bsoft|human_to_bytes
@@ -79,7 +79,7 @@
       become: true
       register: test_uquota_default_after
     - name: Assert default user limits results after re-apply
-      assert:
+      ansible.builtin.assert:
         that:
           - not test_uquota_default_after.changed
     - name: Re-apply user limits
@@ -96,7 +96,7 @@
       become: true
       register: test_uquota_user_after
     - name: Assert user limits results for xfsquotauser after re-apply
-      assert:
+      ansible.builtin.assert:
         that:
           - not test_uquota_user_after.changed
     - name: Reset default user limits
@@ -107,7 +107,7 @@
       become: true
       register: test_reset_uquota_default
     - name: Assert reset of default user limits results
-      assert:
+      ansible.builtin.assert:
         that:
           - test_reset_uquota_default.changed
           - test_reset_uquota_default.bsoft == 0
@@ -125,7 +125,7 @@
       become: true
       register: test_reset_uquota_user
     - name: Assert reset of default user limits results
-      assert:
+      ansible.builtin.assert:
         that:
           - test_reset_uquota_user.changed
           - test_reset_uquota_user.bsoft == 0

--- a/tests/integration/targets/xml/tasks/test-add-children-elements-unicode.yml
+++ b/tests/integration/targets/xml/tasks/test-add-children-elements-unicode.yml
@@ -29,7 +29,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - add_children_elements_unicode is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-add-children-elements.yml
+++ b/tests/integration/targets/xml/tasks/test-add-children-elements.yml
@@ -29,7 +29,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - add_children_elements is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-add-children-from-groupvars.yml
+++ b/tests/integration/targets/xml/tasks/test-add-children-from-groupvars.yml
@@ -28,7 +28,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - add_children_from_groupvars is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-add-children-insertafter.yml
+++ b/tests/integration/targets/xml/tasks/test-add-children-insertafter.yml
@@ -30,7 +30,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - add_children_insertafter is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-add-children-insertbefore.yml
+++ b/tests/integration/targets/xml/tasks/test-add-children-insertbefore.yml
@@ -30,7 +30,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - add_children_insertbefore is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-add-children-with-attributes-unicode.yml
+++ b/tests/integration/targets/xml/tasks/test-add-children-with-attributes-unicode.yml
@@ -31,7 +31,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - add_children_with_attributes_unicode is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-add-children-with-attributes.yml
+++ b/tests/integration/targets/xml/tasks/test-add-children-with-attributes.yml
@@ -34,7 +34,7 @@
 #       So we filter the failure out for these platforms (e.g. CentOS 6)
 #       The module still works fine, we simply are not comparing as smart as we should.
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - add_children_with_attributes is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-add-element-implicitly.yml
+++ b/tests/integration/targets/xml/tasks/test-add-element-implicitly.yml
@@ -110,7 +110,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - comparison is not changed  # identical
   # command: diff -u {{ role_path }}/results/test-add-element-implicitly.xml /tmp/ansible-xml-beers-implicit.xml

--- a/tests/integration/targets/xml/tasks/test-add-namespaced-children-elements.yml
+++ b/tests/integration/targets/xml/tasks/test-add-namespaced-children-elements.yml
@@ -32,7 +32,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - add_namespaced_children_elements is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-children-elements-xml.yml
+++ b/tests/integration/targets/xml/tasks/test-children-elements-xml.yml
@@ -30,7 +30,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - children_elements is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-count-unicode.yml
+++ b/tests/integration/targets/xml/tasks/test-count-unicode.yml
@@ -17,7 +17,7 @@
   register: beers
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - beers is not changed
       - beers.count == 2

--- a/tests/integration/targets/xml/tasks/test-count.yml
+++ b/tests/integration/targets/xml/tasks/test-count.yml
@@ -17,7 +17,7 @@
   register: beers
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - beers is not changed
       - beers.count == 3

--- a/tests/integration/targets/xml/tasks/test-get-element-content-unicode.yml
+++ b/tests/integration/targets/xml/tasks/test-get-element-content-unicode.yml
@@ -17,7 +17,7 @@
   register: get_element_attribute
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - get_element_attribute is not changed
       - get_element_attribute.matches[0]['rating'] is defined and get_element_attribute.matches[0]['rating']['subjective'] == 'да'
@@ -30,7 +30,7 @@
   register: get_element_text
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - get_element_text is not changed
       - get_element_text.matches[0]['rating'] == 'десять'

--- a/tests/integration/targets/xml/tasks/test-get-element-content.yml
+++ b/tests/integration/targets/xml/tasks/test-get-element-content.yml
@@ -17,7 +17,7 @@
   register: get_element_attribute
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - get_element_attribute is not changed
       - get_element_attribute.matches[0]['rating'] is defined
@@ -33,7 +33,7 @@
   ignore_errors: true
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - get_element_attribute_wrong is failed
 
@@ -45,7 +45,7 @@
   register: get_element_text
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - get_element_text is not changed
       - get_element_text.matches[0]['rating'] == '10'

--- a/tests/integration/targets/xml/tasks/test-mutually-exclusive-attributes.yml
+++ b/tests/integration/targets/xml/tasks/test-mutually-exclusive-attributes.yml
@@ -20,7 +20,7 @@
   ignore_errors: true
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - module_output is not changed
       - module_output is failed

--- a/tests/integration/targets/xml/tasks/test-preserve-doctype.yml
+++ b/tests/integration/targets/xml/tasks/test-preserve-doctype.yml
@@ -27,7 +27,7 @@
   register: comparison
 
 - name: Test expected result (DOCTYPE is preserved)
-  assert:
+  ansible.builtin.assert:
     that:
       - set_attribute_doctype is changed
       - comparison is not changed
@@ -41,6 +41,6 @@
   register: set_attribute_doctype_idempotent
 
 - name: Test idempotency
-  assert:
+  ansible.builtin.assert:
     that:
       - set_attribute_doctype_idempotent is not changed

--- a/tests/integration/targets/xml/tasks/test-pretty-print-only.yml
+++ b/tests/integration/targets/xml/tasks/test-pretty-print-only.yml
@@ -26,7 +26,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - pretty_print_only is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-pretty-print.yml
+++ b/tests/integration/targets/xml/tasks/test-pretty-print.yml
@@ -27,7 +27,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - pretty_print is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-print-match.yml
+++ b/tests/integration/targets/xml/tasks/test-print-match.yml
@@ -16,7 +16,7 @@
   register: print_match_result
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - print_match_result is not changed
       - print_match_result.matches | length == 3
@@ -32,7 +32,7 @@
   register: print_match_empty
 
 - name: Test expected result for no matches
-  assert:
+  ansible.builtin.assert:
     that:
       - print_match_empty is not changed
       - print_match_empty.matches | length == 0

--- a/tests/integration/targets/xml/tasks/test-remove-attribute-nochange.yml
+++ b/tests/integration/targets/xml/tasks/test-remove-attribute-nochange.yml
@@ -25,7 +25,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_attribute is not changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-remove-attribute.yml
+++ b/tests/integration/targets/xml/tasks/test-remove-attribute.yml
@@ -28,7 +28,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_attribute is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-remove-element-nochange.yml
+++ b/tests/integration/targets/xml/tasks/test-remove-element-nochange.yml
@@ -25,7 +25,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_element is not changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-remove-element.yml
+++ b/tests/integration/targets/xml/tasks/test-remove-element.yml
@@ -28,7 +28,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_element is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-remove-namespaced-attribute-nochange.yml
+++ b/tests/integration/targets/xml/tasks/test-remove-namespaced-attribute-nochange.yml
@@ -30,7 +30,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_namespaced_attribute is not changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-remove-namespaced-attribute.yml
+++ b/tests/integration/targets/xml/tasks/test-remove-namespaced-attribute.yml
@@ -33,7 +33,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_namespaced_attribute is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-remove-namespaced-element-nochange.yml
+++ b/tests/integration/targets/xml/tasks/test-remove-namespaced-element-nochange.yml
@@ -30,7 +30,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_namespaced_element is not changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-remove-namespaced-element.yml
+++ b/tests/integration/targets/xml/tasks/test-remove-namespaced-element.yml
@@ -33,7 +33,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_namespaced_element is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-set-attribute-value-boolean.yml
+++ b/tests/integration/targets/xml/tasks/test-set-attribute-value-boolean.yml
@@ -22,7 +22,7 @@
   ignore_errors: true
 
 - name: Assert that passing a boolean attribute value raises an error
-  assert:
+  ansible.builtin.assert:
     that:
       - set_attribute_boolean_false is failed
       - "'was parsed for' in set_attribute_boolean_false.msg"
@@ -38,7 +38,7 @@
   ignore_errors: true
 
 - name: Assert that passing a boolean element value raises an error
-  assert:
+  ansible.builtin.assert:
     that:
       - set_element_boolean_true is failed
       - "'was parsed for' in set_element_boolean_true.msg"
@@ -54,6 +54,6 @@
   register: set_attribute_string_false
 
 - name: Assert that passing a quoted string attribute value succeeds
-  assert:
+  ansible.builtin.assert:
     that:
       - set_attribute_string_false is changed

--- a/tests/integration/targets/xml/tasks/test-set-attribute-value-unicode.yml
+++ b/tests/integration/targets/xml/tasks/test-set-attribute-value-unicode.yml
@@ -29,7 +29,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_attribute_value_unicode is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-set-attribute-value.yml
+++ b/tests/integration/targets/xml/tasks/test-set-attribute-value.yml
@@ -29,7 +29,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_attribute_value is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-set-children-elements-level.yml
+++ b/tests/integration/targets/xml/tasks/test-set-children-elements-level.yml
@@ -52,7 +52,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_children_elements_level is changed
       - comparison is not changed  # identical
@@ -75,7 +75,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_children_again is not changed
       - comparison is not changed   # identical

--- a/tests/integration/targets/xml/tasks/test-set-children-elements-unicode.yml
+++ b/tests/integration/targets/xml/tasks/test-set-children-elements-unicode.yml
@@ -30,7 +30,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_children_elements_unicode is changed
       - comparison is not changed  # identical
@@ -46,7 +46,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_children_again is not changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-set-children-elements-value.yml
+++ b/tests/integration/targets/xml/tasks/test-set-children-elements-value.yml
@@ -36,7 +36,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_children_elements_value is changed
       - comparison is not changed  # identical
@@ -58,7 +58,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_children_again is not changed
       - comparison is not changed   # identical

--- a/tests/integration/targets/xml/tasks/test-set-children-elements.yml
+++ b/tests/integration/targets/xml/tasks/test-set-children-elements.yml
@@ -24,7 +24,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_children_elements is changed
       - comparison is not changed  # identical
@@ -56,7 +56,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_children_elements is changed
       - comparison is not changed  # identical
@@ -79,7 +79,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_children_again is not changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-set-element-value-empty.yml
+++ b/tests/integration/targets/xml/tasks/test-set-element-value-empty.yml
@@ -28,7 +28,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_element_value_empty is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-set-element-value-predicate.yml
+++ b/tests/integration/targets/xml/tasks/test-set-element-value-predicate.yml
@@ -40,7 +40,7 @@
   register: comparison
 
 - name: Assert create_if_missing=false with predicate no-match is a no-op
-  assert:
+  ansible.builtin.assert:
     that:
       - set_predicate_first_run is changed
       - set_predicate_second_run is not changed
@@ -62,7 +62,7 @@
   register: set_nonexistent
 
 - name: Assert create_if_missing=false with missing simple path is a no-op
-  assert:
+  ansible.builtin.assert:
     that:
       - set_nonexistent is not changed
 
@@ -90,7 +90,7 @@
   register: set_predicate_create_again
 
 - name: Assert create_if_missing=true creates the node and is then idempotent
-  assert:
+  ansible.builtin.assert:
     that:
       - set_predicate_create is changed
       - set_predicate_create_again is not changed

--- a/tests/integration/targets/xml/tasks/test-set-element-value-unicode.yml
+++ b/tests/integration/targets/xml/tasks/test-set-element-value-unicode.yml
@@ -42,7 +42,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_element_first_run is changed
       - set_element_second_run is not changed

--- a/tests/integration/targets/xml/tasks/test-set-element-value.yml
+++ b/tests/integration/targets/xml/tasks/test-set-element-value.yml
@@ -42,7 +42,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_element_first_run is changed
       - set_element_second_run is not changed

--- a/tests/integration/targets/xml/tasks/test-set-namespaced-attribute-value.yml
+++ b/tests/integration/targets/xml/tasks/test-set-namespaced-attribute-value.yml
@@ -34,7 +34,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_namespaced_attribute_value is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml/tasks/test-set-namespaced-children-elements.yml
+++ b/tests/integration/targets/xml/tasks/test-set-namespaced-children-elements.yml
@@ -54,7 +54,7 @@
   # command: diff /tmp/ansible-xml-namespaced-beers-1.xml /tmp/ansible-xml-namespaced-beers-2.xml
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_children_again is not changed  # idempotency
       - set_namespaced_attribute_value is changed

--- a/tests/integration/targets/xml/tasks/test-set-namespaced-element-value.yml
+++ b/tests/integration/targets/xml/tasks/test-set-namespaced-element-value.yml
@@ -46,7 +46,7 @@
   # command: diff -u {{ role_path }}/results/test-set-namespaced-element-value.xml /tmp/ansible-xml-namespaced-beers.xml
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - set_element_first_run is changed
       - set_element_second_run is not changed

--- a/tests/integration/targets/xml/tasks/test-xmlstring.yml
+++ b/tests/integration/targets/xml/tasks/test-xmlstring.yml
@@ -27,7 +27,7 @@
   register: comparison
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - xmlresponse is not changed
       - comparison is not changed  # identical
@@ -51,7 +51,7 @@
 
 # FIXME: This change is related to the newline added by pretty_print
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - xmlresponse is changed
       - comparison is not changed  # identical
@@ -78,7 +78,7 @@
 
 # FIXME: This change is related to the newline added by pretty_print
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - xmlresponse_modification is changed
       - comparison is not changed  # identical

--- a/tests/integration/targets/xml_info/tasks/test-count.yml
+++ b/tests/integration/targets/xml_info/tasks/test-count.yml
@@ -11,7 +11,7 @@
   register: beers
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - beers is not changed
       - beers.count == 3
@@ -25,7 +25,7 @@
   register: beers_xpath
 
 - name: Test expected result for xpath count mode
-  assert:
+  ansible.builtin.assert:
     that:
       - beers_xpath is not changed
       - beers_xpath.count == 3

--- a/tests/integration/targets/xml_info/tasks/test-get-element-content.yml
+++ b/tests/integration/targets/xml_info/tasks/test-get-element-content.yml
@@ -11,7 +11,7 @@
   register: get_element_attribute
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - get_element_attribute is not changed
       - get_element_attribute.count == 1
@@ -26,7 +26,7 @@
   register: get_element_text
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - get_element_text is not changed
       - get_element_text.count == 1

--- a/tests/integration/targets/xml_info/tasks/test-print-match.yml
+++ b/tests/integration/targets/xml_info/tasks/test-print-match.yml
@@ -11,7 +11,7 @@
   register: paths_result
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - paths_result is not changed
       - paths_result.count == 3
@@ -28,7 +28,7 @@
   register: paths_empty
 
 - name: Test expected result for no matches
-  assert:
+  ansible.builtin.assert:
     that:
       - paths_empty is not changed
       - paths_empty.count == 0

--- a/tests/integration/targets/xml_info/tasks/test-xmlstring.yml
+++ b/tests/integration/targets/xml_info/tasks/test-xmlstring.yml
@@ -11,7 +11,7 @@
   register: count_result
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - count_result is not changed
       - count_result.count == 3
@@ -24,7 +24,7 @@
   register: text_result
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - text_result is not changed
       - text_result.count == 1
@@ -39,7 +39,7 @@
   register: match_result
 
 - name: Test expected result
-  assert:
+  ansible.builtin.assert:
     that:
       - match_result is not changed
       - match_result.count == 3

--- a/tests/integration/targets/yarn/tasks/tests.yml
+++ b/tests/integration/targets/yarn/tasks/tests.yml
@@ -39,7 +39,7 @@
         PATH: '{{ node_bin_path }}:{{ ansible_facts.env.PATH }}'
       register: yarn_install
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not (yarn_install is changed)
 
@@ -54,7 +54,7 @@
       register: yarn_install_check
 
     - name: verify test yarn global installation in check mode
-      assert:
+      ansible.builtin.assert:
         that:
           - yarn_install_check.err is defined
           - yarn_install_check.out is defined
@@ -72,7 +72,7 @@
         PATH: '{{ node_bin_path }}:{{ ansible_facts.env.PATH }}'
       register: yarn_install_old_package
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - yarn_install_old_package is changed
 
@@ -95,7 +95,7 @@
         PATH: '{{ node_bin_path }}:{{ ansible_facts.env.PATH }}'
       register: yarn_update_old_package
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - yarn_update_old_package is changed
 
@@ -110,7 +110,7 @@
       register: yarn_uninstall_package
 
     - name: 'Assert package removed'
-      assert:
+      ansible.builtin.assert:
         that:
           - yarn_uninstall_package is changed
 
@@ -125,7 +125,7 @@
         PATH: '{{ node_bin_path }}:{{ ansible_facts.env.PATH }}'
       register: yarn_global_install_old_binary
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - yarn_global_install_old_binary is changed
 
@@ -139,7 +139,7 @@
         PATH: '{{ node_bin_path }}:{{ ansible_facts.env.PATH }}'
       register: yarn_global_update_old_binary
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - yarn_global_update_old_binary is changed
 
@@ -153,7 +153,7 @@
         PATH: '{{ node_bin_path }}:{{ ansible_facts.env.PATH }}'
       register: yarn_global_uninstall_binary
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - yarn_global_uninstall_binary is changed
 
@@ -168,7 +168,7 @@
         PATH: '{{ node_bin_path }}:{{ ansible_facts.env.PATH }}'
       register: yarn_global_install_old_package
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - yarn_global_install_old_package is changed
 
@@ -182,7 +182,7 @@
         PATH: '{{ node_bin_path }}:{{ ansible_facts.env.PATH }}'
       register: yarn_global_update_old_package
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - yarn_global_update_old_package is changed
 
@@ -196,6 +196,6 @@
         PATH: '{{ node_bin_path }}:{{ ansible_facts.env.PATH }}'
       register: yarn_global_uninstall_package
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - yarn_global_uninstall_package is changed

--- a/tests/integration/targets/yum_versionlock/tasks/main.yml
+++ b/tests/integration/targets/yum_versionlock/tasks/main.yml
@@ -68,7 +68,7 @@
           when: yum_updates.results | length != 0
 
         - name: Assert everything is fine
-          assert:
+          ansible.builtin.assert:
             that:
               - lock_all_packages is changed
               - lock_all_packages_again is not changed

--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -41,7 +41,7 @@
 - debug: var=rpm_result
 
 - name: verify uninstallation of hello
-  assert:
+  ansible.builtin.assert:
     that:
       - "zypper_result.rc == 0"
       - "rpm_result.rc == 1"
@@ -54,7 +54,7 @@
   register: zypper_result
 
 - name: verify no change on re-uninstall
-  assert:
+  ansible.builtin.assert:
     that:
       - "not zypper_result.changed"
 
@@ -74,7 +74,7 @@
 - debug: var=rpm_result
 
 - name: verify installation of hello
-  assert:
+  ansible.builtin.assert:
     that:
       - "zypper_result.rc == 0"
       - "zypper_result.changed"
@@ -88,7 +88,7 @@
   register: zypper_result
 
 - name: verify no change on second install
-  assert:
+  ansible.builtin.assert:
     that:
       - "not zypper_result.changed"
 
@@ -112,7 +112,7 @@
   register: rpm_metamail_result
 
 - name: verify packages uninstalled
-  assert:
+  ansible.builtin.assert:
     that:
       - "rpm_hello_result.rc != 0"
       - "rpm_metamail_result.rc != 0"
@@ -136,7 +136,7 @@
   register: rpm_metamail_result
 
 - name: verify packages installed
-  assert:
+  ansible.builtin.assert:
     that:
       - "zypper_result.rc == 0"
       - "zypper_result.changed"
@@ -159,7 +159,7 @@
   ignore_errors: true
 
 - name: verify package installation failed
-  assert:
+  ansible.builtin.assert:
     that:
       - "zypper_result.rc == 104"
       - "zypper_result.msg.startswith('No provider of')"
@@ -185,7 +185,7 @@
 - debug: var=zypper_result
 
 - name: verify we failed installation of broken rpm
-  assert:
+  ansible.builtin.assert:
     that:
       - "zypper_result.rc == 3"
       - "'Problem reading the RPM header' in zypper_result.stdout"
@@ -240,7 +240,7 @@
   register: rpm_result
 
 - name: verify installation of empty
-  assert:
+  ansible.builtin.assert:
     that:
       - "zypper_result.rc == 0"
       - "zypper_result.changed"
@@ -263,7 +263,7 @@
   register: stat_result
 
 - name: check that we extract rpm package in testdir folder and folder var is exist
-  assert:
+  ansible.builtin.assert:
     that:
       - "stat_result.stat.exists == true"
 
@@ -318,7 +318,7 @@
   register: rpm_result
 
 - name: verify installation of post_error
-  assert:
+  ansible.builtin.assert:
     that:
       - "zypper_result.rc == 0"
       - "zypper_result.changed"
@@ -342,7 +342,7 @@
   register: rpm_result
 
 - name: verify installation of post_error
-  assert:
+  ansible.builtin.assert:
     that:
       - "zypper_result.rc == 107"
       - "not zypper_result.changed"
@@ -402,7 +402,7 @@
   register: zypper_res3
 
 - name: verify simultaneous install/remove worked
-  assert:
+  ansible.builtin.assert:
     that:
       - zypper_res1 is successful
       - zypper_res1 is changed
@@ -422,7 +422,7 @@
   ignore_errors: true
 
 - name: verify simultaneous install/remove failed with absent
-  assert:
+  ansible.builtin.assert:
     that:
       - zypper_res is failed
       - zypper_res.msg == "Can not combine '+' prefix with state=remove/absent."
@@ -434,7 +434,7 @@
     state: absent
   ignore_errors: true
   register: zypper_patch
-- assert:
+- ansible.builtin.assert:
     that:
       - zypper_patch is failed
       - zypper_patch.msg.startswith('Can not remove patches.')
@@ -445,7 +445,7 @@
     state: absent
   ignore_errors: true
   register: zypper_rm
-- assert:
+- ansible.builtin.assert:
     that:
       - zypper_rm is failed
       - zypper_rm.msg.startswith('Can not remove via URL.')
@@ -470,7 +470,7 @@
     state: present
   register: zypper_install_pattern2
 
-- assert:
+- ansible.builtin.assert:
     that:
       - zypper_install_pattern1 is changed
       - zypper_install_pattern2 is not changed
@@ -492,7 +492,7 @@
     state: present
   register: zypperin2
 
-- assert:
+- ansible.builtin.assert:
     that:
       - zypperin1 is succeeded
       - zypperin1 is changed
@@ -515,7 +515,7 @@
   register: zypper_result_update_cache_check
 
 
-- assert:
+- ansible.builtin.assert:
     that:
       - zypper_result_update_cache is successful
       - zypper_result_update_cache_check is successful
@@ -540,7 +540,7 @@
 #   ignore_errors: true
 #   register: zypper_pkg_conflict
 #
-# - assert:
+# - ansible.builtin.assert:
 #     that:
 #       - zypper_pkg_conflict is failed
 #       - "'conflicts with netcat-openbsd provided' in zypper_pkg_conflict.stdout"
@@ -590,7 +590,7 @@
       register: duplicate_out
 
     - name: Check failure when installing rpms with duplicate files without replacefiles option
-      assert:
+      ansible.builtin.assert:
         that:
           - zypper_duplicate_result.results[0] is successful
           - zypper_duplicate_result.results[1] is failed
@@ -614,7 +614,7 @@
       register: duplicate_out
 
     - name: Check success installing rpms with duplicate files using replacefiles option
-      assert:
+      ansible.builtin.assert:
         that:
           - zypper_duplicate_result is successful
           - zypper_duplicate_result is changed

--- a/tests/integration/targets/zypper_repository/tasks/test.yml
+++ b/tests/integration/targets/zypper_repository/tasks/test.yml
@@ -32,7 +32,7 @@
       register: after
 
     - name: verify repo configuration has been restored
-      assert:
+      ansible.builtin.assert:
         that:
           - before.stdout == after.stdout
 

--- a/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -22,7 +22,7 @@
   register: zypper_result
 
 - name: verify no change on test repo deletion
-  assert:
+  ansible.builtin.assert:
     that:
       - "not zypper_result.changed"
 
@@ -34,7 +34,7 @@
   register: zypper_result
 
 - name: verify repo addition
-  assert:
+  ansible.builtin.assert:
     that:
       - "zypper_result.changed"
 
@@ -46,7 +46,7 @@
   register: zypper_result
 
 - name: verify no change on second install
-  assert:
+  ansible.builtin.assert:
     that:
       - "not zypper_result.changed"
 
@@ -58,7 +58,7 @@
   register: zypper_result
 
 - name: Verify change on URL only change
-  assert:
+  ansible.builtin.assert:
     that:
       - "zypper_result.changed"
 
@@ -74,7 +74,7 @@
   register: zypper_result
 
 - name: verify autorefresh option set properly
-  assert:
+  ansible.builtin.assert:
     that:
       - '"autorefresh=\"0\"" in zypper_result.stdout'
 
@@ -90,7 +90,7 @@
   register: zypper_result
 
 - name: verify priority option set properly
-  assert:
+  ansible.builtin.assert:
     that:
       - '"priority=\"55\"" in zypper_result.stdout'
 
@@ -113,7 +113,7 @@
   register: zypper_result2
 
 - name: ensure same url cause update of existing repo even if name differ
-  assert:
+  ansible.builtin.assert:
     that:
       - "zypper_result1.rc != 0"
       - "'not found' in zypper_result1.stderr"
@@ -134,7 +134,7 @@
   register: zypper_result
 
 - name: ensure url get updated on repo with same name
-  assert:
+  ansible.builtin.assert:
     that:
       - "'/science/' not in zypper_result.stdout"
       - "'/devel:/languages:/ruby/' in zypper_result.stdout"
@@ -170,7 +170,7 @@
       register: add_repo_again
 
     - name: no update in case of $releasever usage in url
-      assert:
+      ansible.builtin.assert:
         that:
           - add_repo is changed
           - add_repo_again is not changed
@@ -182,7 +182,7 @@
       register: remove_repo
 
     - name: verify repo was removed
-      assert:
+      ansible.builtin.assert:
         that:
           - remove_repo is changed
 
@@ -192,7 +192,7 @@
       register: releaseverrepo_etc_zypp_reposd
 
     - name: verify removal of file releaseverrepo.repo in /etc/zypp/repos.d/
-      assert:
+      ansible.builtin.assert:
         that:
           - "'releaseverrepo' not in releaseverrepo_etc_zypp_reposd.stdout"
 
@@ -211,7 +211,7 @@
   register: add_repo_again
 
 - name: no update in case of $basearch usage in url
-  assert:
+  ansible.builtin.assert:
     that:
       - add_repo is changed
       - add_repo_again is not changed
@@ -223,7 +223,7 @@
   register: remove_repo
 
 - name: verify repo was removed
-  assert:
+  ansible.builtin.assert:
     that:
       - remove_repo is changed
 
@@ -243,7 +243,7 @@
       register: get_repository_details_from_zypper
 
     - name: verify adding via .repo file was successful
-      assert:
+      ansible.builtin.assert:
         that:
           - "added_by_repo_file is changed"
           - "get_repository_details_from_zypper.rc == 0"
@@ -256,7 +256,7 @@
       register: added_again_by_repo_file
 
     - name: verify nothing was changed adding a repo with the same .repo file
-      assert:
+      ansible.builtin.assert:
         that:
           - added_again_by_repo_file is not changed
 
@@ -272,7 +272,7 @@
       register: etc_zypp_reposd
 
     - name: verify removal via .repo file was successful, including cleanup of local .repo file in /etc/zypp/repos.d/
-      assert:
+      ansible.builtin.assert:
         that:
           - "removed_by_repo_file"
           - "'/systemsmanagement:/Uyuni:/Stable/' not in etc_zypp_reposd.stdout"
@@ -296,7 +296,7 @@
       register: get_repository_details_from_zypper_for_systemsmanagement_Uyuni_Utils
 
     - name: verify adding repository via local .repo file was successful
-      assert:
+      ansible.builtin.assert:
         that:
           - "added_by_repo_local_file is changed"
           - "get_repository_details_from_zypper_for_systemsmanagement_Uyuni_Utils.rc == 0"

--- a/tests/integration/targets/zypper_repository/tasks/zypper_repository_info.yml
+++ b/tests/integration/targets/zypper_repository/tasks/zypper_repository_info.yml
@@ -15,7 +15,7 @@
   register: repositories
 
 - name: verify, that test-repo is returned by the repodatalist
-  assert:
+  ansible.builtin.assert:
     that:
       - "{{ 'test' in repositories.repodatalist|map(attribute='name') | list }}"
 


### PR DESCRIPTION
##### SUMMARY
Follow-up to #11979.

First step to changing
```diff
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -19,7 +19,7 @@ skip_list:
   - command-instead-of-module
   - command-instead-of-shell
   - complexity
-  - fqcn
+  - fqcn[action]
   - galaxy
   - ignore-errors
   - jinja
```

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
integration tests
