### PR TITLE
terraform: plan file name displayed twice in return value ```command```

### DIFF
--- a/plugins/modules/terraform.py
+++ b/plugins/modules/terraform.py
@@ -710,7 +710,7 @@ def main():
                 msg="Aborting command because it would destroy some resources. "
                 "Consider switching the 'check_destroy' to false to suppress this error"
             )
-        command.append(plan_file)
+        # command.append(plan_file)
 
     result_diff = dict()
     if module._diff or module.check_mode:


### PR DESCRIPTION
- terraform plan file name displayed twice
- in the return value 'command'
- captured in the registered var of terraform task
- creating confusions (when explaining to people, who don't know about ansible) while debugging actual issues 🙂

ansible tasks yml file:
```
- name: create terraform plan
  community.general.terraform:
    project_path: "{{ terraform_directory }}"
    force_init: true
    state: planned
    plan_file: "{{ terraform_plan_file }}"
  register: __terraform_planned

- ansible.builtin.debug:
    var: __terraform_planned['command']
```

ansible output:
```
TASK [terraform_orchestrator : create terraform plan] ******************************************************************************************
ok: [localhost]

TASK [terraform_orchestrator : ansible.builtin.debug] ******************************************************************************************
ok: [localhost] =>
    __terraform_planned['command']: /home/devops/packages/terraform/binaries/terraform_latest/terraform
        plan -lock=true -no-color -input=false -detailed-exitcode -out terraform_plan_02-08-2026_17:41:28
        terraform_plan_02-08-2026_17:41:28
```

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
- community.general.terraform
