### PR TITLE
Deprecate the Module for Linode API v3

### DIFF
--- a/changelogs/fragments/12467-deprecate-linode.yml
+++ b/changelogs/fragments/12467-deprecate-linode.yml
@@ -1,2 +1,2 @@
 deprecated_features:
-  - linode - Linode has deprecated its legacy API v3; the module will be removed from community.general 14.0.0. Use ``community.general.linode_v4`` instead (https://github.com/ansible-collections/community.general/pull/12467).
+  - linode - Linode has sunset its legacy API v3; the module will be removed from community.general 14.0.0. Use ``community.general.linode_v4`` instead (https://github.com/ansible-collections/community.general/pull/12467).

--- a/changelogs/fragments/12467-deprecate-linode.yml
+++ b/changelogs/fragments/12467-deprecate-linode.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - linode - Linode has deprecated its legacy API v3; the module will be removed from community.general 14.0.0. Use ``community.general.linode_v4`` instead (https://github.com/ansible-collections/community.general/pull/12467).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -444,6 +444,10 @@ plugin_routing:
       tombstone:
         removal_version: 3.0.0
         warning_text: Use community.general.ldap_attrs instead.
+    linode:
+      deprecation:
+        removal_version: 14.0.0
+        warning_text: The module relies on the deprecated Linode API v3; use community.general.linode_v4 instead.
     logicmonitor:
       tombstone:
         removal_version: 1.0.0

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -447,7 +447,7 @@ plugin_routing:
     linode:
       deprecation:
         removal_version: 14.0.0
-        warning_text: The module relies on the deprecated Linode API v3; use community.general.linode_v4 instead.
+        warning_text: The module relies on the sunset Linode API v3; use community.general.linode_v4 instead.
     logicmonitor:
       tombstone:
         removal_version: 1.0.0

--- a/plugins/modules/linode.py
+++ b/plugins/modules/linode.py
@@ -13,7 +13,7 @@ description:
   - Manage Linode Public Cloud instances and optionally wait for it to be 'running'.
 deprecated:
   removed_in: 14.0.0
-  why: The module relies on Linode's legacy API v3, which has been deprecated by Linode, and on the unmaintained C(linode-python) library.
+  why: The module relies on Linode's legacy API v3, which has been sunset by Linode, and on the unmaintained C(linode-python) library.
   alternative: Use M(community.general.linode_v4) instead, which uses the Linode API v4.
 extends_documentation_fragment:
   - community.general._attributes

--- a/plugins/modules/linode.py
+++ b/plugins/modules/linode.py
@@ -11,6 +11,10 @@ module: linode
 short_description: Manage instances on the Linode Public Cloud
 description:
   - Manage Linode Public Cloud instances and optionally wait for it to be 'running'.
+deprecated:
+  removed_in: 14.0.0
+  why: The module relies on Linode's legacy API v3, which has been deprecated by Linode, and on the unmaintained C(linode-python) library.
+  alternative: Use M(community.general.linode_v4) instead, which uses the Linode API v4.
 extends_documentation_fragment:
   - community.general._attributes
 attributes:


### PR DESCRIPTION
##### SUMMARY
Deprecate the `linode` module, which is based on Linode API v3.

Linode API v3 has long since been sunset by Linode and the module's client library (`linode-python`) is unmaintained, so the module cannot work anymore. Following maintainer feedback below, this deprecates the module with a short deprecation period instead of removing it right away — removal is planned for community.general 14.0.0, matching the `layman` (#11070) and `jboss` (#11457) deprecations.

- Add a `deprecated:` block to the module's `DOCUMENTATION` (`removed_in: 14.0.0`)
- Add a `deprecation:` entry for the module in `meta/runtime.yml`, so ansible-core emits a runtime warning when the module is used
- Add a `deprecated_features` changelog fragment

The API v4 based `community.general.linode_v4` module and the `community.general.linode` inventory plugin (both built on `linode_api4`) are unaffected by this change.

##### COMPONENT NAME
linode

##### ADDITIONAL INFORMATION
Originally proposed as a direct removal; reworked as a deprecation per https://github.com/ansible-collections/community.general/pull/12467#issuecomment-5062465269. The actual removal (deleting the files and turning the `meta/runtime.yml` entry into a `tombstone`) can then be done in a separate PR for 14.0.0.