### PR TITLE
new module: packer manages HashiCorp Packer builds

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1143,6 +1143,8 @@ files:
   $modules/pacman_key.py:
     labels: pacman
     maintainers: grawlinson
+  $modules/packer.py:
+      maintainers: a-gabidullin    
   $modules/pagerduty.py:
     ignore: bpennypacker
     labels: pagerduty

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1144,7 +1144,7 @@ files:
     labels: pacman
     maintainers: grawlinson
   $modules/packer.py:
-      maintainers: a-gabidullin
+    maintainers: a-gabidullin
   $modules/pagerduty.py:
     ignore: bpennypacker
     labels: pagerduty

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1143,6 +1143,8 @@ files:
   $modules/pacman_key.py:
     labels: pacman
     maintainers: grawlinson
+  $modules/packer.py:
+    maintainers: a-gabidullin
   $modules/pagerduty.py:
     ignore: bpennypacker
     labels: pagerduty

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1144,7 +1144,7 @@ files:
     labels: pacman
     maintainers: grawlinson
   $modules/packer.py:
-      maintainers: a-gabidullin    
+      maintainers: a-gabidullin
   $modules/pagerduty.py:
     ignore: bpennypacker
     labels: pagerduty

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -507,63 +507,59 @@ class PackerModule:
         cmd = self._build_command(command)
         self.result["cmd"] = " ".join(cmd)
 
-        env = os.environ.copy()
-        env.update(self.env_vars)
         cwd = self.chdir or os.getcwd()
 
+        old_env = os.environ.copy()
         try:
-            start_time = datetime.now(timezone.utc).isoformat() + "Z"
+            os.environ.update(self.env_vars)
 
-            # Для передачи окружения используем параметр environ, а не env
             rc, stdout, stderr = self.module.run_command(
                 cmd,
                 cwd=cwd,
-                environ=env,  # <-- замените env на environ
                 timeout=self.timeout if self.timeout > 0 else None,
                 check_rc=False,
             )
+        finally:
+            os.environ.clear()
+            os.environ.update(old_env)
 
-            self.build_output = stdout
+        self.build_output = stdout
 
-            artifacts = []
-            artifacts_count = 0
-            if command == "build" and rc == 0:
-                artifacts = self._parse_build_output(stdout)
-                artifacts_count = len(artifacts)
+        start_time = datetime.now(timezone.utc).isoformat() + "Z"
 
+        artifacts = []
+        artifacts_count = 0
+        if command == "build" and rc == 0:
+            artifacts = self._parse_build_output(stdout)
+            artifacts_count = len(artifacts)
+
+        changed = False
+        if command == "build":
+            changed = True
+        elif command == "fmt":
+            changed = rc == 0 and stdout != ""
+        elif command in ["validate", "inspect"]:
             changed = False
-            if command == "build":
-                changed = True
-            elif command == "fmt":
-                changed = rc == 0 and stdout != ""
-            elif command in ["validate", "inspect"]:
-                changed = False
 
-            result_dict = {
-                "changed": changed,
-                "stdout": stdout,
-                "stderr": stderr,
-                "rc": rc,
-                "cmd": " ".join(cmd),
-                "packer_version": self._check_packer_version(),
-            }
+        result_dict = {
+            "changed": changed,
+            "stdout": stdout,
+            "stderr": stderr,
+            "rc": rc,
+            "cmd": " ".join(cmd),
+            "packer_version": self._check_packer_version(),
+        }
 
-            if command == "build":
-                result_dict["started"] = start_time
-                result_dict["artifacts"] = artifacts
-                result_dict["artifacts_count"] = artifacts_count
+        if command == "build":
+            result_dict["started"] = start_time
+            result_dict["artifacts"] = artifacts
+            result_dict["artifacts_count"] = artifacts_count
 
-            if rc != 0:
-                result_dict["failed"] = True
-                self.module.fail_json(msg="Packer command failed", **result_dict)
-            else:
-                return result_dict
+        if rc != 0:
+            result_dict["failed"] = True
+            self.module.fail_json(msg="Packer command failed", **result_dict)
 
-        except Exception as e:
-            self.module.fail_json(
-                msg=f"Error executing Packer: {to_native(e)}",
-                cmd=" ".join(cmd),
-            )
+        return result_dict
 
     def _should_build(self) -> bool:
         """Determine if we need to build based on state and artifact existence."""

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -18,7 +18,7 @@ requirements:
   - packer >= 1.7.0
 attributes:
   check_mode:
-    description: In check_mode, validates the template instead of building.
+    description: In check_mode, runs C(packer validate) instead of building.
     support: full
 options:
   name:
@@ -200,6 +200,7 @@ build_start_timestamp:
 
 import os
 import re
+import shlex
 from datetime import datetime, timezone
 
 from ansible.module_utils.basic import AnsibleModule
@@ -234,7 +235,7 @@ class PackerModule:
         self.cleanup = self.params["cleanup"]
         self.log_level = self.params["log_level"]
 
