### PR TITLE
Ansible-lint: use command instead of shell if possible

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -17,7 +17,6 @@ skip_list:
   - args
   - avoid-implicit
   - command-instead-of-module
-  - command-instead-of-shell
   - complexity
   - fqcn
   - galaxy

--- a/tests/integration/targets/alternatives/tasks/test.yml
+++ b/tests/integration/targets/alternatives/tasks/test.yml
@@ -36,7 +36,7 @@
   when: not with_link
 
 - name: execute dummy command
-  ansible.builtin.shell: dummy
+  ansible.builtin.command: dummy
   register: cmd
 
 - name: check expected command was executed

--- a/tests/integration/targets/alternatives/tasks/tests_family.yml
+++ b/tests/integration/targets/alternatives/tasks/tests_family.yml
@@ -13,7 +13,7 @@
     state: selected
 
 - name: Ensure that the alternative has family assigned
-  ansible.builtin.shell: 'grep family1 {{ alternatives_dir }}/dummy'
+  ansible.builtin.command: 'grep family1 {{ alternatives_dir }}/dummy'
 
 - name: Add two alternatives with different families
   alternatives:
@@ -39,7 +39,7 @@
   ansible.builtin.shell: 'head -n1 {{ alternatives_dir }}/dummy | grep "^manual"'
 
 - name: Execute the current dummy command
-  ansible.builtin.shell: dummy
+  ansible.builtin.command: dummy
   register: cmd
 
 # Despite the fact that there is alternative with higher priority (/usr/bin/dummy1),
@@ -56,7 +56,7 @@
     state: absent
 
 - name: Execute the current dummy command
-  ansible.builtin.shell: dummy
+  ansible.builtin.command: dummy
   register: cmd
 
 - name: Ensure that the next alternative is selected as having the highest priority from the family

--- a/tests/integration/targets/alternatives/tasks/tests_set_priority.yml
+++ b/tests/integration/targets/alternatives/tasks/tests_set_priority.yml
@@ -12,7 +12,7 @@
   register: alternative
 
 - name: execute dummy command
-  ansible.builtin.shell: dummy
+  ansible.builtin.command: dummy
   register: cmd
 
 - name: check if link group is in manual mode

--- a/tests/integration/targets/alternatives/tasks/tests_state.yml
+++ b/tests/integration/targets/alternatives/tasks/tests_state.yml
@@ -22,7 +22,7 @@
 
 # Execute current selected 'dummy' and ensure it's the alternative we expect
 - name: Execute the current dummy command
-  ansible.builtin.shell: dummy
+  ansible.builtin.command: dummy
   register: cmd
 
 - name: Ensure that the expected command was executed
@@ -45,7 +45,7 @@
   ansible.builtin.shell: 'head -n1 {{ alternatives_dir }}/dummy | grep "^manual$"'
 
 - name: Execute the current dummy command
-  ansible.builtin.shell: dummy
+  ansible.builtin.command: dummy
   register: cmd
 
 - name: Ensure that the expected command was executed
@@ -67,7 +67,7 @@
   ansible.builtin.shell: 'head -n1 {{ alternatives_dir }}/dummy | grep "^manual$"'
 
 - name: Execute the current dummy command
-  ansible.builtin.shell: dummy
+  ansible.builtin.command: dummy
   register: cmd
 
 - name: Ensure that the expected command was executed
@@ -89,7 +89,7 @@
   ansible.builtin.shell: 'head -n1 {{ alternatives_dir }}/dummy | grep "^auto$"'
 
 - name: Execute the current dummy command
-  ansible.builtin.shell: dummy
+  ansible.builtin.command: dummy
   register: cmd
 
 - name: Ensure that the expected command was executed
@@ -106,12 +106,12 @@
     state: absent
 
 - name: Ensure that the link group is in auto mode
-  ansible.builtin.shell: 'grep "/usr/bin/dummy2" {{ alternatives_dir }}/dummy'
+  ansible.builtin.command: 'grep "/usr/bin/dummy2" {{ alternatives_dir }}/dummy'
   register: cmd
   failed_when: cmd.rc == 0
 
 - name: Execute the current dummy command
