### PR TITLE
uv_python: fix and improve tests

### DIFF
--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -11,8 +11,8 @@
 - name: Determine Python versions
   ansible.builtin.set_fact:
     python_3_14: "3.14"
-    python_3_13: "3.13"
-    python_3_13_5: "3.13.5"
+    python_3_13: "3.{{ 12 if ansible_facts.python.version.minor == 13 else 13 }}"
+    python_3_13_5: "3.{{ 12 if ansible_facts.python.version.minor == 13 else 13 }}.5"
 
 - name: Install uv python package
   ansible.builtin.pip:

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -8,6 +8,12 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+- name: Determine Python versions
+  ansible.builtin.set_fact:
+    python_3_14: "3.14"
+    python_3_13: "3.13"
+    python_3_13_5: "3.13.5"
+
 - name: Install uv python package
   ansible.builtin.pip:
     name: uv
@@ -21,33 +27,33 @@
   args:
     creates: "{{ ansible_env.HOME }}/ansible/bin/uv"
 
-- name: Check if Python 3.14 exists already
-  ansible.builtin.command: uv python find 3.14
+- name: Check if Python {{ python_3_14 }} exists already
+  ansible.builtin.command: uv python find {{ python_3_14 }}
   ignore_errors: true
   register: check_python_314_exists
   changed_when: false
 
-- name: Install Python 3.14 in check mode
+- name: Install Python {{ python_3_14 }} in check mode
   community.general.uv_python:
-    version: "3.14"
+    version: "{{ python_3_14 }}"
     state: present
   check_mode: true
   register: install_check_mode
 
-- name: Verify Python 3.14 installation in check mode
+- name: Verify Python {{ python_3_14 }} installation in check mode
   ansible.builtin.assert:
     that:
       - (install_check_mode is changed) == (check_python_314_exists is failed)
       - install_check_mode is not failed
       - install_check_mode.python_versions | length >= 1
 
-- name: Install Python 3.14
+- name: Install Python {{ python_3_14 }}
   community.general.uv_python:
-    version: "3.14"
+    version: "{{ python_3_14 }}"
     state: present
   register: install_python
 
-- name: Verify Python 3.14 installation
+- name: Verify Python {{ python_3_14 }} installation
   ansible.builtin.assert:
     that:
       - (install_python is changed) == (check_python_314_exists is failed)
@@ -61,18 +67,18 @@
     follow: true
   register: python_path_stats
 
-- name: Verify that Python 3.14 install path exists on host
+- name: Verify that Python {{ python_3_14 }} install path exists on host
   ansible.builtin.fail:
     msg: "Python install path {{ install_python.python_paths[0] }} is not correct"
   when: not python_path_stats.stat.exists
 
-- name: Re-install Python 3.14
+- name: Re-install Python {{ python_3_14 }}
   community.general.uv_python:
-    version: "3.14"
+    version: "{{ python_3_14 }}"
     state: present
   register: reinstall_python
 
-- name: Verify Python 3.14 re-installation
+- name: Verify Python {{ python_3_14 }} re-installation
   ansible.builtin.assert:
     that:
       - reinstall_python is not changed
@@ -80,37 +86,37 @@
       - reinstall_python.python_versions | length >= 1
       - reinstall_python.python_paths | length >= 1
 
-- name: Check if Python 3.13.5 exists already
-  ansible.builtin.command: uv python find 3.13.5
+- name: Check if Python {{ python_3_13_5 }} exists already
+  ansible.builtin.command: uv python find {{ python_3_13_5 }}
   ignore_errors: true
   register: check_python_3135_exists
   changed_when: false
 
-- name: Install Python 3.13.5
+- name: Install Python {{ python_3_13_5 }}
   community.general.uv_python:
-    version: 3.13.5
+    version: "{{ python_3_13_5 }}"
   register: install_python_3135
 
-- name: Verify Python 3.13.5 installation
+- name: Verify Python {{ python_3_13_5 }} installation
   ansible.builtin.assert:
     that:
       - (install_python_3135 is changed) == (check_python_3135_exists is failed)
       - install_python_3135 is not failed
-      - '"3.13.5" in install_python_3135.python_versions'
+      - python_3_13_5 in install_python_3135.python_versions
       - install_python_3135.python_paths | length >= 1
 
