### PR TITLE
homebrew_tap: add trust option

### DIFF
--- a/changelogs/fragments/12220-homebrew-tap-trust.yml
+++ b/changelogs/fragments/12220-homebrew-tap-trust.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - homebrew_tap - add ``trust`` option to control whether Homebrew trusts the tapped repositories (https://github.com/ansible-collections/community.general/issues/12220).
+  - homebrew_tap - add ``trust`` option to control whether Homebrew trusts the tapped repositories (https://github.com/ansible-collections/community.general/issues/12220, https://github.com/ansible-collections/community.general/pull/12503).

--- a/changelogs/fragments/12220-homebrew-tap-trust.yml
+++ b/changelogs/fragments/12220-homebrew-tap-trust.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - homebrew_tap - add ``trust`` option to control whether Homebrew trusts the tapped repositories (https://github.com/ansible-collections/community.general/issues/12220).

--- a/plugins/modules/homebrew_tap.py
+++ b/plugins/modules/homebrew_tap.py
@@ -116,7 +116,8 @@ def a_valid_tap(tap):
 
 def normalized_tap(tap: str) -> str:
     """Returns the tap name in the form Homebrew itself reports it."""
-    return re.sub("homebrew-", "", tap.lower())
+    user, dummy, repo = tap.lower().partition("/")
+    return f"{user}/{repo.removeprefix('homebrew-')}"
 
 
 def already_tapped(module, brew_path, tap, taps=None):

--- a/plugins/modules/homebrew_tap.py
+++ b/plugins/modules/homebrew_tap.py
@@ -114,7 +114,7 @@ def a_valid_tap(tap):
     return regex.match(tap)
 
 
-def normalized_tap(tap):
+def normalized_tap(tap: str) -> str:
     """Returns the tap name in the form Homebrew itself reports it."""
     return re.sub("homebrew-", "", tap.lower())
 
@@ -236,7 +236,7 @@ def remove_taps(module, brew_path, taps):
     return (failed, changed, msg)
 
 
-def trusted_taps(module, brew_path):
+def trusted_taps(module: AnsibleModule, brew_path: str) -> set[str]:
     """Returns the set of currently trusted taps."""
     rc, out, err = module.run_command([brew_path, "trust", "--json", "v1"])
     if rc != 0:
@@ -252,13 +252,13 @@ def trusted_taps(module, brew_path):
     return {normalized_tap(tap) for tap in taps}
 
 
-def taps_to_change(module, brew_path, taps, trust):
+def taps_to_change(module: AnsibleModule, brew_path: str, taps: list[str], trust: bool) -> list[str]:
     """Returns the taps whose trust state does not match `trust` yet."""
     trusted = trusted_taps(module, brew_path)
     return [tap for tap in taps if (normalized_tap(tap) in trusted) != trust]
 
 
-def set_trust(module, brew_path, taps, trust):
+def set_trust(module: AnsibleModule, brew_path: str, taps: list[str], trust: bool) -> tuple[bool, bool, str]:
     """Trusts or untrusts one or more taps."""
     command = "trust" if trust else "untrust"
     outstanding = taps_to_change(module, brew_path, taps, trust)

--- a/plugins/modules/homebrew_tap.py
+++ b/plugins/modules/homebrew_tap.py
@@ -18,6 +18,7 @@ author:
 short_description: Tap a Homebrew repository
 description:
   - Tap external Homebrew repositories.
+  - Optionally control whether Homebrew trusts the tapped repositories.
 extends_documentation_fragment:
   - community.general._attributes
 attributes:
@@ -45,6 +46,16 @@ options:
     choices: ['present', 'absent']
     default: 'present'
     type: str
+  trust:
+    description:
+      - Whether Homebrew trusts the repository. Homebrew refuses to load formulae, casks and commands from untrusted
+        third-party taps.
+      - V(true) trusts the repository, V(false) stops trusting it. When this option is not specified, the trust state
+        of the repository is left untouched.
+      - Combining V(true) with O(state=absent) is an error.
+      - This requires a Homebrew version providing the C(brew trust) command.
+    type: bool
+    version_added: '13.3.0'
   path:
     description:
       - A V(:) separated list of paths to search for C(brew) executable.
@@ -73,8 +84,25 @@ EXAMPLES = r"""
   community.general.homebrew_tap:
     name: telemachus/brew
     url: 'https://bitbucket.org/telemachus/brew'
+
+- name: Tap a Homebrew repository and trust it
+  community.general.homebrew_tap:
+    name: hashicorp/tap
+    trust: true
+
+- name: Stop trusting a Homebrew repository, but keep it tapped
+  community.general.homebrew_tap:
+    name: hashicorp/tap
+    trust: false
+
+- name: Untrust and untap a Homebrew repository
+  community.general.homebrew_tap:
+    name: hashicorp/tap
+    trust: false
+    state: absent
 """
 
+import json
 import re
 
 from ansible.module_utils.basic import AnsibleModule
@@ -86,13 +114,17 @@ def a_valid_tap(tap):
     return regex.match(tap)
 
 
+def normalized_tap(tap):
+    """Returns the tap name in the form Homebrew itself reports it."""
+    return re.sub("homebrew-", "", tap.lower())
+
+
 def already_tapped(module, brew_path, tap, taps=None):
     """Returns True if already tapped."""
     if taps is None:
         rc, out, err = module.run_command([brew_path, "tap"])
         taps = [tap_.strip().lower() for tap_ in out.split("\n") if tap_]
-    tap_name = re.sub("homebrew-", "", tap.lower())
-    return tap_name in taps
+    return normalized_tap(tap) in taps
 
 
 def add_tap(module, brew_path, tap, url=None, taps=None):
@@ -204,12 +236,63 @@ def remove_taps(module, brew_path, taps):
     return (failed, changed, msg)
 
 
+def trusted_taps(module, brew_path):
+    """Returns the set of currently trusted taps."""
+    rc, out, err = module.run_command([brew_path, "trust", "--json", "v1"])
+    if rc != 0:
+        module.fail_json(
+            msg=f"failed to list trusted taps, the 'trust' option requires a Homebrew version providing 'brew trust': {err}"
+        )
+
+    try:
+        taps = json.loads(out)["taps"]
+    except (ValueError, KeyError, TypeError) as e:
+        module.fail_json(msg=f"failed to parse the output of 'brew trust --json v1': {e}")
+
+    return {normalized_tap(tap) for tap in taps}
+
+
+def taps_to_change(module, brew_path, taps, trust):
+    """Returns the taps whose trust state does not match `trust` yet."""
+    trusted = trusted_taps(module, brew_path)
+    return [tap for tap in taps if (normalized_tap(tap) in trusted) != trust]
+
+
+def set_trust(module, brew_path, taps, trust):
+    """Trusts or untrusts one or more taps."""
+    command = "trust" if trust else "untrust"
+    outstanding = taps_to_change(module, brew_path, taps, trust)
+    unchanged = len(taps) - len(outstanding)
+
+    if not outstanding:
+        return (False, False, f"{command}ed: 0, already {command}ed: {unchanged}")
+
+    if module.check_mode:
+        module.exit_json(changed=True)
+
+    rc, out, err = module.run_command([brew_path, command, "--tap"] + outstanding)
+
+    # `brew trust` and `brew untrust` exit successfully even when they changed
+    # nothing, so read the resulting state back instead of trusting the rc.
+    still_outstanding = taps_to_change(module, brew_path, outstanding, trust)
+    if still_outstanding:
+        failures = ", ".join(still_outstanding)
+        return (
+            True,
+            False,
+            f"{command}ed: 0, already {command}ed: {unchanged}, error: failed to {command}: {failures} due to {err}",
+        )
+
+    return (False, True, f"{command}ed: {len(outstanding)}, already {command}ed: {unchanged}")
+
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(aliases=["tap"], type="list", required=True, elements="str"),
             url=dict(),
             state=dict(default="present", choices=["present", "absent"]),
+            trust=dict(type="bool"),
             path=dict(
                 default="/usr/local/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
                 type="path",
@@ -230,8 +313,11 @@ def main():
 
     taps = module.params["name"]
     url = module.params["url"]
+    trust = module.params["trust"]
 
     if module.params["state"] == "present":
+        failed, changed, msg = False, False, ""
+
         if url is None:
             # No tap URL provided explicitly, continue with bulk addition
             # of all the taps.
@@ -245,13 +331,31 @@ def main():
             else:
                 failed, changed, msg = add_tap(module, brew_path, taps[0], url)
 
+        if not failed and trust is not None:
+            # Adjust trust after tapping, so that a tap added by this very run
+            # is immediately usable.
+            failed, trust_changed, trust_msg = set_trust(module, brew_path, taps, trust)
+            changed = changed or trust_changed
+            msg = f"{msg}, {trust_msg}"
+
         if failed:
             module.fail_json(msg=msg)
         else:
             module.exit_json(changed=changed, msg=msg)
 
     elif module.params["state"] == "absent":
-        failed, changed, msg = remove_taps(module, brew_path, taps)
+        if trust:
+            module.fail_json(msg="trust=true may not be used with state=absent.")
+
+        failed, changed, msg = False, False, ""
+        if trust is False:
+            # Untapping does not drop the trust entry, so untrust explicitly.
+            failed, changed, msg = set_trust(module, brew_path, taps, False)
+
+        if not failed:
+            failed, remove_changed, remove_msg = remove_taps(module, brew_path, taps)
+            changed = changed or remove_changed
+            msg = f"{msg}, {remove_msg}" if msg else remove_msg
 
         if failed:
             module.fail_json(msg=msg)

--- a/plugins/modules/homebrew_tap.py
+++ b/plugins/modules/homebrew_tap.py
@@ -117,7 +117,7 @@ def a_valid_tap(tap):
 def normalized_tap(tap: str) -> str:
     """Returns the tap name in the form Homebrew itself reports it."""
     user, dummy, repo = tap.lower().partition("/")
-    return f"{user}/{repo.removeprefix('homebrew-')}"
+    return f"{user}/{re.sub('^homebrew-', '', repo)}"
 
 
 def already_tapped(module, brew_path, tap, taps=None):

--- a/tests/integration/targets/homebrew/tasks/formulae.yml
+++ b/tests/integration/targets/homebrew/tasks/formulae.yml
@@ -305,17 +305,24 @@
 
 # Test install from homebrew tap
 - block:
-    - name: Tap hashicorp repository
+    - name: Tap and trust hashicorp repository
       community.general.homebrew_tap:
         name: hashicorp/tap
+        trust: true
       become: true
       become_user: "{{ brew_stat.stat.pw_name }}"
 
-    - name: "Trust tap (TODO: let homebrew_tap do this)"
-      ansible.builtin.command:
-        cmd: brew trust hashicorp/tap
+    - name: Tap and trust hashicorp repository again
+      community.general.homebrew_tap:
+        name: hashicorp/tap
+        trust: true
       become: true
       become_user: "{{ brew_stat.stat.pw_name }}"
+      register: tap_idempotency_result
+
+    - ansible.builtin.assert:
+        that:
+          - tap_idempotency_result is not changed
 
     - name: Install terraform from tap
       community.general.homebrew:
@@ -358,17 +365,24 @@
 
 # Test tap with no public fallback
 - block:
-    - name: Tap ascii-image-converter homebrew repository
+    - name: Tap and trust ascii-image-converter homebrew repository
       community.general.homebrew_tap:
         name: TheZoraiz/ascii-image-converter
+        trust: true
       become: true
       become_user: "{{ brew_stat.stat.pw_name }}"
 
-    - name: "Trust tap (TODO: let homebrew_tap do this)"
-      ansible.builtin.command:
-        cmd: brew trust thezoraiz/ascii-image-converter
+    - name: Tap and trust ascii-image-converter homebrew repository again
+      community.general.homebrew_tap:
+        name: TheZoraiz/ascii-image-converter
+        trust: true
       become: true
       become_user: "{{ brew_stat.stat.pw_name }}"
+      register: tap_idempotency_result
+
+    - ansible.builtin.assert:
+        that:
+          - tap_idempotency_result is not changed
 
     - name: Install ascii from full tap name
       community.general.homebrew:

--- a/tests/unit/plugins/modules/test_homebrew_tap.py
+++ b/tests/unit/plugins/modules/test_homebrew_tap.py
@@ -26,6 +26,9 @@ def trust_output(*taps):
 def test_normalized_tap():
     assert normalized_tap("HasHicorp/TAp") == "hashicorp/tap"
     assert normalized_tap("telemachus/homebrew-brew") == "telemachus/brew"
+    # Only the repository is prefixed with `homebrew-`, so a repository merely
+    # containing that string keeps it.
+    assert normalized_tap("telemachus/my-homebrew-tools") == "telemachus/my-homebrew-tools"
 
 
 def test_trusted_taps(mocker):

--- a/tests/unit/plugins/modules/test_homebrew_tap.py
+++ b/tests/unit/plugins/modules/test_homebrew_tap.py
@@ -1,0 +1,128 @@
+# Copyright (c) Ansible project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ansible_collections.community.general.plugins.modules.homebrew_tap import (
+    normalized_tap,
+    set_trust,
+    taps_to_change,
+    trusted_taps,
+)
+
+BREW_PATH = "/usr/local/bin/brew"
+
+
+def trust_output(*taps):
+    """Builds the reply of `brew trust --json v1`."""
+    return (0, json.dumps({"taps": list(taps), "formulae": [], "casks": [], "commands": []}), "")
+
+
+def test_normalized_tap():
+    assert normalized_tap("HasHicorp/TAp") == "hashicorp/tap"
+    assert normalized_tap("telemachus/homebrew-brew") == "telemachus/brew"
+
+
+def test_trusted_taps(mocker):
+    module = mocker.Mock()
+    module.run_command.return_value = trust_output("hashicorp/tap", "telemachus/brew")
+
+    assert trusted_taps(module, BREW_PATH) == {"hashicorp/tap", "telemachus/brew"}
+    module.run_command.assert_called_once_with([BREW_PATH, "trust", "--json", "v1"])
+
+
+def test_trusted_taps_requires_a_homebrew_providing_brew_trust(mocker):
+    module = mocker.Mock()
+    module.run_command.return_value = (1, "", "Unknown command: trust")
+    module.fail_json.side_effect = SystemExit
+
+    with pytest.raises(SystemExit):
+        trusted_taps(module, BREW_PATH)
+
+    assert "brew trust" in module.fail_json.call_args.kwargs["msg"]
+
+
+@pytest.mark.parametrize(
+    ("trust", "expected"),
+    [
+        (True, ["telemachus/homebrew-brew"]),
+        (False, ["HasHicorp/TAp"]),
+    ],
+)
+def test_taps_to_change_ignores_case_and_homebrew_prefix(mocker, trust, expected):
+    module = mocker.Mock()
+    module.run_command.return_value = trust_output("hashicorp/tap")
+
+    taps = ["HasHicorp/TAp", "telemachus/homebrew-brew"]
+    assert taps_to_change(module, BREW_PATH, taps, trust) == expected
+
+
+def test_set_trust_does_nothing_when_already_trusted(mocker):
+    module = mocker.Mock()
+    module.check_mode = False
+    module.run_command.return_value = trust_output("hashicorp/tap")
+
+    assert set_trust(module, BREW_PATH, ["hashicorp/tap"], True) == (False, False, "trusted: 0, already trusted: 1")
+    module.run_command.assert_called_once_with([BREW_PATH, "trust", "--json", "v1"])
+
+
+def test_set_trust_only_passes_outstanding_taps(mocker):
+    module = mocker.Mock()
+    module.check_mode = False
+    module.run_command.side_effect = [
+        trust_output("hashicorp/tap"),
+        (0, "Trusted tap: telemachus/brew", ""),
+        trust_output("hashicorp/tap", "telemachus/brew"),
+    ]
+
+    taps = ["hashicorp/tap", "telemachus/brew"]
+    assert set_trust(module, BREW_PATH, taps, True) == (False, True, "trusted: 1, already trusted: 1")
+    assert module.run_command.call_args_list[1].args[0] == [BREW_PATH, "trust", "--tap", "telemachus/brew"]
+
+
+def test_set_trust_untrusts(mocker):
+    module = mocker.Mock()
+    module.check_mode = False
+    module.run_command.side_effect = [
+        trust_output("hashicorp/tap"),
+        (0, "Untrusted tap: hashicorp/tap", ""),
+        trust_output(),
+    ]
+
+    assert set_trust(module, BREW_PATH, ["hashicorp/tap"], False) == (False, True, "untrusted: 1, already untrusted: 0")
+    assert module.run_command.call_args_list[1].args[0] == [BREW_PATH, "untrust", "--tap", "hashicorp/tap"]
+
+
+def test_set_trust_reports_a_tap_that_was_not_trusted(mocker):
+    # `brew trust` exits successfully even when it changed nothing, so the
+    # resulting state has to be read back.
+    module = mocker.Mock()
+    module.check_mode = False
+    module.run_command.side_effect = [
+        trust_output(),
+        (0, "", "Warning: no such tap"),
+        trust_output(),
+    ]
+
+    failed, changed, msg = set_trust(module, BREW_PATH, ["hashicorp/tap"], True)
+
+    assert (failed, changed) == (True, False)
+    assert "failed to trust: hashicorp/tap" in msg
+
+
+def test_set_trust_in_check_mode_does_not_run_brew_trust(mocker):
+    module = mocker.Mock()
+    module.check_mode = True
+    module.run_command.return_value = trust_output()
+    module.exit_json.side_effect = SystemExit
+
+    with pytest.raises(SystemExit):
+        set_trust(module, BREW_PATH, ["hashicorp/tap"], True)
+
+    module.exit_json.assert_called_once_with(changed=True)
+    module.run_command.assert_called_once_with([BREW_PATH, "trust", "--json", "v1"])


### PR DESCRIPTION
##### SUMMARY

Homebrew added a [trust store](https://docs.brew.sh/Tap-Trust) and now refuses to load formulae, casks and commands from untrusted third-party taps, so tapping a repository is no longer enough to use it. This is what broke the `homebrew` integration tests, worked around in #12253 by shelling out to `brew trust` with a `TODO: let homebrew_tap do this`.

This adds a `trust` option to `homebrew_tap`, and removes that workaround.

Fixes #12220.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

homebrew_tap

##### ADDITIONAL INFORMATION

**Semantics.** `trust` is a `bool` with **no default**, so leaving it unset keeps the current behaviour exactly and never invokes `brew trust` — older Homebrew versions are unaffected:

| `state` | `trust` | Behaviour |
|---|---|---|
| `present` | unset | tap only — unchanged |
| `present` | `true` | ensure tapped, then trusted |
| `present` | `false` | ensure tapped, then untrusted |
| `absent` | unset | untap only — unchanged |
| `absent` | `false` | untrust, then untap |
| `absent` | `true` | fails — contradictory |

Trust is applied *after* tapping so a tap added in the same run is immediately usable, and untrust happens *before* untapping. `brew untap` does not drop the trust entry, hence `state=absent, trust=false` rather than doing it implicitly — that would be a behaviour change for existing users.

**Change detection.** `brew trust` and `brew untrust` are already idempotent and exit `0` even when they change nothing (`Already trusted tap: foo/bar`), so the rc is useless here. The module reads state from `brew trust --json v1` before and after instead, and reports a failure if a tap it asked for is still not in the expected state.

Tap names are matched with the module's existing normalisation (`re.sub("homebrew-", "", tap.lower())`), which I confirmed is exactly what Homebrew itself applies — `brew trust --tap Foo/homebrew-Bar` stores `foo/bar`. That rule was inlined in `already_tapped()`; it is now a `normalized_tap()` helper shared by both, so the two can't drift.

**Tests.** New unit tests cover the normalisation, batching, check mode, and the exits-0-but-changed-nothing case. The two `brew trust` workarounds in `tests/integration/targets/homebrew/tasks/formulae.yml` are replaced by `homebrew_tap` with `trust: true`, plus an idempotency assertion; the existing `Install terraform from tap` / `Install ascii from full tap name` tasks that follow are what prove the tap really did get trusted, since they are the tasks that failed before #12253.

Verified locally against Homebrew 6.0.13 with an isolated `XDG_CONFIG_HOME`:

```paste below
# trust, check mode
localhost | CHANGED => { "changed": true }
# ...and trust.json is untouched: {"taps":[],"formulae":[],"casks":[],"commands":[]}

# trust, mixed case
localhost | CHANGED => {
    "changed": true,
    "msg": "added: 0, unchanged: 1, trusted: 1, already trusted: 0"
}
localhost | SUCCESS => {
    "changed": false,
    "msg": "added: 0, unchanged: 1, trusted: 0, already trusted: 1"
}

# untrust, keeping the tap
localhost | CHANGED => {
    "changed": true,
    "msg": "added: 0, unchanged: 1, untrusted: 1, already untrusted: 0"
}
localhost | SUCCESS => {
    "changed": false,
    "msg": "added: 0, unchanged: 1, untrusted: 0, already untrusted: 1"
}

# trust unset - unchanged behaviour, brew trust never invoked
localhost | SUCCESS => {
    "changed": false,
    "msg": "added: 0, unchanged: 1"
}

# contradictory request
localhost | FAILED! => {
    "changed": false,
    "msg": "trust=true may not be used with state=absent."
}
```

**Not covered here:** `brew trust` also handles formulae, casks and external commands. Those don't map onto `homebrew_tap`, and #12220 originally proposed a separate `homebrew_trust` module for the full surface. Happy to follow up if you'd prefer that shape instead of, or in addition to, this option.
