### PR TITLE
Ansible-lint: use FQCN for remaining ansible-core modules, and replace yum with dnf

### DIFF
--- a/plugins/connection/chroot.py
+++ b/plugins/connection/chroot.py
@@ -66,7 +66,7 @@ EXAMPLES = r"""
 - hosts: chroots
   connection: community.general.chroot
   tasks:
-    - debug:
+    - ansible.builtin.debug:
         msg: "This is coming from chroot environment"
 """
 

--- a/tests/integration/targets/archive/tasks/main.yml
+++ b/tests/integration/targets/archive/tasks/main.yml
@@ -44,7 +44,7 @@
 
 # Install dependencies
 - name: Ensure zip is present to create test archive (yum)
-  ansible.builtin.yum: name=zip state=latest
+  ansible.builtin.dnf: name=zip state=latest
   when: ansible_facts.pkg_mgr == 'yum'
 
 - name: Ensure zip is present to create test archive (apt)

--- a/tests/integration/targets/callback_log_plays/ping_log.yml
+++ b/tests/integration/targets/callback_log_plays/ping_log.yml
@@ -6,4 +6,4 @@
 - hosts: localhost
   gather_facts: false
   tasks:
-    - ping:
+    - ansible.builtin.ping:

--- a/tests/integration/targets/connection/test_connection.yml
+++ b/tests/integration/targets/connection/test_connection.yml
@@ -11,7 +11,7 @@
     ### raw with unicode arg and output
 
     - name: raw with unicode arg and output
-      raw: echo 汉语
+      ansible.builtin.raw: echo 汉语
       register: command
     - name: check output of raw with unicode arg and output
       ansible.builtin.assert:
@@ -37,7 +37,7 @@
       ansible.builtin.file: path={{ local_tmp }}-汉语/汉语.txt state=absent
       delegate_to: localhost
     - name: fetch remote file with unicode filename and content
-      fetch: src={{ remote_tmp }}-汉语/汉语.txt dest={{ local_tmp }}-汉语/汉语.txt fail_on_missing=true validate_checksum=true flat=true
+      ansible.builtin.fetch: src={{ remote_tmp }}-汉语/汉语.txt dest={{ local_tmp }}-汉语/汉语.txt fail_on_missing=true validate_checksum=true flat=true
 
     ### remove local and remote temp files
 

--- a/tests/integration/targets/flatpak/tasks/main.yml
+++ b/tests/integration/targets/flatpak/tasks/main.yml
@@ -47,7 +47,7 @@
   always:
 
     - name: Check HTTP server status
-      async_status:
+      ansible.builtin.async_status:
         jid: "{{ webserver_status.ansible_job_id }}"
       ignore_errors: true
 

--- a/tests/integration/targets/gem/tasks/main.yml
+++ b/tests/integration/targets/gem/tasks/main.yml
@@ -130,7 +130,7 @@
       register: install_gem_result
 
     - name: Find gems in custom directory
-      find:
+      ansible.builtin.find:
         paths: "{{ remote_tmp_dir }}/gems/gems"
         file_type: directory
         contains: gist
@@ -152,7 +152,7 @@
       register: install_gem_result
 
     - name: Find gems in custom directory
-      find:
+      ansible.builtin.find:
         paths: "{{ remote_tmp_dir }}/gems/gems"
         file_type: directory
         contains: gist

--- a/tests/integration/targets/hg/tasks/install.yml
+++ b/tests/integration/targets/hg/tasks/install.yml
@@ -38,7 +38,7 @@
   when: ansible_facts.pkg_mgr == 'dnf'
 
 - name: install mercurial (yum)
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: mercurial
   when: ansible_facts.pkg_mgr == 'yum'
 

--- a/tests/integration/targets/hg/tasks/uninstall.yml
+++ b/tests/integration/targets/hg/tasks/uninstall.yml
@@ -47,7 +47,7 @@
   when: ansible_facts.pkg_mgr in ['pkgng', 'community.general.pkgng']
 
 - name: restore the default python
-  raw: mv "{{ which_python.stdout }}.default" "{{ which_python.stdout }}"
+  ansible.builtin.raw: mv "{{ which_python.stdout }}.default" "{{ which_python.stdout }}"
 
 - name: restore the default pip
-  raw: mv "{{ which_pip.stdout }}.default" "{{ which_pip.stdout }}"
+  ansible.builtin.raw: mv "{{ which_pip.stdout }}.default" "{{ which_pip.stdout }}"

--- a/tests/integration/targets/iptables_state/tasks/tests/00-basic.yml
+++ b/tests/integration/targets/iptables_state/tasks/tests/00-basic.yml
@@ -9,7 +9,7 @@
     state: absent
 
 - name: "ensure our next rule is not there (iptables)"