-  ansible.builtin.shell: dummy
+  ansible.builtin.command: dummy
   register: cmd
 
 - name: Ensure that the expected command was executed

--- a/tests/integration/targets/cronvar/tasks/main.yml
+++ b/tests/integration/targets/cronvar/tasks/main.yml
@@ -131,7 +131,7 @@
     state: present
 
 - name: Assert empty var present
-  ansible.builtin.shell: crontab -l
+  ansible.builtin.command: crontab -l
   register: result
   changed_when: false
 

--- a/tests/integration/targets/filesystem/tasks/create_fs.yml
+++ b/tests/integration/targets/filesystem/tasks/create_fs.yml
@@ -17,7 +17,7 @@
       - 'fs_result is success'
 
 - name: "Get UUID of created filesystem"
-  ansible.builtin.shell:
+  ansible.builtin.shell:  # noqa: command-instead-of-shell
     cmd: "{{ get_uuid_cmd }}"
   changed_when: false
   register: uuid
@@ -30,7 +30,7 @@
   register: fs2_result
 
 - name: "Get UUID of the filesystem"
-  ansible.builtin.shell:
+  ansible.builtin.shell:  # noqa: command-instead-of-shell
     cmd: "{{ get_uuid_cmd }}"
   changed_when: false
   register: uuid2
@@ -51,7 +51,7 @@
   register: fs3_result
 
 - name: "Get UUID of the new filesystem"
-  ansible.builtin.shell:
+  ansible.builtin.shell:  # noqa: command-instead-of-shell
     cmd: "{{ get_uuid_cmd }}"
   changed_when: false
   register: uuid3
@@ -91,7 +91,7 @@
       register: fs4_result
 
     - name: "Get UUID of the filesystem"
-      ansible.builtin.shell:
+      ansible.builtin.shell:  # noqa: command-instead-of-shell
         cmd: "{{ get_uuid_cmd }}"
       changed_when: false
       register: uuid4

--- a/tests/integration/targets/filesystem/tasks/overwrite_another_fs.yml
+++ b/tests/integration/targets/filesystem/tasks/overwrite_another_fs.yml
@@ -14,7 +14,7 @@
     cmd: 'mkfs.minix {{ dev }}'
 
 - name: 'Get UUID of the new filesystem'
-  ansible.builtin.shell:
+  ansible.builtin.shell:  # noqa: command-instead-of-shell
     cmd: "{{ get_uuid_cmd }}"
   changed_when: false
   register: uuid
@@ -28,7 +28,7 @@
   ignore_errors: true
 
 - name: 'Get UUID of the filesystem'
-  ansible.builtin.shell:
+  ansible.builtin.shell:  # noqa: command-instead-of-shell
     cmd: "{{ get_uuid_cmd }}"
   changed_when: false
   register: uuid2
@@ -48,7 +48,7 @@
   register: fs_result2
 
 - name: 'Get UUID of the new filesystem'
-  ansible.builtin.shell:
+  ansible.builtin.shell:  # noqa: command-instead-of-shell
     cmd: "{{ get_uuid_cmd }}"
   changed_when: false
   register: uuid3

--- a/tests/integration/targets/filesystem/tasks/remove_fs.yml
+++ b/tests/integration/targets/filesystem/tasks/remove_fs.yml
@@ -12,7 +12,7 @@
     label: '{{ label }}'
 
 - name: "Get filesystem UUID with 'blkid'"
-  ansible.builtin.shell:
+  ansible.builtin.shell:  # noqa: command-instead-of-shell
     cmd: "{{ get_uuid_cmd }}"
   changed_when: false
   register: blkid_ref
@@ -32,7 +32,7 @@
   check_mode: true
 
 - name: "Get filesystem UUID with 'blkid' (should remain the same)"
