### PR TITLE
Ansible-lint: use community.general.write_binary_file instead of ansible.builtin.copy with implicit binary data

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -15,7 +15,6 @@ skip_list:
 
   # To be checked and maybe fixed:
   - args
-  - avoid-implicit
   - command-instead-of-module
   - command-instead-of-shell
   - complexity

--- a/tests/integration/targets/ini_file/tasks/tests/01-value.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/01-value.yml
@@ -542,14 +542,14 @@
 
 
 - name: test-value 21 - Create starting ini file
-  ansible.builtin.copy:
+  community.general.write_binary_file:
     # The content below is the following text file with BOM:
     # [section1]
     # var1=aaa
     # var2=bbb
     # [section2]
     # var3=ccc
-    content: !!binary |
+    content: |
       77u/W3NlY3Rpb24xXQp2YXIxPWFhYQp2YXIyPWJiYgpbc2VjdGlvbjJdCnZhcjM9Y2NjCg==
     dest: "{{ output_file }}"
 

--- a/tests/integration/targets/ini_file/tasks/tests/03-encoding.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/03-encoding.yml
@@ -5,8 +5,8 @@
 
 # Regression test for https://github.com/ansible-collections/community.general/pull/2578#issuecomment-868092282
 - name: Create UTF-8 test file
-  ansible.builtin.copy:
-    content: !!binary |
+  community.general.write_binary_file:
+    content: |
       W2FwcDptYWluXQphdmFpbGFibGVfbGFuZ3VhZ2VzID0gZW4gZnIgZXMgZGUgcHQgamEgbHQgemhf
       VFcgaWQgZGEgcHRfQlIgcnUgc2wgaXQgbmxfTkwgdWsgdGEgc2kgY3MgbmIgaHUKIyBGdWxsIGxh
       bmd1YWdlIG5hbWVzIGluIG5hdGl2ZSBsYW5ndWFnZSAoY29tbWEgc2VwYXJhdGVkKQphdmFpbGFi


### PR DESCRIPTION
##### SUMMARY
Follow-up to #11979.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
integration tests