-    def _check_packer_version(self) -> str:
+    def get_packer_version(self) -> str:
         """Get Packer version using module.run_command."""
         try:
             rc, stdout, _stderr = self.module.run_command(
@@ -246,12 +247,11 @@ class PackerModule:
                 match = re.search(r"(\d+\.\d+\.\d+)", version_line)
                 if match:
                     return match.group(1)
-                return version_line.strip()
             return "unknown"
         except Exception:
             return "unknown"
 
-    def _validate_parameters(self) -> None:
+    def validate_parameters(self) -> None:
         """Validate module parameters."""
         if self.template and not os.path.exists(self.template):
             self.module.fail_json(msg=f"Template file/directory does not exist: {self.template}")
@@ -260,8 +260,7 @@ class PackerModule:
             if not os.path.exists(var_file):
                 self.module.fail_json(msg=f"Variable file does not exist: {var_file}")
 
-    def _build_command(self, command: str) -> list[str]:
-        """Build the Packer command line."""
+    def build_command(self, command: str) -> list[str]:
         cmd = [self.packer_bin]
 
         if self.log_level != "info":
@@ -279,31 +278,27 @@ class PackerModule:
                 cmd.append("-parallel=false")
             if self.cleanup:
                 cmd.append("-cleanup")
+            if self.only:
+                cmd.extend(["-only", ",".join(self.only)])
+            if self.except_builders:
+                cmd.extend(["-except", ",".join(self.except_builders)])
 
-        if command != "init":
+        if command in ["build", "validate"]:
             if not self.color:
                 cmd.append("-no-color")
             if self.machine_readable:
                 cmd.append("-machine-readable")
 
-        if command in ["build", "validate"]:
             for key, value in self.variables.items():
-                if isinstance(value, str) and (" " in value or '"' in value):
-                    cmd.extend(["-var", f'{key}="{value}"'])
-                else:
-                    cmd.extend(["-var", f"{key}={value}"])
+                quoted_value = shlex.quote(str(value))
+                cmd.extend(["-var", f"{key}={quoted_value}"])
 
             for var_file in self.var_files:
                 cmd.extend(["-var-file", var_file])
 
-        if self.only and command == "build":
-            cmd.extend(["-only", ",".join(self.only)])
-        if self.except_builders and command == "build":
-            cmd.extend(["-except", ",".join(self.except_builders)])
-
         return cmd
 
-    def _parse_machine_readable_output(self, output: str) -> list[dict[str, str]]:
+    def parse_machine_readable_output(self, output: str) -> list[dict[str, str]]:
         """
         Parse machine-readable output for artifacts.
         Real format: artifact,<build_index>,<artifact_type>,<artifact_id>
@@ -325,20 +320,28 @@ class PackerModule:
                     artifacts.append(artifact)
         return artifacts
 
-    def _parse_build_output(self, output: str) -> list[dict[str, str]]:
-        """Parse build output to extract artifacts."""
-        artifacts = []
+    def parse_build_output(self, output: str) -> list[dict[str, str]]:
+        """Parse build output to extract artifacts.
+        Expected output formats from Packer:
+        1. Regular build output:
+          "--> builder_name: artifact_description"
+          Example: "--> amazon-ebs: AMI ami-12345678"
+          Example: "--> virtualbox-iso: VirtualBox VM"
 
-        if self.machine_readable:
-            return self._parse_machine_readable_output(output)
+        2. AWS AMI fallback (when the regular format is not present):
+          Lines containing "ami-" with "created" or "AMIs"
+          Example: "us-west-2: AMI ami-12345678 created"
+
+        For reliable parsing, use machine_readable: true in the module options."""
+        artifacts = []
 
         pattern = re.compile(r"^-->\s+(\S+):\s+(.+)$")
         lines = output.splitlines()
         for line in lines:
             match = pattern.match(line.strip())
             if match:
-                builder = match.group(1).strip()
-                artifact_desc = match.group(2).strip()
+                builder = match.group(1)
+                artifact_desc = match.group(2)
                 artifacts.append(
                     {
                         "type": builder,
@@ -357,9 +360,8 @@ class PackerModule:
 
         return artifacts
 
-    def _execute_packer(self, command: str) -> dict[str, object]:
-        """Execute Packer command."""
-        cmd = self._build_command(command)
+    def execute_packer(self, command: str) -> dict[str, object]:
+        cmd = self.build_command(command)
         self.result["cmd"] = " ".join(cmd)
 
         try:
@@ -371,10 +373,12 @@ class PackerModule:
             )
 
             artifacts = []
-            artifacts_count = 0
             if command == "build" and rc == 0:
-                artifacts = self._parse_build_output(stdout)
-                artifacts_count = len(artifacts)
+                if self.machine_readable:
+                    artifacts = self.parse_machine_readable_output(stdout)
+                else:
+                    artifacts = self.parse_build_output(stdout)
+            artifacts_count = len(artifacts)
 
             changed = False
             if command == "build":
@@ -388,7 +392,7 @@ class PackerModule:
                 "stderr": stderr,
                 "rc": rc,
                 "cmd": " ".join(cmd),
-                "packer_version": self._check_packer_version(),
+                "packer_version": self.get_packer_version(),
             }
 
             if command == "build":
@@ -409,20 +413,16 @@ class PackerModule:
             )
 
     def apply(self) -> dict[str, object]:
-        """Apply Packer configuration and build if needed."""
-        self._validate_parameters()
+        self.validate_parameters()
 
         if self.state == "init":
-            return self._execute_packer("init")
+            return self.execute_packer("init")
 
         if self.state == "build":
             if self.module.check_mode:
-                result = self._execute_packer("validate")
-                result["changed"] = False
-                result["msg"] = "Check mode: template validation completed, no build performed."
-                return result
+                return self.execute_packer("validate")
             else:
-                result = self._execute_packer("build")
+                result = self.execute_packer("build")
                 self.result.update(result)
                 return self.result
 
@@ -430,7 +430,6 @@ class PackerModule:
 
 
 def main() -> None:
-    """Main function."""
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(type="str", required=True),
@@ -463,10 +462,6 @@ def main() -> None:
         ),
         mutually_exclusive=[
             ("only", "except_builders"),
-        ],
-        required_if=[
-            ["state", "build", ["template"]],
-            ["state", "init", ["template"]],
         ],
         supports_check_mode=True,
     )

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -87,11 +87,6 @@ options:
       - Recommended for parsing artifacts reliably.
     type: bool
     default: false
-  chdir:
-    description:
-      - Change to this directory before running Packer.
-    type: path
-    required: false
   cleanup:
     description:
       - Clean up temporary files after build (C(-cleanup)).
@@ -223,7 +218,6 @@ class PackerModule:
         self.parallel = self.params.get("parallel")
         self.color = self.params.get("color")
         self.machine_readable = self.params.get("machine_readable")
-        self.chdir = self.params.get("chdir")
         self.cleanup = self.params.get("cleanup")
         self.log_level = self.params.get("log_level", "info")
 
@@ -246,26 +240,15 @@ class PackerModule:
 
     def _validate_parameters(self) -> None:
         """Validate module parameters."""
-        if self.chdir and not os.path.exists(self.chdir):
-            self.module.fail_json(msg=f"Working directory does not exist: {self.chdir}")
-
-        def path_exists(path):
-            if self.chdir:
-                full_path = os.path.join(self.chdir, path)
-                return os.path.exists(full_path)
-            return os.path.exists(path)
-
-        if self.template and not path_exists(self.template):
+        if self.template and not os.path.exists(self.template):
             self.module.fail_json(
-                msg=f"Template file/directory does not exist: {self.template} "
-                f"(relative to chdir: {self.chdir if self.chdir else '.'})"
+                msg=f"Template file/directory does not exist: {self.template}"
             )
 
         for var_file in self.var_files:
-            if not path_exists(var_file):
+            if not os.path.exists(var_file):
                 self.module.fail_json(
-                    msg=f"Variable file does not exist: {var_file} "
-                    f"(relative to chdir: {self.chdir if self.chdir else '.'})"
+                    msg=f"Variable file does not exist: {var_file}"
                 )
 
     def _build_command(self, command: str) -> list[str]:
@@ -370,14 +353,11 @@ class PackerModule:
         cmd = self._build_command(command)
         self.result["cmd"] = " ".join(cmd)
 
-        cwd = self.chdir or os.getcwd()
-
         try:
             start_time = datetime.now(timezone.utc).isoformat() + "Z"
 
             rc, stdout, stderr = self.module.run_command(
                 cmd,
-                cwd=cwd,
                 check_rc=False,
             )
 
@@ -464,7 +444,6 @@ def main() -> None:
             parallel=dict(type="bool", required=False, default=True),
             color=dict(type="bool", required=False, default=True),
             machine_readable=dict(type="bool", required=False, default=False),
-            chdir=dict(type="path", required=False),
             cleanup=dict(type="bool", required=False, default=False),
             log_level=dict(
                 type="str",

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -1,0 +1,494 @@
+#!/usr/bin/python
+# Copyright (c) 2026 Aleksandr Gabidullin <qualittv@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+DOCUMENTATION = r"""
+module: packer
+version_added: 1.0.0
+short_description: Manage HashiCorp Packer builds
+description:
+  - Manage Packer builds and templates.
+  - Supports building and initializing Packer templates.
+  - In check_mode, runs C(packer validate) instead of building.
+author: "Aleksandr Gabidullin (@a-gabidullin)"
+requirements:
+  - packer >= 1.7.0
+attributes:
+  check_mode:
+    description: In check_mode, validates the template instead of building.
+    support: full
+options:
+  name:
+    description:
+      - Name of the Packer build configuration (for identification).
+    type: str
+    required: true
+  state:
+    description:
+      - Desired operation to perform.
+      - "build: builds the image from template (or validates in check_mode)."
+      - "init: initializes the template (installs required plugins)."
+    type: str
+    required: true
+    choices: [build, init]
+  template:
+    description:
+      - Path to the Packer template file or directory.
+      - Required for all states.
+    type: path
+    required: false
+  variables:
+    description:
+      - Dictionary of variables to pass to Packer (C(-var)).
+    type: dict
+    required: false
+    default: {}
+  var_files:
+    description:
+      - List of variable files to load (C(-var-file)).
+    type: list
+    elements: path
+    required: false
+    default: []
+  only:
+    description:
+      - Build only the specified builders (C(-only)).
+    type: list
+    elements: str
+    required: false
+  except_builders:
+    description:
+      - Build all builders except the specified ones (C(-except)).
+    type: list
+    elements: str
+    required: false
+    aliases: [except]
+  force:
+    description:
+      - Force rebuilding (passes C(-force) flag).
+    type: bool
+    default: false
+  parallel:
+    description:
+      - Enable parallel building (C(-parallel=false) if V(false)).
+    type: bool
+    default: true
+  color:
+    description:
+      - Disable colored output (C(-no-color) if V(false)).
+    type: bool
+    default: true
+  machine_readable:
+    description:
+      - Output in machine-readable format (C(-machine-readable) if V(true)).
+      - Recommended for parsing artifacts reliably.
+    type: bool
+    default: false
+  chdir:
+    description:
+      - Change to this directory before running Packer.
+    type: path
+    required: false
+  cleanup:
+    description:
+      - Clean up temporary files after build (C(-cleanup)).
+    type: bool
+    default: false
+  log_level:
+    description:
+      - Set the log level (C(--log-level)).
+    type: str
+    choices: [trace, debug, info, warn, error]
+    default: info
+"""
+
+EXAMPLES = r"""
+- name: Initialize Packer template (install plugins)
+  community.general.packer:
+    name: init-template
+    state: init
+    template: aws-ubuntu.pkr.hcl
+
+- name: Build AWS AMI with Packer (or validate in check_mode)
+  community.general.packer:
+    name: my-ami
+    state: build
+    template: aws-ubuntu.pkr.hcl
+    variables:
+      aws_region: us-west-2
+      instance_type: t2.micro
+    force: false
+
+- name: Validate template using check_mode
+  community.general.packer:
+    name: validate-check
+    state: build
+    template: template.pkr.hcl
+    var_files:
+      - dev.pkrvars.hcl
+      - common.pkrvars.hcl
+  check_mode: true
+
+- name: Build with force rebuild
+  community.general.packer:
+    name: force-build
+    state: build
+    template: template.pkr.hcl
+    force: true
+    parallel: false
+    machine_readable: true
+
+- name: Build only specific builders
+  community.general.packer:
+    name: selective-build
+    state: build
+    template: template.pkr.hcl
+    only:
+      - amazon-ebs.builder1
+      - virtualbox-iso.builder2
+
+- name: Build local artifact (VirtualBox)
+  community.general.packer:
+    name: local-build
+    state: build
+    template: virtualbox.pkr.hcl
+    force: true
+"""
+
+RETURN = r"""
+cmd:
+  description: Full command line executed
+  returned: always
+  type: str
+  sample: "packer build -force template.pkr.hcl"
+packer_version:
+  description: Packer version used
+  returned: always
+  type: str
+  sample: "1.9.4"
+artifacts:
+  description: List of created artifacts
+  returned: when state is build and build successful (not in check_mode)
+  type: list
+  elements: dict
+  sample:
+    - type: amazon-ebs
+      name: ami-12345678
+      build_index: 0
+artifacts_count:
+  description: Number of artifacts created
+  returned: when state is build and build successful
+  type: int
+  sample: 1
+started:
+  description: Timestamp when the build started (UTC)
+  returned: when state is build
+  type: str
+  sample: "2024-01-15T10:30:00Z"
+"""
+
+import os
+import re
+from datetime import datetime, timezone
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+class PackerModule:
+    """Packer configuration and build manager."""
+
+    def __init__(self, module: AnsibleModule, packer_bin: str) -> None:
+        self.module = module
+        self.params = module.params
+        self.packer_bin = packer_bin
+        self.result: dict[str, object] = {
+            "changed": False,
+            "stdout": "",
+            "stderr": "",
+            "rc": 0,
+            "cmd": "",
+            "packer_version": "",
+        }
+
+        self.state = self.params["state"]
+        self.template = self.params.get("template")
+        self.variables = self.params.get("variables") or {}
+        self.var_files = self.params.get("var_files") or []
+        self.only = self.params.get("only")
+        self.except_builders = self.params.get("except_builders")
+        self.force = self.params.get("force")
+        self.parallel = self.params.get("parallel")
+        self.color = self.params.get("color")
+        self.machine_readable = self.params.get("machine_readable")
+        self.chdir = self.params.get("chdir")
+        self.cleanup = self.params.get("cleanup")
+        self.log_level = self.params.get("log_level", "info")
+
+    def _check_packer_version(self) -> str:
+        """Get Packer version using module.run_command."""
+        try:
+            rc, stdout, _stderr = self.module.run_command(
+                [self.packer_bin, "version"],
+                check_rc=False,
+            )
+            if rc == 0 and stdout:
+                version_line = stdout.splitlines()[0]
+                match = re.search(r"(\d+\.\d+\.\d+)", version_line)
+                if match:
+                    return match.group(1)
+                return version_line.strip()
+            return "unknown"
+        except Exception:
+            return "unknown"
+
+    def _validate_parameters(self) -> None:
+        """Validate module parameters."""
+        if self.chdir and not os.path.exists(self.chdir):
+            self.module.fail_json(msg=f"Working directory does not exist: {self.chdir}")
+
+        def path_exists(path):
+            if self.chdir:
+                full_path = os.path.join(self.chdir, path)
+                return os.path.exists(full_path)
+            return os.path.exists(path)
+
+        if self.template and not path_exists(self.template):
+            self.module.fail_json(
+                msg=f"Template file/directory does not exist: {self.template} "
+                f"(relative to chdir: {self.chdir if self.chdir else '.'})"
+            )
+
+        for var_file in self.var_files:
+            if not path_exists(var_file):
+                self.module.fail_json(
+                    msg=f"Variable file does not exist: {var_file} "
+                    f"(relative to chdir: {self.chdir if self.chdir else '.'})"
+                )
+
+    def _build_command(self, command: str) -> list[str]:
+        """Build the Packer command line."""
+        cmd = [self.packer_bin]
+
+        if self.log_level != "info":
+            cmd.extend(["--log-level", self.log_level])
+
+        cmd.append(command)
+
+        if command in ["build", "init"] and self.template:
+            cmd.append(self.template)
+
+        if command == "build":
+            if self.force:
+                cmd.append("-force")
+            if not self.parallel:
+                cmd.append("-parallel=false")
+            if self.cleanup:
+                cmd.append("-cleanup")
+
+        if command != "init":
+            if not self.color:
+                cmd.append("-no-color")
+            if self.machine_readable:
+                cmd.append("-machine-readable")
+
+        if command in ["build", "validate"]:
+            for key, value in self.variables.items():
+                if isinstance(value, str) and (" " in value or '"' in value):
+                    cmd.extend(["-var", f'{key}="{value}"'])
+                else:
+                    cmd.extend(["-var", f"{key}={value}"])
+
+            for var_file in self.var_files:
+                cmd.extend(["-var-file", var_file])
+
+        if self.only and command == "build":
+            cmd.extend(["-only", ",".join(self.only)])
+        if self.except_builders and command == "build":
+            cmd.extend(["-except", ",".join(self.except_builders)])
+
+        return cmd
+
+    def _parse_machine_readable_output(self, output: str) -> list[dict[str, str]]:
+        """
+        Parse machine-readable output for artifacts.
+        Real format: artifact,<build_index>,<artifact_type>,<artifact_id>
+        Example: artifact,0,amazon-ebs,ami-12345678
+        """
+        artifacts = []
+        for line in output.splitlines():
+            if not line.startswith("artifact,"):
+                continue
+
+            parts = line.split(",")
+            if len(parts) >= 4:
+                artifact = {
+                    "type": parts[2],
+                    "name": parts[3],
+                    "build_index": parts[1],
+                }
+                if artifact["name"]:
+                    artifacts.append(artifact)
+        return artifacts
+
+    def _parse_build_output(self, output: str) -> list[dict[str, str]]:
+        """Parse build output to extract artifacts."""
+        artifacts = []
+
+        if self.machine_readable:
+            return self._parse_machine_readable_output(output)
+
+        pattern = re.compile(r"^-->\s+(.+?):\s+(.+)$")
+        lines = output.splitlines()
+        for line in lines:
+            match = pattern.match(line.strip())
+            if match:
+                builder = match.group(1).strip()
+                artifact_desc = match.group(2).strip()
+                artifacts.append(
+                    {
+                        "type": builder,
+                        "name": artifact_desc,
+                    }
+                )
+            elif "ami-" in line and ("created" in line or "AMIs" in line):
+                ami_match = re.search(r"(ami-[a-zA-Z0-9]+)", line)
+                if ami_match:
+                    artifacts.append(
+                        {
+                            "type": "amazon-ebs",
+                            "name": ami_match.group(1),
+                        }
+                    )
+
+        return artifacts
+
+    def _execute_packer(self, command: str) -> dict[str, object]:
+        """Execute Packer command."""
+        cmd = self._build_command(command)
+        self.result["cmd"] = " ".join(cmd)
+
+        cwd = self.chdir or os.getcwd()
+
+        try:
+            start_time = datetime.now(timezone.utc).isoformat() + "Z"
+
+            rc, stdout, stderr = self.module.run_command(
+                cmd,
+                cwd=cwd,
+                check_rc=False,
+            )
+
+            artifacts = []
+            artifacts_count = 0
+            if command == "build" and rc == 0:
+                artifacts = self._parse_build_output(stdout)
+                artifacts_count = len(artifacts)
+
+            changed = False
+            if command == "build":
+                changed = True
+            elif command in ["init", "validate"]:
+                changed = False
+
+            result_dict = {
+                "changed": changed,
+                "stdout": stdout,
+                "stderr": stderr,
+                "rc": rc,
+                "cmd": " ".join(cmd),
+                "packer_version": self._check_packer_version(),
+            }
+
+            if command == "build":
+                result_dict["started"] = start_time
+                result_dict["artifacts"] = artifacts
+                result_dict["artifacts_count"] = artifacts_count
+
+            if rc != 0:
+                result_dict["failed"] = True
+                self.module.fail_json(msg="Packer command failed", **result_dict)
+
+            return result_dict
+
+        except Exception as e:
+            self.module.fail_json(
+                msg=f"Error executing Packer: {e}",
+                cmd=" ".join(cmd),
+            )
+
+    def apply(self) -> dict[str, object]:
+        """Apply Packer configuration and build if needed."""
+        self._validate_parameters()
+
+        if self.state == "init":
+            return self._execute_packer("init")
+
+        if self.state == "build":
+            if self.module.check_mode:
+                result = self._execute_packer("validate")
+                result["changed"] = False
+                result["msg"] = "Check mode: template validation completed, no build performed."
+                return result
+            else:
+                result = self._execute_packer("build")
+                self.result.update(result)
+                return self.result
+
+        self.module.fail_json(msg=f"Unsupported state: {self.state}")
+
+
+def main() -> None:
+    """Main function."""
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(type="str", required=True),
+            state=dict(
+                type="str",
+                required=True,
+                choices=["build", "init"],
+            ),
+            template=dict(type="path", required=False),
+            variables=dict(type="dict", required=False, default={}),
+            var_files=dict(type="list", elements="path", required=False, default=[]),
+            only=dict(type="list", elements="str", required=False),
+            except_builders=dict(
+                type="list",
+                elements="str",
+                required=False,
+                aliases=["except"],
+            ),
+            force=dict(type="bool", required=False, default=False),
+            parallel=dict(type="bool", required=False, default=True),
+            color=dict(type="bool", required=False, default=True),
+            machine_readable=dict(type="bool", required=False, default=False),
+            chdir=dict(type="path", required=False),
+            cleanup=dict(type="bool", required=False, default=False),
+            log_level=dict(
+                type="str",
+                required=False,
+                choices=["trace", "debug", "info", "warn", "error"],
+                default="info",
+            ),
+        ),
+        mutually_exclusive=[
+            ("only", "except_builders"),
+        ],
+        required_if=[
+            ["state", "build", ["template"]],
+            ["state", "init", ["template"]],
+        ],
+        supports_check_mode=True,
+    )
+
+    packer_bin = module.get_bin_path("packer", required=True)
+
+    packer_module = PackerModule(module, packer_bin)
+    result = packer_module.apply()
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -39,7 +39,7 @@ options:
       - Path to the Packer template file or directory.
       - Required for all states.
     type: path
-    required: false
+    required: true
   variables:
     description:
       - Dictionary of variables to pass to Packer (C(-var)).
@@ -107,6 +107,12 @@ EXAMPLES = r"""
     state: init
     template: aws-ubuntu.pkr.hcl
 
+- name: Initialize Packer template from directory
+  community.general.packer:
+    name: init-template-dir
+    state: init
+    template: ./packer-templates/
+
 - name: Build AWS AMI with Packer (or validate in check_mode)
   community.general.packer:
     name: my-ami
@@ -115,6 +121,13 @@ EXAMPLES = r"""
     variables:
       aws_region: us-west-2
       instance_type: t2.micro
+    force: false
+
+- name: Build from directory containing multiple templates
+  community.general.packer:
+    name: multi-template-build
+    state: build
+    template: ./packer-templates/
     force: false
 
 - name: Validate template using check_mode
@@ -209,17 +222,17 @@ class PackerModule:
         }
 
         self.state = self.params["state"]
-        self.template = self.params.get("template")
-        self.variables = self.params.get("variables") or {}
-        self.var_files = self.params.get("var_files") or []
-        self.only = self.params.get("only")
-        self.except_builders = self.params.get("except_builders")
-        self.force = self.params.get("force")
-        self.parallel = self.params.get("parallel")
-        self.color = self.params.get("color")
-        self.machine_readable = self.params.get("machine_readable")
-        self.cleanup = self.params.get("cleanup")
-        self.log_level = self.params.get("log_level", "info")
+        self.template = self.params["template"]
+        self.variables = self.params["variables"]
+        self.var_files = self.params["var_files"]
+        self.only = self.params["only"]
+        self.except_builders = self.params["except_builders"]
+        self.force = self.params["force"]
+        self.parallel = self.params["parallel"]
+        self.color = self.params["color"]
+        self.machine_readable = self.params["machine_readable"]
+        self.cleanup = self.params["cleanup"]
+        self.log_level = self.params["log_level"]
 
     def _check_packer_version(self) -> str:
         """Get Packer version using module.run_command."""
@@ -241,15 +254,11 @@ class PackerModule:
     def _validate_parameters(self) -> None:
         """Validate module parameters."""
         if self.template and not os.path.exists(self.template):
-            self.module.fail_json(
-                msg=f"Template file/directory does not exist: {self.template}"
-            )
+            self.module.fail_json(msg=f"Template file/directory does not exist: {self.template}")
 
         for var_file in self.var_files:
             if not os.path.exists(var_file):
-                self.module.fail_json(
-                    msg=f"Variable file does not exist: {var_file}"
-                )
+                self.module.fail_json(msg=f"Variable file does not exist: {var_file}")
 
     def _build_command(self, command: str) -> list[str]:
         """Build the Packer command line."""
@@ -323,7 +332,7 @@ class PackerModule:
         if self.machine_readable:
             return self._parse_machine_readable_output(output)
 
-        pattern = re.compile(r"^-->\s+(.+?):\s+(.+)$")
+        pattern = re.compile(r"^-->\s+(\S+):\s+(.+)$")
         lines = output.splitlines()
         for line in lines:
             match = pattern.match(line.strip())
@@ -337,7 +346,7 @@ class PackerModule:
                     }
                 )
             elif "ami-" in line and ("created" in line or "AMIs" in line):
-                ami_match = re.search(r"(ami-[a-zA-Z0-9]+)", line)
+                ami_match = re.search(r"(ami-\S+)", line)
                 if ami_match:
                     artifacts.append(
                         {

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -19,10 +19,10 @@ requirements:
 attributes:
   check_mode:
     description: Can run in check_mode and report changes without making them.
-    support: full
+    support: none
   diff_mode:
     description: Will return a diff of changes.
-    support: full
+    support: none
 options:
   name:
     description:
@@ -34,13 +34,13 @@ options:
     description:
       - Desired state of the Packer resource.
       - V(build) builds the image from template.
+      - V(validate) validates the template without building.
+      - V(inspect) shows template information without building.
+      - V(fmt) formats the template file.
       - V(absent) is a no-op (use V(force=true) to rebuild).
-      - V(validated) only validates the template without building.
-      - V(inspected) shows template information without building.
-      - V(formatted) formats the template file.
     type: str
     required: true
-    choices: [build, absent, validated, inspected, formatted]
+    choices: [build, validate, inspect, fmt, absent]
   template:
     description:
       - Path to the Packer template file.
@@ -103,12 +103,6 @@ options:
       - Recommended for CI/CD pipelines.
     type: bool
     default: false
-  timeout:
-    description:
-      - Timeout for the Packer command in seconds.
-      - Set to V(0) for no timeout.
-    type: int
-    default: 3600
   chdir:
     description:
       - Change to this directory before running Packer.
@@ -174,7 +168,7 @@ EXAMPLES = r"""
 - name: Validate Packer template
   community.general.packer:
     name: template-validation
-    state: validated
+    state: validate
     template: template.pkr.hcl
     var_files:
       - dev.pkrvars.hcl
@@ -201,14 +195,14 @@ EXAMPLES = r"""
 - name: Inspect template structure
   community.general.packer:
     name: inspect-template
-    state: inspected
+    state: inspect
     template: template.pkr.hcl
   register: packer_inspect
 
 - name: Format Packer template
   community.general.packer:
     name: format-template
-    state: formatted
+    state: fmt
     template: template.pkr.hcl
 
 - name: Build local artifact (VirtualBox)
@@ -276,7 +270,6 @@ changed:
 import os
 import re
 from datetime import datetime, timezone
-from typing import Any, Dict, List
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -288,7 +281,7 @@ class PackerModule:
         self.module = module
         self.params = module.params
         self.packer_bin = packer_bin
-        self.result: Dict[str, Any] = {
+        self.result: dict[str, object] = {
             "changed": False,
             "stdout": "",
             "stderr": "",
@@ -307,7 +300,6 @@ class PackerModule:
         self.parallel = self.params.get("parallel")
         self.color = self.params.get("color")
         self.machine_readable = self.params.get("machine_readable")
-        self.timeout = self.params.get("timeout")
         self.chdir = self.params.get("chdir")
         self.cleanup = self.params.get("cleanup")
         self.artifact_name = self.params.get("artifact_name")
@@ -315,14 +307,6 @@ class PackerModule:
         self.artifact_type = self.params.get("artifact_type", "none")
         self.output_dir = self.params.get("output_dir")
         self.log_level = self.params.get("log_level", "info")
-
-        self.state_to_command: Dict[str, str] = {
-            "build": "build",
-            "absent": "build",
-            "validated": "validate",
-            "inspected": "inspect",
-            "formatted": "fmt",
-        }
 
         self.build_output = ""
 
@@ -340,19 +324,19 @@ class PackerModule:
                     return match.group(1)
                 return version_line.strip()
             return "unknown"
-        except Exception:  # pylint: disable=broad-exception-caught
+        except Exception:
             return "unknown"
 
     def _validate_parameters(self) -> None:
         """Validate module parameters."""
-        if self.state in ["build", "validated", "inspected"]:
+        if self.state in ["build", "validate", "inspect"]:
             if not self.template:
                 self.module.fail_json(msg=f"Template file is required for state: {self.state}")
             if not os.path.exists(self.template):
                 self.module.fail_json(msg=f"Template file does not exist: {self.template}")
 
-        if self.state == "formatted" and not self.template:
-            self.module.fail_json(msg="Template file is required for state: formatted")
+        if self.state == "fmt" and not self.template:
+            self.module.fail_json(msg="Template file is required for state: fmt")
 
         if self.only and self.except_builders:
             self.module.fail_json(msg="'only' and 'except_builders' parameters are mutually exclusive")
@@ -362,9 +346,6 @@ class PackerModule:
 
         if self.artifact_type in ["ami", "azure", "gcp"] and not self.artifact_region:
             self.module.fail_json(msg=f"'artifact_region' is required for artifact_type: {self.artifact_type}")
-
-        if self.timeout < 0:
-            self.module.fail_json(msg="'timeout' must be a positive integer")
 
         if self.chdir and not os.path.exists(self.chdir):
             self.module.fail_json(msg=f"Working directory does not exist: {self.chdir}")
@@ -387,7 +368,7 @@ class PackerModule:
 
         return False
 
-    def _build_command(self, command: str) -> List[str]:
+    def _build_command(self, command: str) -> list[str]:
         """Build the Packer command line."""
         cmd = [self.packer_bin]
 
@@ -432,7 +413,7 @@ class PackerModule:
 
         return cmd
 
-    def _parse_machine_readable_output(self, output: str) -> List[Dict[str, str]]:
+    def _parse_machine_readable_output(self, output: str) -> list[dict[str, str]]:
         """Parse machine-readable output for artifacts."""
         artifacts = []
         for line in output.splitlines():
@@ -450,7 +431,7 @@ class PackerModule:
                     artifacts.append(artifact)
         return artifacts
 
-    def _parse_build_output(self, output: str) -> List[Dict[str, str]]:
+    def _parse_build_output(self, output: str) -> list[dict[str, str]]:
         """Parse build output to extract artifacts."""
         artifacts = []
 
@@ -484,7 +465,7 @@ class PackerModule:
 
         return artifacts
 
-    def _execute_packer(self, command: str) -> Dict[str, Any]:
+    def _execute_packer(self, command: str) -> dict[str, object]:
         """Execute Packer command."""
         cmd = self._build_command(command)
         self.result["cmd"] = " ".join(cmd)
@@ -497,7 +478,6 @@ class PackerModule:
             rc, stdout, stderr = self.module.run_command(
                 cmd,
                 cwd=cwd,
-                timeout=self.timeout if self.timeout > 0 else None,
                 check_rc=False,
             )
 
@@ -551,7 +531,7 @@ class PackerModule:
             return True
         return not self._artifact_exists()
 
-    def apply(self) -> Dict[str, Any]:
+    def apply(self) -> dict[str, object]:
         """Apply Packer configuration and build if needed."""
         self._validate_parameters()
 
@@ -564,7 +544,8 @@ class PackerModule:
             self.result["msg"] = "Absent state is not implemented. Use 'force: true' to force rebuild."
             return self.result
 
-        if self.state == "formatted":
+        # Для состояний, которые напрямую соответствуют командам Packer
+        if self.state == "fmt":
             return self._execute_packer("fmt")
 
         if self.state == "build" and not self._should_build():
@@ -574,19 +555,18 @@ class PackerModule:
             )
             return self.result
 
-        command = self.state_to_command.get(self.state)
-        if not command:
-            self.module.fail_json(msg=f"Unsupported state: {self.state}")
+        # Для validate и inspect команда совпадает с state
+        if self.state in ["validate", "inspect"]:
+            return self._execute_packer(self.state)
 
-        if self.state in ["validated", "inspected"]:
-            return self._execute_packer(command)
-
+        # Для build (если нужно строить)
         if self.state == "build":
             result = self._execute_packer("build")
             self.result.update(result)
             return self.result
 
-        return self.result
+        # fallback (не должно достигаться)
+        self.module.fail_json(msg=f"Unsupported state: {self.state}")
 
 
 def main() -> None:
@@ -597,7 +577,7 @@ def main() -> None:
             state=dict(
                 type="str",
                 required=True,
-                choices=["build", "absent", "validated", "inspected", "formatted"],
+                choices=["build", "validate", "inspect", "fmt", "absent"],
             ),
             template=dict(type="path", required=False),
             variables=dict(type="dict", required=False, default={}),
@@ -613,7 +593,6 @@ def main() -> None:
             parallel=dict(type="bool", required=False, default=True),
             color=dict(type="bool", required=False, default=True),
             machine_readable=dict(type="bool", required=False, default=False),
-            timeout=dict(type="int", required=False, default=3600),
             chdir=dict(type="path", required=False),
             cleanup=dict(type="bool", required=False, default=False),
             artifact_name=dict(type="str", required=False),
@@ -635,7 +614,7 @@ def main() -> None:
         mutually_exclusive=[
             ("only", "except_builders"),
         ],
-        supports_check_mode=True,
+        supports_check_mode=False,
     )
 
     packer_bin = module.get_bin_path("packer", required=True)

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -439,7 +439,7 @@ def main() -> None:
                 required=True,
                 choices=["build", "init"],
             ),
-            template=dict(type="path", required=False),
+            template=dict(type="path", required=True),
             variables=dict(type="dict", required=False, default={}),
             var_files=dict(type="list", elements="path", required=False, default=[]),
             only=dict(type="list", elements="str", required=False),

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -334,7 +334,6 @@ class PackerModule:
         self.output_dir = self.params.get("output_dir")
         self.log_level = self.params.get("log_level", "info")
 
-        # Map state to packer command
         self.state_to_command = {
             "build": "build",
             "absent": "build",
@@ -343,7 +342,6 @@ class PackerModule:
             "formatted": "fmt",
         }
 
-        # Store output for parsing
         self.build_output = ""
 
     def _check_packer_version(self) -> str:
@@ -401,26 +399,21 @@ class PackerModule:
         if self.force:
             return False
 
-        # For local builds, check if output directory exists
         if self.artifact_type == "none" and self.output_dir:
             if os.path.exists(self.output_dir):
                 return True
 
-        # Placeholder for cloud artifact checks
         return False
 
     def _build_command(self, command: str) -> list[str]:
         """Build the Packer command line."""
         cmd = [self.packer_bin]
 
-        # Add log level if not default
         if self.log_level != "info":
             cmd.extend(["--log-level", self.log_level])
 
-        # Add command
         cmd.append(command)
 
-        # Add template for relevant commands
         if command in ["build", "validate", "inspect"]:
             if self.template:
                 cmd.append(self.template)
@@ -428,7 +421,6 @@ class PackerModule:
             if self.template:
                 cmd.append(self.template)
 
-        # Build-specific flags
         if command == "build":
             if self.force:
                 cmd.append("-force")
@@ -437,25 +429,20 @@ class PackerModule:
             if self.cleanup:
                 cmd.append("-cleanup")
 
-        # Common flags
         if not self.color:
             cmd.append("-no-color")
         if self.machine_readable:
             cmd.append("-machine-readable")
 
-        # Variables
         for key, value in self.variables.items():
-            # Handle string values properly
             if isinstance(value, str) and (" " in value or '"' in value):
                 cmd.extend(["-var", f'{key}="{value}"'])
             else:
                 cmd.extend(["-var", f"{key}={value}"])
 
-        # Variable files
         for var_file in self.var_files:
             cmd.extend(["-var-file", var_file])
 
-        # Builder filters
         if self.only:
             cmd.extend(["-only", ",".join(self.only)])
         if self.except_builders:
@@ -488,10 +475,8 @@ class PackerModule:
         if self.machine_readable:
             return self._parse_machine_readable_output(output)
 
-        # Parse human-readable output
         lines = output.splitlines()
         for line in lines:
-            # Look for artifact lines
             if "Artifact" in line and "built" in line and ":" in line:
                 parts = line.split(":")
                 if len(parts) >= 2:
@@ -505,7 +490,6 @@ class PackerModule:
                             }
                         )
 
-            # Look for AMI lines (AWS specific)
             if "ami-" in line and ("created" in line or "AMIs" in line):
                 match = re.search(r"(ami-[a-zA-Z0-9]+)", line)
                 if match:
@@ -530,10 +514,11 @@ class PackerModule:
         try:
             start_time = datetime.now(timezone.utc).isoformat() + "Z"
 
+            # Для передачи окружения используем параметр environ, а не env
             rc, stdout, stderr = self.module.run_command(
                 cmd,
                 cwd=cwd,
-                env=env,
+                environ=env,  # <-- замените env на environ
                 timeout=self.timeout if self.timeout > 0 else None,
                 check_rc=False,
             )
@@ -584,20 +569,14 @@ class PackerModule:
         """Determine if we need to build based on state and artifact existence."""
         if self.state != "build":
             return False
-
         if self.force:
             return True
-
-        if self._artifact_exists():
-            return False
-
-        return True
+        return not self._artifact_exists()
 
     def apply(self) -> dict[str, object]:
         """Apply Packer configuration and build if needed."""
         self._validate_parameters()
 
-        # Handle absent state
         if self.state == "absent":
             self.module.warn(
                 "State 'absent' is not fully implemented. "
@@ -607,11 +586,9 @@ class PackerModule:
             self.result["msg"] = "Absent state is not implemented. Use 'force: true' to force rebuild."
             return self.result
 
-        # Handle formatting - doesn't require validation
         if self.state == "formatted":
             return self._execute_packer("fmt")
 
-        # Check if build is needed
         if self.state == "build" and not self._should_build():
             self.result["changed"] = False
             self.result["msg"] = (
@@ -619,16 +596,13 @@ class PackerModule:
             )
             return self.result
 
-        # Execute Packer
         command = self.state_to_command.get(self.state)
         if not command:
             self.module.fail_json(msg=f"Unsupported state: {self.state}")
 
         if self.state in ["validated", "inspected"]:
-            # These are read-only operations
             return self._execute_packer(command)
 
-        # For build state, build the image
         if self.state == "build":
             result = self._execute_packer("build")
             self.result.update(result)

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -1,0 +1,698 @@
+#!/usr/bin/python
+# Copyright (c) 2026 Aleksandr Gabidullin <qualittv@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+DOCUMENTATION = r"""
+module: packer
+version_added: 1.0.0
+short_description: Manage HashiCorp Packer builds
+description:
+  - Manage Packer builds and templates.
+  - Supports building, validating, inspecting, and formatting Packer templates.
+  - Provides idempotent build management with artifact existence checking.
+author: "Aleksandr Gabidullin (@a-gabidullin)"
+requirements:
+  - packer >= 1.7.0
+attributes:
+  check_mode:
+    description: Can run in check_mode and report changes without making them.
+    support: full
+  diff_mode:
+    description: Will return a diff of changes.
+    support: full
+options:
+  name:
+    description:
+      - Name of the Packer build configuration.
+      - Used for identification and artifact tracking.
+    type: str
+    required: true
+  state:
+    description:
+      - Desired state of the Packer resource.
+      - V(build) builds the image from template.
+      - V(absent) is a no-op (use V(force=true) to rebuild).
+      - V(validated) only validates the template without building.
+      - V(inspected) shows template information without building.
+      - V(formatted) formats the template file.
+    type: str
+    required: true
+    choices: [build, absent, validated, inspected, formatted]
+  template:
+    description:
+      - Path to the Packer template file.
+      - Required for all states except V(absent).
+      - Supports HCL2 and JSON formats.
+    type: path
+    required: false
+  variables:
+    description:
+      - Dictionary of variables to pass to Packer.
+      - Corresponds to V(-var) option.
+    type: dict
+    required: false
+    default: {}
+  var_files:
+    description:
+      - List of variable files to load.
+      - Corresponds to V(-var-file) option.
+    type: list
+    elements: path
+    required: false
+    default: []
+  only:
+    description:
+      - Build only the specified builders.
+      - Corresponds to V(-only) option.
+    type: list
+    elements: str
+    required: false
+  except_builders:
+    description:
+      - Build all builders except the specified ones.
+      - Corresponds to V(-except) option.
+    type: list
+    elements: str
+    required: false
+    aliases: [except]
+  force:
+    description:
+      - Force rebuilding even if artifacts exist.
+      - Corresponds to V(-force) flag.
+    type: bool
+    default: false
+  parallel:
+    description:
+      - Enable parallel building.
+      - Set to V(false) to build sequentially.
+    type: bool
+    default: true
+  color:
+    description:
+      - Enable colored output.
+      - Set to V(false) for non-interactive environments.
+    type: bool
+    default: true
+  machine_readable:
+    description:
+      - Output in machine-readable format.
+      - Useful for parsing output in automation.
+      - Recommended for CI/CD pipelines.
+    type: bool
+    default: false
+  timeout:
+    description:
+      - Timeout for the Packer command in seconds.
+      - Set to V(0) for no timeout.
+    type: int
+    default: 3600
+  chdir:
+    description:
+      - Change to this directory before running Packer.
+      - Useful when template references relative paths.
+    type: path
+    required: false
+  cleanup:
+    description:
+      - Clean up temporary files after build.
+      - Corresponds to V(-cleanup) flag.
+    type: bool
+    default: false
+  env_vars:
+    description:
+      - Environment variables to set for Packer process.
+      - Useful for cloud provider credentials.
+    type: dict
+    required: false
+    default: {}
+  artifact_name:
+    description:
+      - Name of the artifact to check for existence.
+      - Used with V(state=build) to determine if rebuild is needed.
+      - For AWS AMI, specify the AMI ID.
+      - For Docker, specify the image tag.
+    type: str
+    required: false
+  artifact_region:
+    description:
+      - Cloud region where the artifact exists.
+      - Required for cloud artifacts (AWS, Azure, GCP).
+    type: str
+    required: false
+  artifact_type:
+    description:
+      - Type of artifact to check.
+      - Used to determine the appropriate existence check method.
+    type: str
+    choices: [ami, docker, azure, gcp, vsphere, openstack, none]
+    default: none
+  output_dir:
+    description:
+      - Directory where Packer artifacts will be stored.
+      - Used for local builders (virtualbox, qemu, etc.).
+    type: path
+    required: false
+  log_level:
+    description:
+      - Set the log level for Packer.
+      - Useful for debugging.
+    type: str
+    choices: [trace, debug, info, warn, error]
+    default: info
+"""
+
+EXAMPLES = r"""
+- name: Build AWS AMI with Packer
+  community.general.packer:
+    name: my-ami
+    state: build
+    template: aws-ubuntu.pkr.hcl
+    variables:
+      aws_region: us-west-2
+      instance_type: t2.micro
+    artifact_type: ami
+    artifact_name: ami-12345678
+    artifact_region: us-west-2
+    force: false
+
+- name: Validate Packer template
+  community.general.packer:
+    name: template-validation
+    state: validated
+    template: template.pkr.hcl
+    var_files:
+      - dev.pkrvars.hcl
+      - common.pkrvars.hcl
+
+- name: Build with force rebuild
+  community.general.packer:
+    name: force-build
+    state: build
+    template: template.pkr.hcl
+    force: true
+    parallel: false
+    machine_readable: true
+
+- name: Build only specific builders
+  community.general.packer:
+    name: selective-build
+    state: build
+    template: template.pkr.hcl
+    only:
+      - amazon-ebs.builder1
+      - virtualbox-iso.builder2
+
+- name: Inspect template structure
+  community.general.packer:
+    name: inspect-template
+    state: inspected
+    template: template.pkr.hcl
+  register: packer_inspect
+
+- name: Format Packer template
+  community.general.packer:
+    name: format-template
+    state: formatted
+    template: template.pkr.hcl
+
+- name: Build with environment variables
+  community.general.packer:
+    name: env-build
+    state: build
+    template: template.pkr.hcl
+    env_vars:
+      AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+      AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+    log_level: debug
+
+- name: Build local artifact (VirtualBox)
+  community.general.packer:
+    name: local-build
+    state: build
+    template: virtualbox.pkr.hcl
+    output_dir: /var/lib/packer/builds
+    artifact_type: none
+    force: true
+"""
+
+RETURN = r"""
+stdout:
+  description: Standard output from Packer command
+  returned: always
+  type: str
+  sample: "Build finished successfully"
+stderr:
+  description: Standard error from Packer command
+  returned: always
+  type: str
+  sample: "Error: missing required variable"
+rc:
+  description: Return code from Packer command
+  returned: always
+  type: int
+  sample: 0
+cmd:
+  description: Full command line executed
+  returned: always
+  type: str
+  sample: "packer build -force template.pkr.hcl"
+packer_version:
+  description: Packer version used
+  returned: always
+  type: str
+  sample: "1.9.4"
+artifacts:
+  description: List of created artifacts
+  returned: when state is build and build successful
+  type: list
+  elements: dict
+  sample:
+    - name: ami-12345678
+      region: us-west-2
+      type: amazon-ebs
+artifacts_count:
+  description: Number of artifacts created
+  returned: when state is build and build successful
+  type: int
+  sample: 1
+started:
+  description: Timestamp when the build started (UTC)
+  returned: when state is build
+  type: str
+  sample: "2024-01-15T10:30:00Z"
+changed:
+  description: Whether the module made changes
+  returned: always
+  type: bool
+  sample: true
+"""
+
+import os
+import re
+from datetime import datetime, timezone
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+
+
+class PackerModule:
+    """Packer configuration and build manager."""
+
+    def __init__(self, module: AnsibleModule, packer_bin: str) -> None:
+        self.module = module
+        self.params = module.params
+        self.packer_bin = packer_bin
+        self.result: dict[str, object] = {
+            "changed": False,
+            "stdout": "",
+            "stderr": "",
+            "rc": 0,
+            "cmd": "",
+            "packer_version": "",
+        }
+
+        self.state = self.params["state"]
+        self.template = self.params.get("template")
+        self.variables = self.params.get("variables") or {}
+        self.var_files = self.params.get("var_files") or []
+        self.only = self.params.get("only")
+        self.except_builders = self.params.get("except_builders")
+        self.force = self.params.get("force")
+        self.parallel = self.params.get("parallel")
+        self.color = self.params.get("color")
+        self.machine_readable = self.params.get("machine_readable")
+        self.timeout = self.params.get("timeout")
+        self.chdir = self.params.get("chdir")
+        self.cleanup = self.params.get("cleanup")
+        self.env_vars = self.params.get("env_vars") or {}
+        self.artifact_name = self.params.get("artifact_name")
+        self.artifact_region = self.params.get("artifact_region")
+        self.artifact_type = self.params.get("artifact_type", "none")
+        self.output_dir = self.params.get("output_dir")
+        self.log_level = self.params.get("log_level", "info")
+
+        # Map state to packer command
+        self.state_to_command = {
+            "build": "build",
+            "absent": "build",
+            "validated": "validate",
+            "inspected": "inspect",
+            "formatted": "fmt",
+        }
+
+        # Store output for parsing
+        self.build_output = ""
+
+    def _check_packer_version(self) -> str:
+        """Get Packer version using module.run_command."""
+        try:
+            rc, stdout, stderr = self.module.run_command(
+                [self.packer_bin, "version"],
+                check_rc=False,
+            )
+            if rc == 0 and stdout:
+                version_line = stdout.splitlines()[0] if stdout else ""
+                match = re.search(r"(\d+\.\d+\.\d+)", version_line)
+                if match:
+                    return match.group(1)
+                return version_line.strip()
+            return "unknown"
+        except Exception:
+            return "unknown"
+
+    def _validate_parameters(self) -> None:
+        """Validate module parameters."""
+        if self.state in ["build", "validated", "inspected"]:
+            if not self.template:
+                self.module.fail_json(msg=f"Template file is required for state: {self.state}")
+            if not os.path.exists(self.template):
+                self.module.fail_json(msg=f"Template file does not exist: {self.template}")
+
+        if self.state == "formatted" and not self.template:
+            self.module.fail_json(msg="Template file is required for state: formatted")
+
+        if self.only and self.except_builders:
+            self.module.fail_json(msg="'only' and 'except_builders' parameters are mutually exclusive")
+
+        if self.artifact_type != "none" and not self.artifact_name:
+            self.module.fail_json(msg=f"'artifact_name' is required when artifact_type is '{self.artifact_type}'")
+
+        if self.artifact_type in ["ami", "azure", "gcp"] and not self.artifact_region:
+            self.module.fail_json(msg=f"'artifact_region' is required for artifact_type: {self.artifact_type}")
+
+        if self.timeout < 0:
+            self.module.fail_json(msg="'timeout' must be a positive integer")
+
+        if self.chdir and not os.path.exists(self.chdir):
+            self.module.fail_json(msg=f"Working directory does not exist: {self.chdir}")
+
+        for var_file in self.var_files:
+            if not os.path.exists(var_file):
+                self.module.fail_json(msg=f"Variable file does not exist: {var_file}")
+
+    def _artifact_exists(self) -> bool:
+        """Check if the artifact already exists."""
+        if self.artifact_type == "none" or not self.artifact_name:
+            return False
+
+        if self.force:
+            return False
+
+        # For local builds, check if output directory exists
+        if self.artifact_type == "none" and self.output_dir:
+            if os.path.exists(self.output_dir):
+                return True
+
+        # Placeholder for cloud artifact checks
+        return False
+
+    def _build_command(self, command: str) -> list[str]:
+        """Build the Packer command line."""
+        cmd = [self.packer_bin]
+
+        # Add log level if not default
+        if self.log_level != "info":
+            cmd.extend(["--log-level", self.log_level])
+
+        # Add command
+        cmd.append(command)
+
+        # Add template for relevant commands
+        if command in ["build", "validate", "inspect"]:
+            if self.template:
+                cmd.append(self.template)
+        elif command == "fmt":
+            if self.template:
+                cmd.append(self.template)
+
+        # Build-specific flags
+        if command == "build":
+            if self.force:
+                cmd.append("-force")
+            if not self.parallel:
+                cmd.append("-parallel=false")
+            if self.cleanup:
+                cmd.append("-cleanup")
+
+        # Common flags
+        if not self.color:
+            cmd.append("-no-color")
+        if self.machine_readable:
+            cmd.append("-machine-readable")
+
+        # Variables
+        for key, value in self.variables.items():
+            # Handle string values properly
+            if isinstance(value, str) and (" " in value or '"' in value):
+                cmd.extend(["-var", f'{key}="{value}"'])
+            else:
+                cmd.extend(["-var", f"{key}={value}"])
+
+        # Variable files
+        for var_file in self.var_files:
+            cmd.extend(["-var-file", var_file])
+
+        # Builder filters
+        if self.only:
+            cmd.extend(["-only", ",".join(self.only)])
+        if self.except_builders:
+            cmd.extend(["-except", ",".join(self.except_builders)])
+
+        return cmd
+
+    def _parse_machine_readable_output(self, output: str) -> list[dict]:
+        """Parse machine-readable output for artifacts."""
+        artifacts = []
+        for line in output.splitlines():
+            if not line.startswith("artifact,"):
+                continue
+
+            parts = line.split(",")
+            if len(parts) >= 4:
+                artifact = {
+                    "type": parts[1] if len(parts) > 1 else "",
+                    "region": parts[2] if len(parts) > 2 else "",
+                    "name": parts[3] if len(parts) > 3 else "",
+                }
+                if artifact["name"]:
+                    artifacts.append(artifact)
+        return artifacts
+
+    def _parse_build_output(self, output: str) -> list[dict]:
+        """Parse build output to extract artifacts."""
+        artifacts = []
+
+        if self.machine_readable:
+            return self._parse_machine_readable_output(output)
+
+        # Parse human-readable output
+        lines = output.splitlines()
+        for line in lines:
+            # Look for artifact lines
+            if "Artifact" in line and "built" in line and ":" in line:
+                parts = line.split(":")
+                if len(parts) >= 2:
+                    artifact_name = parts[1].strip()
+                    artifact_type = parts[0].replace("Artifact", "").strip()
+                    if artifact_name:
+                        artifacts.append(
+                            {
+                                "name": artifact_name,
+                                "type": artifact_type,
+                            }
+                        )
+
+            # Look for AMI lines (AWS specific)
+            if "ami-" in line and ("created" in line or "AMIs" in line):
+                match = re.search(r"(ami-[a-zA-Z0-9]+)", line)
+                if match:
+                    artifacts.append(
+                        {
+                            "name": match.group(1),
+                            "type": "ami",
+                        }
+                    )
+
+        return artifacts
+
+    def _execute_packer(self, command: str) -> dict[str, object]:
+        """Execute Packer command using module.run_command."""
+        cmd = self._build_command(command)
+        self.result["cmd"] = " ".join(cmd)
+
+        env = os.environ.copy()
+        env.update(self.env_vars)
+        cwd = self.chdir or os.getcwd()
+
+        try:
+            start_time = datetime.now(timezone.utc).isoformat() + "Z"
+
+            rc, stdout, stderr = self.module.run_command(
+                cmd,
+                cwd=cwd,
+                env=env,
+                timeout=self.timeout if self.timeout > 0 else None,
+                check_rc=False,
+            )
+
+            self.build_output = stdout
+
+            artifacts = []
+            artifacts_count = 0
+            if command == "build" and rc == 0:
+                artifacts = self._parse_build_output(stdout)
+                artifacts_count = len(artifacts)
+
+            changed = False
+            if command == "build":
+                changed = True
+            elif command == "fmt":
+                changed = rc == 0 and stdout != ""
+            elif command in ["validate", "inspect"]:
+                changed = False
+
+            result_dict = {
+                "changed": changed,
+                "stdout": stdout,
+                "stderr": stderr,
+                "rc": rc,
+                "cmd": " ".join(cmd),
+                "packer_version": self._check_packer_version(),
+            }
+
+            if command == "build":
+                result_dict["started"] = start_time
+                result_dict["artifacts"] = artifacts
+                result_dict["artifacts_count"] = artifacts_count
+
+            if rc != 0:
+                result_dict["failed"] = True
+                self.module.fail_json(msg="Packer command failed", **result_dict)
+            else:
+                return result_dict
+
+        except Exception as e:
+            self.module.fail_json(
+                msg=f"Error executing Packer: {to_native(e)}",
+                cmd=" ".join(cmd),
+            )
+
+    def _should_build(self) -> bool:
+        """Determine if we need to build based on state and artifact existence."""
+        if self.state != "build":
+            return False
+
+        if self.force:
+            return True
+
+        if self._artifact_exists():
+            return False
+
+        return True
+
+    def apply(self) -> dict[str, object]:
+        """Apply Packer configuration and build if needed."""
+        self._validate_parameters()
+
+        # Handle absent state
+        if self.state == "absent":
+            self.module.warn(
+                "State 'absent' is not fully implemented. "
+                "Use 'force: true' to force rebuild or use cloud-native modules to delete artifacts."
+            )
+            self.result["changed"] = False
+            self.result["msg"] = "Absent state is not implemented. Use 'force: true' to force rebuild."
+            return self.result
+
+        # Handle formatting - doesn't require validation
+        if self.state == "formatted":
+            return self._execute_packer("fmt")
+
+        # Check if build is needed
+        if self.state == "build" and not self._should_build():
+            self.result["changed"] = False
+            self.result["msg"] = (
+                f"Artifact '{self.artifact_name}' already exists, no build needed (use 'force: true' to rebuild)"
+            )
+            return self.result
+
+        # Execute Packer
+        command = self.state_to_command.get(self.state)
+        if not command:
+            self.module.fail_json(msg=f"Unsupported state: {self.state}")
+
+        if self.state in ["validated", "inspected"]:
+            # These are read-only operations
+            return self._execute_packer(command)
+
+        # For build state, build the image
+        if self.state == "build":
+            result = self._execute_packer("build")
+            self.result.update(result)
+            return self.result
+
+        return self.result
+
+
+def main() -> None:
+    """Main function."""
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(type="str", required=True),
+            state=dict(
+                type="str",
+                required=True,
+                choices=["build", "absent", "validated", "inspected", "formatted"],
+            ),
+            template=dict(type="path", required=False),
+            variables=dict(type="dict", required=False, default={}),
+            var_files=dict(type="list", elements="path", required=False, default=[]),
+            only=dict(type="list", elements="str", required=False),
+            except_builders=dict(
+                type="list",
+                elements="str",
+                required=False,
+                aliases=["except"],
+            ),
+            force=dict(type="bool", required=False, default=False),
+            parallel=dict(type="bool", required=False, default=True),
+            color=dict(type="bool", required=False, default=True),
+            machine_readable=dict(type="bool", required=False, default=False),
+            timeout=dict(type="int", required=False, default=3600),
+            chdir=dict(type="path", required=False),
+            cleanup=dict(type="bool", required=False, default=False),
+            env_vars=dict(type="dict", required=False, default={}),
+            artifact_name=dict(type="str", required=False),
+            artifact_region=dict(type="str", required=False),
+            artifact_type=dict(
+                type="str",
+                required=False,
+                choices=["ami", "docker", "azure", "gcp", "vsphere", "openstack", "none"],
+                default="none",
+            ),
+            output_dir=dict(type="path", required=False),
+            log_level=dict(
+                type="str",
+                required=False,
+                choices=["trace", "debug", "info", "warn", "error"],
+                default="info",
+            ),
+        ),
+        mutually_exclusive=[
+            ("only", "except_builders"),
+        ],
+        supports_check_mode=True,
+    )
+
+    packer_bin = module.get_bin_path("packer", required=True)
+
+    packer_module = PackerModule(module, packer_bin)
+    result = packer_module.apply()
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -121,13 +121,6 @@ options:
       - Corresponds to V(-cleanup) flag.
     type: bool
     default: false
-  env_vars:
-    description:
-      - Environment variables to set for Packer process.
-      - Useful for cloud provider credentials.
-    type: dict
-    required: false
-    default: {}
   artifact_name:
     description:
       - Name of the artifact to check for existence.
@@ -217,16 +210,6 @@ EXAMPLES = r"""
     name: format-template
     state: formatted
     template: template.pkr.hcl
-
-- name: Build with environment variables
-  community.general.packer:
-    name: env-build
-    state: build
-    template: template.pkr.hcl
-    env_vars:
-      AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
-      AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
-    log_level: debug
 
 - name: Build local artifact (VirtualBox)
   community.general.packer:
@@ -326,7 +309,6 @@ class PackerModule:
         self.timeout = self.params.get("timeout")
         self.chdir = self.params.get("chdir")
         self.cleanup = self.params.get("cleanup")
-        self.env_vars = self.params.get("env_vars") or {}
         self.artifact_name = self.params.get("artifact_name")
         self.artifact_region = self.params.get("artifact_region")
         self.artifact_type = self.params.get("artifact_type", "none")
@@ -506,24 +488,17 @@ class PackerModule:
         cmd = self._build_command(command)
         self.result["cmd"] = " ".join(cmd)
 
-        env = os.environ.copy()
-        env.update(self.env_vars)
         cwd = self.chdir or os.getcwd()
 
         try:
             start_time = datetime.now(timezone.utc).isoformat() + "Z"
 
-            result = subprocess.run(
+            rc, stdout, stderr = self.module.run_command(
                 cmd,
-                capture_output=True,
-                text=True,
                 cwd=cwd,
-                env=env,
                 timeout=self.timeout if self.timeout > 0 else None,
-                check=False,
+                check_rc=False,
             )
-
-            rc, stdout, stderr = result.returncode, result.stdout, result.stderr
 
             self.build_output = stdout
 
@@ -561,11 +536,6 @@ class PackerModule:
 
             return result_dict
 
-        except subprocess.TimeoutExpired:
-            self.module.fail_json(
-                msg=f"Packer command timed out after {self.timeout} seconds",
-                cmd=" ".join(cmd),
-            )
         except Exception as e:
             self.module.fail_json(
                 msg=f"Error executing Packer: {str(e)}",
@@ -645,7 +615,6 @@ def main() -> None:
             timeout=dict(type="int", required=False, default=3600),
             chdir=dict(type="path", required=False),
             cleanup=dict(type="bool", required=False, default=False),
-            env_vars=dict(type="dict", required=False, default={}),
             artifact_name=dict(type="str", required=False),
             artifact_region=dict(type="str", required=False),
             artifact_type=dict(

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 DOCUMENTATION = r"""
 module: packer
-version_added: 1.0.0
+version_added: 13.4.0
 short_description: Manage HashiCorp Packer builds
 description:
   - Manage Packer builds and templates.

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -276,6 +276,7 @@ changed:
 import os
 import re
 from datetime import datetime, timezone
+from typing import Any, Dict, List
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -287,7 +288,7 @@ class PackerModule:
         self.module = module
         self.params = module.params
         self.packer_bin = packer_bin
-        self.result: dict[str, object] = {
+        self.result: Dict[str, Any] = {
             "changed": False,
             "stdout": "",
             "stderr": "",
@@ -315,7 +316,7 @@ class PackerModule:
         self.output_dir = self.params.get("output_dir")
         self.log_level = self.params.get("log_level", "info")
 
-        self.state_to_command = {
+        self.state_to_command: Dict[str, str] = {
             "build": "build",
             "absent": "build",
             "validated": "validate",
@@ -328,7 +329,7 @@ class PackerModule:
     def _check_packer_version(self) -> str:
         """Get Packer version using module.run_command."""
         try:
-            rc, stdout, stderr = self.module.run_command(
+            rc, stdout, _stderr = self.module.run_command(
                 [self.packer_bin, "version"],
                 check_rc=False,
             )
@@ -339,7 +340,7 @@ class PackerModule:
                     return match.group(1)
                 return version_line.strip()
             return "unknown"
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             return "unknown"
 
     def _validate_parameters(self) -> None:
@@ -386,7 +387,7 @@ class PackerModule:
 
         return False
 
-    def _build_command(self, command: str) -> list[str]:
+    def _build_command(self, command: str) -> List[str]:
         """Build the Packer command line."""
         cmd = [self.packer_bin]
 
@@ -431,7 +432,7 @@ class PackerModule:
 
         return cmd
 
-    def _parse_machine_readable_output(self, output: str) -> list[dict]:
+    def _parse_machine_readable_output(self, output: str) -> List[Dict[str, str]]:
         """Parse machine-readable output for artifacts."""
         artifacts = []
         for line in output.splitlines():
@@ -449,7 +450,7 @@ class PackerModule:
                     artifacts.append(artifact)
         return artifacts
 
-    def _parse_build_output(self, output: str) -> list[dict]:
+    def _parse_build_output(self, output: str) -> List[Dict[str, str]]:
         """Parse build output to extract artifacts."""
         artifacts = []
 
@@ -483,7 +484,7 @@ class PackerModule:
 
         return artifacts
 
-    def _execute_packer(self, command: str) -> dict[str, object]:
+    def _execute_packer(self, command: str) -> Dict[str, Any]:
         """Execute Packer command."""
         cmd = self._build_command(command)
         self.result["cmd"] = " ".join(cmd)
@@ -550,7 +551,7 @@ class PackerModule:
             return True
         return not self._artifact_exists()
 
-    def apply(self) -> dict[str, object]:
+    def apply(self) -> Dict[str, Any]:
         """Apply Packer configuration and build if needed."""
         self._validate_parameters()
 

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -29,11 +29,11 @@ options:
   state:
     description:
       - Desired operation to perform.
-      - "build: builds the image from template (or validates in check_mode)."
-      - "init: initializes the template (installs required plugins)."
     type: str
     required: true
-    choices: [build, init]
+    choices:
+      build: builds the image from template (or validates in check_mode).
+      init: initializes the template (installs required plugins).
   template:
     description:
       - Path to the Packer template file or directory.
@@ -160,18 +160,18 @@ EXAMPLES = r"""
 
 RETURN = r"""
 cmd:
-  description: Full command line executed
+  description: Full command line executed.
   returned: always
   type: str
   sample: "packer build -force template.pkr.hcl"
 packer_version:
-  description: Packer version used
+  description: Packer version used.
   returned: always
   type: str
   sample: "1.9.4"
 artifacts:
-  description: List of created artifacts
-  returned: when state is build and build successful (not in check_mode)
+  description: List of created artifacts.
+  returned: when O(state=build) and build successful (not in check_mode)
   type: list
   elements: dict
   sample:
@@ -179,13 +179,13 @@ artifacts:
       name: ami-12345678
       build_index: 0
 artifacts_count:
-  description: Number of artifacts created
-  returned: when state is build and build successful
+  description: Number of artifacts created.
+  returned: when O(state=build) and build successful
   type: int
   sample: 1
-started:
-  description: Timestamp when the build started (UTC)
-  returned: when state is build
+build_start_timestamp:
+  description: Timestamp when the build started (UTC).
+  returned: when O(state=build)
   type: str
   sample: "2024-01-15T10:30:00Z"
 """
@@ -403,7 +403,7 @@ class PackerModule:
             }
 
             if command == "build":
-                result_dict["started"] = start_time
+                result_dict["build_start_timestamp"] = start_time
                 result_dict["artifacts"] = artifacts
                 result_dict["artifacts_count"] = artifacts_count
 

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -11,147 +11,107 @@ version_added: 1.0.0
 short_description: Manage HashiCorp Packer builds
 description:
   - Manage Packer builds and templates.
-  - Supports building, validating, inspecting, and formatting Packer templates.
-  - Provides idempotent build management with artifact existence checking.
+  - Supports building, validating, inspecting, formatting, and initializing Packer templates.
+  - For idempotent builds, use V(force) or external artifact checks.
 author: "Aleksandr Gabidullin (@a-gabidullin)"
 requirements:
   - packer >= 1.7.0
-attributes:
-  check_mode:
-    description: Can run in check_mode and report changes without making them.
-    support: none
-  diff_mode:
-    description: Will return a diff of changes.
-    support: none
 options:
   name:
     description:
-      - Name of the Packer build configuration.
-      - Used for identification and artifact tracking.
+      - Name of the Packer build configuration (for identification).
     type: str
     required: true
   state:
     description:
-      - Desired state of the Packer resource.
+      - Desired operation to perform.
       - V(build) builds the image from template.
       - V(validate) validates the template without building.
       - V(inspect) shows template information without building.
       - V(fmt) formats the template file.
+      - V(init) initializes the template (installs required plugins).
       - V(absent) is a no-op (use V(force=true) to rebuild).
     type: str
     required: true
-    choices: [build, validate, inspect, fmt, absent]
+    choices: [build, validate, inspect, fmt, init, absent]
   template:
     description:
-      - Path to the Packer template file.
+      - Path to the Packer template file or directory.
       - Required for all states except V(absent).
-      - Supports HCL2 and JSON formats.
     type: path
     required: false
   variables:
     description:
-      - Dictionary of variables to pass to Packer.
-      - Corresponds to V(-var) option.
+      - Dictionary of variables to pass to Packer (V(-var)).
     type: dict
     required: false
     default: {}
   var_files:
     description:
-      - List of variable files to load.
-      - Corresponds to V(-var-file) option.
+      - List of variable files to load (V(-var-file)).
     type: list
     elements: path
     required: false
     default: []
   only:
     description:
-      - Build only the specified builders.
-      - Corresponds to V(-only) option.
+      - Build only the specified builders (V(-only)).
     type: list
     elements: str
     required: false
   except_builders:
     description:
-      - Build all builders except the specified ones.
-      - Corresponds to V(-except) option.
+      - Build all builders except the specified ones (V(-except)).
     type: list
     elements: str
     required: false
     aliases: [except]
   force:
     description:
-      - Force rebuilding even if artifacts exist.
-      - Corresponds to V(-force) flag.
+      - Force rebuilding (passes V(-force) flag).
     type: bool
     default: false
   parallel:
     description:
-      - Enable parallel building.
-      - Set to V(false) to build sequentially.
+      - Enable parallel building (V(-parallel=false) to disable).
     type: bool
     default: true
   color:
     description:
-      - Enable colored output.
-      - Set to V(false) for non-interactive environments.
+      - Enable colored output (V(-no-color) if false).
     type: bool
     default: true
   machine_readable:
     description:
-      - Output in machine-readable format.
-      - Useful for parsing output in automation.
-      - Recommended for CI/CD pipelines.
+      - Output in machine-readable format (V(-machine-readable)).
+      - Recommended for parsing artifacts reliably.
     type: bool
     default: false
   chdir:
     description:
       - Change to this directory before running Packer.
-      - Useful when template references relative paths.
     type: path
     required: false
   cleanup:
     description:
-      - Clean up temporary files after build.
-      - Corresponds to V(-cleanup) flag.
+      - Clean up temporary files after build (V(-cleanup)).
     type: bool
     default: false
-  artifact_name:
-    description:
-      - Name of the artifact to check for existence.
-      - Used with V(state=build) to determine if rebuild is needed.
-      - For AWS AMI, specify the AMI ID.
-      - For Docker, specify the image tag.
-    type: str
-    required: false
-  artifact_region:
-    description:
-      - Cloud region where the artifact exists.
-      - Required for cloud artifacts (AWS, Azure, GCP).
-    type: str
-    required: false
-  artifact_type:
-    description:
-      - Type of artifact to check.
-      - Used to determine the appropriate existence check method.
-    type: str
-    choices: [ami, docker, azure, gcp, vsphere, openstack, none]
-    default: none
-  output_dir:
-    description:
-      - Directory where Packer artifacts will be stored.
-      - Used for local builders (virtualbox, qemu, etc.).
-    type: path
-    required: false
   log_level:
     description:
-      - Set the log level for Packer.
-      - Useful for debugging.
+      - Set the log level (V(--log-level)).
     type: str
     choices: [trace, debug, info, warn, error]
     default: info
 """
 
 EXAMPLES = r"""
+- name: Initialize Packer template (install plugins)
+  community.general.packer:
+    name: init-template
+    state: init
+    template: aws-ubuntu.pkr.hcl
+
 - name: Build AWS AMI with Packer
   community.general.packer:
     name: my-ami
@@ -160,9 +120,6 @@ EXAMPLES = r"""
     variables:
       aws_region: us-west-2
       instance_type: t2.micro
-    artifact_type: ami
-    artifact_name: ami-12345678
-    artifact_region: us-west-2
     force: false
 
 - name: Validate Packer template
@@ -210,8 +167,6 @@ EXAMPLES = r"""
     name: local-build
     state: build
     template: virtualbox.pkr.hcl
-    output_dir: /var/lib/packer/builds
-    artifact_type: none
     force: true
 """
 
@@ -247,9 +202,9 @@ artifacts:
   type: list
   elements: dict
   sample:
-    - name: ami-12345678
-      region: us-west-2
-      type: amazon-ebs
+    - type: amazon-ebs
+      name: ami-12345678
+      build_index: 0
 artifacts_count:
   description: Number of artifacts created
   returned: when state is build and build successful
@@ -302,13 +257,7 @@ class PackerModule:
         self.machine_readable = self.params.get("machine_readable")
         self.chdir = self.params.get("chdir")
         self.cleanup = self.params.get("cleanup")
-        self.artifact_name = self.params.get("artifact_name")
-        self.artifact_region = self.params.get("artifact_region")
-        self.artifact_type = self.params.get("artifact_type", "none")
-        self.output_dir = self.params.get("output_dir")
         self.log_level = self.params.get("log_level", "info")
-
-        self.build_output = ""
 
     def _check_packer_version(self) -> str:
         """Get Packer version using module.run_command."""
@@ -329,11 +278,11 @@ class PackerModule:
 
     def _validate_parameters(self) -> None:
         """Validate module parameters."""
-        if self.state in ["build", "validate", "inspect"]:
+        if self.state in ["build", "validate", "inspect", "init"]:
             if not self.template:
-                self.module.fail_json(msg=f"Template file is required for state: {self.state}")
+                self.module.fail_json(msg=f"Template file/directory is required for state: {self.state}")
             if not os.path.exists(self.template):
-                self.module.fail_json(msg=f"Template file does not exist: {self.template}")
+                self.module.fail_json(msg=f"Template file/directory does not exist: {self.template}")
 
         if self.state == "fmt" and not self.template:
             self.module.fail_json(msg="Template file is required for state: fmt")
@@ -341,32 +290,12 @@ class PackerModule:
         if self.only and self.except_builders:
             self.module.fail_json(msg="'only' and 'except_builders' parameters are mutually exclusive")
 
-        if self.artifact_type != "none" and not self.artifact_name:
-            self.module.fail_json(msg=f"'artifact_name' is required when artifact_type is '{self.artifact_type}'")
-
-        if self.artifact_type in ["ami", "azure", "gcp"] and not self.artifact_region:
-            self.module.fail_json(msg=f"'artifact_region' is required for artifact_type: {self.artifact_type}")
-
         if self.chdir and not os.path.exists(self.chdir):
             self.module.fail_json(msg=f"Working directory does not exist: {self.chdir}")
 
         for var_file in self.var_files:
             if not os.path.exists(var_file):
                 self.module.fail_json(msg=f"Variable file does not exist: {var_file}")
-
-    def _artifact_exists(self) -> bool:
-        """Check if the artifact already exists."""
-        if self.artifact_type == "none" or not self.artifact_name:
-            return False
-
-        if self.force:
-            return False
-
-        if self.artifact_type == "none" and self.output_dir:
-            if os.path.exists(self.output_dir):
-                return True
-
-        return False
 
     def _build_command(self, command: str) -> list[str]:
         """Build the Packer command line."""
@@ -377,7 +306,7 @@ class PackerModule:
 
         cmd.append(command)
 
-        if command in ["build", "validate", "inspect"]:
+        if command in ["build", "validate", "inspect", "init"]:
             if self.template:
                 cmd.append(self.template)
         elif command == "fmt":
@@ -392,29 +321,37 @@ class PackerModule:
             if self.cleanup:
                 cmd.append("-cleanup")
 
-        if not self.color:
-            cmd.append("-no-color")
-        if self.machine_readable:
-            cmd.append("-machine-readable")
+        # Для init эти опции не применяются
+        if command != "init":
+            if not self.color:
+                cmd.append("-no-color")
+            if self.machine_readable:
+                cmd.append("-machine-readable")
 
-        for key, value in self.variables.items():
-            if isinstance(value, str) and (" " in value or '"' in value):
-                cmd.extend(["-var", f'{key}="{value}"'])
-            else:
-                cmd.extend(["-var", f"{key}={value}"])
+        # Переменные и var-файлы только для команд, которые их поддерживают
+        if command in ["build", "validate", "inspect"]:
+            for key, value in self.variables.items():
+                if isinstance(value, str) and (" " in value or '"' in value):
+                    cmd.extend(["-var", f'{key}="{value}"'])
+                else:
+                    cmd.extend(["-var", f"{key}={value}"])
 
-        for var_file in self.var_files:
-            cmd.extend(["-var-file", var_file])
+            for var_file in self.var_files:
+                cmd.extend(["-var-file", var_file])
 
-        if self.only:
+        if self.only and command == "build":
             cmd.extend(["-only", ",".join(self.only)])
-        if self.except_builders:
+        if self.except_builders and command == "build":
             cmd.extend(["-except", ",".join(self.except_builders)])
 
         return cmd
 
     def _parse_machine_readable_output(self, output: str) -> list[dict[str, str]]:
-        """Parse machine-readable output for artifacts."""
+        """
+        Parse machine-readable output for artifacts.
+        Real format: artifact,<build_index>,<artifact_type>,<artifact_id>
+        Example: artifact,0,amazon-ebs,ami-12345678
+        """
         artifacts = []
         for line in output.splitlines():
             if not line.startswith("artifact,"):
@@ -422,10 +359,11 @@ class PackerModule:
 
             parts = line.split(",")
             if len(parts) >= 4:
+                # parts[1] = build index, parts[2] = type, parts[3] = id
                 artifact = {
-                    "type": parts[1] if len(parts) > 1 else "",
-                    "region": parts[2] if len(parts) > 2 else "",
-                    "name": parts[3] if len(parts) > 3 else "",
+                    "type": parts[2],
+                    "name": parts[3],
+                    "build_index": parts[1],
                 }
                 if artifact["name"]:
                     artifacts.append(artifact)
@@ -435,31 +373,32 @@ class PackerModule:
         """Parse build output to extract artifacts."""
         artifacts = []
 
+        # Если включен machine-readable, используем специализированный парсер
         if self.machine_readable:
             return self._parse_machine_readable_output(output)
 
         lines = output.splitlines()
         for line in lines:
-            if "Artifact" in line and "built" in line and ":" in line:
-                parts = line.split(":")
-                if len(parts) >= 2:
-                    artifact_name = parts[1].strip()
-                    artifact_type = parts[0].replace("Artifact", "").strip()
-                    if artifact_name:
-                        artifacts.append(
-                            {
-                                "name": artifact_name,
-                                "type": artifact_type,
-                            }
-                        )
-
-            if "ami-" in line and ("created" in line or "AMIs" in line):
-                match = re.search(r"(ami-[a-zA-Z0-9]+)", line)
-                if match:
+            # Стандартный вывод Packer: "--> <builder>: <artifact_description>"
+            # Пример: "--> amazon-ebs: AMI ami-12345678"
+            match = re.match(r"^-->\s+(.+?):\s+(.+)$", line.strip())
+            if match:
+                builder = match.group(1).strip()
+                artifact_desc = match.group(2).strip()
+                artifacts.append(
+                    {
+                        "type": builder,
+                        "name": artifact_desc,
+                    }
+                )
+            # Fallback: поиск AMI ID для AWS (на случай, если формат изменился)
+            elif "ami-" in line and ("created" in line or "AMIs" in line):
+                ami_match = re.search(r"(ami-[a-zA-Z0-9]+)", line)
+                if ami_match:
                     artifacts.append(
                         {
-                            "name": match.group(1),
-                            "type": "ami",
+                            "type": "amazon-ebs",
+                            "name": ami_match.group(1),
                         }
                     )
 
@@ -481,8 +420,6 @@ class PackerModule:
                 check_rc=False,
             )
 
-            self.build_output = stdout
-
             artifacts = []
             artifacts_count = 0
             if command == "build" and rc == 0:
@@ -494,7 +431,7 @@ class PackerModule:
                 changed = True
             elif command == "fmt":
                 changed = rc == 0 and stdout != ""
-            elif command in ["validate", "inspect"]:
+            elif command in ["validate", "inspect", "init"]:
                 changed = False
 
             result_dict = {
@@ -523,14 +460,6 @@ class PackerModule:
                 cmd=" ".join(cmd),
             )
 
-    def _should_build(self) -> bool:
-        """Determine if we need to build based on state and artifact existence."""
-        if self.state != "build":
-            return False
-        if self.force:
-            return True
-        return not self._artifact_exists()
-
     def apply(self) -> dict[str, object]:
         """Apply Packer configuration and build if needed."""
         self._validate_parameters()
@@ -544,28 +473,19 @@ class PackerModule:
             self.result["msg"] = "Absent state is not implemented. Use 'force: true' to force rebuild."
             return self.result
 
-        # Для состояний, которые напрямую соответствуют командам Packer
-        if self.state == "fmt":
-            return self._execute_packer("fmt")
+        if self.state in ["fmt", "init"]:
+            return self._execute_packer(self.state)
 
-        if self.state == "build" and not self._should_build():
-            self.result["changed"] = False
-            self.result["msg"] = (
-                f"Artifact '{self.artifact_name}' already exists, no build needed (use 'force: true' to rebuild)"
-            )
-            return self.result
-
-        # Для validate и inspect команда совпадает с state
         if self.state in ["validate", "inspect"]:
             return self._execute_packer(self.state)
 
-        # Для build (если нужно строить)
         if self.state == "build":
+            # Всегда строим (идемпотентность на усмотрение пользователя)
             result = self._execute_packer("build")
             self.result.update(result)
             return self.result
 
-        # fallback (не должно достигаться)
+        # fallback
         self.module.fail_json(msg=f"Unsupported state: {self.state}")
 
 
@@ -577,7 +497,7 @@ def main() -> None:
             state=dict(
                 type="str",
                 required=True,
-                choices=["build", "validate", "inspect", "fmt", "absent"],
+                choices=["build", "validate", "inspect", "fmt", "init", "absent"],
             ),
             template=dict(type="path", required=False),
             variables=dict(type="dict", required=False, default={}),
@@ -595,15 +515,6 @@ def main() -> None:
             machine_readable=dict(type="bool", required=False, default=False),
             chdir=dict(type="path", required=False),
             cleanup=dict(type="bool", required=False, default=False),
-            artifact_name=dict(type="str", required=False),
-            artifact_region=dict(type="str", required=False),
-            artifact_type=dict(
-                type="str",
-                required=False,
-                choices=["ami", "docker", "azure", "gcp", "vsphere", "openstack", "none"],
-                default="none",
-            ),
-            output_dir=dict(type="path", required=False),
             log_level=dict(
                 type="str",
                 required=False,

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -295,7 +295,6 @@ import re
 from datetime import datetime, timezone
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 
 class PackerModule:
@@ -503,63 +502,75 @@ class PackerModule:
         return artifacts
 
     def _execute_packer(self, command: str) -> dict[str, object]:
-        """Execute Packer command using module.run_command."""
+        """Execute Packer command."""
         cmd = self._build_command(command)
         self.result["cmd"] = " ".join(cmd)
 
+        env = os.environ.copy()
+        env.update(self.env_vars)
         cwd = self.chdir or os.getcwd()
 
-        old_env = os.environ.copy()
         try:
-            os.environ.update(self.env_vars)
+            start_time = datetime.now(timezone.utc).isoformat() + "Z"
 
-            rc, stdout, stderr = self.module.run_command(
+            result = subprocess.run(
                 cmd,
+                capture_output=True,
+                text=True,
                 cwd=cwd,
+                env=env,
                 timeout=self.timeout if self.timeout > 0 else None,
-                check_rc=False,
+                check=False,
             )
-        finally:
-            os.environ.clear()
-            os.environ.update(old_env)
 
-        self.build_output = stdout
+            rc, stdout, stderr = result.returncode, result.stdout, result.stderr
 
-        start_time = datetime.now(timezone.utc).isoformat() + "Z"
+            self.build_output = stdout
 
-        artifacts = []
-        artifacts_count = 0
-        if command == "build" and rc == 0:
-            artifacts = self._parse_build_output(stdout)
-            artifacts_count = len(artifacts)
+            artifacts = []
+            artifacts_count = 0
+            if command == "build" and rc == 0:
+                artifacts = self._parse_build_output(stdout)
+                artifacts_count = len(artifacts)
 
-        changed = False
-        if command == "build":
-            changed = True
-        elif command == "fmt":
-            changed = rc == 0 and stdout != ""
-        elif command in ["validate", "inspect"]:
             changed = False
+            if command == "build":
+                changed = True
+            elif command == "fmt":
+                changed = rc == 0 and stdout != ""
+            elif command in ["validate", "inspect"]:
+                changed = False
 
-        result_dict = {
-            "changed": changed,
-            "stdout": stdout,
-            "stderr": stderr,
-            "rc": rc,
-            "cmd": " ".join(cmd),
-            "packer_version": self._check_packer_version(),
-        }
+            result_dict = {
+                "changed": changed,
+                "stdout": stdout,
+                "stderr": stderr,
+                "rc": rc,
+                "cmd": " ".join(cmd),
+                "packer_version": self._check_packer_version(),
+            }
 
-        if command == "build":
-            result_dict["started"] = start_time
-            result_dict["artifacts"] = artifacts
-            result_dict["artifacts_count"] = artifacts_count
+            if command == "build":
+                result_dict["started"] = start_time
+                result_dict["artifacts"] = artifacts
+                result_dict["artifacts_count"] = artifacts_count
 
-        if rc != 0:
-            result_dict["failed"] = True
-            self.module.fail_json(msg="Packer command failed", **result_dict)
+            if rc != 0:
+                result_dict["failed"] = True
+                self.module.fail_json(msg="Packer command failed", **result_dict)
 
-        return result_dict
+            return result_dict
+
+        except subprocess.TimeoutExpired:
+            self.module.fail_json(
+                msg=f"Packer command timed out after {self.timeout} seconds",
+                cmd=" ".join(cmd),
+            )
+        except Exception as e:
+            self.module.fail_json(
+                msg=f"Error executing Packer: {str(e)}",
+                cmd=" ".join(cmd),
+            )
 
     def _should_build(self) -> bool:
         """Determine if we need to build based on state and artifact existence."""

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -76,7 +76,7 @@ options:
     description:
       - Disable colored output (C(-no-color) if V(false)).
     type: bool
-    default: true
+    default: false
   machine_readable:
     description:
       - Output in machine-readable format (C(-machine-readable) if V(true)).
@@ -95,7 +95,6 @@ options:
     choices: [trace, debug, info, warn, error]
     default: info
 """
-
 EXAMPLES = r"""
 - name: Initialize Packer template (install plugins)
   community.general.packer:
@@ -161,13 +160,7 @@ EXAMPLES = r"""
     template: virtualbox.pkr.hcl
     force: true
 """
-
 RETURN = r"""
-cmd:
-  description: Full command line executed.
-  returned: always
-  type: str
-  sample: "packer build -force template.pkr.hcl"
 packer_version:
   description: Packer version used.
   returned: always
@@ -196,10 +189,13 @@ build_start_timestamp:
 
 import os
 import re
-import shlex
 from datetime import datetime, timezone
 
 from ansible.module_utils.basic import AnsibleModule
+
+VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
+BUILD_ARTIFACT_RE = re.compile(r"^-->\s+(\S+):\s+(.+)$")
+AMI_ARTIFACT_RE = re.compile(r"(ami-\S+)")
 
 
 class PackerModule:
@@ -209,15 +205,6 @@ class PackerModule:
         self.module = module
         self.params = module.params
         self.packer_bin = packer_bin
-        self.result: dict[str, object] = {
-            "changed": False,
-            "stdout": "",
-            "stderr": "",
-            "rc": 0,
-            "cmd": "",
-            "packer_version": "",
-        }
-
         self.state = self.params["state"]
         self.template = self.params["template"]
         self.variables = self.params["variables"]
@@ -233,23 +220,19 @@ class PackerModule:
 
     def get_packer_version(self) -> str:
         """Get Packer version using module.run_command."""
-        try:
-            rc, stdout, _stderr = self.module.run_command(
-                [self.packer_bin, "version"],
-                check_rc=False,
-            )
-            if rc == 0 and stdout:
-                version_line = stdout.splitlines()[0]
-                match = re.search(r"(\d+\.\d+\.\d+)", version_line)
-                if match:
-                    return match.group(1)
-            return "unknown"
-        except Exception:
-            return "unknown"
+        rc, stdout, _stderr = self.module.run_command(
+            [self.packer_bin, "version"],
+            check_rc=False,
+        )
+        if rc == 0 and stdout:
+            match = VERSION_RE.search(stdout.splitlines()[0])
+            if match:
+                return match.group(1)
+        return "unknown"
 
     def validate_parameters(self) -> None:
         """Validate module parameters."""
-        if self.template and not os.path.exists(self.template):
+        if not os.path.exists(self.template):
             self.module.fail_json(msg=f"Template file/directory does not exist: {self.template}")
 
         for var_file in self.var_files:
@@ -258,13 +241,12 @@ class PackerModule:
 
     def build_command(self, command: str) -> list[str]:
         cmd = [self.packer_bin]
-
         if self.log_level != "info":
             cmd.extend(["--log-level", self.log_level])
 
         cmd.append(command)
 
-        if command in ["build", "init"] and self.template:
+        if command in ["build", "init"]:
             cmd.append(self.template)
 
         if command == "build":
@@ -286,8 +268,7 @@ class PackerModule:
                 cmd.append("-machine-readable")
 
             for key, value in self.variables.items():
-                quoted_value = shlex.quote(str(value))
-                cmd.extend(["-var", f"{key}={quoted_value}"])
+                cmd.extend(["-var", f"{key}={value}"])
 
             for var_file in self.var_files:
                 cmd.extend(["-var-file", var_file])
@@ -295,57 +276,36 @@ class PackerModule:
         return cmd
 
     def parse_machine_readable_output(self, output: str) -> list[dict[str, str]]:
-        """
-        Parse machine-readable output for artifacts.
-        Real format: artifact,<build_index>,<artifact_type>,<artifact_id>
-        Example: artifact,0,amazon-ebs,ami-12345678
-        """
+        """Parse machine-readable output for artifacts."""
         artifacts = []
         for line in output.splitlines():
             if not line.startswith("artifact,"):
                 continue
-
             parts = line.split(",")
-            if len(parts) >= 4:
-                artifact = {
-                    "type": parts[2],
-                    "name": parts[3],
-                    "build_index": parts[1],
-                }
-                if artifact["name"]:
-                    artifacts.append(artifact)
+            if len(parts) >= 4 and parts[3]:
+                artifacts.append(
+                    {
+                        "type": parts[2],
+                        "name": parts[3],
+                        "build_index": parts[1],
+                    }
+                )
         return artifacts
 
     def parse_build_output(self, output: str) -> list[dict[str, str]]:
-        """Parse build output to extract artifacts.
-        Expected output formats from Packer:
-        1. Regular build output:
-          "--> builder_name: artifact_description"
-          Example: "--> amazon-ebs: AMI ami-12345678"
-          Example: "--> virtualbox-iso: VirtualBox VM"
-
-        2. AWS AMI fallback (when the regular format is not present):
-          Lines containing "ami-" with "created" or "AMIs"
-          Example: "us-west-2: AMI ami-12345678 created"
-
-        For reliable parsing, use machine_readable: true in the module options."""
+        """Parse build output to extract artifacts."""
         artifacts = []
-
-        pattern = re.compile(r"^-->\s+(\S+):\s+(.+)$")
-        lines = output.splitlines()
-        for line in lines:
-            match = pattern.match(line.strip())
+        for line in output.splitlines():
+            match = BUILD_ARTIFACT_RE.match(line.strip())
             if match:
-                builder = match.group(1)
-                artifact_desc = match.group(2)
                 artifacts.append(
                     {
-                        "type": builder,
-                        "name": artifact_desc,
+                        "type": match.group(1),
+                        "name": match.group(2),
                     }
                 )
             elif "ami-" in line and ("created" in line or "AMIs" in line):
-                ami_match = re.search(r"(ami-\S+)", line)
+                ami_match = AMI_ARTIFACT_RE.search(line)
                 if ami_match:
                     artifacts.append(
                         {
@@ -353,76 +313,47 @@ class PackerModule:
                             "name": ami_match.group(1),
                         }
                     )
-
         return artifacts
 
     def execute_packer(self, command: str) -> dict[str, object]:
         cmd = self.build_command(command)
-        self.result["cmd"] = " ".join(cmd)
+        start_time = datetime.now(timezone.utc).isoformat() + "Z"
+        rc, stdout, stderr = self.module.run_command(cmd, check_rc=True)
 
-        try:
-            start_time = datetime.now(timezone.utc).isoformat() + "Z"
+        artifacts = []
+        if command == "build":
+            if self.machine_readable:
+                artifacts = self.parse_machine_readable_output(stdout)
+            else:
+                artifacts = self.parse_build_output(stdout)
 
-            rc, stdout, stderr = self.module.run_command(
-                cmd,
-                check_rc=False,
+        result_dict = {
+            "changed": command == "build" or command == "init",
+            "stdout": stdout,
+            "stderr": stderr,
+            "rc": rc,
+            "packer_version": self.get_packer_version(),
+        }
+
+        if command == "build":
+            result_dict.update(
+                {
+                    "build_start_timestamp": start_time,
+                    "artifacts": artifacts,
+                    "artifacts_count": len(artifacts),
+                }
             )
 
-            artifacts = []
-            if command == "build" and rc == 0:
-                if self.machine_readable:
-                    artifacts = self.parse_machine_readable_output(stdout)
-                else:
-                    artifacts = self.parse_build_output(stdout)
-            artifacts_count = len(artifacts)
-
-            changed = False
-            if command == "build":
-                changed = True
-            elif command == "init" and rc == 0:
-                changed = True
-            elif command == "validate":
-                changed = False
-
-            result_dict = {
-                "changed": changed,
-                "stdout": stdout,
-                "stderr": stderr,
-                "rc": rc,
-                "cmd": " ".join(cmd),
-                "packer_version": self.get_packer_version(),
-            }
-
-            if command == "build":
-                result_dict["build_start_timestamp"] = start_time
-                result_dict["artifacts"] = artifacts
-                result_dict["artifacts_count"] = artifacts_count
-
-            if rc != 0:
-                result_dict["failed"] = True
-                self.module.fail_json(msg="Packer command failed", **result_dict)
-
-            return result_dict
-
-        except Exception as e:
-            self.module.fail_json(
-                msg=f"Error executing Packer: {e}",
-                cmd=" ".join(cmd),
-            )
+        return result_dict
 
     def apply(self) -> dict[str, object]:
         self.validate_parameters()
 
         if self.state == "init":
             return self.execute_packer("init")
-
-        if self.state == "build":
-            if self.module.check_mode:
-                return self.execute_packer("validate")
-            else:
-                return self.execute_packer("build")
-
-        self.module.fail_json(msg=f"Unsupported state: {self.state}")
+        if self.module.check_mode:
+            return self.execute_packer("validate")
+        return self.execute_packer("build")
 
 
 def main() -> None:
@@ -445,7 +376,7 @@ def main() -> None:
             ),
             force=dict(type="bool", default=False),
             parallel=dict(type="bool", default=True),
-            color=dict(type="bool", default=True),
+            color=dict(type="bool", default=False),
             machine_readable=dict(type="bool", default=False),
             cleanup=dict(type="bool", default=False),
             log_level=dict(
@@ -459,7 +390,6 @@ def main() -> None:
         ],
         supports_check_mode=True,
     )
-
     packer_bin = module.get_bin_path("packer", required=True)
 
     packer_module = PackerModule(module, packer_bin)

--- a/plugins/modules/packer.py
+++ b/plugins/modules/packer.py
@@ -32,7 +32,7 @@ options:
     type: str
     required: true
     choices:
-      build: builds the image from template (or validates in check_mode).
+      build: builds the image from template (or validates in check mode).
       init: initializes the template (installs required plugins).
   template:
     description:
@@ -44,27 +44,23 @@ options:
     description:
       - Dictionary of variables to pass to Packer (C(-var)).
     type: dict
-    required: false
     default: {}
   var_files:
     description:
       - List of variable files to load (C(-var-file)).
     type: list
     elements: path
-    required: false
     default: []
   only:
     description:
       - Build only the specified builders (C(-only)).
     type: list
     elements: str
-    required: false
   except_builders:
     description:
       - Build all builders except the specified ones (C(-except)).
     type: list
     elements: str
-    required: false
     aliases: [except]
   force:
     description:
@@ -383,7 +379,9 @@ class PackerModule:
             changed = False
             if command == "build":
                 changed = True
-            elif command in ["init", "validate"]:
+            elif command == "init" and rc == 0:
+                changed = True
+            elif command == "validate":
                 changed = False
 
             result_dict = {
@@ -422,9 +420,7 @@ class PackerModule:
             if self.module.check_mode:
                 return self.execute_packer("validate")
             else:
-                result = self.execute_packer("build")
-                self.result.update(result)
-                return self.result
+                return self.execute_packer("build")
 
         self.module.fail_json(msg=f"Unsupported state: {self.state}")
 
@@ -439,23 +435,21 @@ def main() -> None:
                 choices=["build", "init"],
             ),
             template=dict(type="path", required=True),
-            variables=dict(type="dict", required=False, default={}),
-            var_files=dict(type="list", elements="path", required=False, default=[]),
-            only=dict(type="list", elements="str", required=False),
+            variables=dict(type="dict", default={}),
+            var_files=dict(type="list", elements="path", default=[]),
+            only=dict(type="list", elements="str"),
             except_builders=dict(
                 type="list",
                 elements="str",
-                required=False,
                 aliases=["except"],
             ),
-            force=dict(type="bool", required=False, default=False),
-            parallel=dict(type="bool", required=False, default=True),
-            color=dict(type="bool", required=False, default=True),
-            machine_readable=dict(type="bool", required=False, default=False),
-            cleanup=dict(type="bool", required=False, default=False),
+            force=dict(type="bool", default=False),
+            parallel=dict(type="bool", default=True),
+            color=dict(type="bool", default=True),
+            machine_readable=dict(type="bool", default=False),
+            cleanup=dict(type="bool", default=False),
             log_level=dict(
                 type="str",
-                required=False,
                 choices=["trace", "debug", "info", "warn", "error"],
                 default="info",
             ),

--- a/tests/unit/plugins/modules/test_packer.py
+++ b/tests/unit/plugins/modules/test_packer.py
@@ -361,4 +361,3 @@ class TestPackerModule(unittest.TestCase):
                 packer.main()
             self.assertIn("fail_json called", str(context.exception))
             mock_module_for_test.fail_json.assert_called_once()
-

--- a/tests/unit/plugins/modules/test_packer.py
+++ b/tests/unit/plugins/modules/test_packer.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import os
 import shutil
-import subprocess
 import sys
 import tempfile
 import unittest
@@ -77,7 +76,6 @@ class TestPackerModule(unittest.TestCase):
             "timeout": 3600,
             "chdir": None,
             "cleanup": False,
-            "env_vars": {},
             "artifact_name": None,
             "artifact_region": None,
             "artifact_type": "none",
@@ -243,7 +241,6 @@ class TestPackerModule(unittest.TestCase):
             "timeout": 3600,
             "chdir": None,
             "cleanup": False,
-            "env_vars": {},
             "artifact_name": None,
             "artifact_region": None,
             "artifact_type": "none",
@@ -320,20 +317,6 @@ class TestPackerModule(unittest.TestCase):
         result = packer_module.apply()
         self.assertTrue(result["changed"])
 
-    def test_timeout_handling(self):
-        from ansible_collections.community.general.plugins.modules import packer
-
-        self._setup_module_params(state="build", timeout=1)
-        self.mock_module.run_command.side_effect = subprocess.TimeoutExpired(cmd="packer build", timeout=1)
-
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-
-        with self.assertRaises(Exception) as context:
-            packer_module.apply()
-        self.assertIn("fail_json called", str(context.exception))
-        self.mock_module.fail_json.assert_called_once()
-
     def test_only_and_except_mutually_exclusive(self):
         from ansible_collections.community.general.plugins.modules import packer
 
@@ -369,31 +352,6 @@ class TestPackerModule(unittest.TestCase):
         self.assertTrue(result["changed"])
         cmd = result["cmd"]
         self.assertIn("--log-level debug", cmd)
-
-    def test_env_vars_parameter(self):
-        from ansible_collections.community.general.plugins.modules import packer
-
-        env_vars = {"AWS_ACCESS_KEY_ID": "test-key", "AWS_SECRET_ACCESS_KEY": "test-secret"}
-        self._setup_module_params(state="build", env_vars=env_vars)
-        self.mock_module.run_command.return_value = (0, "Build finished", "")
-
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-        result = packer_module.apply()
-
-        self.assertTrue(result["changed"])
-        build_call = None
-        for call in self.mock_module.run_command.call_args_list:
-            args, kwargs = call
-            if args[0] and isinstance(args[0], list) and "build" in args[0]:
-                build_call = call
-                break
-        self.assertIsNotNone(build_call, "No call with 'build' command found")
-        args, kwargs = build_call
-        self.assertIn("environ", kwargs)
-        env = kwargs["environ"]
-        self.assertEqual(env.get("AWS_ACCESS_KEY_ID"), "test-key")
-        self.assertEqual(env.get("AWS_SECRET_ACCESS_KEY"), "test-secret")
 
     def test_check_mode(self):
         from ansible_collections.community.general.plugins.modules import packer

--- a/tests/unit/plugins/modules/test_packer.py
+++ b/tests/unit/plugins/modules/test_packer.py
@@ -248,7 +248,6 @@ class TestPackerModule(unittest.TestCase):
 
         self.assertFalse(result["changed"])
         self.assertEqual(result["rc"], 0)
-        self.assertIn("Check mode", result["msg"])
         self.assertIn("validate", result["cmd"])
         self.assertNotIn("build", result["cmd"])
 

--- a/tests/unit/plugins/modules/test_packer.py
+++ b/tests/unit/plugins/modules/test_packer.py
@@ -47,7 +47,6 @@ class TestPackerModule(unittest.TestCase):
         self.mock_module.check_mode = False
         self.mock_module.get_bin_path = Mock(return_value="/usr/local/bin/packer")
         self.mock_module.warn = Mock()
-        # Мок для run_command — будет переопределяться в каждом тесте
         self.mock_module.run_command = Mock(return_value=(0, "", ""))
         self.mock_ansible_basic.AnsibleModule.return_value = self.mock_module
 
@@ -300,7 +299,6 @@ class TestPackerModule(unittest.TestCase):
             artifact_region="us-west-2",
         )
 
-        # Первый запуск: артефакт существует, сборка пропускается
         with patch.object(packer.PackerModule, "_artifact_exists", return_value=True):
             packer_bin = self.mock_module.get_bin_path.return_value
             packer_module = packer.PackerModule(self.mock_module, packer_bin)
@@ -308,7 +306,6 @@ class TestPackerModule(unittest.TestCase):
             self.assertFalse(result["changed"])
             self.assertIn("already exists", str(result.get("msg", "")))
 
-        # Второй запуск: force=True, сборка выполняется
         self._setup_module_params(
             state="build",
             artifact_type="ami",
@@ -327,7 +324,6 @@ class TestPackerModule(unittest.TestCase):
         from ansible_collections.community.general.plugins.modules import packer
 
         self._setup_module_params(state="build", timeout=1)
-        # Симулируем TimeoutExpired в run_command
         self.mock_module.run_command.side_effect = subprocess.TimeoutExpired(cmd="packer build", timeout=1)
 
         packer_bin = self.mock_module.get_bin_path.return_value
@@ -386,19 +382,16 @@ class TestPackerModule(unittest.TestCase):
         result = packer_module.apply()
 
         self.assertTrue(result["changed"])
-        # Проверяем, что в вызове run_command переданы переменные окружения
-        # Найдём вызов с командой, содержащей 'build'
         build_call = None
         for call in self.mock_module.run_command.call_args_list:
             args, kwargs = call
-            # args[0] — это список аргументов команды
             if args[0] and isinstance(args[0], list) and "build" in args[0]:
                 build_call = call
                 break
         self.assertIsNotNone(build_call, "No call with 'build' command found")
         args, kwargs = build_call
-        self.assertIn("env", kwargs)
-        env = kwargs["env"]
+        self.assertIn("environ", kwargs)
+        env = kwargs["environ"]
         self.assertEqual(env.get("AWS_ACCESS_KEY_ID"), "test-key")
         self.assertEqual(env.get("AWS_SECRET_ACCESS_KEY"), "test-secret")
 

--- a/tests/unit/plugins/modules/test_packer.py
+++ b/tests/unit/plugins/modules/test_packer.py
@@ -73,7 +73,6 @@ class TestPackerModule(unittest.TestCase):
             "parallel": True,
             "color": True,
             "machine_readable": False,
-            "chdir": None,
             "cleanup": False,
             "log_level": "info",
         }
@@ -277,7 +276,7 @@ class TestPackerModule(unittest.TestCase):
             packer_module.apply()
         self.assertIn("fail_json called", str(context.exception))
         self.mock_module.fail_json.assert_called_with(
-            msg="Template file/directory does not exist: /nonexistent/template.pkr.hcl (relative to chdir: .)"
+            msg="Template file/directory does not exist: /nonexistent/template.pkr.hcl"
         )
 
     def test_var_file_not_exists(self):
@@ -291,31 +290,8 @@ class TestPackerModule(unittest.TestCase):
             packer_module.apply()
         self.assertIn("fail_json called", str(context.exception))
         self.mock_module.fail_json.assert_called_with(
-            msg="Variable file does not exist: /nonexistent/file.pkrvars.hcl (relative to chdir: .)"
+            msg="Variable file does not exist: /nonexistent/file.pkrvars.hcl"
         )
-
-    def test_chdir_with_relative_paths(self):
-        from ansible_collections.community.general.plugins.modules import packer
-
-        subdir = os.path.join(self.test_dir, "subdir")
-        os.makedirs(subdir)
-        template_in_subdir = os.path.join(subdir, "test.pkr.hcl")
-        shutil.copy(self.template_path, template_in_subdir)
-        var_file = os.path.join(subdir, "vars.pkrvars.hcl")
-        with open(var_file, "w") as f:
-            f.write('aws_region = "us-west-2"\n')
-
-        self._setup_module_params(state="build", chdir=subdir, template="test.pkr.hcl", var_files=["vars.pkrvars.hcl"])
-        self.mock_module.run_command.return_value = (0, "Build finished", "")
-
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-        result = packer_module.apply()
-
-        self.assertTrue(result["changed"])
-        cmd = result["cmd"]
-        self.assertIn("test.pkr.hcl", cmd)
-        self.assertIn("vars.pkrvars.hcl", cmd)
 
     @patch("os.getcwd")
     def test_packer_not_installed(self, mock_getcwd):
@@ -336,7 +312,6 @@ class TestPackerModule(unittest.TestCase):
             "parallel": True,
             "color": True,
             "machine_readable": False,
-            "chdir": None,
             "cleanup": False,
             "log_level": "info",
         }

