### PR TITLE
consul_kv: add consul_kv_info module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -545,6 +545,8 @@ files:
   $modules/consul:
     ignore: colin-nolan Hakon
     maintainers: $team_consul
+  $modules/consul_kv_info.py:
+    maintainers: $team_consul Shreyashxredhat
   $modules/copr.py:
     maintainers: schlupov
   $modules/cpanm.py:

--- a/changelogs/fragments/12388-consul-kv-deprecate-get-value.yml
+++ b/changelogs/fragments/12388-consul-kv-deprecate-get-value.yml
@@ -1,6 +1,0 @@
-deprecated_features:
-  - consul_kv - using the module with O(state=present) without providing O(value) to read a key is
-    deprecated. Use the new M(community.general.consul_kv_info) module instead. The read functionality
-    will be removed in community.general 15.0.0
-    (https://github.com/ansible-collections/community.general/issues/12388,
-    https://github.com/ansible-collections/community.general/pull/12455).

--- a/changelogs/fragments/12388-consul-kv-deprecate-get-value.yml
+++ b/changelogs/fragments/12388-consul-kv-deprecate-get-value.yml
@@ -1,0 +1,6 @@
+deprecated_features:
+  - consul_kv - using the module with O(state=present) without providing O(value) to read a key is
+    deprecated. Use the new M(community.general.consul_kv_info) module instead. The read functionality
+    will be removed in community.general 15.0.0
+    (https://github.com/ansible-collections/community.general/issues/12388,
+    https://github.com/ansible-collections/community.general/pull/12455).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -11,6 +11,7 @@ action_groups:
     - consul_auth_method
     - consul_binding_rule
     - consul_kv
+    - consul_kv_info
     - consul_policy
     - consul_role
     - consul_session

--- a/plugins/modules/consul_kv.py
+++ b/plugins/modules/consul_kv.py
@@ -36,7 +36,9 @@ options:
     description:
       - The action to take with the supplied key and value. If the state is V(present) and O(value) is set, the key contents
         is set to the value supplied and RV(ignore:changed) is set to V(true) only if the value was different to the current contents.
-        If the state is V(present) and O(value) is not set, the existing value associated to the key is returned. The state
+        If the state is V(present) and O(value) is not set, the existing value associated to the key is returned.
+        This behavior is B(deprecated) and will be removed in community.general 15.0.0. Use
+        M(community.general.consul_kv_info) to read key/value entries instead. The state
         V(absent) is used to remove the key/value pair, again RV(ignore:changed) is set to V(true) only if the key actually existed
         prior to the removal. An attempt can be made to obtain or free the lock associated with a key/value pair with the
         states V(acquire) or V(release) respectively. A valid session must be supplied to make the attempt RV(ignore:changed) is V(true)
@@ -52,6 +54,8 @@ options:
   value:
     description:
       - The value should be associated with the given key, required if O(state) is V(present).
+      - Omitting O(value) with O(state=present) to read a key is B(deprecated) and will be removed in
+        community.general 15.0.0. Use M(community.general.consul_kv_info) instead.
     type: str
   recurse:
     description:
@@ -84,9 +88,9 @@ options:
 
 
 EXAMPLES = r"""
-# If the key does not exist, the value associated to the "data" property in `retrieved_key` will be `None`
-# If the key value is empty string, `retrieved_key["data"]["Value"]` will be `None`
-- name: Retrieve a value from the key/value store
+# Reading a key with consul_kv (state=present, no value) is deprecated.
+# Use community.general.consul_kv_info instead:
+- name: Retrieve a value from the key/value store (deprecated, use consul_kv_info)
   community.general.consul_kv:
     key: somekey
   register: retrieved_key
@@ -179,6 +183,12 @@ def lock(module, consul_module, state):
 
 
 def get_value(module, consul_module):
+    module.deprecate(
+        "Using community.general.consul_kv with state=present without providing a value to read "
+        "a key is deprecated. Use community.general.consul_kv_info instead.",
+        version="15.0.0",
+        collection_name="community.general",
+    )
     key = module.params["key"]
     index, existing = consul_module.kv_get(
         key,

--- a/plugins/modules/consul_kv.py
+++ b/plugins/modules/consul_kv.py
@@ -84,17 +84,12 @@ options:
       - The name of the datacenter to query. If unspecified, the query defaults to the datacenter of the Consul agent on O(host).
     type: str
     version_added: 10.0.0
+seealso:
+  - module: community.general.consul_kv_info
 """
 
 
 EXAMPLES = r"""
-# Reading a key with consul_kv (state=present, no value) will be deprecated.
-# Use community.general.consul_kv_info instead:
-- name: Retrieve a value from the key/value store (use consul_kv_info instead)
-  community.general.consul_kv:
-    key: somekey
-  register: retrieved_key
-
 - name: Add or update the value associated with a key in the key/value store
   community.general.consul_kv:
     key: somekey

--- a/plugins/modules/consul_kv.py
+++ b/plugins/modules/consul_kv.py
@@ -37,7 +37,7 @@ options:
       - The action to take with the supplied key and value. If the state is V(present) and O(value) is set, the key contents
         is set to the value supplied and RV(ignore:changed) is set to V(true) only if the value was different to the current contents.
         If the state is V(present) and O(value) is not set, the existing value associated to the key is returned.
-        This behavior is B(deprecated) and will be removed in community.general 15.0.0. Use
+        This behavior will be B(deprecated) in the future. Use
         M(community.general.consul_kv_info) to read key/value entries instead. The state
         V(absent) is used to remove the key/value pair, again RV(ignore:changed) is set to V(true) only if the key actually existed
         prior to the removal. An attempt can be made to obtain or free the lock associated with a key/value pair with the
@@ -54,8 +54,8 @@ options:
   value:
     description:
       - The value should be associated with the given key, required if O(state) is V(present).
-      - Omitting O(value) with O(state=present) to read a key is B(deprecated) and will be removed in
-        community.general 15.0.0. Use M(community.general.consul_kv_info) instead.
+      - Omitting O(value) with O(state=present) to read a key will be B(deprecated) in the future.
+        Use M(community.general.consul_kv_info) instead.
     type: str
   recurse:
     description:
@@ -88,9 +88,9 @@ options:
 
 
 EXAMPLES = r"""
-# Reading a key with consul_kv (state=present, no value) is deprecated.
+# Reading a key with consul_kv (state=present, no value) will be deprecated.
 # Use community.general.consul_kv_info instead:
-- name: Retrieve a value from the key/value store (deprecated, use consul_kv_info)
+- name: Retrieve a value from the key/value store (use consul_kv_info instead)
   community.general.consul_kv:
     key: somekey
   register: retrieved_key
@@ -183,12 +183,6 @@ def lock(module, consul_module, state):
 
 
 def get_value(module, consul_module):
-    module.deprecate(
-        "Using community.general.consul_kv with state=present without providing a value to read "
-        "a key is deprecated. Use community.general.consul_kv_info instead.",
-        version="15.0.0",
-        collection_name="community.general",
-    )
     key = module.params["key"]
     index, existing = consul_module.kv_get(
         key,

--- a/plugins/modules/consul_kv_info.py
+++ b/plugins/modules/consul_kv_info.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (c) 2025, Shreyash Bhosale <shreyashpb16@gmail.com>
+# Copyright (c) 2026, Shreyash Bhosale <shrbhosa@redhat.com>
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,10 +9,9 @@ from __future__ import annotations
 DOCUMENTATION = r"""
 module: consul_kv_info
 short_description: Retrieve entries from the key/value store of a Consul cluster
-version_added: 13.4.0
+version_added: 13.3.0
 description:
   - Retrieve one or more key/value entries from a Consul cluster.
-  - If O(recurse) is V(true), all entries sharing the prefix specified by O(key) are returned.
   - See U(https://developer.hashicorp.com/consul/api-docs/kv) for more details.
 author:
   - Shreyash Bhosale (@Shreyashxredhat)
@@ -24,7 +23,7 @@ extends_documentation_fragment:
   - community.general._attributes.info_module
 attributes:
   action_group:
-    version_added: 13.4.0
+    version_added: 13.3.0
 options:
   key:
     description:
@@ -64,13 +63,12 @@ EXAMPLES = r"""
 RETURN = r"""
 data:
   description:
-    - The KV entry or list of entries.
-    - When O(recurse) is V(false), this is a single dictionary with the keys C(Key), C(Value), C(Flags), and others
-      returned by the Consul API.
-    - When O(recurse) is V(true), this is a list of such dictionaries.
-    - V(null) if the key does not exist.
+    - The list of KV entries matching the query.
+    - Each element is a dictionary with the keys C(Key), C(Value), C(Flags), and others returned by the Consul API.
+    - The list is empty if the key does not exist.
   returned: always
-  type: raw
+  type: list
+  elements: dict
 index:
   description:
     - The Consul index value from the C(X-Consul-Index) response header.
@@ -91,9 +89,8 @@ from ansible_collections.community.general.plugins.module_utils._consul import (
 )
 
 
-def _decode_value(entry):
-    if entry.get("Value") is not None:
-        entry["Value"] = base64.b64decode(entry["Value"])
+def _decode_value(value):
+    return None if value is None else base64.b64decode(value)
 
 
 def _quote_key(key):
@@ -109,16 +106,16 @@ def _kv_get(consul_module, key, recurse=False, dc=None):
     except RequestError as e:
         if e.status == HTTPStatus.NOT_FOUND:
             index = e.response_headers.get("X-Consul-Index") if e.response_headers else None
-            return index, None
+            return index, []
         raise
     index = headers.get("X-Consul-Index") if headers is not None else None
     if not body:
-        return index, None
+        return index, []
     for entry in body:
-        _decode_value(entry)
+        entry["Value"] = _decode_value(entry.get("Value"))
     if recurse:
         return index, body
-    return index, body[0]
+    return index, [body[0]]
 
 
 def main():

--- a/plugins/modules/consul_kv_info.py
+++ b/plugins/modules/consul_kv_info.py
@@ -1,0 +1,155 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2025, Shreyash Bhosale <shreyashpb16@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+DOCUMENTATION = r"""
+module: consul_kv_info
+short_description: Retrieve entries from the key/value store of a Consul cluster
+version_added: 13.4.0
+description:
+  - Retrieve one or more key/value entries from a Consul cluster.
+  - If O(recurse) is V(true), all entries sharing the prefix specified by O(key) are returned.
+  - See U(https://developer.hashicorp.com/consul/api-docs/kv) for more details.
+author:
+  - Shreyash Bhosale (@Shreyashxredhat)
+extends_documentation_fragment:
+  - community.general._consul
+  - community.general._consul.actiongroup_consul
+  - community.general._consul.token
+  - community.general._attributes
+  - community.general._attributes.info_module
+attributes:
+  action_group:
+    version_added: 13.4.0
+options:
+  key:
+    description:
+      - The key to retrieve.
+      - When O(recurse) is V(true), this is treated as a prefix.
+    type: str
+    required: true
+  recurse:
+    description:
+      - If V(true), retrieve all entries sharing the prefix specified by O(key).
+    type: bool
+    default: false
+  datacenter:
+    description:
+      - The name of the datacenter to query. If unspecified, the query defaults to the datacenter of the Consul agent
+        on O(host).
+    type: str
+"""
+
+EXAMPLES = r"""
+- name: Retrieve a single key
+  community.general.consul_kv_info:
+    key: somekey
+  register: result
+
+- name: Display the value
+  ansible.builtin.debug:
+    msg: "{{ result.data }}"
+
+- name: Retrieve all keys under a prefix
+  community.general.consul_kv_info:
+    key: app/config/
+    recurse: true
+  register: result
+"""
+
+RETURN = r"""
+data:
+  description:
+    - The KV entry or list of entries.
+    - When O(recurse) is V(false), this is a single dictionary with the keys C(Key), C(Value), C(Flags), and others
+      returned by the Consul API.
+    - When O(recurse) is V(true), this is a list of such dictionaries.
+    - V(null) if the key does not exist.
+  returned: always
+  type: raw
+index:
+  description:
+    - The Consul index value from the C(X-Consul-Index) response header.
+  returned: always
+  type: str
+"""
+
+import base64
+from http import HTTPStatus
+from urllib.parse import quote
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.community.general.plugins.module_utils._consul import (
+    AUTH_ARGUMENTS_SPEC,
+    RequestError,
+    _ConsulModule,
+)
+
+
+def _decode_value(entry):
+    if entry.get("Value") is not None:
+        entry["Value"] = base64.b64decode(entry["Value"])
+
+
+def _quote_key(key):
+    return quote(key, safe="/")
+
+
+def _kv_get(consul_module, key, recurse=False, dc=None):
+    params = {"dc": dc}
+    if recurse:
+        params["recurse"] = "true"
+    try:
+        body, headers = consul_module.request("GET", ("kv", _quote_key(key)), params=params)
+    except RequestError as e:
+        if e.status == HTTPStatus.NOT_FOUND:
+            index = e.response_headers.get("X-Consul-Index") if e.response_headers else None
+            return index, None
+        raise
+    index = headers.get("X-Consul-Index") if headers is not None else None
+    if not body:
+        return index, None
+    for entry in body:
+        _decode_value(entry)
+    if recurse:
+        return index, body
+    return index, body[0]
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            datacenter=dict(type="str"),
+            key=dict(type="str", required=True, no_log=False),
+            recurse=dict(type="bool", default=False),
+            **AUTH_ARGUMENTS_SPEC,
+        ),
+        supports_check_mode=True,
+    )
+    consul_module = _ConsulModule(module)
+
+    try:
+        index, data = _kv_get(
+            consul_module,
+            module.params["key"],
+            recurse=module.params["recurse"],
+            dc=module.params["datacenter"],
+        )
+        module.exit_json(changed=False, index=index, data=data)
+    except RequestError as e:
+        body = e.response_data
+        if isinstance(body, bytes):
+            body = body.decode("utf-8", errors="replace")
+        body = (body or "").strip()
+        module.fail_json(msg=body or f"HTTP {e.status}")
+    except Exception as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/consul_kv_info.py
+++ b/plugins/modules/consul_kv_info.py
@@ -21,9 +21,6 @@ extends_documentation_fragment:
   - community.general._consul.token
   - community.general._attributes
   - community.general._attributes.info_module
-attributes:
-  action_group:
-    version_added: 13.3.0
 options:
   key:
     description:

--- a/plugins/modules/consul_kv_info.py
+++ b/plugins/modules/consul_kv_info.py
@@ -76,10 +76,6 @@ index:
   type: str
 """
 
-import base64
-from http import HTTPStatus
-from urllib.parse import quote
-
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.community.general.plugins.module_utils._consul import (
@@ -87,35 +83,6 @@ from ansible_collections.community.general.plugins.module_utils._consul import (
     RequestError,
     _ConsulModule,
 )
-
-
-def _decode_value(value):
-    return None if value is None else base64.b64decode(value)
-
-
-def _quote_key(key):
-    return quote(key, safe="/")
-
-
-def _kv_get(consul_module, key, recurse=False, dc=None):
-    params = {"dc": dc}
-    if recurse:
-        params["recurse"] = "true"
-    try:
-        body, headers = consul_module.request("GET", ("kv", _quote_key(key)), params=params)
-    except RequestError as e:
-        if e.status == HTTPStatus.NOT_FOUND:
-            index = e.response_headers.get("X-Consul-Index") if e.response_headers else None
-            return index, []
-        raise
-    index = headers.get("X-Consul-Index") if headers is not None else None
-    if not body:
-        return index, []
-    for entry in body:
-        entry["Value"] = _decode_value(entry.get("Value"))
-    if recurse:
-        return index, body
-    return index, [body[0]]
 
 
 def main():
@@ -131,12 +98,15 @@ def main():
     consul_module = _ConsulModule(module)
 
     try:
-        index, data = _kv_get(
-            consul_module,
+        index, data = consul_module.kv_get(
             module.params["key"],
             recurse=module.params["recurse"],
             dc=module.params["datacenter"],
         )
+        if data is None:
+            data = []
+        elif not isinstance(data, list):
+            data = [data]
         module.exit_json(changed=False, index=index, data=data)
     except RequestError as e:
         body = e.response_data

--- a/tests/integration/targets/consul/tasks/consul_kv_info.yml
+++ b/tests/integration/targets/consul/tasks/consul_kv_info.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2025, Shreyash Bhosale (@Shreyashxredhat)
+# Copyright (c) 2026, Shreyash Bhosale (@Shreyashxredhat)
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -11,7 +11,8 @@
 - ansible.builtin.assert:
     that:
       - result is not changed
-      - result.data.Value == 'foo1'
+      - result.data | length == 1
+      - result.data[0].Value == 'foo1'
       - result.index is defined
 
 - name: Read a non-existent key
@@ -22,7 +23,7 @@
 - ansible.builtin.assert:
     that:
       - result is not changed
-      - result.data is none
+      - result.data | length == 0
 
 - name: Read all keys under a prefix
   consul_kv_info:

--- a/tests/integration/targets/consul/tasks/consul_kv_info.yml
+++ b/tests/integration/targets/consul/tasks/consul_kv_info.yml
@@ -1,0 +1,37 @@
+---
+# Copyright (c) 2025, Shreyash Bhosale (@Shreyashxredhat)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Read an existing key
+  consul_kv_info:
+    key: data/value1
+  register: result
+
+- ansible.builtin.assert:
+    that:
+      - result is not changed
+      - result.data.Value == 'foo1'
+      - result.index is defined
+
+- name: Read a non-existent key
+  consul_kv_info:
+    key: does/not/exist
+  register: result
+
+- ansible.builtin.assert:
+    that:
+      - result is not changed
+      - result.data is none
+
+- name: Read all keys under a prefix
+  consul_kv_info:
+    key: data/
+    recurse: true
+  register: result
+
+- ansible.builtin.assert:
+    that:
+      - result is not changed
+      - result.data | length == 3
+      - result.data | map(attribute='Key') | sort == ['data/value1', 'data/value2', 'data/value3']

--- a/tests/integration/targets/consul/tasks/main.yml
+++ b/tests/integration/targets/consul/tasks/main.yml
@@ -107,6 +107,7 @@
             - ansible.builtin.import_tasks: consul_binding_rule.yml
             - ansible.builtin.import_tasks: consul_agent_service.yml
             - ansible.builtin.import_tasks: consul_agent_check.yml
+            - ansible.builtin.import_tasks: consul_kv_info.yml
           module_defaults:
             group/community.general.consul:
               token: "{{ consul_management_token }}"


### PR DESCRIPTION

  ##### SUMMARY

  Add a new `consul_kv_info` module for reading key/value entries from Consul, and
  document in `consul_kv` that the read path (calling with `state=present` without
  providing `value`) will be deprecated in the future.

  - New `consul_kv_info` module using the shared `_ConsulModule.kv_get()` method
    (from #12515) - always returns `data` as a list
  - Documentation updates to `consul_kv`: future deprecation notes on `state` and
    `value` options, `seealso` pointing to `consul_kv_info`, removed read-only example
  - Integration tests for the new module
  - BOTMETA entry and action group registration

  Fixes #12388

  ##### ISSUE TYPE

  - New Module/Plugin Pull Request

  ##### COMPONENT NAME

  - consul_kv
  - consul_kv_info
