### PR TITLE
Redfish: Added workaround for Supermicro in VirtualMediaInsert command to treat 'NotConnected' slots as empty

### DIFF
--- a/changelogs/fragments/6969-redfish-supermicro-virtual-media-discover-empty-workaround.yml
+++ b/changelogs/fragments/6969-redfish-supermicro-virtual-media-discover-empty-workaround.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redfish_command - add workaround in ``VirtualMediaInsert`` for Supermicro systems to treat slots marked as ``NotConnected`` as empty (https://github.com/ansible-collections/community.general/issues/6969, https://github.com/ansible-collections/community.general/pull/7470).

--- a/changelogs/fragments/6969-redfish-supermicro-virtual-media-discover-empty-workaround.yml
+++ b/changelogs/fragments/6969-redfish-supermicro-virtual-media-discover-empty-workaround.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - redfish_command - add workaround in ``VirtualMediaInsert`` for Supermicro systems to treat slots marked as ``NotConnected`` as empty (https://github.com/ansible-collections/community.general/issues/6969, https://github.com/ansible-collections/community.general/pull/7470).
+  - redfish_command - add workaround in ``VirtualMediaInsert`` for Supermicro systems to treat slots marked as ``NotConnected`` as empty (https://github.com/ansible-collections/community.general/issues/6969, https://github.com/ansible-collections/community.general/pull/12537).

--- a/plugins/module_utils/_redfish_utils.py
+++ b/plugins/module_utils/_redfish_utils.py
@@ -3035,6 +3035,11 @@ class RedfishUtils:
             # if ejected, 'Inserted' should be False and 'ImageName' cleared
             if not data.get("Inserted", False) and not data.get("ImageName"):
                 return uri, data
+            # WORKAROUND
+            # Supermicro systems do not properly clear out ImageName when media is ejected
+            if vendor == 'Supermicro':
+                if data.get('ConnectedVia') == 'NotConnected':
+                    return uri, data
         return None, None
 
     @staticmethod

--- a/plugins/module_utils/_redfish_utils.py
+++ b/plugins/module_utils/_redfish_utils.py
@@ -3037,8 +3037,8 @@ class RedfishUtils:
                 return uri, data
             # WORKAROUND
             # Supermicro systems do not properly clear out ImageName when media is ejected
-            if vendor == 'Supermicro':
-                if data.get('ConnectedVia') == 'NotConnected':
+            if vendor == "Supermicro":
+                if data.get("ConnectedVia") == "NotConnected":
                     return uri, data
         return None, None
 


### PR DESCRIPTION
##### SUMMARY

When scanning the virtual media list for empty slots, Supermicro systems do not properly clear out the "ImageName" property per the Redfish spec. However, they do show "ConnectedVia" as "NotConnected" when the media is ejected. Added a workaround specific to Supermicro systems to treat this as an empty slot.

Fix #6969 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
redfish_utils, redfish_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Currently a draft right now; I do not have a Supermicro system available to test this change. @jyundt you mentioned in the issue you might have something available. Is this true?

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
