### PR TITLE
setup_redis_replication: drop unused `old_redis` slaveof fallback

### DIFF
--- a/tests/integration/targets/setup_redis_replication/defaults/main.yml
+++ b/tests/integration/targets/setup_redis_replication/defaults/main.yml
@@ -50,8 +50,6 @@ redis_module: redis
 
 redis_password: PASS
 
-old_redis: false
-
 # Master
 master_port: 6379
 master_conf: /etc/redis-master.conf

--- a/tests/integration/targets/setup_redis_replication/tasks/setup_redis_cluster.yml
+++ b/tests/integration/targets/setup_redis_replication/tasks/setup_redis_cluster.yml
@@ -57,7 +57,7 @@
   ansible.builtin.command: "{{ redis_bin[ansible_facts.distribution] }} {{ master_conf }}"
 
 - name: Start redis replica
-  ansible.builtin.command: "{{ redis_bin[ansible_facts.distribution] }} {{ replica_conf }} --{% if old_redis %}slaveof{% else %}replicaof{% endif %} 127.0.0.1 {{ master_port }}"
+  ansible.builtin.command: "{{ redis_bin[ansible_facts.distribution] }} {{ replica_conf }} --replicaof 127.0.0.1 {{ master_port }}"
 
 - name: Wait for redis master to be started
   ansible.builtin.wait_for:


### PR DESCRIPTION
##### SUMMARY
Removes the unused `old_redis` variable and its `slaveof`/`replicaof` conditional in the `setup_redis_replication` integration test target. Nothing in the suite ever set `old_redis` to `true`, so the fallback path was dead code; the replica start task now always uses `replicaof`.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
tests/integration/targets/setup_redis_replication

##### ADDITIONAL INFORMATION