### PR TITLE
incus/lxd connection: raise on file transfer error

### DIFF
--- a/changelogs/fragments/12464-incus-lxd-file-transfer-errors.yml
+++ b/changelogs/fragments/12464-incus-lxd-file-transfer-errors.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "incus connection plugin - detect failed ``incus file push``/``incus file pull`` transfers and raise a clear error naming the instance and the CLI stderr, instead of silently reporting success and failing later with a misleading ``chmod: No such file or directory`` error (https://github.com/ansible-collections/community.general/pull/12464)."
+  - "lxd connection plugin - detect failed ``lxc file push``/``lxc file pull`` transfers and raise a clear error naming the instance and the CLI stderr, instead of silently reporting success and failing later with a misleading ``chmod: No such file or directory`` error (https://github.com/ansible-collections/community.general/pull/12464)."

--- a/changelogs/fragments/incus-lxd-file-transfer-errors.yml
+++ b/changelogs/fragments/incus-lxd-file-transfer-errors.yml
@@ -1,3 +1,0 @@
-bugfixes:
-  - "incus connection plugin - detect failed ``incus file push``/``incus file pull`` transfers and raise a clear error naming the instance and the CLI stderr, instead of silently reporting success and failing later with a misleading ``chmod: No such file or directory`` error."
-  - "lxd connection plugin - detect failed ``lxc file push``/``lxc file pull`` transfers and raise a clear error naming the instance and the CLI stderr, instead of silently reporting success and failing later with a misleading ``chmod: No such file or directory`` error."

--- a/changelogs/fragments/incus-lxd-file-transfer-errors.yml
+++ b/changelogs/fragments/incus-lxd-file-transfer-errors.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "incus connection plugin - detect failed ``incus file push``/``incus file pull`` transfers and raise a clear error naming the instance and the CLI stderr, instead of silently reporting success and failing later with a misleading ``chmod: No such file or directory`` error."
+  - "lxd connection plugin - detect failed ``lxc file push``/``lxc file pull`` transfers and raise a clear error naming the instance and the CLI stderr, instead of silently reporting success and failing later with a misleading ``chmod: No such file or directory`` error."

--- a/plugins/connection/incus.py
+++ b/plugins/connection/incus.py
@@ -80,11 +80,11 @@ options:
 import os
 import re
 import shlex
-from subprocess import PIPE, Popen, call
+from subprocess import PIPE, Popen
 
 from ansible.errors import AnsibleConnectionFailure, AnsibleError, AnsibleFileNotFound
 from ansible.module_utils.common.process import get_bin_path
-from ansible.module_utils.common.text.converters import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.plugins.connection import ConnectionBase
 
 
@@ -306,7 +306,13 @@ class Connection(ConnectionBase):
 
         local_cmd = [to_bytes(i, errors="surrogate_or_strict") for i in local_cmd]
 