-  iptables:
+  ansible.builtin.iptables:
     chain: OUTPUT
     jump: ACCEPT
     state: absent
@@ -195,7 +195,7 @@
 
 
 - name: "change iptables state (iptables)"
-  iptables:
+  ansible.builtin.iptables:
     chain: OUTPUT
     jump: ACCEPT
 

--- a/tests/integration/targets/iptables_state/tasks/tests/01-tables.yml
+++ b/tests/integration/targets/iptables_state/tasks/tests/01-tables.yml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: "ensure our next rule is not there (iptables)"
-  iptables:
+  ansible.builtin.iptables:
     table: nat
     chain: INPUT
     jump: ACCEPT
@@ -128,7 +128,7 @@
 
 
 - name: "change NAT table (iptables)"
-  iptables:
+  ansible.builtin.iptables:
     table: nat
     chain: INPUT
     jump: ACCEPT

--- a/tests/integration/targets/jenkins_credential/tasks/pre.yml
+++ b/tests/integration/targets/jenkins_credential/tasks/pre.yml
@@ -6,7 +6,7 @@
   include_vars: "{{ role_path }}/vars/credentials.yml"
 
 - name: Make sure Jenkins is ready
-  uri:
+  ansible.builtin.uri:
     url: http://localhost:8080/login
     status_code: 200
     return_content: false

--- a/tests/integration/targets/keycloak_authentication/tasks/main.yml
+++ b/tests/integration/targets/keycloak_authentication/tasks/main.yml
@@ -26,7 +26,7 @@
     memory: 2200M
 
 - name: Wait for Keycloak
-  uri:
+  ansible.builtin.uri:
     url: "{{ url }}/admin/"
     status_code: 200
     validate_certs: false

--- a/tests/integration/targets/keycloak_authentication_v2/tasks/tests/test_setup.yml
+++ b/tests/integration/targets/keycloak_authentication_v2/tasks/tests/test_setup.yml
@@ -17,7 +17,7 @@
     memory: 2200M
 
 - name: Wait for Keycloak
-  uri:
+  ansible.builtin.uri:
     url: "{{ url }}/admin/"
     status_code: 200
     validate_certs: false

--- a/tests/integration/targets/keycloak_client/tasks/main.yml
+++ b/tests/integration/targets/keycloak_client/tasks/main.yml
@@ -10,7 +10,7 @@
   until: result is success
 
 - name: Wait for Keycloak
-  uri:
+  ansible.builtin.uri:
     url: "{{ url }}/admin/"
     status_code: 200
     validate_certs: false

--- a/tests/integration/targets/keycloak_client_rolescope/tasks/main.yml
+++ b/tests/integration/targets/keycloak_client_rolescope/tasks/main.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 - name: Wait for Keycloak
-  uri:
+  ansible.builtin.uri:
     url: "{{ url }}/admin/"
     status_code: 200
     validate_certs: false

--- a/tests/integration/targets/keycloak_clientscope_rolemappings/tasks/main.yml
+++ b/tests/integration/targets/keycloak_clientscope_rolemappings/tasks/main.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 - name: Wait for Keycloak
-  uri:
+  ansible.builtin.uri:
     url: "{{ url }}/admin/"
     status_code: 200
     validate_certs: false

--- a/tests/integration/targets/keycloak_component_info/tasks/main.yml
+++ b/tests/integration/targets/keycloak_component_info/tasks/main.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 - name: Wait for Keycloak
-  uri:
+  ansible.builtin.uri:
     url: "{{ url }}/admin/"
     status_code: 200
     validate_certs: false

--- a/tests/integration/targets/keycloak_realm/tasks/main.yml
+++ b/tests/integration/targets/keycloak_realm/tasks/main.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 - name: Wait for Keycloak
-  uri:
+  ansible.builtin.uri:
     url: "{{ url }}/admin/"
     status_code: 200
     validate_certs: false

--- a/tests/integration/targets/keycloak_realm_users_info/tasks/main.yml
+++ b/tests/integration/targets/keycloak_realm_users_info/tasks/main.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 - name: Wait for Keycloak
-  uri:
+  ansible.builtin.uri:
     url: "{{ url }}/admin/"
     status_code: 200
     validate_certs: false

--- a/tests/integration/targets/launchd/tasks/tests/test_runatload.yml
+++ b/tests/integration/targets/launchd/tasks/tests/test_runatload.yml
@@ -25,7 +25,7 @@
       - test_1_launchd_start_result.status.status_code == '0'
 
 - name: "[{{ item }}] Validate that RunAtLoad is set to true"