-- name: Re-install Python 3.13.5
+- name: Re-install Python {{ python_3_13_5 }}
   community.general.uv_python:
-    version: 3.13.5
+    version: "{{ python_3_13_5 }}"
     state: present
   register: reinstall_python
 
-- name: Verify Python 3.13.5 installation
+- name: Verify Python {{ python_3_13_5 }} installation
   ansible.builtin.assert:
     that:
       - reinstall_python is not changed
       - reinstall_python is not failed
-      - '"3.13.5" in reinstall_python.python_versions'
+      - python_3_13_5 in reinstall_python.python_versions
 
 - name: Remove uninstalled Python 3.10 # removes latest patch version for 3.10 if exists
   community.general.uv_python:
@@ -125,52 +131,52 @@
       - remove_python is not failed
       - remove_python.python_versions | length == 0
 
-- name: Remove Python 3.13.5 in check mode
+- name: Remove Python {{ python_3_13_5 }} in check mode
   community.general.uv_python:
-    version: 3.13.5
+    version: "{{ python_3_13_5 }}"
     state: absent
   check_mode: true
   register: remove_python_in_check_mode
 
-- name: Verify Python 3.13.5 deletion in check mode
+- name: Verify Python {{ python_3_13_5 }} deletion in check mode
   ansible.builtin.assert:
     that:
       - (remove_python_in_check_mode is changed) == (install_python_3135 is changed)
       - remove_python_in_check_mode is not failed
 
-- name: Additional check for Python 3.13.5 deletion in check mode
+- name: Additional check for Python {{ python_3_13_5 }} deletion in check mode
   when: install_python_3135 is changed
   ansible.builtin.assert:
     that:
-      - '"3.13.5" in remove_python_in_check_mode.python_versions'
+      - 'python_3_13_5 in remove_python_in_check_mode.python_versions'
       - remove_python_in_check_mode.python_paths | length >= 1
 
-- name: Remove Python 3.13.5
+- name: Remove Python {{ python_3_13_5 }}
   community.general.uv_python:
-    version: 3.13.5
+    version: "{{ python_3_13_5 }}"
     state: absent
   register: remove_python
 
-- name: Verify Python 3.13.5 deletion
+- name: Verify Python {{ python_3_13_5 }} deletion
   ansible.builtin.assert:
     that:
       - (remove_python is changed) == (install_python_3135 is changed)
       - remove_python is not failed
 
-- name: Additional check for Python 3.13.5 deletion
+- name: Additional check for Python {{ python_3_13_5 }} deletion
   when: install_python_3135 is changed
   ansible.builtin.assert:
     that:
       - remove_python.python_paths | length >= 1
-      - '"3.13.5" in remove_python.python_versions'
+      - 'python_3_13_5 in remove_python.python_versions'
 
-- name: Remove Python 3.13.5 again
+- name: Remove Python {{ python_3_13_5 }} again
   community.general.uv_python:
-    version: 3.13.5
+    version: "{{ python_3_13_5 }}"
     state: absent
   register: remove_python
 
-- name: Verify Python 3.13.5 deletion again
+- name: Verify Python {{ python_3_13_5 }} deletion again
   ansible.builtin.assert:
     that:
       - remove_python is not changed
@@ -178,13 +184,13 @@
       - remove_python.python_versions | length == 0
       - remove_python.python_paths | length == 0
 
-- name: Upgrade Python 3.13
+- name: Upgrade Python {{ python_3_13 }}
   community.general.uv_python:
-    version: 3.13
+    version: "{{ python_3_13 }}"
     state: latest
   register: upgrade_python
 
-- name: Verify Python 3.13 upgrade
+- name: Verify Python {{ python_3_13 }} upgrade
   ansible.builtin.assert:
     that:
       - upgrade_python is changed
@@ -192,28 +198,28 @@
       - upgrade_python.python_versions | length >= 1
       - upgrade_python.python_paths | length >= 1
 
-- name: Upgrade Python 3.13 in check mode
+- name: Upgrade Python {{ python_3_13 }} in check mode
   community.general.uv_python:
-    version: 3.13
+    version: "{{ python_3_13 }}"
     state: latest
   check_mode: true
   register: upgrade_python
 
