### PR TITLE
Module ufw: fix insert_relative_to

### DIFF
--- a/changelogs/fragments/12531-fix-ufw-insert_relative_to.yml
+++ b/changelogs/fragments/12531-fix-ufw-insert_relative_to.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ufw - fix ipv6 rule determination and insert_relative_to (https://github.com/ansible-collections/community.general/pull/12531).

--- a/changelogs/fragments/12531-fix-ufw-insert_relative_to.yml
+++ b/changelogs/fragments/12531-fix-ufw-insert_relative_to.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ufw - fix IPv6 rule determination and insert_relative_to (https://github.com/ansible-collections/community.general/pull/12531).
+  - ufw - fix IPv6 rule determination and ``insert_relative_to`` (https://github.com/ansible-collections/community.general/pull/12531).

--- a/changelogs/fragments/12531-fix-ufw-insert_relative_to.yml
+++ b/changelogs/fragments/12531-fix-ufw-insert_relative_to.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ufw - fix ipv6 rule determination and insert_relative_to (https://github.com/ansible-collections/community.general/pull/12531).
+  - ufw - fix IPv6 rule determination and insert_relative_to (https://github.com/ansible-collections/community.general/pull/12531).

--- a/plugins/modules/ufw.py
+++ b/plugins/modules/ufw.py
@@ -532,7 +532,10 @@ def main():
                 else:
                     (dummy, numbered_state, dummy) = module.run_command([ufw_bin, "status", "numbered"])
                     numbered_line_re = re.compile(R"^\[ *([0-9]+)\] ")
-                    lines = [(numbered_line_re.match(line), bool(ipv6_regexp.search(line))) for line in numbered_state.splitlines()]
+                    lines = [
+                        (numbered_line_re.match(line), bool(ipv6_regexp.search(line)))
+                        for line in numbered_state.splitlines()
+                    ]
                     lines = [(int(matcher.group(1)), ipv6) for (matcher, ipv6) in lines if matcher]
                     last_number = max([no for (no, ipv6) in lines]) if lines else 0
                     has_ipv4 = any(not ipv6 for (no, ipv6) in lines)

--- a/plugins/modules/ufw.py
+++ b/plugins/modules/ufw.py
@@ -546,18 +546,16 @@ def main():
                     last_ipv6 = max([no for (no, ipv6) in lines if ipv6]) if has_ipv6 else None
 
                     if last_ipv4 and first_ipv6 and last_ipv4 > first_ipv6:
-                        raise ValueError("ufw output could not be parsed correctly. ipv4 follows ipv6!")
+                        module.warn("ufw output could not be parsed correctly. ipv4 follows ipv6!")
 
                     if relative_to_cmd == "first-ipv4":
                         relative_to = 1
                     elif relative_to_cmd == "last-ipv4":
                         relative_to = last_ipv4 or 1
                     elif relative_to_cmd == "first-ipv6":
-                        relative_to = first_ipv6 or last_ipv4 + 1 if last_ipv4 else 1
+                        relative_to = first_ipv6 or (last_ipv4 + 1 if last_ipv4 else 1)
                     elif relative_to_cmd == "last-ipv6":
-                        relative_to = last_ipv6 or last_number + 1
-                    else:
-                        raise ValueError(f'Undefinded value for "insert_relative_to": {relative_to_cmd}')
+                        relative_to = last_ipv6 or (last_number + 1)
 
                     insert_to = params["insert"] + relative_to
                     if insert_to > last_number:

--- a/plugins/modules/ufw.py
+++ b/plugins/modules/ufw.py
@@ -533,7 +533,7 @@ def main():
                     (dummy, numbered_state, dummy) = module.run_command([ufw_bin, "status", "numbered"])
                     numbered_line_re = re.compile(R"^\[ *([0-9]+)\] ")
                     lines = [
-                        (numbered_line_re.match(line), bool(ipv6_regexp.search(line)))
+                        (numbered_line_re.match(line), bool("(v6)" in line or ipv6_regexp.search(line)))
                         for line in numbered_state.splitlines()
                     ]
                     lines = [(int(matcher.group(1)), ipv6) for (matcher, ipv6) in lines if matcher]

--- a/plugins/modules/ufw.py
+++ b/plugins/modules/ufw.py
@@ -531,35 +531,27 @@ def main():
                 if relative_to_cmd == "zero":
                     insert_to = params["insert"]
                 else:
-                    dummy, numbered_state, dummy = module.run_command([ufw_bin, "status", "numbered"])
-                    # Format is: [no] To Action From # Comment
-                    numbered_line_re = re.compile(
-                        r"^\[ *([0-9]+)] [^#\n]*(DENY|ALLOW|REJECT|LIMIT) (IN|OUT) +([^# \n][^#\n]+[^# \n])"
-                    )
-                    last_number = last_ipv4 = first_ipv6 = last_ipv6 = 0
-                    for line in numbered_state.splitlines():
-                        if line_match := numbered_line_re.match(line):
-                            no = int(line_match.group(1))
-                            last_number = no
-                            try:
-                                ip = ip_address(line_match.group(4).strip())
-                                ipv6 = isinstance(ip, IPv6Address)
-                            except ValueError:
-                                ipv6 = "(v6)" in line
-                            if ipv6:
-                                first_ipv6 = first_ipv6 or no
-                                last_ipv6 = no
-                            elif first_ipv6:
-                                raise ValueError("ufw output could not be parsed correctly. ipv4 follows ipv6!")
-                            else:
-                                last_ipv4 = no
+                    (dummy, numbered_state, dummy) = module.run_command([ufw_bin, "status", "numbered"])
+                    numbered_line_re = re.compile(R"^\[ *([0-9]+)\] ")
+                    lines = [(numbered_line_re.match(line), bool(ipv6_regexp.search(line))) for line in numbered_state.splitlines()]
+                    lines = [(int(matcher.group(1)), ipv6) for (matcher, ipv6) in lines if matcher]
+                    last_number = max([no for (no, ipv6) in lines]) if lines else 0
+                    has_ipv4 = any(not ipv6 for (no, ipv6) in lines)
+                    has_ipv6 = any(ipv6 for (no, ipv6) in lines)
+
+                    last_ipv4 = max([no for (no, ipv6) in lines if not ipv6]) if has_ipv4 else None
+                    first_ipv6 = min([no for (no, ipv6) in lines if ipv6]) if has_ipv6 else None
+                    last_ipv6 = max([no for (no, ipv6) in lines if ipv6]) if has_ipv6 else None
+
+                    if last_ipv4 and first_ipv6 and last_ipv4 > first_ipv6:
+                        raise ValueError("ufw output could not be parsed correctly. ipv4 follows ipv6!")
 
                     if relative_to_cmd == "first-ipv4":
                         relative_to = 1
                     elif relative_to_cmd == "last-ipv4":
                         relative_to = last_ipv4 or 1
                     elif relative_to_cmd == "first-ipv6":
-                        relative_to = first_ipv6 or last_ipv4 + 1
+                        relative_to = first_ipv6 or last_ipv4 + 1 if last_ipv4 else 1
                     elif relative_to_cmd == "last-ipv6":
                         relative_to = last_ipv6 or last_number + 1
                     else:

--- a/plugins/modules/ufw.py
+++ b/plugins/modules/ufw.py
@@ -552,17 +552,16 @@ def main():
                             else:
                                 last_ipv4 = no
 
-                    match relative_to_cmd:
-                        case 'first-ipv4':
-                            relative_to = 1
-                        case 'last-ipv4':
-                            relative_to = last_ipv4 or 1
-                        case 'first-ipv6':
-                            relative_to = first_ipv6 or last_ipv4 + 1
-                        case 'last-ipv6':
-                            relative_to = last_ipv6 or last_number + 1
-                        case _:
-                            raise ValueError(f'Undefinded value for "insert_relative_to": {relative_to_cmd}')
+                    if relative_to_cmd == 'first-ipv4':
+                        relative_to = 1
+                    elif relative_to_cmd == 'last-ipv4':
+                        relative_to = last_ipv4 or 1
+                    elif relative_to_cmd == 'first-ipv6':
+                        relative_to = first_ipv6 or last_ipv4 + 1
+                    elif relative_to_cmd == 'last-ipv6':
+                        relative_to = last_ipv6 or last_number + 1
+                    else:
+                        raise ValueError(f'Undefinded value for "insert_relative_to": {relative_to_cmd}')
 
                     insert_to = params["insert"] + relative_to
                     if insert_to > last_number:

--- a/plugins/modules/ufw.py
+++ b/plugins/modules/ufw.py
@@ -287,7 +287,7 @@ EXAMPLES = r"""
 """
 
 import re
-from ipaddress import ip_address, IPv6Address
+from ipaddress import IPv6Address, ip_address
 from operator import itemgetter
 
 from ansible.module_utils.basic import AnsibleModule
@@ -533,7 +533,9 @@ def main():
                 else:
                     dummy, numbered_state, dummy = module.run_command([ufw_bin, "status", "numbered"])
                     # Format is: [no] To Action From # Comment
-                    numbered_line_re = re.compile(r"^\[ *([0-9]+)] [^#\n]*(DENY|ALLOW|REJECT|LIMIT) (IN|OUT) +([^# \n][^#\n]+[^# \n])")
+                    numbered_line_re = re.compile(
+                        r"^\[ *([0-9]+)] [^#\n]*(DENY|ALLOW|REJECT|LIMIT) (IN|OUT) +([^# \n][^#\n]+[^# \n])"
+                    )
                     last_number = last_ipv4 = first_ipv6 = last_ipv6 = 0
                     for line in numbered_state.splitlines():
                         if line_match := numbered_line_re.match(line):
@@ -548,17 +550,17 @@ def main():
                                 first_ipv6 = first_ipv6 or no
                                 last_ipv6 = no
                             elif first_ipv6:
-                                raise ValueError('ufw output could not be parsed correctly. ipv4 follows ipv6!')
+                                raise ValueError("ufw output could not be parsed correctly. ipv4 follows ipv6!")
                             else:
                                 last_ipv4 = no
 
-                    if relative_to_cmd == 'first-ipv4':
+                    if relative_to_cmd == "first-ipv4":
                         relative_to = 1
-                    elif relative_to_cmd == 'last-ipv4':
+                    elif relative_to_cmd == "last-ipv4":
                         relative_to = last_ipv4 or 1
-                    elif relative_to_cmd == 'first-ipv6':
+                    elif relative_to_cmd == "first-ipv6":
                         relative_to = first_ipv6 or last_ipv4 + 1
-                    elif relative_to_cmd == 'last-ipv6':
+                    elif relative_to_cmd == "last-ipv6":
                         relative_to = last_ipv6 or last_number + 1
                     else:
                         raise ValueError(f'Undefinded value for "insert_relative_to": {relative_to_cmd}')

--- a/plugins/modules/ufw.py
+++ b/plugins/modules/ufw.py
@@ -287,6 +287,7 @@ EXAMPLES = r"""
 """
 
 import re
+from ipaddress import ip_address, IPv6Address
 from operator import itemgetter
 
 from ansible.module_utils.basic import AnsibleModule
@@ -530,21 +531,39 @@ def main():
                 if relative_to_cmd == "zero":
                     insert_to = params["insert"]
                 else:
-                    (dummy, numbered_state, dummy) = module.run_command([ufw_bin, "status", "numbered"])
-                    numbered_line_re = re.compile(R"^\[ *([0-9]+)\] ")
-                    lines = [(numbered_line_re.match(line), "(v6)" in line) for line in numbered_state.splitlines()]
-                    lines = [(int(matcher.group(1)), ipv6) for (matcher, ipv6) in lines if matcher]
-                    last_number = max([no for (no, ipv6) in lines]) if lines else 0
-                    has_ipv4 = any(not ipv6 for (no, ipv6) in lines)
-                    has_ipv6 = any(ipv6 for (no, ipv6) in lines)
-                    if relative_to_cmd == "first-ipv4":
-                        relative_to = 1
-                    elif relative_to_cmd == "last-ipv4":
-                        relative_to = max([no for (no, ipv6) in lines if not ipv6]) if has_ipv4 else 1
-                    elif relative_to_cmd == "first-ipv6":
-                        relative_to = max([no for (no, ipv6) in lines if not ipv6]) + 1 if has_ipv4 else 1
-                    elif relative_to_cmd == "last-ipv6":
-                        relative_to = last_number if has_ipv6 else last_number + 1
+                    _, numbered_state, _ = module.run_command([ufw_bin, "status", "numbered"])
+                    # Format is: [no] To Action From # Comment
+                    numbered_line_re = re.compile(r"^\[ *([0-9]+)] [^#\n]*(DENY|ALLOW|REJECT|LIMIT) (IN|OUT) +([^# \n][^#\n]+[^# \n])")
+                    last_number = last_ipv4 = first_ipv6 = last_ipv6 = 0
+                    for line in numbered_state.splitlines():
+                        if line_match := numbered_line_re.match(line):
+                            no = int(line_match.group(1))
+                            last_number = no
+                            try:
+                                ip = ip_address(line_match.group(4).strip())
+                                ipv6 = isinstance(ip, IPv6Address)
+                            except ValueError:
+                                ipv6 = "(v6)" in line
+                            if ipv6:
+                                first_ipv6 = first_ipv6 or no
+                                last_ipv6 = no
+                            elif first_ipv6:
+                                raise ValueError('ufw output could not be parsed correctly. ipv4 follows ipv6!')
+                            else:
+                                last_ipv4 = no
+
+                    match relative_to_cmd:
+                        case 'first-ipv4':
+                            relative_to = 1
+                        case 'last-ipv4':
+                            relative_to = last_ipv4 or 1
+                        case 'first-ipv6':
+                            relative_to = first_ipv6 or last_ipv4 + 1
+                        case 'last-ipv6':
+                            relative_to = last_ipv6 or last_number + 1
+                        case _:
+                            raise ValueError(f'Undefinded value for "insert_relative_to": {relative_to_cmd}')
+
                     insert_to = params["insert"] + relative_to
                     if insert_to > last_number:
                         # ufw does not like it when the insert number is larger than the
@@ -569,7 +588,7 @@ def main():
                 value = params[key]
                 cmd.append([value, template % (value)])
 
-            ufw_major, ufw_minor, dummy = ufw_version()
+            ufw_major, ufw_minor, _ = ufw_version()
             # comment is supported only in ufw version after 0.35
             if (ufw_major == 0 and ufw_minor >= 35) or ufw_major > 0:
                 cmd.append([params["comment"], f"comment '{params['comment']}'"])

--- a/plugins/modules/ufw.py
+++ b/plugins/modules/ufw.py
@@ -531,7 +531,7 @@ def main():
                 if relative_to_cmd == "zero":
                     insert_to = params["insert"]
                 else:
-                    _, numbered_state, _ = module.run_command([ufw_bin, "status", "numbered"])
+                    dummy, numbered_state, dummy = module.run_command([ufw_bin, "status", "numbered"])
                     # Format is: [no] To Action From # Comment
                     numbered_line_re = re.compile(r"^\[ *([0-9]+)] [^#\n]*(DENY|ALLOW|REJECT|LIMIT) (IN|OUT) +([^# \n][^#\n]+[^# \n])")
                     last_number = last_ipv4 = first_ipv6 = last_ipv6 = 0
@@ -588,7 +588,7 @@ def main():
                 value = params[key]
                 cmd.append([value, template % (value)])
 
-            ufw_major, ufw_minor, _ = ufw_version()
+            ufw_major, ufw_minor, dummy = ufw_version()
             # comment is supported only in ufw version after 0.35
             if (ufw_major == 0 and ufw_minor >= 35) or ufw_major > 0:
                 cmd.append([params["comment"], f"comment '{params['comment']}'"])

--- a/plugins/modules/ufw.py
+++ b/plugins/modules/ufw.py
@@ -287,7 +287,6 @@ EXAMPLES = r"""
 """
 
 import re
-from ipaddress import IPv6Address, ip_address
 from operator import itemgetter
 
 from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
##### SUMMARY
Fixes wrong determination of first-ipv6 address and therefore wrong behaviour of "insert_relative_to"

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.general.ufw

##### ADDITIONAL INFORMATION

Previous implementation relied on having the "(v6)" string in lines to identify v6 rules, but this is not necessarily the case.
This lead to wrong determination of the first-ipv6 address, because it relied on identifying the last ipv4, which was in some cases wrong identified by a missing "v6" string.

The new implementation takes a different approach:
With an improved REGEX pattern the whole line is parsed and the destination part is identified. There we try to convert the string into an ip address and then check, whether it is an ipv6. If this fails, we also have a look on the "v6" string.

Second improvement targets to improve readability by using a loop instead of multiple list comprehensions for the determination of first/last ipv6.
ValueErrors are raised if ipv4/ipv6 rules appear in the wrong order and therefore an erroneous ipv6 determination is likely or if the "insert_relative_to" has an undefined value.