-  ansible.builtin.shell:
+  ansible.builtin.shell:  # noqa: command-instead-of-shell
     cmd: "{{ get_uuid_cmd }}"
   changed_when: false
   register: blkid
@@ -51,7 +51,7 @@
   register: wipefs
 
 - name: "Get filesystem UUID with 'blkid' (should be empty)"
-  ansible.builtin.shell:
+  ansible.builtin.shell:  # noqa: command-instead-of-shell
     cmd: "{{ get_uuid_cmd }}"
   changed_when: false
   failed_when: false

--- a/tests/integration/targets/filesystem/tasks/reset_fs_uuid.yml
+++ b/tests/integration/targets/filesystem/tasks/reset_fs_uuid.yml
@@ -15,7 +15,7 @@
       register: fs_result
 
     - name: "Get UUID of created filesystem"
-      ansible.builtin.shell:
+      ansible.builtin.shell:  # noqa: command-instead-of-shell
         cmd: "{{ get_uuid_cmd }}"
       changed_when: false
       register: uuid
@@ -28,7 +28,7 @@
       register: fs_resetuuid_result
 
     - name: "Get UUID of the filesystem"
-      ansible.builtin.shell:
+      ansible.builtin.shell:  # noqa: command-instead-of-shell
         cmd: "{{ get_uuid_cmd }}"
       changed_when: false
       register: uuid2

--- a/tests/integration/targets/filesystem/tasks/set_fs_uuid_on_creation.yml
+++ b/tests/integration/targets/filesystem/tasks/set_fs_uuid_on_creation.yml
@@ -20,7 +20,7 @@
       register: fs_result
 
     - name: "Get UUID of the created filesystem"
-      ansible.builtin.shell:
+      ansible.builtin.shell:  # noqa: command-instead-of-shell
         cmd: "{{ get_uuid_cmd }}"
       changed_when: false
       register: uuid

--- a/tests/integration/targets/filesystem/tasks/set_fs_uuid_on_creation_with_opts.yml
+++ b/tests/integration/targets/filesystem/tasks/set_fs_uuid_on_creation_with_opts.yml
@@ -23,7 +23,7 @@
       register: fs_result2
 
     - name: "Get UUID of the created filesystem"
-      ansible.builtin.shell:
+      ansible.builtin.shell:  # noqa: command-instead-of-shell
         cmd: "{{ get_uuid_cmd }}"
       changed_when: false
       register: uuid2

--- a/tests/integration/targets/hg/tasks/run-tests.yml
+++ b/tests/integration/targets/hg/tasks/run-tests.yml
@@ -10,10 +10,10 @@
     checkout_dir: "{{ remote_tmp_dir }}/hg_project_test"
 
 - name: clean out the remote_tmp_dir
-  ansible.builtin.shell: rm -rf "{{ checkout_dir }}"
+  ansible.builtin.command: rm -rf "{{ checkout_dir }}"
 
 - name: verify that mercurial is installed so this test can continue
-  ansible.builtin.shell: which hg
+  ansible.builtin.command: which hg
 
 - name: initial checkout
   hg:
@@ -21,7 +21,7 @@
     dest: "{{ checkout_dir }}"
   register: hg_result
 
-- ansible.builtin.shell: ls {{ checkout_dir }}
+- ansible.builtin.command: ls {{ checkout_dir }}
 
 - name: verify information about the initial clone
   ansible.builtin.assert:

--- a/tests/integration/targets/hg/tasks/uninstall.yml
+++ b/tests/integration/targets/hg/tasks/uninstall.yml
@@ -30,7 +30,7 @@
 
 # the yum module does not have an autoremove parameter
 - name: uninstall packages which were not originally installed (yum)
-  ansible.builtin.shell: yum -y autoremove mercurial
+  ansible.builtin.command: yum -y autoremove mercurial
   when: ansible_facts.pkg_mgr == 'yum'
 
 - name: uninstall packages which were not originally installed

