### PR TITLE
gitlab_hook - add custom_webhook_template option

### DIFF
--- a/changelogs/fragments/11233-gitlab_hook-custom-webhook-template.yml
+++ b/changelogs/fragments/11233-gitlab_hook-custom-webhook-template.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - gitlab_hook - add ``custom_webhook_template`` option to configure a custom webhook payload template on project hooks (https://github.com/ansible-collections/community.general/issues/11233, https://github.com/ansible-collections/community.general/pull/12496).

--- a/changelogs/fragments/11233-gitlab_hook-custom-webhook-template.yml
+++ b/changelogs/fragments/11233-gitlab_hook-custom-webhook-template.yml
@@ -1,3 +1,2 @@
----
 minor_changes:
   - gitlab_hook - add ``custom_webhook_template`` option to configure a custom webhook payload template on project hooks (https://github.com/ansible-collections/community.general/issues/11233, https://github.com/ansible-collections/community.general/pull/12496).

--- a/plugins/modules/gitlab_hook.py
+++ b/plugins/modules/gitlab_hook.py
@@ -138,7 +138,7 @@ EXAMPLES = r"""
     hook_url: "https://my-ci-server.example.com/gitlab-hook"
     state: present
     push_events: true
-    custom_webhook_template: !unsafe '{"event": "{{object_kind}}", "project": "{{project.name}}"}'    
+    custom_webhook_template: !unsafe '{"event": "{{object_kind}}", "project": "{{project.name}}"}'
 
 - name: "Delete the previous hook"
   community.general.gitlab_hook:

--- a/plugins/modules/gitlab_hook.py
+++ b/plugins/modules/gitlab_hook.py
@@ -115,7 +115,6 @@ options:
     description:
       - Custom webhook template for the project webhook
     type: str
-    version_added: '13.3.0'
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/gitlab_hook.py
+++ b/plugins/modules/gitlab_hook.py
@@ -113,8 +113,9 @@ options:
     type: str
   custom_webhook_template:
     description:
-      - Custom webhook template for the project webhook
+      - Custom webhook template for the project webhook.
     type: str
+    version_added: 13.3.0
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/gitlab_hook.py
+++ b/plugins/modules/gitlab_hook.py
@@ -210,7 +210,7 @@ class GitLabHook:
             "wiki_page_events": options["wiki_page_events"],
             "enable_ssl_verification": options["enable_ssl_verification"],
             "token": options["token"],
-            "custom_webhook_template": options["custom_webhook_template"]
+            "custom_webhook_template": options["custom_webhook_template"],
         }
 
         # Because we have already call userExists in main()
@@ -384,7 +384,7 @@ def main():
                 "releases_events": releases_events,
                 "enable_ssl_verification": enable_ssl_verification,
                 "token": hook_token,
-                "custom_webhook_template": custom_webhook_template
+                "custom_webhook_template": custom_webhook_template,
             },
         ):
             module.exit_json(

--- a/plugins/modules/gitlab_hook.py
+++ b/plugins/modules/gitlab_hook.py
@@ -111,6 +111,11 @@ options:
       - If this is present it always results in a change as it cannot be retrieved from GitLab.
       - It shows up in the C(X-GitLab-Token) HTTP request header.
     type: str
+  custom_webhook_template:
+    description:
+      - Custom webhook template for the project webhook
+    type: str
+    version_added: '13.3.0'
 """
 
 EXAMPLES = r"""
@@ -206,6 +211,7 @@ class GitLabHook:
             "wiki_page_events": options["wiki_page_events"],
             "enable_ssl_verification": options["enable_ssl_verification"],
             "token": options["token"],
+            "custom_webhook_template": options["custom_webhook_template"]
         }
 
         # Because we have already call userExists in main()
@@ -308,6 +314,7 @@ def main():
             releases_events=dict(type="bool"),
             hook_validate_certs=dict(type="bool", default=False, aliases=["enable_ssl_verification"]),
             token=dict(type="str", no_log=True),
+            custom_webhook_template=dict(type="str"),
         )
     )
 
@@ -343,6 +350,7 @@ def main():
     releases_events = module.params["releases_events"]
     enable_ssl_verification = module.params["hook_validate_certs"]
     hook_token = module.params["token"]
+    custom_webhook_template = module.params["custom_webhook_template"]
 
     gitlab_hook = GitLabHook(module, gitlab_instance)
 
@@ -377,6 +385,7 @@ def main():
                 "releases_events": releases_events,
                 "enable_ssl_verification": enable_ssl_verification,
                 "token": hook_token,
+                "custom_webhook_template": custom_webhook_template
             },
         ):
             module.exit_json(

--- a/plugins/modules/gitlab_hook.py
+++ b/plugins/modules/gitlab_hook.py
@@ -130,6 +130,16 @@ EXAMPLES = r"""
     tag_push_events: true
     token: "my-super-secret-token-that-my-ci-server-will-check"
 
+- name: Add a project hook with a custom webhook template
+  community.general.gitlab_hook:
+    api_url: https://gitlab.example.com/
+    api_token: "{{ access_token }}"
+    project: "my_group/my_project"
+    hook_url: "https://my-ci-server.example.com/gitlab-hook"
+    state: present
+    push_events: true
+    custom_webhook_template: !unsafe '{"event": "{{object_kind}}", "project": "{{project.name}}"}'    
+
 - name: "Delete the previous hook"
   community.general.gitlab_hook:
     api_url: https://gitlab.example.com/


### PR DESCRIPTION
##### SUMMARY
Add the `custom_webhook_template` option to the `gitlab_hook` module, allowing a
custom webhook payload template to be set and updated on project hooks.

Fixes #11233

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
gitlab_hook

##### ADDITIONAL INFORMATION
Tested locally against GitLab EE 18.9.2 via python-gitlab
8.4.0 and 8.5.0:
- create with `custom_webhook_template` -> changed
- re-run with identical template -> ok (idempotent, no change)
- changed template -> changed

I was not sure with version_added string in documentation so i removed this again. 