### PR TITLE
filesystem: warn if blkid probe fails

### DIFF
--- a/changelogs/fragments/filesystem-fails-if-blkid-probe-fails.yml
+++ b/changelogs/fragments/filesystem-fails-if-blkid-probe-fails.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - filesystem - print a warning if ``blkid -c`` probe fails and show the error message from ``blkid`` (https://github.com/ansible-collections/community.general/pull/12500).

--- a/plugins/modules/filesystem.py
+++ b/plugins/modules/filesystem.py
@@ -721,6 +721,10 @@ def main():
     cmd = module.get_bin_path("blkid", required=True)
     rc, raw_fs, err = module.run_command([cmd, "-c", os.devnull, "-o", "value", "-s", "TYPE", str(dev)])
     fs = raw_fs.strip()
+    # blkid exit codes: 0 = filesystem found, 2 = nothing found (blank device).
+    # Any other code means probe failed.
+    if rc not in (0, 2):
+        module.warn(f"blkid failed probing {dev} (rc={rc}): {err.strip()}")
     # BusyBox blkid may ignore -o/-s flags and output the full device info line,
     # e.g. '/dev/sda2: UUID="..." TYPE="btrfs"' instead of just 'btrfs'
     if fs and " " in fs:


### PR DESCRIPTION
##### SUMMARY

In our Ansible playbooks, we observe roughly a 5-10% failure rate for idempotency for this module when run on Ubuntu 24.04 hosts which already have a filesystem on the given device. We are not sure why `blkid -c` fails, but hopefully this change will provide some more insight there.

Regardless, if the `blkid -c` call fails, then the code would previously attempt to call `filesystem.create()`, which would then fail when trying to format a filesystem that already existed.

In such cases, we should fail early and with a more informative error message.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

`filesystem`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