--- a/tests/integration/targets/lvm_pv/tasks/resizing.yml
+++ b/tests/integration/targets/lvm_pv/tasks/resizing.yml
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Growing the loop device file to 100MB
-  ansible.builtin.shell: truncate -s 100M {{ remote_tmp_dir }}/test_lvm_pv.img
+  ansible.builtin.command: truncate -s 100M {{ remote_tmp_dir }}/test_lvm_pv.img
 
 - name: Refreshing the loop device
-  ansible.builtin.shell: losetup -c {{ loop_device.stdout }}
+  ansible.builtin.command: losetup -c {{ loop_device.stdout }}
 
 - name: Resizing the physical volume
   community.general.lvm_pv:

--- a/tests/integration/targets/lvm_pv_move_data/tasks/moving.yml
+++ b/tests/integration/targets/lvm_pv_move_data/tasks/moving.yml
@@ -9,10 +9,10 @@
     creates: "{{ remote_tmp_dir }}/tmp_mount/test_file"
 
 - name: Growing the second loop device file to 1500MB
-  ansible.builtin.shell: truncate -s 1500M {{ remote_tmp_dir }}/test_lvm_pv_02.img
+  ansible.builtin.command: truncate -s 1500M {{ remote_tmp_dir }}/test_lvm_pv_02.img
 
 - name: Refreshing the second loop device
-  ansible.builtin.shell: losetup -c {{ loop_device_02.stdout }}
+  ansible.builtin.command: losetup -c {{ loop_device_02.stdout }}
 
 - name: Resizing the second physical volume
   community.general.lvm_pv:

--- a/tests/integration/targets/mail/tasks/main.yml
+++ b/tests/integration/targets/mail/tasks/main.yml
@@ -35,7 +35,7 @@
     # FIXME: Verify the mail after it was send would be nice
     #        This would require either dumping the content, or registering async task output
     - name: Start test smtpserver
-      ansible.builtin.shell: '{{ ansible_facts.python.executable }} {{ remote_tmp_dir }}/smtpserver.py 10025:10465'
+      ansible.builtin.command: '{{ ansible_facts.python.executable }} {{ remote_tmp_dir }}/smtpserver.py 10025:10465'
       async: 45
       poll: 0
       register: smtpserver

--- a/tests/integration/targets/monit/tasks/test_reload_present.yml
+++ b/tests/integration/targets/monit/tasks/test_reload_present.yml
@@ -31,7 +31,7 @@
   failed_when: result is not skip and result is success
 
 - name: start process
-  ansible.builtin.shell: "{{ process_run_cmd }}"
+  ansible.builtin.command: "{{ process_run_cmd }}"
 
 - ansible.builtin.import_tasks: check_state.yml
   vars:

--- a/tests/integration/targets/nomad/tasks/main.yml
+++ b/tests/integration/targets/nomad/tasks/main.yml
@@ -75,4 +75,4 @@
   always:
 
     - name: kill nomad
-      ansible.builtin.shell: pkill nomad
+      ansible.builtin.command: pkill nomad

--- a/tests/integration/targets/npm/tasks/no_bin_links.yml
+++ b/tests/integration/targets/npm/tasks/no_bin_links.yml
@@ -13,7 +13,7 @@
     node_path: '{{ remote_dir }}/{{ nodejs_path }}/bin'
     package: 'ncp'
   block:
-    - ansible.builtin.shell: npm --version
+    - ansible.builtin.command: npm --version
       environment:
         PATH: '{{ node_path }}:{{ ansible_facts.env.PATH }}'
       register: npm_version

--- a/tests/integration/targets/npm/tasks/test.yml
+++ b/tests/integration/targets/npm/tasks/test.yml
@@ -15,7 +15,7 @@
   environment:
     PATH: '{{ node_path }}:{{ ansible_facts.env.PATH }}'
   block:
-    - ansible.builtin.shell: npm --version
+    - ansible.builtin.command: npm --version
       register: npm_version
 
     - ansible.builtin.debug:

