### PR TITLE
slack: support reply_broadcast message event

### DIFF
--- a/changelogs/fragments/slack-reply-broadcast.yml
+++ b/changelogs/fragments/slack-reply-broadcast.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - slack - add ``reply_broadcast`` option to allow a threaded reply (``thread_id``) to also be broadcast to the main channel, mirroring Slack's ``reply_broadcast`` API parameter (https://github.com/ansible-collections/community.general/pull/CHANGEME).
+  - slack - add ``reply_broadcast`` option to allow a threaded reply (``thread_id``) to also be broadcast to the main channel (https://github.com/ansible-collections/community.general/pull/12535).

--- a/changelogs/fragments/slack-reply-broadcast.yml
+++ b/changelogs/fragments/slack-reply-broadcast.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - slack - add ``reply_broadcast`` option to allow a threaded reply (``thread_id``) to also be broadcast to the main channel, mirroring Slack's ``reply_broadcast`` API parameter (https://github.com/ansible-collections/community.general/pull/CHANGEME).

--- a/plugins/modules/slack.py
+++ b/plugins/modules/slack.py
@@ -67,6 +67,15 @@ options:
     description:
       - Optional. Timestamp of parent message to thread this message, see U(https://api.slack.com/docs/message-threading).
     type: str
+  reply_broadcast:
+    description:
+      - Used in conjunction with O(thread_id).
+      - If V(true), a threaded reply is broadcast to the whole channel, in addition to the thread it was posted in.
+      - See U(https://api.slack.com/events/message/reply_broadcast) for more information.
+      - Only has an effect when a WebAPI token is used, since incoming webhooks do not support this parameter.
+    type: bool
+    default: false
+    version_added: 13.3.0
   message_id:
     description:
       - Optional. Message ID to edit, instead of posting a new message.
@@ -281,6 +290,14 @@ EXAMPLES = r"""
     color: good
     msg: 'And this is my threaded response!'
 
+- name: Add a threaded response and also broadcast it to the channel
+  community.general.slack:
+    channel: '#ansible'
+    token: xoxb-1234-56789abcdefghijklmnopqrstuvwxyz
+    thread_id: "{{ slack_response['ts'] }}"
+    reply_broadcast: true
+    msg: 'This threaded response is also shown in the channel!'
+
 - name: Send a message to be edited later on
   community.general.slack:
     token: thetoken/generatedby/slack
@@ -365,6 +382,7 @@ def build_payload_for_slack(
     text,
     channel,
     thread_id,
+    reply_broadcast,
     username,
     icon_url,
     icon_emoji,
@@ -394,6 +412,8 @@ def build_payload_for_slack(
             payload["channel"] = channel
     if thread_id is not None:
         payload["thread_ts"] = thread_id
+        if reply_broadcast:
+            payload["reply_broadcast"] = True
     if username is not None:
         payload["username"] = username
     if icon_emoji is not None:
@@ -605,6 +625,7 @@ def main():
             msg=dict(type="str"),
             channel=dict(type="str"),
             thread_id=dict(type="str"),
+            reply_broadcast=dict(type="bool", default=False),
             username=dict(type="str", default="Ansible"),
             icon_url=dict(type="str", default="https://docs.ansible.com/favicon/favicon.ico"),
             icon_emoji=dict(type="str"),
@@ -634,6 +655,7 @@ def main():
     text = module.params["msg"]
     channel = module.params["channel"]
     thread_id = module.params["thread_id"]
+    reply_broadcast = module.params["reply_broadcast"]
     username = module.params["username"]
     icon_url = module.params["icon_url"]
     icon_emoji = module.params["icon_emoji"]
@@ -681,6 +703,7 @@ def main():
         text,
         channel,
         thread_id,
+        reply_broadcast,
         username,
         icon_url,
         icon_emoji,

--- a/tests/unit/plugins/modules/test_slack.py
+++ b/tests/unit/plugins/modules/test_slack.py
@@ -84,6 +84,47 @@ class TestSlackModule(ModuleTestCase):
         assert call_data["thread_ts"] == "100.00"
         assert fetch_url_mock.call_args[1]["url"] == "https://hooks.slack.com/services/TXX/BYY/ZZZ"
 
+    def test_message_with_thread_and_reply_broadcast(self):
+        """tests sending a threaded message that is also broadcast to the channel"""
+        with set_module_args(
+            {
+                "token": "TXX/BYY/ZZZ",
+                "msg": "test",
+                "thread_id": "100.00",
+                "reply_broadcast": True,
+            }
+        ):
+            with patch.object(slack, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 200})
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
+
+        self.assertTrue(fetch_url_mock.call_count, 1)
+        call_data = json.loads(fetch_url_mock.call_args[1]["data"])
+        assert call_data["thread_ts"] == "100.00"
+        assert call_data["reply_broadcast"] is True
+        assert fetch_url_mock.call_args[1]["url"] == "https://hooks.slack.com/services/TXX/BYY/ZZZ"
+
+    def test_message_with_thread_and_reply_broadcast_false(self):
+        """tests that reply_broadcast is omitted from the payload when false"""
+        with set_module_args(
+            {
+                "token": "TXX/BYY/ZZZ",
+                "msg": "test",
+                "thread_id": "100.00",
+                "reply_broadcast": False,
+            }
+        ):
+            with patch.object(slack, "fetch_url") as fetch_url_mock:
+                fetch_url_mock.return_value = (None, {"status": 200})
+                with self.assertRaises(AnsibleExitJson):
+                    self.module.main()
+
+        self.assertTrue(fetch_url_mock.call_count, 1)
+        call_data = json.loads(fetch_url_mock.call_args[1]["data"])
+        assert call_data["thread_ts"] == "100.00"
+        assert "reply_broadcast" not in call_data
+
     # https://github.com/ansible-collections/community.general/issues/1097
     def test_ts_in_message_does_not_cause_edit(self):
         with set_module_args({"token": "xoxa-123456789abcdef", "msg": "test with ts"}):


### PR DESCRIPTION
### SUMMARY

Add a `reply_broadcast` option to the `slack` module to allow a threaded reply (`thread_id`) to also be broadcast to the main channel, mirroring Slack's native `reply_broadcast` message event (see https://api.slack.com/events/message/reply_broadcast).

Currently, when posting a message as a threaded reply via `thread_id`, there is no way to also have that reply surfaced in the main channel — you have to send a second, separate message. This PR exposes Slack's own `reply_broadcast` parameter so this can be done in a single task.

Key details:

* New boolean option `reply_broadcast` (default `false`).
* Only takes effect together with `thread_id`; the payload key is only set when `reply_broadcast` is `true`, to avoid sending unnecessary fields to Slack's API.
* Only has an effect when a WebAPI token is used — Incoming Webhooks don't support this parameter, so it is silently a no-op there.
* Documentation and an example added.
* Unit tests added covering both the broadcast and non-broadcast cases.

### ISSUE TYPE

* Feature Pull Request

### COMPONENT NAME

`slack`

### ADDITIONAL INFORMATION

```yaml
- name: Add a threaded response and also broadcast it to the channel
  community.general.slack:
    channel: '#ansible'
    token: xoxb-1234-56789abcdefghijklmnopqrstuvwxyz
    thread_id: "{{ slack_response['ts'] }}"
    reply_broadcast: true
    msg: 'This threaded response is also shown in the channel!'