### PR TITLE
CI: Restrict argcomplete to < 3.7.1 on Python 3.9

### DIFF
--- a/tests/integration/targets/pipx/tasks/main.yml
+++ b/tests/integration/targets/pipx/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Install pipx>=1.7.0
   ansible.builtin.pip:
     name: pipx>=1.7.0
-    extra_args: --user
+    extra_args: "--user -c {{ remote_constraints }}"
 
 - name: Determine packaging level
   block:

--- a/tests/integration/targets/pipx_info/meta/main.yml
+++ b/tests/integration/targets/pipx_info/meta/main.yml
@@ -5,4 +5,3 @@
 
 dependencies:
   - setup_remote_constraints
-  - setup_remote_tmp_dir

--- a/tests/integration/targets/pipx_info/tasks/main.yml
+++ b/tests/integration/targets/pipx_info/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Install pipx>=1.7.0
   ansible.builtin.pip:
     name: pipx>=1.7.0
-    extra_args: --user
+    extra_args: "--user -c {{ remote_constraints }}"
 
 ##############################################################################
 - name: Ensure applications are uninstalled

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -17,3 +17,4 @@ pyone == 1.1.9 # newer versions do not pass current integration tests
 cffi >= 1.14.2, != 1.14.3 # Yanked version which older versions of pip will still install:
 py-consul < 1.3.0 ; python_version < '3.8'  # 1.3.0 dropped support for Python 3.5, 3.6, 3.7
 py-consul < 1.5.4 ; python_version < '3.9'  # 1.5.4 dropped support for Python 3.8
+argcomplete < 3.7.1 ; python_version < '3.10'  # 3.7.1 uses Python 3.10+ syntax


### PR DESCRIPTION
##### SUMMARY
Right now CI fails on Python 3.9 due to the latest argcomplete using Python 3.10+ constructs.

Ref: https://github.com/kislyuk/argcomplete/issues/559

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
pipx tests
pipx_info tests