-- name: Verify Python 3.13 upgrade in check mode
+- name: Verify Python {{ python_3_13 }} upgrade in check mode
   ansible.builtin.assert:
     that:
       - upgrade_python is not changed
       - upgrade_python is not failed
       - upgrade_python.python_versions | length >= 1
 
-- name: Upgrade Python 3.13 again
+- name: Upgrade Python {{ python_3_13 }} again
   community.general.uv_python:
-    version: 3.13
+    version: "{{ python_3_13 }}"
     state: latest
   check_mode: true
   register: upgrade_python
 
-- name: Verify Python 3.13 upgrade again
+- name: Verify Python {{ python_3_13 }} upgrade again
   ansible.builtin.assert:
     that:
       - upgrade_python is not changed
@@ -261,19 +267,19 @@
       - unsupported_python is not changed
       - unsupported_python is failed
 
-- name: Delete Python 3.13 version
+- name: Delete Python {{ python_3_13 }} version
   community.general.uv_python:
-    version: "3.13"
+    version: "{{ python_3_13 }}"
     state: absent
   register: uninstall_result
 
-- name: Verify Python 3.13 deletion
+- name: Verify Python {{ python_3_13 }} deletion
   ansible.builtin.assert:
     that:
       - uninstall_result is changed
       - uninstall_result is not failed
       - uninstall_result.python_versions | length >= 1
-      - '"3.13" in uninstall_result.python_versions[0]'
+      - python_3_13 in uninstall_result.python_versions[0]
 
 - name: No specified version
   community.general.uv_python:

--- a/tests/integration/targets/uv_python/tasks/main.yaml
+++ b/tests/integration/targets/uv_python/tasks/main.yaml
@@ -50,8 +50,8 @@
 - name: Verify Python 3.14 installation
   ansible.builtin.assert:
     that:
-      - install_python.changed == check_python_314_exists.failed
-      - install_python.failed is false
+      - (install_python is changed) == (check_python_314_exists is failed)
+      - install_python is not failed
       - install_python.python_versions | length >= 1
       - install_python.python_paths | length >= 1
 
@@ -94,8 +94,8 @@
 - name: Verify Python 3.13.5 installation
   ansible.builtin.assert:
     that:
-      - install_python_3135.changed == check_python_3135_exists.failed
-      - install_python_3135.failed is false
+      - (install_python_3135 is changed) == (check_python_3135_exists is failed)
+      - install_python_3135 is not failed
       - '"3.13.5" in install_python_3135.python_versions'
       - install_python_3135.python_paths | length >= 1
 
@@ -108,8 +108,8 @@
 - name: Verify Python 3.13.5 installation
   ansible.builtin.assert:
     that:
-      - reinstall_python.changed is false
-      - reinstall_python.failed is false
+      - reinstall_python is not changed
+      - reinstall_python is not failed
       - '"3.13.5" in reinstall_python.python_versions'
 
 - name: Remove uninstalled Python 3.10 # removes latest patch version for 3.10 if exists
@@ -121,8 +121,8 @@
 - name: Verify Python 3.10 deletion
   ansible.builtin.assert:
     that:
-      - remove_python.changed is false
-      - remove_python.failed is false
+      - remove_python is not changed
+      - remove_python is not failed
       - remove_python.python_versions | length == 0
 
 - name: Remove Python 3.13.5 in check mode
@@ -135,11 +135,11 @@
 - name: Verify Python 3.13.5 deletion in check mode
   ansible.builtin.assert:
     that:
-      - remove_python_in_check_mode.changed == install_python_3135.changed
-      - remove_python_in_check_mode.failed is false
+      - (remove_python_in_check_mode is changed) == (install_python_3135 is changed)
+      - remove_python_in_check_mode is not failed
 
 - name: Additional check for Python 3.13.5 deletion in check mode
-  when: install_python_3135.changed is true
+  when: install_python_3135 is changed
   ansible.builtin.assert:
     that:
       - '"3.13.5" in remove_python_in_check_mode.python_versions'
@@ -154,11 +154,11 @@
 - name: Verify Python 3.13.5 deletion
   ansible.builtin.assert:
     that:
