### PR TITLE
12478 keycloak_realm: Control whether undefined realm attributes are pruned

### DIFF
--- a/changelogs/fragments/12478-keycloak_realm-control-pruning-of-undefined-realm-attributes.yml
+++ b/changelogs/fragments/12478-keycloak_realm-control-pruning-of-undefined-realm-attributes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak_realm - add parameter prune_undefined_realm_attributes to control whether undefined realm attributes get pruned (https://github.com/ansible-collections/community.general/issues/12478, https://github.com/ansible-collections/community.general/pull/12479/).

--- a/plugins/modules/keycloak_realm.py
+++ b/plugins/modules/keycloak_realm.py
@@ -435,6 +435,13 @@ options:
     aliases:
       - permanentLockout
     type: bool
+  prune_undefined_realm_attributes:
+    description:
+      - If True all realm attributes which are not defined in the attributes dict will be deleted
+    aliases:
+      - pruneUndefinedRealmAttributes
+    type: bool
+    default: true
   quick_login_check_milli_seconds:
     description:
       - The realm quick login check in milliseconds.
@@ -839,6 +846,9 @@ from ansible_collections.community.general.plugins.module_utils._keycloak import
     get_token,
     keycloak_argument_spec,
 )
+from ansible_collections.community.general.plugins.module_utils._keycloak_utils import (
+    merge_settings_without_absent_nulls,
+)
 
 
 def normalise_cr(realmrep):
@@ -961,6 +971,7 @@ def main():
         password_policy=dict(type="str", aliases=["passwordPolicy"], no_log=False),
         organizations_enabled=dict(type="bool", aliases=["organizationsEnabled"]),
         permanent_lockout=dict(type="bool", aliases=["permanentLockout"]),
+        prune_undefined_realm_attributes=dict(type="bool", aliases=["pruneUndefinedRealmAttributes"], default=True),
         quick_login_check_milli_seconds=dict(type="int", aliases=["quickLoginCheckMilliSeconds"]),
         refresh_token_max_reuse=dict(type="int", aliases=["refreshTokenMaxReuse"], no_log=False),
         registration_allowed=dict(type="bool", aliases=["registrationAllowed"]),
@@ -1072,9 +1083,10 @@ def main():
 
     realm = module.params.get("realm")
     state = module.params.get("state")
+    prune_undefined_realm_attributes = module.params.get("prune_undefined_realm_attributes")
 
     # convert module parameters to realm representation parameters (if they belong in there)
-    params_to_ignore = list(keycloak_argument_spec().keys()) + ["state"]
+    params_to_ignore = list(keycloak_argument_spec().keys()) + ["state", "prune_undefined_realm_attributes"]
 
     # Filter and map the parameters names that apply to the role
     realm_params = [x for x in module.params if x not in params_to_ignore and module.params.get(x) is not None]
@@ -1090,6 +1102,9 @@ def main():
 
     for realm_param in realm_params:
         new_param_value = module.params.get(realm_param)
+        if camel(realm_param) == "attributes" and not prune_undefined_realm_attributes:
+            new_param_value = merge_settings_without_absent_nulls(before_realm.get("attributes"), new_param_value)
+
         changeset[camel(realm_param)] = new_param_value
 
     # Prepare the desired values using the existing values (non-existence results in a dict that is save to use as a basis)

--- a/tests/integration/targets/keycloak_realm/tasks/main.yml
+++ b/tests/integration/targets/keycloak_realm/tasks/main.yml
@@ -96,3 +96,90 @@
       - result.end_state.clientOfflineSessionMaxLifespan == 200
       - result.end_state.oauth2DeviceCodeLifespan == 700
       - result.end_state.oauth2DevicePollingInterval == 800
+
+- name: Modify realm attributes without pruning undefined attributes. Step 1 - Introduce custom realm attributes
+  community.general.keycloak_realm:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    id: "{{ realm }}"
+    realm: "{{ realm }}"
+    prune_undefined_realm_attributes: false
+    state: present
+    attributes:
+      custom-realm-attribute-1: 123
+      custom-realm-attribute-2: true
+  register: result
+
+- name: Assert realm attribute without pruning undefined data result (Step 1)
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.end_state.attributes["custom-realm-attribute-1"] == "123"
+      - result.end_state.attributes["custom-realm-attribute-2"] == "true"
+
+- name: Modify realm attributes without pruning undefined attributes. Step 2 - Verify unchanged custom realm attributes
+  community.general.keycloak_realm:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    id: "{{ realm }}"
+    realm: "{{ realm }}"
+    prune_undefined_realm_attributes: false
+    state: present
+    attributes:
+      custom-realm-attribute-2: false
+  register: result
+
+- name: Assert realm attribute without pruning undefined data result (Step 2)
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.end_state.attributes["custom-realm-attribute-1"] == "123" # should still be 123
+      - result.end_state.attributes["custom-realm-attribute-2"] == "false"
+
+- name: Modify realm attributes with pruning undefined attributes
+  community.general.keycloak_realm:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    id: "{{ realm }}"
+    realm: "{{ realm }}"
+    prune_undefined_realm_attributes: true
+    state: present
+    attributes:
+      custom-realm-attribute-3: custom-attribute-3
+  register: result
+
+- name: Assert realm attribute with pruning undefined data result
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.end_state.attributes["custom-realm-attribute-1"] is not defined
+      - result.end_state.attributes["custom-realm-attribute-2"] is not defined
+      - result.end_state.attributes["custom-realm-attribute-3"] == "custom-attribute-3"
+
+- name: Modify realm attributes prunes undefined attributes by default
+  community.general.keycloak_realm:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    id: "{{ realm }}"
+    realm: "{{ realm }}"
+    state: present
+    attributes:
+      custom-realm-attribute-4: custom-attribute-4
+  register: result
+
+- name: Assert realm attribute with pruning undefined data result
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.end_state.attributes["custom-realm-attribute-1"] is not defined
+      - result.end_state.attributes["custom-realm-attribute-2"] is not defined
+      - result.end_state.attributes["custom-realm-attribute-3"] is not defined
+      - result.end_state.attributes["custom-realm-attribute-4"] == "custom-attribute-4"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
See https://github.com/ansible-collections/community.general/issues/12478

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_realm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