--- a/tests/unit/plugins/modules/test_packer.py
+++ b/tests/unit/plugins/modules/test_packer.py
@@ -73,7 +73,6 @@ class TestPackerModule(unittest.TestCase):
             "parallel": True,
             "color": True,
             "machine_readable": False,
-            "timeout": 3600,
             "chdir": None,
             "cleanup": False,
             "artifact_name": None,
@@ -88,7 +87,7 @@ class TestPackerModule(unittest.TestCase):
     def test_validate_template(self):
         from ansible_collections.community.general.plugins.modules import packer
 
-        self._setup_module_params(state="validated")
+        self._setup_module_params(state="validate")
         self.mock_module.run_command.return_value = (0, "Template validated successfully", "")
 
         packer_bin = self.mock_module.get_bin_path.return_value
@@ -186,7 +185,7 @@ class TestPackerModule(unittest.TestCase):
     def test_inspect_template(self):
         from ansible_collections.community.general.plugins.modules import packer
 
-        self._setup_module_params(state="inspected")
+        self._setup_module_params(state="inspect")
         self.mock_module.run_command.return_value = (0, "Template inspection output", "")
 
         packer_bin = self.mock_module.get_bin_path.return_value
@@ -199,7 +198,7 @@ class TestPackerModule(unittest.TestCase):
     def test_format_template(self):
         from ansible_collections.community.general.plugins.modules import packer
 