--- a/tests/integration/targets/pkgng/tasks/setup-testjail.yml
+++ b/tests/integration/targets/pkgng/tasks/setup-testjail.yml
@@ -66,7 +66,7 @@
 
 - name: Setup ezjail base
   when: not ezjail_base_jail.stat.exists
-  ansible.builtin.shell: "ezjail-admin install {{ pkgng_jail_log_redirect }}"
+  ansible.builtin.command: "ezjail-admin install {{ pkgng_jail_log_redirect }}"
   changed_when: false
 
 - name: Has testjail
@@ -76,7 +76,7 @@
 
 - name: Create testjail
   when: not ezjail_test_jail.stat.exists
-  ansible.builtin.shell: "ezjail-admin create testjail 'lo1|127.0.1.1' {{ pkgng_jail_log_redirect }}"
+  ansible.builtin.command: "ezjail-admin create testjail 'lo1|127.0.1.1' {{ pkgng_jail_log_redirect }}"
   changed_when: false
 
 - name: Configure testjail to use Cloudflare DNS

--- a/tests/integration/targets/setup_openldap/tasks/main.yml
+++ b/tests/integration/targets/setup_openldap/tasks/main.yml
@@ -76,7 +76,7 @@
         - ldap_inc_config.ldif
 
     - name: Configure admin password for cn=config
-      ansible.builtin.shell: "ldapmodify -Y EXTERNAL -H ldapi:/// -f /tmp/{{ item }}"
+      ansible.builtin.command: "ldapmodify -Y EXTERNAL -H ldapi:/// -f /tmp/{{ item }}"
       loop:
         - rootpw_cnconfig.ldif
         - cert_cnconfig.ldif
@@ -84,7 +84,7 @@
 
     - name: Add initial config
       become: true
-      ansible.builtin.shell: 'ldapadd -H ldapi:/// -x -D "cn=admin,dc=example,dc=com" -w Test1234! -f /tmp/{{ item }}'
+      ansible.builtin.command: 'ldapadd -H ldapi:/// -x -D "cn=admin,dc=example,dc=com" -w Test1234! -f /tmp/{{ item }}'
       loop:
         - initial_config.ldif
         - ldap_inc_config.ldif

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -43,7 +43,7 @@
   when: ansible_facts.service_mgr == 'systemd' and ansible_facts.distribution == 'Fedora'
 
 - name: Kill all postgres processes
-  ansible.builtin.shell: 'pkill -u {{ pg_user }}'
+  ansible.builtin.command: 'pkill -u {{ pg_user }}'
   become: true
   when: ansible_facts.distribution == 'CentOS' and ansible_facts.distribution_major_version == '8'
   ignore_errors: true
@@ -223,7 +223,7 @@
     seconds: 5
 
 - name: Kill all postgres processes
-  ansible.builtin.shell: 'pkill -u {{ pg_user }}'
+  ansible.builtin.command: 'pkill -u {{ pg_user }}'
   become: true
   when: ansible_facts.distribution == 'CentOS' and ansible_facts.distribution_major_version == '8'
   ignore_errors: true

--- a/tests/integration/targets/sysrc/tasks/main.yml
+++ b/tests/integration/targets/sysrc/tasks/main.yml
@@ -9,11 +9,11 @@
     - ansible_facts.distribution == 'FreeBSD'
   block:
     - name: Cache original contents of /etc/rc.conf
-      ansible.builtin.shell: "cat /etc/rc.conf"
+      ansible.builtin.command: "cat /etc/rc.conf"
       register: cached_etc_rcconf_content
 
     - name: Cache original contents of /boot/loader.conf
-      ansible.builtin.shell: "cat /boot/loader.conf"
+      ansible.builtin.command: "cat /boot/loader.conf"
       register: cached_boot_loaderconf_content
 
     ##
@@ -409,7 +409,7 @@
       register: sysrc_10394_changed
 
     - name: Get file content
-      ansible.builtin.shell: "cat /tmp/10394.conf"
+      ansible.builtin.command: "cat /tmp/10394.conf"
       register: sysrc_10394_content
 
     - name: Ensure sysrc changed k1 from v1 to v2

