### PR TITLE
one_vm: add update_attributes for idempotent USER_TEMPLATE updates on existing VMs

### DIFF
--- a/changelogs/fragments/12498-one_vm-update-attributes.yml
+++ b/changelogs/fragments/12498-one_vm-update-attributes.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - one_vm - add ``update_attributes`` parameter to merge USER_TEMPLATE key/value pairs
+    onto existing VMs via the ``one.vm.update`` API with append/merge semantics, enabling
+    idempotent attribute updates on running VMs without teardown
+    (https://github.com/ansible-collections/community.general/issues/12498, https://github.com/ansible-collections/community.general/pull/12499).

--- a/changelogs/fragments/12498-one_vm-update-attributes.yml
+++ b/changelogs/fragments/12498-one_vm-update-attributes.yml
@@ -2,4 +2,4 @@ minor_changes:
   - one_vm - add ``update_attributes`` parameter to merge USER_TEMPLATE key/value pairs
     onto existing VMs via the ``one.vm.update`` API with append/merge semantics, enabling
     idempotent attribute updates on running VMs without teardown
-    (https://github.com/ansible-collections/community.general/issues/12498, https://github.com/ansible-collections/community.general/pull/12499).
+    (https://github.com/ansible-collections/community.general/issues/12498, https://github.com/ansible-collections/community.general/pull/12536).

--- a/plugins/modules/one_vm.py
+++ b/plugins/modules/one_vm.py
@@ -207,6 +207,32 @@ options:
       - B(VIDEO:) V(ATS), V(IOMMU), V(RESOLUTION), V(TYPE), V(VRAM).
     type: dict
     version_added: 6.3.0
+  update_attributes:
+    description:
+      - A dictionary of USER_TEMPLATE key/value pairs to merge onto existing VMs.
+      - Unlike O(attributes), which is applied only at VM creation, this parameter is
+        reconciled on every run by calling the C(one.vm.update) API with append/merge
+        semantics. It runs for VMs matched via O(instance_ids), O(attributes)/O(labels),
+        or O(exact_count) (including when O(template_name)/O(template_id) is set for
+        create/count matching).
+      - With O(count) alone (no O(exact_count)), only newly created VMs from that run are
+        reconciled; prefer O(exact_count) to keep a matched fleet in sync.
+      - On a brand-new instantiate, prefer also setting the same keys in O(attributes)
+        so they exist from first boot; O(update_attributes) then becomes a no-op once
+        values already match.
+      - Keys are automatically uppercased. Only string and integer values are accepted.
+        Scalar values are compared as strings so that for example V(8080) matches a stored
+        C("8080") without perpetual updates. Prefer string scalars; OpenNebula booleans are
+        typically stored as C(YES)/C(NO), not Python V(true)/V(false).
+      - Values of V(null) are not supported; append merge cannot remove USER_TEMPLATE keys.
+      - With O(exact_count), reconciled VMs are listed in R(tagged_instances), not
+        necessarily in the C(instances) return value, which tracks only creates/terminates
+        in that run.
+      - Cannot set keys restricted by OpenNebula (for example V(CPU), V(VCPU), V(MEMORY), V(DISK)).
+      - Mutually exclusive with O(state=absent).
+    type: dict
+    default: {}
+    version_added: 13.3.0
 author:
   - "Milan Ilic (@ilicmilan)"
   - "Jan Meerkamp (@meerkampdvv)"
@@ -439,6 +465,35 @@ EXAMPLES = r"""
         SSH_PUBLIC_KEY: |-
           ssh-rsa ...
           ssh-ed25519 ...
+
+- name: "Set USER_TEMPLATE attributes on a running VM (idempotent)"
+  community.general.one_vm:
+    instance_ids: 351
+    update_attributes:
+      PROJECT: myproject
+      ENVIRONMENT: prod
+      ROLE: web
+
+- name: "Ensure USER_TEMPLATE attributes are set on VMs matched by name attribute"
+  community.general.one_vm:
+    attributes:
+      name: my-vm-###
+    update_attributes:
+      SUBROLE: head
+
+- name: "Reconcile USER_TEMPLATE on exact_count VMs (works with template_name)"
+  community.general.one_vm:
+    template_name: my-base-template
+    exact_count: 1
+    count_attributes:
+      NAME: my-vm-00
+    attributes:
+      NAME: my-vm-00
+      ROLE: k8s
+      SUBROLE: head
+    update_attributes:
+      SUBROLE: head
+    state: present
 """
 
 RETURN = r"""
@@ -564,6 +619,8 @@ tagged_instances:
   description:
     - A list of instances info based on a specific attributes and/or labels that are specified with O(count_attributes) and
       O(count_labels) options.
+    - When using O(exact_count) with O(update_attributes), steady-state USER_TEMPLATE reconciliation populates this list
+      even when the C(instances) return value is empty.
   type: list
   elements: dict
   returned: success
@@ -1016,6 +1073,45 @@ def update_vms(module, client, vms, *args):
     changed = False
     for vm in vms:
         changed = update_vm(module, client, vm, *args) or changed
+    return changed
+
+
+def update_vm_user_template(module, client, vm, update_attributes_dict):
+    """Merge USER_TEMPLATE keys onto a VM via one.vm.update (append).
+
+    Skips the XML-RPC call when every requested key already matches, so
+    idempotent re-runs do not touch the API.
+    """
+    if not update_attributes_dict:
+        return False
+
+    before = client.vm.info(vm.ID).USER_TEMPLATE or {}
+    needs_update = any(not _user_template_values_equal(before.get(k), v) for k, v in update_attributes_dict.items())
+    if not needs_update:
+        return False
+
+    if module.check_mode:
+        return True
+
+    # 1: Merge new template with the existing one.
+    client.vm.update(vm.ID, render(update_attributes_dict), 1)
+    return True
+
+
+def _user_template_values_equal(current, desired):
+    """Compare USER_TEMPLATE values with OpenNebula string storage in mind."""
+    if current is None:
+        return False
+    if isinstance(desired, (dict, list)) or isinstance(current, (dict, list)):
+        return current == desired
+    # OpenNebula stores scalars as strings; normalise so PORT: 8080 matches "8080".
+    return str(current) == str(desired)
+
+
+def update_vms_user_template(module, client, vms, update_attributes_dict):
+    changed = False
+    for vm in vms:
+        changed = update_vm_user_template(module, client, vm, update_attributes_dict) or changed
     return changed
 
 
@@ -1584,12 +1680,24 @@ TEMPLATE_RESTRICTED_ATTRIBUTES = [
 ]
 
 
-def check_attributes(module, attributes):
+def check_attributes(module, attributes, purpose="filtering VMs"):
     for key in attributes.keys():
         if key in TEMPLATE_RESTRICTED_ATTRIBUTES:
-            module.fail_json(msg=f"Restricted attribute `{key}` cannot be used when filtering VMs.")
+            module.fail_json(msg=f"Restricted attribute `{key}` cannot be used when {purpose}.")
     # Check the format of the name attribute
     check_name_attribute(module, attributes)
+
+
+def check_update_attributes_values(module, update_attributes):
+    for key, value in update_attributes.items():
+        if value is None:
+            module.fail_json(
+                msg=(f"update_attributes key `{key}` cannot be null; append merge cannot remove USER_TEMPLATE keys.")
+            )
+        elif isinstance(value, bool) or not isinstance(value, (str, int)):
+            module.fail_json(
+                msg=f"update_attributes key `{key}` must be a string or integer, not {type(value).__name__}."
+            )
 
 
 def disk_save_as(module, client, vm, disk_saveas, wait_timeout):
@@ -1679,6 +1787,7 @@ def main():
         "disk_saveas": {"type": "dict"},
         "persistent": {"default": False, "type": "bool"},
         "updateconf": {"type": "dict"},
+        "update_attributes": {"default": {}, "type": "dict"},
     }
 
     module = AnsibleModule(
@@ -1737,6 +1846,7 @@ def main():
     disk_saveas = params.get("disk_saveas")
     persistent = params.get("persistent")
     updateconf = params.get("updateconf")
+    update_attributes = params.get("update_attributes")
 
     if not (auth.username and auth.password):
         module.warn("Credentials missing")
@@ -1758,6 +1868,13 @@ def main():
 
     if updateconf:
         check_updateconf(module, updateconf)
+
+    if update_attributes:
+        if state == "absent":
+            module.fail_json(msg="Option update_attributes cannot be used when state is 'absent'.")
+        check_update_attributes_values(module, update_attributes)
+        update_attributes = {k.upper(): v for k, v in update_attributes.items()}
+        check_attributes(module, update_attributes, purpose="setting update_attributes")
 
     if count_labels and not labels:
         module.warn(
@@ -1914,6 +2031,12 @@ def main():
 
     if template_id is None and updateconf is not None:
         changed = update_vms(module, one_client, vms, updateconf) or changed
+
+    # Reconcile USER_TEMPLATE on all resolved VMs. Do not gate on template_id:
+    # exact_count / template_name paths still need to update attributes on
+    # already-running matches (attributes alone only apply at instantiate).
+    if update_attributes:
+        changed = update_vms_user_template(module, one_client, vms, update_attributes) or changed
 
     if wait and not module.check_mode and state != "present":
         wait_for = {

--- a/tests/unit/plugins/modules/test_one_vm.py
+++ b/tests/unit/plugins/modules/test_one_vm.py
@@ -4,9 +4,18 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
+from unittest.mock import MagicMock
+
 import pytest
 
-from ansible_collections.community.general.plugins.modules.one_vm import parse_updateconf
+from ansible_collections.community.general.plugins.modules.one_vm import (
+    _user_template_values_equal,
+    check_update_attributes_values,
+    parse_updateconf,
+    update_vm_user_template,
+    update_vms_user_template,
+)
 
 PARSE_UPDATECONF_VALID = [
     (
@@ -54,3 +63,169 @@ PARSE_UPDATECONF_VALID = [
 def test_parse_updateconf(vm_template, expected_result):
     result = parse_updateconf(vm_template)
     assert result == expected_result, repr(result)
+
+
+@pytest.mark.parametrize(
+    "current,desired,expected",
+    [
+        (None, "head", False),
+        ("head", "head", True),
+        ("8080", 8080, True),
+        (True, True, True),
+        ("YES", True, False),  # str(True) is "True", not "YES"
+        ({"A": "1"}, {"A": "1"}, True),
+        ({"A": "1"}, {"A": "2"}, False),
+    ],
+)
+def test_user_template_values_equal(current, desired, expected):
+    assert _user_template_values_equal(current, desired) is expected
+
+
+def test_check_update_attributes_values_rejects_null():
+    module = MagicMock()
+
+    check_update_attributes_values(module, {"SUBROLE": None})
+
+    module.fail_json.assert_called_once()
+    msg = module.fail_json.call_args.kwargs.get("msg") or module.fail_json.call_args[0][0]
+    assert "cannot be null" in msg
+    assert "SUBROLE" in msg
+
+
+@pytest.mark.parametrize(
+    "value,type_name",
+    [
+        (True, "bool"),
+        (False, "bool"),
+        (1.5, "float"),
+        (["head"], "list"),
+        ({"role": "head"}, "dict"),
+    ],
+)
+def test_check_update_attributes_values_rejects_invalid_types(value, type_name):
+    module = MagicMock()
+
+    check_update_attributes_values(module, {"SUBROLE": value})
+
+    module.fail_json.assert_called_once()
+    msg = module.fail_json.call_args.kwargs.get("msg") or module.fail_json.call_args[0][0]
+    assert "must be a string or integer" in msg
+    assert "SUBROLE" in msg
+    assert type_name in msg
+
+
+@pytest.mark.parametrize("value", ["head", 8080])
+def test_check_update_attributes_values_accepts_string_and_integer(value):
+    module = MagicMock()
+
+    check_update_attributes_values(module, {"SUBROLE": value})
+
+    module.fail_json.assert_not_called()
+
+
+def _module(check_mode=False):
+    module = MagicMock()
+    module.check_mode = check_mode
+    return module
+
+
+def _client_with_user_template(user_template, vm_id=42):
+    client = MagicMock()
+    info = MagicMock()
+    info.USER_TEMPLATE = user_template
+    client.vm.info.return_value = info
+    vm = MagicMock()
+    vm.ID = vm_id
+    return client, vm
+
+
+def test_update_vm_user_template_empty_dict_is_noop():
+    module = _module()
+    client, vm = _client_with_user_template({"ROLE": "k8s"})
+
+    changed = update_vm_user_template(module, client, vm, {})
+
+    assert changed is False
+    client.vm.info.assert_not_called()
+    client.vm.update.assert_not_called()
+
+
+def test_update_vm_user_template_none_user_template_treated_as_empty():
+    module = _module(check_mode=True)
+    client, vm = _client_with_user_template(None)
+
+    changed = update_vm_user_template(module, client, vm, {"SUBROLE": "head"})
+
+    assert changed is True
+    client.vm.update.assert_not_called()
+
+
+def test_update_vm_user_template_check_mode_changed_when_missing():
+    module = _module(check_mode=True)
+    client, vm = _client_with_user_template({"ROLE": "k8s"})
+
+    changed = update_vm_user_template(module, client, vm, {"SUBROLE": "head"})
+
+    assert changed is True
+    client.vm.update.assert_not_called()
+
+
+def test_update_vm_user_template_check_mode_unchanged_when_match():
+    module = _module(check_mode=True)
+    client, vm = _client_with_user_template(OrderedDict([("SUBROLE", "head"), ("ROLE", "k8s")]))
+
+    changed = update_vm_user_template(module, client, vm, {"SUBROLE": "head"})
+
+    assert changed is False
+    client.vm.update.assert_not_called()
+
+
+def test_update_vm_user_template_live_calls_update_with_rendered_merge():
+    module = _module(check_mode=False)
+    client, vm = _client_with_user_template({"ROLE": "k8s"})
+
+    changed = update_vm_user_template(module, client, vm, {"SUBROLE": "head"})
+
+    assert changed is True
+    client.vm.update.assert_called_once_with(42, 'SUBROLE="head"', 1)
+    # Only the pre-flight info() call; no post-update info round-trip
+    assert client.vm.info.call_count == 1
+
+
+def test_update_vm_user_template_live_skips_api_when_already_match():
+    module = _module(check_mode=False)
+    client, vm = _client_with_user_template({"SUBROLE": "worker"})
+
+    changed = update_vm_user_template(module, client, vm, {"SUBROLE": "worker"})
+
+    assert changed is False
+    client.vm.update.assert_not_called()
+
+
+def test_update_vm_user_template_skips_api_when_int_matches_stored_string():
+    module = _module(check_mode=False)
+    client, vm = _client_with_user_template({"PORT": "8080"})
+
+    changed = update_vm_user_template(module, client, vm, {"PORT": 8080})
+
+    assert changed is False
+    client.vm.update.assert_not_called()
+
+
+def test_update_vms_user_template_any_changed():
+    module = _module(check_mode=False)
+    client = MagicMock()
+
+    vm_a = MagicMock(ID=1)
+    vm_b = MagicMock(ID=2)
+
+    # First VM already has SUBROLE=head; second needs update
+    info_a = MagicMock(USER_TEMPLATE={"SUBROLE": "head"})
+    info_b_before = MagicMock(USER_TEMPLATE={})
+    client.vm.info.side_effect = [info_a, info_b_before]
+
+    changed = update_vms_user_template(module, client, [vm_a, vm_b], {"SUBROLE": "head"})
+
+    assert changed is True
+    assert client.vm.update.call_count == 1
+    assert client.vm.update.call_args[0] == (2, 'SUBROLE="head"', 1)


### PR DESCRIPTION
Fixes #12498.

Reopens #12499 after accidental branch history breakage during force-push.

The `one_vm` module currently applies `attributes` (USER_TEMPLATE key/value pairs) only at VM creation. On subsequent runs, `attributes` is used solely for VM _matching_ — the module never reconciles them back onto a running VM. There is no existing workaround: `updateconf` targets a whitelist of `TEMPLATE` fields (OS, CONTEXT, GRAPHICS, etc.), not `USER_TEMPLATE`.

This PR adds an `update_attributes` parameter that calls `one.vm.update` with append/merge semantics (`update_type=1`) on existing VMs — directly analogous to how `updateconf` calls `one.vm.updateconf`.

### Changes

* **`plugins/modules/one_vm.py`**
  * New `update_attributes` parameter (dict, default `{}`)
  * Reuses existing `check_attributes()` validator to block restricted keys (CPU, VCPU, MEMORY, etc.) and auto-uppercases keys
  * Rejects non-string/non-integer values (bools, floats, lists, dicts) per review feedback
  * New `update_vm_user_template()` function with proper `check_mode` support
  * New `update_vms_user_template()` loop, wired into `main()` alongside the existing `updateconf` path
  * `update_attributes` added to module return value
  * DOCUMENTATION, EXAMPLES, RETURN blocks updated
* **`changelogs/fragments/12498-one_vm-update-attributes.yml`** — changelog entry

### Example

```yaml
- name: Set USER_TEMPLATE attributes on a running VM (idempotent)
  community.general.one_vm:
    instance_ids: 351
    update_attributes:
      PROJECT: myproject
      ENVIRONMENT: prod
      ROLE: web
```

### Test plan

* Unit test: verify `client.vm.update` is called with `render(update_attributes_dict)` and `update_type=1`
* Check mode: verify no XMLRPC call is made; `changed` is `True` only when a key would differ
* Live idempotency: run twice with same values → second run reports `changed=false`
* Restricted key rejection: verify `update_attributes: {CPU: 2}` fails with a clear error
* Type validation: reject bool, float, list, dict values