-  replace:
+  ansible.builtin.replace:
     path: "{{ launchd_plist_location }}"
     regexp: |
       \s+<key>RunAtLoad</key>

--- a/tests/integration/targets/monit/tasks/test_reload_present.yml
+++ b/tests/integration/targets/monit/tasks/test_reload_present.yml
@@ -39,7 +39,7 @@
     service_state: "up"
 
 - name: add process config
-  blockinfile:
+  ansible.builtin.blockinfile:
     path: "{{ monitrc }}"
     block: |
       check process httpd_echo with matching "httpd_echo"

--- a/tests/integration/targets/one_host/tasks/main.yml
+++ b/tests/integration/targets/one_host/tasks/main.yml
@@ -235,7 +235,7 @@
 # TEARDOWN
 
 - name: fetch fixtures
-  fetch:
+  ansible.builtin.fetch:
     src: /tmp/opennebula-fixtures.json.gz
     dest: targets/one_host/files
   when:

--- a/tests/integration/targets/one_template/tasks/main.yml
+++ b/tests/integration/targets/one_template/tasks/main.yml
@@ -238,7 +238,7 @@
 # TEARDOWN
 
 - name: "fetch fixtures"
-  fetch:
+  ansible.builtin.fetch:
     src: /tmp/opennebula-fixtures.json.gz
     dest: targets/one_host/files
   when:

--- a/tests/integration/targets/pacman/tasks/remove_nosave.yml
+++ b/tests/integration/targets/pacman/tasks/remove_nosave.yml
@@ -23,7 +23,7 @@
         state: present
 
     - name: Modify {{config_file}}
-      blockinfile:
+      ansible.builtin.blockinfile:
         path: '{{config_file}}'
         block: |
           # something something
@@ -54,7 +54,7 @@
         state: present
 
     - name: Modify {{config_file}}
-      blockinfile:
+      ansible.builtin.blockinfile:
         path: '{{config_file}}'
         block: |
           # something something

--- a/tests/integration/targets/pkgng/tasks/create-outofdate-pkg.yml
+++ b/tests/integration/targets/pkgng/tasks/create-outofdate-pkg.yml
@@ -29,7 +29,7 @@
 # pkg switched from .txz to .pkg in version 1.17.0
 # Might as well look for all valid pkg extensions.
 - name: Find created package file
-  find:
+  ansible.builtin.find:
     path: '{{ pkgng_test_outofdate_pkg_tempdir.path }}'
     use_regex: true
     pattern: '.*\.(pkg|tzst|t[xbg]z|tar)'

--- a/tests/integration/targets/setup_epel/tasks/main.yml
+++ b/tests/integration/targets/setup_epel/tasks/main.yml
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Install EPEL
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts.distribution_major_version }}.noarch.rpm
     disable_gpg_check: true
   when:

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -172,7 +172,7 @@
 
 - block:
     - name: Install langpacks (RHEL8)
-      ansible.builtin.yum:
+      ansible.builtin.dnf:
         name:
           - glibc-langpack-es
           - glibc-langpack-pt

--- a/tests/integration/targets/yum_versionlock/tasks/main.yml
+++ b/tests/integration/targets/yum_versionlock/tasks/main.yml
@@ -9,20 +9,20 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Update procps-ng temporary until issue (#2539) is fixed
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: procps-ng
     state: latest
   when: ansible_facts.distribution == 'Fedora' and ansible_facts.distribution_major_version == '34'
 
 - block:
     - name: Install necessary packages to test yum_versionlock
-      ansible.builtin.yum:
+      ansible.builtin.dnf:
         name: yum-plugin-versionlock
         state: present
       register: yum_versionlock_install
 
     - name: Yum checkupdate
-      ansible.builtin.yum:
+      ansible.builtin.dnf:
         list: updates
       register: yum_updates
 
@@ -60,7 +60,7 @@
           register: unlock_all_packages
 
         - name: Update all packages
-          ansible.builtin.yum:
+          ansible.builtin.dnf:
             name: '*'
             state: latest
           check_mode: true
@@ -79,7 +79,7 @@
       when: yum_updates.results | length != 0
 
     - name: Remove installed packages in case it was not installed
-      ansible.builtin.yum:
+      ansible.builtin.dnf:
         name: yum-plugin-versionlock
         state: absent
       when: yum_versionlock_install is changed


### PR DESCRIPTION
##### SUMMARY
Follow-up to #11979. One commit per action/module.

Once this and the other still open PRs are merged, we can apply:
```diff
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -19,7 +19,7 @@ skip_list:
   - command-instead-of-module
   - command-instead-of-shell
   - complexity
-  - fqcn
+  - fqcn[action]
   - galaxy
   - ignore-errors
   - jinja
```
:tada:

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
integration tests