--- a/tests/integration/targets/timezone/tasks/test.yml
+++ b/tests/integration/targets/timezone/tasks/test.yml
@@ -91,7 +91,7 @@
 ##
 
 - name: check dpkg-reconfigure
-  ansible.builtin.command: type dpkg-reconfigure
+  ansible.builtin.shell: type dpkg-reconfigure  # noqa: command-instead-of-shell
   register: check_dpkg_reconfigure
   ignore_errors: true
   changed_when: false

--- a/tests/integration/targets/timezone/tasks/test.yml
+++ b/tests/integration/targets/timezone/tasks/test.yml
@@ -91,7 +91,7 @@
 ##
 
 - name: check dpkg-reconfigure
-  ansible.builtin.shell: type dpkg-reconfigure
+  ansible.builtin.command: type dpkg-reconfigure
   register: check_dpkg_reconfigure
   ignore_errors: true
   changed_when: false

--- a/tests/integration/targets/yarn/tasks/tests.yml
+++ b/tests/integration/targets/yarn/tasks/tests.yml
@@ -11,7 +11,7 @@
   block:
 
     # Get the version of Yarn and register to a variable
-    - ansible.builtin.shell: '{{ yarn_bin_path }}/yarn --version'
+    - ansible.builtin.command: '{{ yarn_bin_path }}/yarn --version'
       environment:
         PATH: '{{ node_bin_path }}:{{ ansible_facts.env.PATH }}'
       register: yarn_installed_version

--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -34,7 +34,7 @@
   register: zypper_result
 
 - name: check hello with rpm
-  ansible.builtin.shell: rpm -q hello
+  ansible.builtin.command: rpm -q hello
   failed_when: false
   register: rpm_result
 
@@ -69,7 +69,7 @@
   register: zypper_result
 
 - name: check hello with rpm
-  ansible.builtin.shell: rpm -q hello
+  ansible.builtin.command: rpm -q hello
   failed_when: false
   register: rpm_result
 
@@ -107,12 +107,12 @@
   register: zypper_result
 
 - name: check hello with rpm
-  ansible.builtin.shell: rpm -q hello
+  ansible.builtin.command: rpm -q hello
   failed_when: false
   register: rpm_hello_result
 
 - name: check metamail with rpm
-  ansible.builtin.shell: rpm -q metamail
+  ansible.builtin.command: rpm -q metamail
   failed_when: false
   register: rpm_metamail_result
 
@@ -131,12 +131,12 @@
   register: zypper_result
 
 - name: check hello with rpm
-  ansible.builtin.shell: rpm -q hello
+  ansible.builtin.command: rpm -q hello
   failed_when: false
   register: rpm_hello_result
 
 - name: check metamail with rpm
-  ansible.builtin.shell: rpm -q metamail
+  ansible.builtin.command: rpm -q metamail
   failed_when: false
   register: rpm_metamail_result
 
@@ -241,7 +241,7 @@
   register: zypper_result
 
 - name: check empty with rpm
-  ansible.builtin.shell: rpm -q empty
+  ansible.builtin.command: rpm -q empty
   failed_when: false
   register: rpm_result
 
@@ -319,7 +319,7 @@
   register: zypper_result
 
 - name: check post_error rpm
-  ansible.builtin.shell: rpm -q post_error
+  ansible.builtin.command: rpm -q post_error
   failed_when: false
   register: rpm_result
 
@@ -343,7 +343,7 @@
   ignore_errors: true
 
 - name: check post_error rpm
-  ansible.builtin.shell: rpm -q post_error
+  ansible.builtin.command: rpm -q post_error
   failed_when: false
   register: rpm_result
 


### PR DESCRIPTION
##### SUMMARY
This enables the `command-instead-of-shell` rule.

There are some false positives, where the whole shell command is templated. The command in question can have a pipe (depending on the platform), therefore I had to use `noqa` to disable the rule locally.

Follow-up to #11979.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
