### PR TITLE
timezone: make hwclock optional for name-only changes

### DIFF
--- a/changelogs/fragments/12516-timezone-optional-hwclock.yml
+++ b/changelogs/fragments/12516-timezone-optional-hwclock.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - timezone - no longer requires the ``hwclock`` executable for name-only changes on non-systemd systems (https://github.com/ansible-collections/community.general/issues/12516).
+  - timezone - no longer requires the ``hwclock`` executable for name-only changes on non-systemd systems (https://github.com/ansible-collections/community.general/issues/12516, https://github.com/ansible-collections/community.general/pull/12526).

--- a/changelogs/fragments/12516-timezone-optional-hwclock.yml
+++ b/changelogs/fragments/12516-timezone-optional-hwclock.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - timezone - no longer requires the ``hwclock`` executable for name-only changes on non-systemd systems (https://github.com/ansible-collections/community.general/issues/12516).

--- a/plugins/modules/timezone.py
+++ b/plugins/modules/timezone.py
@@ -345,7 +345,7 @@ class NosystemdTimezone(Timezone):
             self.update_timezone = [
                 [self.module.get_bin_path("cp", required=True), "--remove-destination", tzfile, "/etc/localtime"]
             ]
-        self.update_hwclock = self.module.get_bin_path("hwclock", required=True)
+        self.update_hwclock = self.module.get_bin_path("hwclock", required="hwclock" in self.value)
         distribution = get_distribution()
         self.conf_files["name"] = "/etc/timezone"
         self.regexps["name"] = re.compile(r"^([^\s]+)", re.MULTILINE)

--- a/tests/unit/plugins/modules/test_timezone.py
+++ b/tests/unit/plugins/modules/test_timezone.py
@@ -1,0 +1,54 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from unittest.mock import Mock, call, patch
+
+import pytest
+
+from ansible_collections.community.general.plugins.modules import timezone
+
+
+def create_module(*, name=None, hwclock=None):
+    module = Mock()
+    module.argument_spec = {"hwclock": {}, "name": {}}
+    module.params = {"hwclock": hwclock, "name": name}
+
+    paths = {
+        "cp": "/usr/bin/cp",
+        "dpkg-reconfigure": "/usr/sbin/dpkg-reconfigure",
+        "ln": "/usr/bin/ln",
+    }
+
+    def get_bin_path(binary, required=False):
+        path = paths.get(binary)
+        if required and path is None:
+            raise RuntimeError(f"Failed to find required executable {binary}")
+        return path
+
+    module.get_bin_path.side_effect = get_bin_path
+    return module
+
+
+@patch.object(timezone.os.path, "isfile", return_value=True)
+@patch.object(timezone.platform, "system", return_value="Linux")
+def test_name_does_not_require_hwclock(system_mock, isfile_mock):
+    module = create_module(name="Etc/UTC")
+
+    tz = timezone.Timezone(module)
+
+    assert isinstance(tz, timezone.NosystemdTimezone)
+    assert tz.update_hwclock is None
+    assert call("hwclock", required=False) in module.get_bin_path.call_args_list
+
+
+@patch.object(timezone.platform, "system", return_value="Linux")
+def test_hwclock_requires_executable(system_mock):
+    module = create_module(hwclock="UTC")
+
+    with pytest.raises(RuntimeError, match="required executable hwclock"):
+        timezone.Timezone(module)
+
+    assert call("hwclock", required=True) in module.get_bin_path.call_args_list


### PR DESCRIPTION
##### SUMMARY

Allow name-only timezone changes on non-systemd systems without requiring the `hwclock` executable. `NosystemdTimezone` now requires `hwclock` only when the `hwclock` parameter is explicitly requested.

Fixes #12516

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

timezone

##### ADDITIONAL INFORMATION

Regression coverage verifies both behaviors: name-only initialization succeeds when `hwclock` is unavailable, while explicit hardware-clock configuration still requires the executable.

Validation:

- `ansible-test units --color no -v --python 3.13 tests/unit/plugins/modules/test_timezone.py`
- `ansible-test sanity --color no -v --python 3.13 plugins/modules/timezone.py`
- `ruff format --check --config ruff.toml plugins/modules/timezone.py tests/unit/plugins/modules/test_timezone.py`
- `ruff check --config ruff.toml plugins/modules/timezone.py tests/unit/plugins/modules/test_timezone.py`
- `yamllint -c .yamllint changelogs/fragments/12516-timezone-optional-hwclock.yml`