-      - remove_python.changed == install_python_3135.changed
-      - remove_python.failed is false
+      - (remove_python is changed) == (install_python_3135 is changed)
+      - remove_python is not failed
 
 - name: Additional check for Python 3.13.5 deletion
-  when: install_python_3135.changed is true
+  when: install_python_3135 is changed
   ansible.builtin.assert:
     that:
       - remove_python.python_paths | length >= 1
@@ -173,8 +173,8 @@
 - name: Verify Python 3.13.5 deletion again
   ansible.builtin.assert:
     that:
-      - remove_python.changed is false
-      - remove_python.failed is false
+      - remove_python is not changed
+      - remove_python is not failed
       - remove_python.python_versions | length == 0
       - remove_python.python_paths | length == 0
 
@@ -187,8 +187,8 @@
 - name: Verify Python 3.13 upgrade
   ansible.builtin.assert:
     that:
-      - upgrade_python.changed is true
-      - upgrade_python.failed is false
+      - upgrade_python is changed
+      - upgrade_python is not failed
       - upgrade_python.python_versions | length >= 1
       - upgrade_python.python_paths | length >= 1
 
@@ -202,8 +202,8 @@
 - name: Verify Python 3.13 upgrade in check mode
   ansible.builtin.assert:
     that:
-      - upgrade_python.changed is false
-      - upgrade_python.failed is false
+      - upgrade_python is not changed
+      - upgrade_python is not failed
       - upgrade_python.python_versions | length >= 1
 
 - name: Upgrade Python 3.13 again
@@ -216,8 +216,8 @@
 - name: Verify Python 3.13 upgrade again
   ansible.builtin.assert:
     that:
-      - upgrade_python.changed is false
-      - upgrade_python.failed is false
+      - upgrade_python is not changed
+      - upgrade_python is not failed
       - upgrade_python.python_versions | length >= 1
 
 - name: Install unsupported Python version in check mode
@@ -231,8 +231,8 @@
 - name: Verify unsupported Python 2.0 install in check mode
   ansible.builtin.assert:
     that:
-      - unsupported_python_check_mode.changed is false
-      - unsupported_python_check_mode.failed is true
+      - unsupported_python_check_mode is not changed
+      - unsupported_python_check_mode is failed
       - '"Version 2.0 is not available." in unsupported_python_check_mode.msg'
 
 - name: Install unsupported Python version
@@ -245,8 +245,8 @@
 - name: Verify unsupported Python 2.0 install
   ansible.builtin.assert:
     that:
-      - unsupported_python.changed is false
-      - unsupported_python.failed is true
+      - unsupported_python is not changed
+      - unsupported_python is failed
 
 - name: Install unsupported Python version with latest state
   community.general.uv_python:
@@ -258,8 +258,8 @@
 - name: Verify Python 2.0 install with latest state
   ansible.builtin.assert:
     that:
-      - unsupported_python.changed is false
-      - unsupported_python.failed is true
+      - unsupported_python is not changed
+      - unsupported_python is failed
 
 - name: Delete Python 3.13 version
   community.general.uv_python:
@@ -270,8 +270,8 @@
 - name: Verify Python 3.13 deletion
   ansible.builtin.assert:
     that:
-      - uninstall_result.changed is true
-      - uninstall_result.failed is false
+      - uninstall_result is changed
+      - uninstall_result is not failed
       - uninstall_result.python_versions | length >= 1
       - '"3.13" in uninstall_result.python_versions[0]'
 
@@ -285,7 +285,7 @@
 - name: Verify failure when no version is specified
   ansible.builtin.assert:
     that:
-      - no_version.failed is true
+      - no_version is failed
       - '"Unsupported version format" in no_version.msg'
 
 - name: Unsupported version format given
@@ -298,5 +298,5 @@
 - name: Verify failure when unsupported version format is specified
   ansible.builtin.assert:
     that:
-      - wrong_version.failed is true
+      - wrong_version is failed
       - '"Unsupported version format" in wrong_version.msg'


### PR DESCRIPTION
##### SUMMARY
Right now the uv_python tests fail on OpenSuSE Tumbleweed, since it comes with the latest Python 3.13, when upgrading to the latest Python 3.13 in the tests doesn't do anything and thus fails the assertion that something was changed.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
uv_python
