### PR TITLE
opennebula inventory - coerce SSH_PORT to integer

### DIFF
--- a/changelogs/fragments/12437-opennebula-ssh-port-coercion.yml
+++ b/changelogs/fragments/12437-opennebula-ssh-port-coercion.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "opennebula inventory plugin - coerce ``SSH_PORT`` to an integer before setting
+     ``ansible_port`` (https://github.com/ansible-collections/community.general/pull/12437)."

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -274,6 +274,33 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         return result
 
+    @staticmethod
+    def _coerce_ssh_port(raw):
+        """Return a valid TCP port number, or ``None`` if the value is unusable.
+
+        XML-RPC responses from OpenNebula sometimes wrap scalar values in a
+        dict (for example ``{"#text": "22"}``).  Passing that through to
+        ``ansible_port`` breaks OpenSSH with errors like
+        ``Connection to UNKNOWN port 65535``.
+        """
+        if raw in (None, "", False):
+            return None
+        if isinstance(raw, dict):
+            raw = (
+                raw.get("#text")
+                or raw.get("text")
+                or next((v for v in raw.values() if isinstance(v, (str, int)) and str(v).strip()), None)
+            )
+            if raw is None:
+                return None
+        try:
+            port = int(str(raw).strip(), 10)
+        except (TypeError, ValueError):
+            return None
+        if port < 1 or port > 65535:
+            return None
+        return port
+
     def _populate(self):
         hostname_preference = self.get_option("hostname")
         prefer_existing_ansible_host = self.get_option("prefer_existing_ansible_host")
@@ -309,8 +336,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 if not prefer_existing_ansible_host or not existing or "ansible_host" not in existing.vars:
                     self.inventory.set_variable(hostname, "ansible_host", server[hostname_preference])
 
-            if server.get("SSH_PORT"):
-                self.inventory.set_variable(hostname, "ansible_port", server["SSH_PORT"])
+            ssh_port = self._coerce_ssh_port(server.get("SSH_PORT"))
+            if ssh_port is not None:
+                self.inventory.set_variable(hostname, "ansible_port", ssh_port)
 
             # handle constructable implementation: get composed variables if any
             self._set_composite_vars(self.get_option("compose"), server, hostname, strict=strict)

--- a/tests/unit/plugins/inventory/test_opennebula.py
+++ b/tests/unit/plugins/inventory/test_opennebula.py
@@ -430,7 +430,22 @@ def test_populate(inventory, mocker):
     assert host_gitlab.get_vars()["ansible_host"] == "185.165.1.3"
 
     # check for custom ssh port
-    assert host_gitlab.get_vars()["ansible_port"] == "8822"
+    assert host_gitlab.get_vars()["ansible_port"] == 8822
+
+
+def test_coerce_ssh_port():
+    coerce = InventoryModule._coerce_ssh_port
+    assert coerce("22") == 22
+    assert coerce(22) == 22
+    assert coerce({"#text": "8822"}) == 8822
+    assert coerce({"text": "443"}) == 443
+    assert coerce(None) is None
+    assert coerce("") is None
+    assert coerce(False) is None
+    assert coerce({"unexpected": ""}) is None
+    assert coerce("0") is None
+    assert coerce("99999") is None
+    assert coerce("not_a_port") is None
 
 
 def test_populate_uname_gname(inventory, mocker):


### PR DESCRIPTION
##### SUMMARY

Coerce `SSH_PORT` to an integer before setting `ansible_port`.

Replacement for closed #12418 (could not be reopened after force-push). Same change, rebased onto current `main` after #12417 merged.

Split from #12417 per maintainer review.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

opennebula inventory plugin

##### ADDITIONAL INFORMATION

Tested against a live OpenNebula instance where `SSH_PORT` was returned as a dict wrapper.
Changelog simplified per review on #12418.