-        self._setup_module_params(state="formatted")
+        self._setup_module_params(state="fmt")
         self.mock_module.run_command.return_value = (0, self.template_path, "")
 
         packer_bin = self.mock_module.get_bin_path.return_value
@@ -241,7 +240,6 @@ class TestPackerModule(unittest.TestCase):
             "parallel": True,
             "color": True,
             "machine_readable": False,
-            "timeout": 3600,
             "chdir": None,
             "cleanup": False,
             "artifact_name": None,
@@ -355,19 +353,6 @@ class TestPackerModule(unittest.TestCase):
         self.assertTrue(result["changed"])
         cmd = result["cmd"]
         self.assertIn("--log-level debug", cmd)
-
-    def test_check_mode(self):
-        from ansible_collections.community.general.plugins.modules import packer
-
-        self._setup_module_params(state="build")
-        self.mock_module.check_mode = True
-        self.mock_module.run_command.return_value = (0, "Build finished", "")
-
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-        result = packer_module.apply()
-
-        self.assertTrue(result["changed"])
 
 
 if __name__ == "__main__":

--- a/tests/unit/plugins/modules/test_packer.py
+++ b/tests/unit/plugins/modules/test_packer.py
@@ -1,0 +1,364 @@
+# Copyright (c) 2026 Aleksandr Gabidullin <qualittv@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+
+class TestPackerModule(unittest.TestCase):
+    """Unit tests for the packer module."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.test_dir = tempfile.mkdtemp()
+        cls.mock_ansible_basic = Mock()
+        cls.mock_ansible_basic.AnsibleModule = Mock()
+        cls.mock_converters = Mock()
+        cls.mock_converters.to_native = str
+        cls.patcher_basic = patch.dict(
+            "sys.modules",
+            {
+                "ansible.module_utils.basic": cls.mock_ansible_basic,
+                "ansible.module_utils.common.text.converters": cls.mock_converters,
+            },
+        )
+        cls.patcher_basic.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.patcher_basic.stop()
+        if os.path.exists(cls.test_dir):
+            shutil.rmtree(cls.test_dir)
+
+    def setUp(self):
+        self.mock_ansible_basic.AnsibleModule.reset_mock()
+        self.mock_module = Mock()
+        self.mock_module.params = {}
+        self.mock_module.fail_json = Mock(side_effect=Exception("fail_json called"))
+        self.mock_module.exit_json = Mock()
+        self.mock_module.check_mode = False
+        self.mock_module.get_bin_path = Mock(return_value="/usr/local/bin/packer")
+        self.mock_module.warn = Mock()
+        self.mock_module.run_command = Mock(return_value=(0, "", ""))
+        self.mock_ansible_basic.AnsibleModule.return_value = self.mock_module
+
+        self.template_path = os.path.join(self.test_dir, "test.pkr.hcl")
+        with open(self.template_path, "w") as f:
+            f.write('source "null" "test" {\n  communicator = "none"\n}\n\nbuild {\n  sources = ["null.test"]\n}\n')
+
+        for module_name in list(sys.modules.keys()):
+            if "packer" in module_name and "ansible_collections" in module_name:
+                del sys.modules[module_name]
+
+    def tearDown(self):
+        pass
+
+    def _setup_module_params(self, **params):
+        default_params = {
+            "name": "test-build",
+            "state": "build",
+            "template": self.template_path,
+            "variables": {},
+            "var_files": [],
+            "only": None,
+            "except_builders": None,
+            "force": False,
+            "parallel": True,
+            "color": True,
+            "machine_readable": False,
+            "chdir": None,
+            "cleanup": False,
+            "log_level": "info",
+        }
+        default_params.update(params)
+        self.mock_module.params = default_params
+
+    def test_init_successful(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="init")
+        self.mock_module.run_command.return_value = (0, "Plugins installed successfully", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertFalse(result["changed"])
+        self.assertEqual(result["rc"], 0)
+        self.assertIn("Plugins installed", result["stdout"])
+        self.assertIn("init", result["cmd"])
+
+    def test_build_successful(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build")
+        self.mock_module.run_command.return_value = (
+            0,
+            "--> null.test: null artifact\nBuild finished successfully",
+            "",
+        )
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+        self.assertEqual(result["rc"], 0)
+        self.assertIn("artifacts", result)
+        self.assertEqual(result["artifacts"][0]["type"], "null.test")
+        self.assertEqual(result["artifacts"][0]["name"], "null artifact")
+
+    def test_build_with_force(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", force=True)
+        self.mock_module.run_command.return_value = (0, "Build finished", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+        cmd = result["cmd"]
+        self.assertIn("-force", cmd)
+
+    def test_build_with_only(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", only=["null.test"])
+        self.mock_module.run_command.return_value = (0, "Build finished", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+        cmd = result["cmd"]
+        self.assertIn("-only null.test", cmd)
+
+    def test_build_with_variables(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", variables={"aws_region": "us-west-2", "instance_type": "t2.micro"})
+        self.mock_module.run_command.return_value = (0, "Build finished", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+        cmd = result["cmd"]
+        self.assertIn("-var aws_region=us-west-2", cmd)
+        self.assertIn("-var instance_type=t2.micro", cmd)
+
+    def test_build_with_var_files(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        var_file = os.path.join(self.test_dir, "vars.pkrvars.hcl")
+        with open(var_file, "w") as f:
+            f.write('aws_region = "us-west-2"\n')
+
+        self._setup_module_params(state="build", var_files=[var_file])
+        self.mock_module.run_command.return_value = (0, "Build finished", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+        cmd = result["cmd"]
+        self.assertIn(f"-var-file {var_file}", cmd)
+
+    def test_build_with_parallel_disabled(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", parallel=False)
+        self.mock_module.run_command.return_value = (0, "Build finished", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        cmd = result["cmd"]
+        self.assertIn("-parallel=false", cmd)
+
+    def test_build_with_color_disabled(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", color=False)
+        self.mock_module.run_command.return_value = (0, "Build finished", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        cmd = result["cmd"]
+        self.assertIn("-no-color", cmd)
+
+    def test_build_with_machine_readable(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", machine_readable=True)
+        mock_output = "artifact,0,amazon-ebs,ami-12345678\nartifact,1,docker,my-image:latest\n"
+        self.mock_module.run_command.return_value = (0, mock_output, "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+        cmd = result["cmd"]
+        self.assertIn("-machine-readable", cmd)
+        artifacts = result["artifacts"]
+        self.assertEqual(len(artifacts), 2)
+        self.assertEqual(artifacts[0]["type"], "amazon-ebs")
+        self.assertEqual(artifacts[0]["name"], "ami-12345678")
+        self.assertEqual(artifacts[1]["type"], "docker")
+        self.assertEqual(artifacts[1]["name"], "my-image:latest")
+
+    def test_build_with_log_level(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", log_level="debug")
+        self.mock_module.run_command.return_value = (0, "Build finished", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        cmd = result["cmd"]
+        self.assertIn("--log-level debug", cmd)
+
+    def test_build_in_check_mode(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build")
+        self.mock_module.check_mode = True
+        self.mock_module.run_command.return_value = (0, "Template validated successfully", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertFalse(result["changed"])
+        self.assertEqual(result["rc"], 0)
+        self.assertIn("Check mode", result["msg"])
+        self.assertIn("validate", result["cmd"])
+        self.assertNotIn("build", result["cmd"])
+
+    def test_build_failure(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build")
+        self.mock_module.run_command.return_value = (1, "", "Error: missing required variable")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+
+        with self.assertRaises(Exception) as context:
+            packer_module.apply()
+        self.assertIn("fail_json called", str(context.exception))
+
+    def test_template_missing(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", template="/nonexistent/template.pkr.hcl")
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+
+        with self.assertRaises(Exception) as context:
+            packer_module.apply()
+        self.assertIn("fail_json called", str(context.exception))
+        self.mock_module.fail_json.assert_called_with(
+            msg="Template file/directory does not exist: /nonexistent/template.pkr.hcl (relative to chdir: .)"
+        )
+
+    def test_var_file_not_exists(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", var_files=["/nonexistent/file.pkrvars.hcl"])
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+
+        with self.assertRaises(Exception) as context:
+            packer_module.apply()
+        self.assertIn("fail_json called", str(context.exception))
+        self.mock_module.fail_json.assert_called_with(
+            msg="Variable file does not exist: /nonexistent/file.pkrvars.hcl (relative to chdir: .)"
+        )
+
+    def test_chdir_with_relative_paths(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        subdir = os.path.join(self.test_dir, "subdir")
+        os.makedirs(subdir)
+        template_in_subdir = os.path.join(subdir, "test.pkr.hcl")
+        shutil.copy(self.template_path, template_in_subdir)
+        var_file = os.path.join(subdir, "vars.pkrvars.hcl")
+        with open(var_file, "w") as f:
+            f.write('aws_region = "us-west-2"\n')
+
+        self._setup_module_params(state="build", chdir=subdir, template="test.pkr.hcl", var_files=["vars.pkrvars.hcl"])
+        self.mock_module.run_command.return_value = (0, "Build finished", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+        cmd = result["cmd"]
+        self.assertIn("test.pkr.hcl", cmd)
+        self.assertIn("vars.pkrvars.hcl", cmd)
+
+    @patch("os.getcwd")
+    def test_packer_not_installed(self, mock_getcwd):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        mock_getcwd.return_value = self.test_dir
+
+        mock_module_for_test = Mock()
+        mock_module_for_test.params = {
+            "name": "test",
+            "state": "build",
+            "template": self.template_path,
+            "variables": {},
+            "var_files": [],
+            "only": None,
+            "except_builders": None,
+            "force": False,
+            "parallel": True,
+            "color": True,
+            "machine_readable": False,
+            "chdir": None,
+            "cleanup": False,
+            "log_level": "info",
+        }
+        mock_module_for_test.fail_json = Mock(side_effect=Exception("fail_json called"))
+        mock_module_for_test.exit_json = Mock()
+        mock_module_for_test.check_mode = False
+        mock_module_for_test.warn = Mock()
+        mock_module_for_test.run_command = Mock(return_value=(0, "", ""))
+
+        def get_bin_path_side_effect(name, required=False):
+            if name == "packer" and required:
+                mock_module_for_test.fail_json(msg=f"Failed to find required executable '{name}' in PATH")
+            return None
+
+        mock_module_for_test.get_bin_path = Mock(side_effect=get_bin_path_side_effect)
+
+        with patch(
+            "ansible_collections.community.general.plugins.modules.packer.AnsibleModule",
+            return_value=mock_module_for_test,
+        ):
+            with self.assertRaises(Exception) as context:
+                packer.main()
+            self.assertIn("fail_json called", str(context.exception))
+            mock_module_for_test.fail_json.assert_called_once()
+

--- a/tests/unit/plugins/modules/test_packer.py
+++ b/tests/unit/plugins/modules/test_packer.py
@@ -222,8 +222,11 @@ class TestPackerModule(unittest.TestCase):
             packer_module.apply()
         self.assertIn("fail_json called", str(context.exception))
 
-    def test_packer_not_installed(self):
+    @patch("os.getcwd")
+    def test_packer_not_installed(self, mock_getcwd):
         from ansible_collections.community.general.plugins.modules import packer
+
+        mock_getcwd.return_value = self.test_dir
 
         mock_module_for_test = Mock()
         mock_module_for_test.params = {

--- a/tests/unit/plugins/modules/test_packer.py
+++ b/tests/unit/plugins/modules/test_packer.py
@@ -1,0 +1,420 @@
+# Copyright (c) 2026 Aleksandr Gabidullin <qualittv@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+
+class TestPackerModule(unittest.TestCase):
+    """Unit tests for the packer module."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.test_dir = tempfile.mkdtemp()
+        cls.mock_ansible_basic = Mock()
+        cls.mock_ansible_basic.AnsibleModule = Mock()
+        cls.mock_converters = Mock()
+        cls.mock_converters.to_native = str
+        cls.patcher_basic = patch.dict(
+            "sys.modules",
+            {
+                "ansible.module_utils.basic": cls.mock_ansible_basic,
+                "ansible.module_utils.common.text.converters": cls.mock_converters,
+            },
+        )
+        cls.patcher_basic.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.patcher_basic.stop()
+        if os.path.exists(cls.test_dir):
+            shutil.rmtree(cls.test_dir)
+
+    def setUp(self):
+        self.mock_ansible_basic.AnsibleModule.reset_mock()
+        self.mock_module = Mock()
+        self.mock_module.params = {}
+        self.mock_module.fail_json = Mock(side_effect=Exception("fail_json called"))
+        self.mock_module.exit_json = Mock()
+        self.mock_module.check_mode = False
+        self.mock_module.get_bin_path = Mock(return_value="/usr/local/bin/packer")
+        self.mock_module.warn = Mock()
+        # Мок для run_command — будет переопределяться в каждом тесте
+        self.mock_module.run_command = Mock(return_value=(0, "", ""))
+        self.mock_ansible_basic.AnsibleModule.return_value = self.mock_module
+
+        self.template_path = os.path.join(self.test_dir, "test.pkr.hcl")
+        with open(self.template_path, "w") as f:
+            f.write('source "null" "test" {\n  communicator = "none"\n}\n\nbuild {\n  sources = ["null.test"]\n}\n')
+
+        for module_name in list(sys.modules.keys()):
+            if "packer" in module_name and "ansible_collections" in module_name:
+                del sys.modules[module_name]
+
+    def tearDown(self):
+        pass
+
+    def _setup_module_params(self, **params):
+        default_params = {
+            "name": "test-build",
+            "state": "build",
+            "template": self.template_path,
+            "variables": {},
+            "var_files": [],
+            "only": None,
+            "except_builders": None,
+            "force": False,
+            "parallel": True,
+            "color": True,
+            "machine_readable": False,
+            "timeout": 3600,
+            "chdir": None,
+            "cleanup": False,
+            "env_vars": {},
+            "artifact_name": None,
+            "artifact_region": None,
+            "artifact_type": "none",
+            "output_dir": None,
+            "log_level": "info",
+        }
+        default_params.update(params)
+        self.mock_module.params = default_params
+
+    def test_validate_template(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="validated")
+        self.mock_module.run_command.return_value = (0, "Template validated successfully", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertFalse(result["changed"])
+        self.assertEqual(result["rc"], 0)
+        self.assertIn("Template validated", result["stdout"])
+
+    def test_build_successful(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build")
+        self.mock_module.run_command.return_value = (
+            0,
+            (
+                "Build 'null.test' finished after 1 second.\n"
+                "==> Builds finished. The artifacts of successful builds are:\n"
+                "--> null.test: null artifact\n"
+            ),
+            "",
+        )
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+        self.assertEqual(result["rc"], 0)
+        self.assertIn("artifacts", result)
+
+    def test_build_with_force(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", force=True)
+        self.mock_module.run_command.return_value = (0, "Build finished", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+        self.assertEqual(result["rc"], 0)
+        cmd = result["cmd"]
+        self.assertIn("-force", cmd)
+
+    def test_build_with_only(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", only=["null.test"])
+        self.mock_module.run_command.return_value = (0, "Build finished", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+        cmd = result["cmd"]
+        self.assertIn("-only null.test", cmd)
+
+    def test_build_with_variables(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", variables={"aws_region": "us-west-2", "instance_type": "t2.micro"})
+        self.mock_module.run_command.return_value = (0, "Build finished", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+        cmd = result["cmd"]
+        self.assertIn("-var aws_region=us-west-2", cmd)
+        self.assertIn("-var instance_type=t2.micro", cmd)
+
+    def test_build_with_var_files(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        var_file = os.path.join(self.test_dir, "vars.pkrvars.hcl")
+        with open(var_file, "w") as f:
+            f.write('aws_region = "us-west-2"\n')
+
+        self._setup_module_params(state="build", var_files=[var_file])
+        self.mock_module.run_command.return_value = (0, "Build finished", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+        cmd = result["cmd"]
+        self.assertIn(f"-var-file {var_file}", cmd)
+
+    def test_inspect_template(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="inspected")
+        self.mock_module.run_command.return_value = (0, "Template inspection output", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertFalse(result["changed"])
+        self.assertEqual(result["rc"], 0)
+
+    def test_format_template(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="formatted")
+        self.mock_module.run_command.return_value = (0, self.template_path, "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+        self.assertEqual(result["rc"], 0)
+
+    def test_build_failure(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build")
+        self.mock_module.run_command.return_value = (1, "", "Error: missing required variable")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+
+        with self.assertRaises(Exception) as context:
+            packer_module.apply()
+        self.assertIn("fail_json called", str(context.exception))
+
+    def test_packer_not_installed(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        mock_module_for_test = Mock()
+        mock_module_for_test.params = {
+            "name": "test",
+            "state": "build",
+            "template": self.template_path,
+            "variables": {},
+            "var_files": [],
+            "only": None,
+            "except_builders": None,
+            "force": False,
+            "parallel": True,
+            "color": True,
+            "machine_readable": False,
+            "timeout": 3600,
+            "chdir": None,
+            "cleanup": False,
+            "env_vars": {},
+            "artifact_name": None,
+            "artifact_region": None,
+            "artifact_type": "none",
+            "output_dir": None,
+            "log_level": "info",
+        }
+        mock_module_for_test.fail_json = Mock(side_effect=Exception("fail_json called"))
+        mock_module_for_test.exit_json = Mock()
+        mock_module_for_test.check_mode = False
+        mock_module_for_test.warn = Mock()
+        mock_module_for_test.run_command = Mock(return_value=(0, "", ""))
+
+        def get_bin_path_side_effect(name, required=False):
+            if name == "packer" and required:
+                mock_module_for_test.fail_json(msg=f"Failed to find required executable '{name}' in PATH")
+            return None
+
+        mock_module_for_test.get_bin_path = Mock(side_effect=get_bin_path_side_effect)
+
+        with patch(
+            "ansible_collections.community.general.plugins.modules.packer.AnsibleModule",
+            return_value=mock_module_for_test,
+        ):
+            with self.assertRaises(Exception) as context:
+                packer.main()
+            self.assertIn("fail_json called", str(context.exception))
+            mock_module_for_test.fail_json.assert_called_once()
+
+    def test_machine_readable_output_parsing(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", machine_readable=True)
+        mock_output = "artifact,0,us-west-2,ami-12345678\nartifact,1,us-east-1,ami-87654321\n"
+        self.mock_module.run_command.return_value = (0, mock_output, "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+        artifacts = result.get("artifacts", [])
+        self.assertEqual(len(artifacts), 2)
+        self.assertEqual(artifacts[0]["name"], "ami-12345678")
+        self.assertEqual(artifacts[0]["region"], "us-west-2")
+
+    def test_artifact_check(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(
+            state="build",
+            artifact_type="ami",
+            artifact_name="ami-12345678",
+            artifact_region="us-west-2",
+        )
+
+        # Первый запуск: артефакт существует, сборка пропускается
+        with patch.object(packer.PackerModule, "_artifact_exists", return_value=True):
+            packer_bin = self.mock_module.get_bin_path.return_value
+            packer_module = packer.PackerModule(self.mock_module, packer_bin)
+            result = packer_module.apply()
+            self.assertFalse(result["changed"])
+            self.assertIn("already exists", str(result.get("msg", "")))
+
+        # Второй запуск: force=True, сборка выполняется
+        self._setup_module_params(
+            state="build",
+            artifact_type="ami",
+            artifact_name="ami-12345678",
+            artifact_region="us-west-2",
+            force=True,
+        )
+        self.mock_module.run_command.return_value = (0, "Build finished", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+        self.assertTrue(result["changed"])
+
+    def test_timeout_handling(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", timeout=1)
+        # Симулируем TimeoutExpired в run_command
+        self.mock_module.run_command.side_effect = subprocess.TimeoutExpired(cmd="packer build", timeout=1)
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+
+        with self.assertRaises(Exception) as context:
+            packer_module.apply()
+        self.assertIn("fail_json called", str(context.exception))
+        self.mock_module.fail_json.assert_called_once()
+
+    def test_only_and_except_mutually_exclusive(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", only=["builder1"], except_builders=["builder2"])
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+
+        with self.assertRaises(Exception) as context:
+            packer_module.apply()
+        self.assertIn("fail_json called", str(context.exception))
+
+    def test_template_missing(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", template="/nonexistent/template.pkr.hcl")
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+
+        with self.assertRaises(Exception) as context:
+            packer_module.apply()
+        self.assertIn("fail_json called", str(context.exception))
+
+    def test_log_level_parameter(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build", log_level="debug")
+        self.mock_module.run_command.return_value = (0, "Build finished", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+        cmd = result["cmd"]
+        self.assertIn("--log-level debug", cmd)
+
+    def test_env_vars_parameter(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        env_vars = {"AWS_ACCESS_KEY_ID": "test-key", "AWS_SECRET_ACCESS_KEY": "test-secret"}
+        self._setup_module_params(state="build", env_vars=env_vars)
+        self.mock_module.run_command.return_value = (0, "Build finished", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+        # Проверяем, что в вызове run_command переданы переменные окружения
+        # Найдём вызов с командой, содержащей 'build'
+        build_call = None
+        for call in self.mock_module.run_command.call_args_list:
+            args, kwargs = call
+            # args[0] — это список аргументов команды
+            if args[0] and isinstance(args[0], list) and "build" in args[0]:
+                build_call = call
+                break
+        self.assertIsNotNone(build_call, "No call with 'build' command found")
+        args, kwargs = build_call
+        self.assertIn("env", kwargs)
+        env = kwargs["env"]
+        self.assertEqual(env.get("AWS_ACCESS_KEY_ID"), "test-key")
+        self.assertEqual(env.get("AWS_SECRET_ACCESS_KEY"), "test-secret")
+
+    def test_check_mode(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="build")
+        self.mock_module.check_mode = True
+        self.mock_module.run_command.return_value = (0, "Build finished", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertTrue(result["changed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/plugins/modules/test_packer.py
+++ b/tests/unit/plugins/modules/test_packer.py
@@ -257,7 +257,7 @@ class TestPackerModule(unittest.TestCase):
     def test_template_missing(self):
         self._setup_module_params(state="build", template="/nonexistent/template.pkr.hcl")
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(Exception):  # noqa: B017
             self._module().apply()
         self.mock_module.fail_json.assert_called_with(
             msg="Template file/directory does not exist: /nonexistent/template.pkr.hcl"
@@ -266,7 +266,7 @@ class TestPackerModule(unittest.TestCase):
     def test_var_file_not_exists(self):
         self._setup_module_params(state="build", var_files=["/nonexistent/file.pkrvars.hcl"])
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(Exception):  # noqa: B017
             self._module().apply()
         self.mock_module.fail_json.assert_called_with(msg="Variable file does not exist: /nonexistent/file.pkrvars.hcl")
 

--- a/tests/unit/plugins/modules/test_packer.py
+++ b/tests/unit/plugins/modules/test_packer.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 
 import os
 import shutil
-import sys
 import tempfile
 import unittest
 from unittest.mock import Mock, patch
+
+from ansible_collections.community.general.plugins.modules import packer
 
 
 class TestPackerModule(unittest.TestCase):
@@ -53,10 +54,6 @@ class TestPackerModule(unittest.TestCase):
         with open(self.template_path, "w") as f:
             f.write('source "null" "test" {\n  communicator = "none"\n}\n\nbuild {\n  sources = ["null.test"]\n}\n')
 
-        for module_name in list(sys.modules.keys()):
-            if "packer" in module_name and "ansible_collections" in module_name:
-                del sys.modules[module_name]
-
     def tearDown(self):
         pass
 
@@ -80,7 +77,6 @@ class TestPackerModule(unittest.TestCase):
         self.mock_module.params = default_params
 
     def test_init_successful(self):
-        from ansible_collections.community.general.plugins.modules import packer
 
         self._setup_module_params(state="init")
         self.mock_module.run_command.return_value = (0, "Plugins installed successfully", "")
@@ -89,13 +85,12 @@ class TestPackerModule(unittest.TestCase):
         packer_module = packer.PackerModule(self.mock_module, packer_bin)
         result = packer_module.apply()
 
-        self.assertFalse(result["changed"])
+        self.assertTrue(result["changed"])
         self.assertEqual(result["rc"], 0)
         self.assertIn("Plugins installed", result["stdout"])
         self.assertIn("init", result["cmd"])
 
     def test_build_successful(self):
-        from ansible_collections.community.general.plugins.modules import packer
 
         self._setup_module_params(state="build")
         self.mock_module.run_command.return_value = (
@@ -129,7 +124,6 @@ class TestPackerModule(unittest.TestCase):
         self.assertIn("-force", cmd)
 
     def test_build_with_only(self):
-        from ansible_collections.community.general.plugins.modules import packer
 
         self._setup_module_params(state="build", only=["null.test"])
         self.mock_module.run_command.return_value = (0, "Build finished", "")
@@ -143,7 +137,6 @@ class TestPackerModule(unittest.TestCase):
         self.assertIn("-only null.test", cmd)
 
     def test_build_with_variables(self):
-        from ansible_collections.community.general.plugins.modules import packer
 
         self._setup_module_params(state="build", variables={"aws_region": "us-west-2", "instance_type": "t2.micro"})
         self.mock_module.run_command.return_value = (0, "Build finished", "")
@@ -158,7 +151,6 @@ class TestPackerModule(unittest.TestCase):
         self.assertIn("-var instance_type=t2.micro", cmd)
 
     def test_build_with_var_files(self):
-        from ansible_collections.community.general.plugins.modules import packer
 
         var_file = os.path.join(self.test_dir, "vars.pkrvars.hcl")
         with open(var_file, "w") as f:
@@ -176,7 +168,6 @@ class TestPackerModule(unittest.TestCase):
         self.assertIn(f"-var-file {var_file}", cmd)
 
     def test_build_with_parallel_disabled(self):
-        from ansible_collections.community.general.plugins.modules import packer
 
         self._setup_module_params(state="build", parallel=False)
         self.mock_module.run_command.return_value = (0, "Build finished", "")
@@ -189,7 +180,6 @@ class TestPackerModule(unittest.TestCase):
         self.assertIn("-parallel=false", cmd)
 
     def test_build_with_color_disabled(self):
-        from ansible_collections.community.general.plugins.modules import packer
 
         self._setup_module_params(state="build", color=False)
         self.mock_module.run_command.return_value = (0, "Build finished", "")
@@ -202,7 +192,6 @@ class TestPackerModule(unittest.TestCase):
         self.assertIn("-no-color", cmd)
 
     def test_build_with_machine_readable(self):
-        from ansible_collections.community.general.plugins.modules import packer
 
         self._setup_module_params(state="build", machine_readable=True)
         mock_output = "artifact,0,amazon-ebs,ami-12345678\nartifact,1,docker,my-image:latest\n"
@@ -223,7 +212,6 @@ class TestPackerModule(unittest.TestCase):
         self.assertEqual(artifacts[1]["name"], "my-image:latest")
 
     def test_build_with_log_level(self):
-        from ansible_collections.community.general.plugins.modules import packer
 
         self._setup_module_params(state="build", log_level="debug")
         self.mock_module.run_command.return_value = (0, "Build finished", "")
@@ -236,7 +224,6 @@ class TestPackerModule(unittest.TestCase):
         self.assertIn("--log-level debug", cmd)
 
     def test_build_in_check_mode(self):
-        from ansible_collections.community.general.plugins.modules import packer
 
         self._setup_module_params(state="build")
         self.mock_module.check_mode = True
@@ -252,7 +239,6 @@ class TestPackerModule(unittest.TestCase):
         self.assertNotIn("build", result["cmd"])
 
     def test_build_failure(self):
-        from ansible_collections.community.general.plugins.modules import packer
 
         self._setup_module_params(state="build")
         self.mock_module.run_command.return_value = (1, "", "Error: missing required variable")
@@ -265,7 +251,6 @@ class TestPackerModule(unittest.TestCase):
         self.assertIn("fail_json called", str(context.exception))
 
     def test_template_missing(self):
-        from ansible_collections.community.general.plugins.modules import packer
 
         self._setup_module_params(state="build", template="/nonexistent/template.pkr.hcl")
         packer_bin = self.mock_module.get_bin_path.return_value
@@ -279,7 +264,6 @@ class TestPackerModule(unittest.TestCase):
         )
 
     def test_var_file_not_exists(self):
-        from ansible_collections.community.general.plugins.modules import packer
 
         self._setup_module_params(state="build", var_files=["/nonexistent/file.pkrvars.hcl"])
         packer_bin = self.mock_module.get_bin_path.return_value
@@ -292,7 +276,6 @@ class TestPackerModule(unittest.TestCase):
 
     @patch("os.getcwd")
     def test_packer_not_installed(self, mock_getcwd):
-        from ansible_collections.community.general.plugins.modules import packer
 
         mock_getcwd.return_value = self.test_dir
 

--- a/tests/unit/plugins/modules/test_packer.py
+++ b/tests/unit/plugins/modules/test_packer.py
@@ -289,9 +289,7 @@ class TestPackerModule(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             packer_module.apply()
         self.assertIn("fail_json called", str(context.exception))
-        self.mock_module.fail_json.assert_called_with(
-            msg="Variable file does not exist: /nonexistent/file.pkrvars.hcl"
-        )
+        self.mock_module.fail_json.assert_called_with(msg="Variable file does not exist: /nonexistent/file.pkrvars.hcl")
 
     @patch("os.getcwd")
     def test_packer_not_installed(self, mock_getcwd):

--- a/tests/unit/plugins/modules/test_packer.py
+++ b/tests/unit/plugins/modules/test_packer.py
@@ -75,14 +75,25 @@ class TestPackerModule(unittest.TestCase):
             "machine_readable": False,
             "chdir": None,
             "cleanup": False,
-            "artifact_name": None,
-            "artifact_region": None,
-            "artifact_type": "none",
-            "output_dir": None,
             "log_level": "info",
         }
         default_params.update(params)
         self.mock_module.params = default_params
+
+    def test_init_template(self):
+        from ansible_collections.community.general.plugins.modules import packer
+
+        self._setup_module_params(state="init")
+        self.mock_module.run_command.return_value = (0, "Plugins installed successfully", "")
+
+        packer_bin = self.mock_module.get_bin_path.return_value
+        packer_module = packer.PackerModule(self.mock_module, packer_bin)
+        result = packer_module.apply()
+
+        self.assertFalse(result["changed"])
+        self.assertEqual(result["rc"], 0)
+        self.assertIn("Plugins installed", result["stdout"])
+        self.assertIn("init", result["cmd"])
 
     def test_validate_template(self):
         from ansible_collections.community.general.plugins.modules import packer
@@ -105,6 +116,7 @@ class TestPackerModule(unittest.TestCase):
         self.mock_module.run_command.return_value = (
             0,
             (
+                "--> null.test: null artifact\n"
                 "Build 'null.test' finished after 1 second.\n"
                 "==> Builds finished. The artifacts of successful builds are:\n"
                 "--> null.test: null artifact\n"
@@ -119,6 +131,7 @@ class TestPackerModule(unittest.TestCase):
         self.assertTrue(result["changed"])
         self.assertEqual(result["rc"], 0)
         self.assertIn("artifacts", result)
+        self.assertIn("null.test", result["artifacts"][0]["type"])
 
     def test_build_with_force(self):
         from ansible_collections.community.general.plugins.modules import packer
@@ -242,10 +255,6 @@ class TestPackerModule(unittest.TestCase):
             "machine_readable": False,
             "chdir": None,
             "cleanup": False,
-            "artifact_name": None,
-            "artifact_region": None,
-            "artifact_type": "none",
-            "output_dir": None,
             "log_level": "info",
         }
         mock_module_for_test.fail_json = Mock(side_effect=Exception("fail_json called"))
@@ -274,7 +283,8 @@ class TestPackerModule(unittest.TestCase):
         from ansible_collections.community.general.plugins.modules import packer
 
         self._setup_module_params(state="build", machine_readable=True)
-        mock_output = "artifact,0,us-west-2,ami-12345678\nartifact,1,us-east-1,ami-87654321\n"
+        # Реальный формат Packer: artifact,<build_index>,<type>,<id>
+        mock_output = "artifact,0,amazon-ebs,ami-12345678\nartifact,1,docker,my-image:latest\n"
         self.mock_module.run_command.return_value = (0, mock_output, "")
 
         packer_bin = self.mock_module.get_bin_path.return_value
@@ -284,39 +294,10 @@ class TestPackerModule(unittest.TestCase):
         self.assertTrue(result["changed"])
         artifacts = result.get("artifacts", [])
         self.assertEqual(len(artifacts), 2)
+        self.assertEqual(artifacts[0]["type"], "amazon-ebs")
         self.assertEqual(artifacts[0]["name"], "ami-12345678")
-        self.assertEqual(artifacts[0]["region"], "us-west-2")
-
-    def test_artifact_check(self):
-        from ansible_collections.community.general.plugins.modules import packer
-
-        self._setup_module_params(
-            state="build",
-            artifact_type="ami",
-            artifact_name="ami-12345678",
-            artifact_region="us-west-2",
-        )
-
-        with patch.object(packer.PackerModule, "_artifact_exists", return_value=True):
-            packer_bin = self.mock_module.get_bin_path.return_value
-            packer_module = packer.PackerModule(self.mock_module, packer_bin)
-            result = packer_module.apply()
-            self.assertFalse(result["changed"])
-            self.assertIn("already exists", str(result.get("msg", "")))
-
-        self._setup_module_params(
-            state="build",
-            artifact_type="ami",
-            artifact_name="ami-12345678",
-            artifact_region="us-west-2",
-            force=True,
-        )
-        self.mock_module.run_command.return_value = (0, "Build finished", "")
-
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-        result = packer_module.apply()
-        self.assertTrue(result["changed"])
+        self.assertEqual(artifacts[1]["type"], "docker")
+        self.assertEqual(artifacts[1]["name"], "my-image:latest")
 
     def test_only_and_except_mutually_exclusive(self):
         from ansible_collections.community.general.plugins.modules import packer

--- a/tests/unit/plugins/modules/test_packer.py
+++ b/tests/unit/plugins/modules/test_packer.py
@@ -21,14 +21,9 @@ class TestPackerModule(unittest.TestCase):
         cls.test_dir = tempfile.mkdtemp()
         cls.mock_ansible_basic = Mock()
         cls.mock_ansible_basic.AnsibleModule = Mock()
-        cls.mock_converters = Mock()
-        cls.mock_converters.to_native = str
         cls.patcher_basic = patch.dict(
             "sys.modules",
-            {
-                "ansible.module_utils.basic": cls.mock_ansible_basic,
-                "ansible.module_utils.common.text.converters": cls.mock_converters,
-            },
+            {"ansible.module_utils.basic": cls.mock_ansible_basic},
         )
         cls.patcher_basic.start()
 
@@ -46,16 +41,11 @@ class TestPackerModule(unittest.TestCase):
         self.mock_module.exit_json = Mock()
         self.mock_module.check_mode = False
         self.mock_module.get_bin_path = Mock(return_value="/usr/local/bin/packer")
-        self.mock_module.warn = Mock()
         self.mock_module.run_command = Mock(return_value=(0, "", ""))
         self.mock_ansible_basic.AnsibleModule.return_value = self.mock_module
-
         self.template_path = os.path.join(self.test_dir, "test.pkr.hcl")
         with open(self.template_path, "w") as f:
             f.write('source "null" "test" {\n  communicator = "none"\n}\n\nbuild {\n  sources = ["null.test"]\n}\n')
-
-    def tearDown(self):
-        pass
 
     def _setup_module_params(self, **params):
         default_params = {
@@ -68,7 +58,7 @@ class TestPackerModule(unittest.TestCase):
             "except_builders": None,
             "force": False,
             "parallel": True,
-            "color": True,
+            "color": False,
             "machine_readable": False,
             "cleanup": False,
             "log_level": "info",
@@ -76,243 +66,225 @@ class TestPackerModule(unittest.TestCase):
         default_params.update(params)
         self.mock_module.params = default_params
 
+    def _module(self):
+        return packer.PackerModule(self.mock_module, self.mock_module.get_bin_path.return_value)
+
+    def _command(self):
+        """Return the first run_command call (the main packer command, not version check)."""
+        return self.mock_module.run_command.call_args_list[0].args[0]
+
     def test_init_successful(self):
-
         self._setup_module_params(state="init")
-        self.mock_module.run_command.return_value = (0, "Plugins installed successfully", "")
+        self.mock_module.run_command.side_effect = [
+            (0, "Plugins installed successfully", ""),
+            (0, "Packer v1.9.4", ""),
+        ]
 
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-        result = packer_module.apply()
+        result = self._module().apply()
 
         self.assertTrue(result["changed"])
         self.assertEqual(result["rc"], 0)
         self.assertIn("Plugins installed", result["stdout"])
-        self.assertIn("init", result["cmd"])
+        self.assertEqual(self._command(), ["/usr/local/bin/packer", "init", self.template_path])
 
     def test_build_successful(self):
-
         self._setup_module_params(state="build")
-        self.mock_module.run_command.return_value = (
-            0,
-            "--> null.test: null artifact\nBuild finished successfully",
-            "",
-        )
+        self.mock_module.run_command.side_effect = [
+            (0, "--> null.test: null artifact\nBuild finished successfully", ""),
+            (0, "Packer v1.9.4", ""),
+        ]
 
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-        result = packer_module.apply()
+        result = self._module().apply()
 
         self.assertTrue(result["changed"])
         self.assertEqual(result["rc"], 0)
-        self.assertIn("artifacts", result)
         self.assertEqual(result["artifacts"][0]["type"], "null.test")
         self.assertEqual(result["artifacts"][0]["name"], "null artifact")
 
     def test_build_with_force(self):
-        from ansible_collections.community.general.plugins.modules import packer
-
         self._setup_module_params(state="build", force=True)
-        self.mock_module.run_command.return_value = (0, "Build finished", "")
+        self.mock_module.run_command.side_effect = [
+            (0, "Build finished", ""),
+            (0, "Packer v1.9.4", ""),
+        ]
 
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-        result = packer_module.apply()
+        self._module().apply()
 
-        self.assertTrue(result["changed"])
-        cmd = result["cmd"]
-        self.assertIn("-force", cmd)
+        self.assertIn("-force", self._command())
 
     def test_build_with_only(self):
-
         self._setup_module_params(state="build", only=["null.test"])
-        self.mock_module.run_command.return_value = (0, "Build finished", "")
+        self.mock_module.run_command.side_effect = [
+            (0, "Build finished", ""),
+            (0, "Packer v1.9.4", ""),
+        ]
 
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-        result = packer_module.apply()
+        self._module().apply()
 
-        self.assertTrue(result["changed"])
-        cmd = result["cmd"]
-        self.assertIn("-only null.test", cmd)
+        self.assertIn("-only", self._command())
+        self.assertIn("null.test", self._command())
 
     def test_build_with_variables(self):
-
         self._setup_module_params(state="build", variables={"aws_region": "us-west-2", "instance_type": "t2.micro"})
-        self.mock_module.run_command.return_value = (0, "Build finished", "")
+        self.mock_module.run_command.side_effect = [
+            (0, "Build finished", ""),
+            (0, "Packer v1.9.4", ""),
+        ]
 
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-        result = packer_module.apply()
+        self._module().apply()
 
-        self.assertTrue(result["changed"])
-        cmd = result["cmd"]
-        self.assertIn("-var aws_region=us-west-2", cmd)
-        self.assertIn("-var instance_type=t2.micro", cmd)
+        command = self._command()
+        self.assertIn("-var", command)
+        self.assertIn("aws_region=us-west-2", command)
+        self.assertIn("instance_type=t2.micro", command)
 
     def test_build_with_var_files(self):
-
         var_file = os.path.join(self.test_dir, "vars.pkrvars.hcl")
         with open(var_file, "w") as f:
             f.write('aws_region = "us-west-2"\n')
 
         self._setup_module_params(state="build", var_files=[var_file])
-        self.mock_module.run_command.return_value = (0, "Build finished", "")
+        self.mock_module.run_command.side_effect = [
+            (0, "Build finished", ""),
+            (0, "Packer v1.9.4", ""),
+        ]
 
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-        result = packer_module.apply()
+        self._module().apply()
 
-        self.assertTrue(result["changed"])
-        cmd = result["cmd"]
-        self.assertIn(f"-var-file {var_file}", cmd)
+        command = self._command()
+        self.assertIn("-var-file", command)
+        self.assertIn(var_file, command)
 
     def test_build_with_parallel_disabled(self):
-
         self._setup_module_params(state="build", parallel=False)
-        self.mock_module.run_command.return_value = (0, "Build finished", "")
+        self.mock_module.run_command.side_effect = [
+            (0, "Build finished", ""),
+            (0, "Packer v1.9.4", ""),
+        ]
 
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-        result = packer_module.apply()
+        self._module().apply()
 
-        cmd = result["cmd"]
-        self.assertIn("-parallel=false", cmd)
+        self.assertIn("-parallel=false", self._command())
 
     def test_build_with_color_disabled(self):
-
         self._setup_module_params(state="build", color=False)
-        self.mock_module.run_command.return_value = (0, "Build finished", "")
+        self.mock_module.run_command.side_effect = [
+            (0, "Build finished", ""),
+            (0, "Packer v1.9.4", ""),
+        ]
 
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-        result = packer_module.apply()
+        self._module().apply()
 
-        cmd = result["cmd"]
-        self.assertIn("-no-color", cmd)
+        self.assertIn("-no-color", self._command())
+
+    def test_build_with_color_enabled(self):
+        self._setup_module_params(state="build", color=True)
+        self.mock_module.run_command.side_effect = [
+            (0, "Build finished", ""),
+            (0, "Packer v1.9.4", ""),
+        ]
+
+        self._module().apply()
+
+        self.assertNotIn("-no-color", self._command())
 
     def test_build_with_machine_readable(self):
-
         self._setup_module_params(state="build", machine_readable=True)
         mock_output = "artifact,0,amazon-ebs,ami-12345678\nartifact,1,docker,my-image:latest\n"
-        self.mock_module.run_command.return_value = (0, mock_output, "")
+        self.mock_module.run_command.side_effect = [
+            (0, mock_output, ""),
+            (0, "Packer v1.9.4", ""),
+        ]
 
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-        result = packer_module.apply()
+        result = self._module().apply()
 
-        self.assertTrue(result["changed"])
-        cmd = result["cmd"]
-        self.assertIn("-machine-readable", cmd)
-        artifacts = result["artifacts"]
-        self.assertEqual(len(artifacts), 2)
-        self.assertEqual(artifacts[0]["type"], "amazon-ebs")
-        self.assertEqual(artifacts[0]["name"], "ami-12345678")
-        self.assertEqual(artifacts[1]["type"], "docker")
-        self.assertEqual(artifacts[1]["name"], "my-image:latest")
+        self.assertIn("-machine-readable", self._command())
+        self.assertEqual(len(result["artifacts"]), 2)
+        self.assertEqual(result["artifacts"][0]["type"], "amazon-ebs")
+        self.assertEqual(result["artifacts"][0]["name"], "ami-12345678")
+        self.assertEqual(result["artifacts"][1]["type"], "docker")
+        self.assertEqual(result["artifacts"][1]["name"], "my-image:latest")
 
     def test_build_with_log_level(self):
-
         self._setup_module_params(state="build", log_level="debug")
-        self.mock_module.run_command.return_value = (0, "Build finished", "")
+        self.mock_module.run_command.side_effect = [
+            (0, "Build finished", ""),
+            (0, "Packer v1.9.4", ""),
+        ]
 
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-        result = packer_module.apply()
+        self._module().apply()
 
-        cmd = result["cmd"]
-        self.assertIn("--log-level debug", cmd)
+        command = self._command()
+        self.assertEqual(command[1:3], ["--log-level", "debug"])
 
     def test_build_in_check_mode(self):
-
-        self._setup_module_params(state="build")
+        self._setup_module_params(state="build", color=True)
         self.mock_module.check_mode = True
-        self.mock_module.run_command.return_value = (0, "Template validated successfully", "")
+        self.mock_module.run_command.side_effect = [
+            (0, "Template validated successfully", ""),
+            (0, "Packer v1.9.4", ""),
+        ]
 
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-        result = packer_module.apply()
+        result = self._module().apply()
 
         self.assertFalse(result["changed"])
         self.assertEqual(result["rc"], 0)
-        self.assertIn("validate", result["cmd"])
-        self.assertNotIn("build", result["cmd"])
+        self.assertEqual(self._command()[1], "validate")
+
+    def test_run_command_uses_check_rc(self):
+        self._setup_module_params(state="build")
+        self.mock_module.run_command.side_effect = [
+            (0, "Build finished", ""),
+            (0, "Packer v1.9.4", ""),
+        ]
+
+        self._module().apply()
+
+        call_kwargs = self.mock_module.run_command.call_args_list[0].kwargs
+        self.assertEqual(call_kwargs.get("check_rc"), True)
 
     def test_build_failure(self):
-
         self._setup_module_params(state="build")
-        self.mock_module.run_command.return_value = (1, "", "Error: missing required variable")
+        self.mock_module.run_command.side_effect = [
+            (1, "", "Error: missing required variable"),
+            (0, "Packer v1.9.4", ""),
+        ]
 
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
-
-        with self.assertRaises(Exception) as context:
-            packer_module.apply()
-        self.assertIn("fail_json called", str(context.exception))
+        self._module().apply()
+        call_kwargs = self.mock_module.run_command.call_args_list[0].kwargs
+        self.assertEqual(call_kwargs.get("check_rc"), True)
 
     def test_template_missing(self):
-
         self._setup_module_params(state="build", template="/nonexistent/template.pkr.hcl")
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
 
-        with self.assertRaises(Exception) as context:
-            packer_module.apply()
-        self.assertIn("fail_json called", str(context.exception))
+        with self.assertRaises(Exception):
+            self._module().apply()
         self.mock_module.fail_json.assert_called_with(
             msg="Template file/directory does not exist: /nonexistent/template.pkr.hcl"
         )
 
     def test_var_file_not_exists(self):
-
         self._setup_module_params(state="build", var_files=["/nonexistent/file.pkrvars.hcl"])
-        packer_bin = self.mock_module.get_bin_path.return_value
-        packer_module = packer.PackerModule(self.mock_module, packer_bin)
 
-        with self.assertRaises(Exception) as context:
-            packer_module.apply()
-        self.assertIn("fail_json called", str(context.exception))
+        with self.assertRaises(Exception):
+            self._module().apply()
         self.mock_module.fail_json.assert_called_with(msg="Variable file does not exist: /nonexistent/file.pkrvars.hcl")
 
-    @patch("os.getcwd")
-    def test_packer_not_installed(self, mock_getcwd):
+    @patch("ansible_collections.community.general.plugins.modules.packer.AnsibleModule")
+    def test_packer_not_installed(self, mock_ansible_module):
+        mock_module = Mock()
+        mock_module.get_bin_path.side_effect = lambda name, required=False: (
+            mock_module.fail_json(msg=f"Failed to find required executable '{name}' in PATH")
+            if name == "packer" and required
+            else None
+        )
+        mock_module.fail_json.side_effect = Exception("fail_json called")
+        mock_ansible_module.return_value = mock_module
 
-        mock_getcwd.return_value = self.test_dir
+        with self.assertRaises(Exception) as context:
+            packer.main()
+        self.assertIn("fail_json called", str(context.exception))
 
-        mock_module_for_test = Mock()
-        mock_module_for_test.params = {
-            "name": "test",
-            "state": "build",
-            "template": self.template_path,
-            "variables": {},
-            "var_files": [],
-            "only": None,
-            "except_builders": None,
-            "force": False,
-            "parallel": True,
-            "color": True,
-            "machine_readable": False,
-            "cleanup": False,
-            "log_level": "info",
-        }
-        mock_module_for_test.fail_json = Mock(side_effect=Exception("fail_json called"))
-        mock_module_for_test.exit_json = Mock()
-        mock_module_for_test.check_mode = False
-        mock_module_for_test.warn = Mock()
-        mock_module_for_test.run_command = Mock(return_value=(0, "", ""))
 
-        def get_bin_path_side_effect(name, required=False):
-            if name == "packer" and required:
-                mock_module_for_test.fail_json(msg=f"Failed to find required executable '{name}' in PATH")
-            return None
-
-        mock_module_for_test.get_bin_path = Mock(side_effect=get_bin_path_side_effect)
-
-        with patch(
-            "ansible_collections.community.general.plugins.modules.packer.AnsibleModule",
-            return_value=mock_module_for_test,
-        ):
-            with self.assertRaises(Exception) as context:
-                packer.main()
-            self.assertIn("fail_json called", str(context.exception))
-            mock_module_for_test.fail_json.assert_called_once()
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
New module `packer` to manage HashiCorp Packer builds. This module supports:
- Building images from Packer templates
- Validating template syntax
- Inspecting template structure
- Formatting Packer templates
- Idempotent builds with artifact existence checking
- Check mode support
- Machine-readable output parsing

##### ISSUE TYPE
- New Module/Plugin Pull Request

##### COMPONENT NAME
packer

##### ADDITIONAL INFORMATION
This module provides Ansible users with native integration for HashiCorp Packer, allowing them to build, validate, and manage Packer templates directly from playbooks.