-        call(local_cmd)
+        process = Popen(local_cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        _stdout, stderr = process.communicate()
+
+        if process.returncode != 0:
+            raise AnsibleError(
+                f"failed to transfer file to instance {self._instance()}: {to_text(stderr).strip()}"
+            )
 
     def fetch_file(self, in_path, out_path):
         """fetch a file from Incus to local"""
@@ -327,7 +333,13 @@ class Connection(ConnectionBase):
 
         local_cmd = [to_bytes(i, errors="surrogate_or_strict") for i in local_cmd]
 
-        call(local_cmd)
+        process = Popen(local_cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        _stdout, stderr = process.communicate()
+
+        if process.returncode != 0:
+            raise AnsibleError(
+                f"failed to transfer file from instance {self._instance()}: {to_text(stderr).strip()}"
+            )
 
     def close(self):
         """close the connection (nothing to do here)"""

--- a/plugins/connection/incus.py
+++ b/plugins/connection/incus.py
@@ -310,9 +310,7 @@ class Connection(ConnectionBase):
         _stdout, stderr = process.communicate()
 
         if process.returncode != 0:
-            raise AnsibleError(
-                f"failed to transfer file to instance {self._instance()}: {to_text(stderr).strip()}"
-            )
+            raise AnsibleError(f"failed to transfer file to instance {self._instance()}: {to_text(stderr).strip()}")
 
     def fetch_file(self, in_path, out_path):
         """fetch a file from Incus to local"""
@@ -337,9 +335,7 @@ class Connection(ConnectionBase):
         _stdout, stderr = process.communicate()
 
         if process.returncode != 0:
-            raise AnsibleError(
-                f"failed to transfer file from instance {self._instance()}: {to_text(stderr).strip()}"
-            )
+            raise AnsibleError(f"failed to transfer file from instance {self._instance()}: {to_text(stderr).strip()}")
 
     def close(self):
         """close the connection (nothing to do here)"""

--- a/plugins/connection/lxd.py
+++ b/plugins/connection/lxd.py
@@ -215,7 +215,12 @@ class Connection(ConnectionBase):
         local_cmd = [to_bytes(i, errors="surrogate_or_strict") for i in local_cmd]
 
         process = Popen(local_cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-        process.communicate()
+        _stdout, stderr = process.communicate()
+
+        if process.returncode != 0:
+            raise AnsibleError(
+                f"failed to transfer file to instance {self._host()}: {to_text(stderr).strip()}"
+            )
 
     def fetch_file(self, in_path, out_path):
         """fetch a file from lxd to local"""
@@ -231,7 +236,12 @@ class Connection(ConnectionBase):
         local_cmd = [to_bytes(i, errors="surrogate_or_strict") for i in local_cmd]
 
         process = Popen(local_cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-        process.communicate()
+        _stdout, stderr = process.communicate()
+
+        if process.returncode != 0:
+            raise AnsibleError(
+                f"failed to transfer file from instance {self._host()}: {to_text(stderr).strip()}"
+            )
 
     def close(self):
         """close the connection (nothing to do here)"""

--- a/plugins/connection/lxd.py
+++ b/plugins/connection/lxd.py
@@ -218,9 +218,7 @@ class Connection(ConnectionBase):
         _stdout, stderr = process.communicate()
 
         if process.returncode != 0:
-            raise AnsibleError(
-                f"failed to transfer file to instance {self._host()}: {to_text(stderr).strip()}"
-            )
+            raise AnsibleError(f"failed to transfer file to instance {self._host()}: {to_text(stderr).strip()}")
 
     def fetch_file(self, in_path, out_path):
         """fetch a file from lxd to local"""
@@ -239,9 +237,7 @@ class Connection(ConnectionBase):
         _stdout, stderr = process.communicate()
 
         if process.returncode != 0:
-            raise AnsibleError(
-                f"failed to transfer file from instance {self._host()}: {to_text(stderr).strip()}"
-            )
+            raise AnsibleError(f"failed to transfer file from instance {self._host()}: {to_text(stderr).strip()}")
 
     def close(self):
         """close the connection (nothing to do here)"""

--- a/tests/unit/plugins/connection/test_incus.py
+++ b/tests/unit/plugins/connection/test_incus.py
@@ -8,6 +8,7 @@ import typing as t
 from io import StringIO
 
 import pytest
+from ansible.errors import AnsibleError
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
 
@@ -284,3 +285,75 @@ def test_build_command(mocker, testcase):
     built = conn._build_command(testcase["input"]["cmd"])
     tc_cmd = cli_preamble + testcase["output"]
     assert built == tc_cmd, f"\n   built = {built}\ntestcase = {tc_cmd}"
+
+
+def _make_conn(mocker):
+    mocker.patch("ansible.module_utils.common.process.get_bin_path").return_value = "/test/bin/incus"
+    play_context = PlayContext()
+    play_context.shell = "sh"
+    conn = connection_loader.get("community.general.incus", play_context, StringIO())
+    conn.set_option("remote_addr", "server1")
+    conn.set_option("remote_user", "root")
+    return conn
+
+
+def test_put_file_transfer_failure(mocker, tmp_path):
+    """A failed ``incus file push`` must raise instead of silently succeeding."""
+    conn = _make_conn(mocker)
+
+    src = tmp_path / "payload"
+    src.write_text("data")
+
+    process = mocker.MagicMock()
+    process.communicate.return_value = (b"", b"Error: not authorized\n")
+    process.returncode = 1
+    mocker.patch("ansible_collections.community.general.plugins.connection.incus.Popen", return_value=process)
+
+    with pytest.raises(AnsibleError) as exc:
+        conn.put_file(str(src), "/tmp/dest")
+
+    assert "failed to transfer file to instance server1" in str(exc.value)
+    assert "Error: not authorized" in str(exc.value)
+
+
+def test_put_file_transfer_success(mocker, tmp_path):
+    """A successful ``incus file push`` must not raise."""
+    conn = _make_conn(mocker)
+
+    src = tmp_path / "payload"
+    src.write_text("data")
+
+    process = mocker.MagicMock()
+    process.communicate.return_value = (b"", b"")
+    process.returncode = 0
+    mocker.patch("ansible_collections.community.general.plugins.connection.incus.Popen", return_value=process)
+
+    conn.put_file(str(src), "/tmp/dest")
+
+
+def test_fetch_file_transfer_failure(mocker):
+    """A failed ``incus file pull`` must raise instead of silently succeeding."""
+    conn = _make_conn(mocker)
+
+    process = mocker.MagicMock()
+    process.communicate.return_value = (b"", b"Error: Instance is not running.\n")
+    process.returncode = 1
+    mocker.patch("ansible_collections.community.general.plugins.connection.incus.Popen", return_value=process)
+
+    with pytest.raises(AnsibleError) as exc:
+        conn.fetch_file("/tmp/src", "/tmp/dest")
+
+    assert "failed to transfer file from instance server1" in str(exc.value)
+    assert "Error: Instance is not running." in str(exc.value)
+
+
+def test_fetch_file_transfer_success(mocker):
+    """A successful ``incus file pull`` must not raise."""
+    conn = _make_conn(mocker)
+
+    process = mocker.MagicMock()
+    process.communicate.return_value = (b"", b"")
+    process.returncode = 0
+    mocker.patch("ansible_collections.community.general.plugins.connection.incus.Popen", return_value=process)
+
+    conn.fetch_file("/tmp/src", "/tmp/dest")


### PR DESCRIPTION
##### SUMMARY
put_file/fetch_file discarded the CLI's return code and stderr, so a failed push surfaced later as a misleading "Failed to set execute bit" chmod error. Check the return code and raise AnsibleError with the instance name and stderr.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
incus

##### ADDITIONAL INFORMATION

before:

```
Error: Failed to open target file "/root/.ansible/tmp/ansible-tmp-1784701710.31.../AnsiballZ_apt.py": file does not exist

fatal: [forgejo-runner-1.hyperion.johnmaguire.me]: FAILED! => {"msg": "Failed to set execute bit on remote files (rc: 1, err: chmod: cannot access '/root/.ansible/tmp/ansible-tmp-1784701710.31.../AnsiballZ_apt.py': No such file or directory\n)"}
```

after:

```
fatal: [forgejo-runner-1.hyperion.johnmaguire.me]: FAILED! => {"msg": "failed to transfer file to instance forgejo-runner-1: Error: Failed to open target file \"/root/.ansible/tmp/ansible-tmp-1784701710.31.../AnsiballZ_apt.py\": file does not exist"}
```
