### PR TITLE
CI: Replace Alpine 3.23 with 3.24 for devel

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -203,6 +203,12 @@ stages:
       - template: templates/matrix.yml
         parameters:
           targets:
+            - name: Alpine 3.23 + group 1
+              test: ansible-test-integration-2.21-alpine323-azp-posix-1
+            - name: Alpine 3.23 + group 2
+              test: ansible-test-integration-2.21-alpine323-azp-posix-2
+            - name: Alpine 3.23 + group 3
+              test: ansible-test-integration-2.21-alpine323-azp-posix-3
             - name: Fedora 43 + group 1
               test: ansible-test-integration-2.21-fedora43-azp-posix-1
             - name: Fedora 43 + group 2
@@ -231,12 +237,12 @@ stages:
       - template: templates/matrix.yml
         parameters:
           targets:
-            - name: Alpine 3.23 + group 1
-              test: ansible-test-integration-devel-alpine323-azp-posix-1
-            - name: Alpine 3.23 + group 2
-              test: ansible-test-integration-devel-alpine323-azp-posix-2
-            - name: Alpine 3.23 + group 3
-              test: ansible-test-integration-devel-alpine323-azp-posix-3
+            - name: Alpine 3.24 + group 1
+              test: ansible-test-integration-devel-alpine324-azp-posix-1
+            - name: Alpine 3.24 + group 2
+              test: ansible-test-integration-devel-alpine324-azp-posix-2
+            - name: Alpine 3.24 + group 3
+              test: ansible-test-integration-devel-alpine324-azp-posix-3
             - name: Arch Linux + py3.14 + group 1
               test: ansible-test-integration-devel-archlinux-3.14-azp-posix-1
             - name: Arch Linux + py3.14 + group 2
@@ -355,8 +361,8 @@ stages:
       - template: templates/matrix.yml
         parameters:
           targets:
-            - name: Alpine 3.23 + extra VMs
-              test: ansible-test-integration-devel-alpine-3.23-azp-posix-vm
+            - name: Alpine 3.24 + extra VMs
+              test: ansible-test-integration-devel-alpine-3.24-azp-posix-vm
             - name: macOS 26.3 + group 1
               test: ansible-test-integration-devel-macos-26.3-azp-posix-1
             - name: macOS 26.3 + group 2

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -216,7 +216,7 @@ ansible_core = "2.21"
 target = [ "azp/posix/1/", "azp/posix/2/", "azp/posix/3/" ]
 docker = [
     "fedora43",
-    # "alpine323",
+    "alpine323",
     "ubuntu2204",
     "ubuntu2404",
 ]
@@ -243,7 +243,7 @@ docker = [
     "fedora44",
     "ubuntu2604",
     "ubuntu2404",
-    "alpine323",
+    "alpine324",
 ]
 
 [[sessions.ansible_test_integration.groups.sessions]]
@@ -280,7 +280,7 @@ docker = "quay.io/ansible-community/test-image:archlinux"
 ansible_core = "devel"
 target = [ "azp/posix/vm/" ]
 remote = [
-    "alpine/3.23",
+    "alpine/3.24",
     # "fedora/44",
     "ubuntu/26.04",
     "ubuntu/24.04",

--- a/tests/integration/targets/lvg/aliases
+++ b/tests/integration/targets/lvg/aliases
@@ -11,3 +11,4 @@ skip/macos
 skip/alpine3.21 # TODO try to fix
 skip/alpine3.22 # TODO try to fix
 skip/alpine3.23 # TODO try to fix
+skip/alpine3.24 # TODO try to fix


### PR DESCRIPTION
##### SUMMARY
ansible-core devel bumped its Alpine 3.23 VM/container image to 3.24.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
