### PR TITLE
Add more precise ruff configs for modules/module_utils and everything else

### DIFF
--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -21,15 +21,18 @@ code_files = ["."]  # consider all Python files in the collection
 run_isort = false
 run_black = false
 run_ruff_autofix = true
-ruff_autofix_config = "ruff.toml"
+ruff_autofix_config = "ruff-plugins.toml"
+ruff_autofix_modules_config = "ruff-modules.toml"
 ruff_autofix_select = [
     "I",
     "RUF022",
 ]
 run_ruff_check = true
-ruff_check_config = "ruff.toml"
+ruff_check_config = "ruff-plugins.toml"
+ruff_check_modules_config = "ruff-modules.toml"
 run_ruff_format = true
-ruff_format_config = "ruff.toml"
+ruff_format_config = "ruff-plugins.toml"
+ruff_format_modules_config = "ruff-modules.toml"
 run_flake8 = false
 run_pylint = false
 run_yamllint = true

--- a/plugins/callback/loganalytics_ingestion.py
+++ b/plugins/callback/loganalytics_ingestion.py
@@ -149,7 +149,7 @@ import getpass
 import json
 import socket
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from os.path import basename
 from urllib.parse import urlencode
 
@@ -232,7 +232,7 @@ class AzureLogAnalyticsIngestionSource:
         open_url(ingestion_url, data=json.dumps(event_data), headers=headers, method="POST", timeout=self.timeout)
 
     def _rfc1123date(self):
-        return datetime.now(timezone.utc).strftime("%a, %d %b %Y %H:%M:%S GMT")
+        return datetime.now(UTC).strftime("%a, %d %b %Y %H:%M:%S GMT")
 
     # This method wraps the private method with the appropriate error handling.
     def send_to_loganalytics(self, playbook_name, result, state):

--- a/plugins/filter/from_toml.py
+++ b/plugins/filter/from_toml.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
+import tomllib
 import typing as t
 from collections.abc import Mapping
 
-import tomllib
 from ansible.errors import AnsibleFilterError
 
 

--- a/ruff-modules.toml
+++ b/ruff-modules.toml
@@ -1,0 +1,7 @@
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Felix Fontein <felix@fontein.de>
+
+extend = "ruff.toml"
+
+target-version = "py38"

--- a/ruff-plugins.toml
+++ b/ruff-plugins.toml
@@ -1,0 +1,7 @@
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Felix Fontein <felix@fontein.de>
+
+extend = "ruff.toml"
+
+target-version = "py311"


### PR DESCRIPTION
##### SUMMARY
I added two config files `ruff-modules.toml` and `ruff-plugins.toml` that inherit everything except `target-version` from `ruff.toml`, and set up antsibull-nox to use these files.

The result is:
* `nox -e formatters` and `nox -e codeqa` use specific config files for specific Python files.
* if someone uses an IDE plugin that runs `ruff format` or `ruff check`, it will use `ruff.toml`, which shouldn't cause problems because a) a plugin uses a construct that's not allowed for moudles, or b) suggests changes that are fine for plugins but not allowed for modules. It might provide wrong feedback in some cases, like import sorting for `lugins/filter/from_toml.py`, but in most cases it should be fine.

##### ISSUE TYPE
- Refactoring Pull Request
- Test Pull Request

##### COMPONENT NAME
CI
plugins/callback/loganalytics_ingestion.py
plugins/filter/from_toml.py
