### PR TITLE
Add appimage module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -492,12 +492,12 @@ files:
   $modules/apache2_module.py:
     ignore: robinro
     maintainers: berendt n0trax
-  $modules/appimage.py:
-    maintainers: travisbeale
   $modules/apk.py:
     ignore: kbrebanov
     labels: apk
     maintainers: tdtrask
+  $modules/appimage.py:
+    maintainers: travisbeale
   $modules/apt_repo.py:
     maintainers: obirvalger
   $modules/apt_rpm.py:

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -492,6 +492,8 @@ files:
   $modules/apache2_module.py:
     ignore: robinro
     maintainers: berendt n0trax
+  $modules/appimage.py:
+    maintainers: travisbeale
   $modules/apk.py:
     ignore: kbrebanov
     labels: apk

--- a/plugins/modules/appimage.py
+++ b/plugins/modules/appimage.py
@@ -170,16 +170,18 @@ def normalized_catalog_name(name):
     return "".join(c for c in name.lower() if c.isalnum())
 
 
-def is_github_releases_url(url):
-    parsed = urlparse(url)
+def is_github_releases_url(url, parsed=None):
+    if parsed is None:
+        parsed = urlparse(url)
     path_parts = [part for part in parsed.path.split("/") if part]
     return parsed.netloc.lower() == "github.com" and len(path_parts) >= 3 and path_parts[2] == "releases"
 
 
-def parse_github_releases_url(url):
-    parsed = urlparse(url)
+def parse_github_releases_url(url, parsed=None):
+    if parsed is None:
+        parsed = urlparse(url)
     path_parts = [part for part in parsed.path.split("/") if part]
-    if not is_github_releases_url(url):
+    if not is_github_releases_url(url, parsed):
         raise ValueError("URL is not a GitHub releases page")
     owner = path_parts[0]
     repo = path_parts[1]
@@ -195,8 +197,8 @@ def github_api_url(owner, repo, tag):
     return f"https://api.github.com/repos/{owner}/{repo}/releases/latest"
 
 
-def github_api_url_from_releases_url(url, state, version):
-    owner, repo, tag_from_url = parse_github_releases_url(url)
+def github_api_url_from_releases_url(url, state, version, parsed=None):
+    owner, repo, tag_from_url = parse_github_releases_url(url, parsed)
     tag = None if state == "latest" else version or tag_from_url
     return github_api_url(owner, repo, tag)
 
@@ -284,8 +286,9 @@ def select_catalog_download_url(module, item):
     module.fail_json(msg=f"AppImage catalog entry {item.get('name')!r} does not contain a supported download link")
 
 
-def local_appimage_path(source):
-    parsed = urlparse(source)
+def local_appimage_path(source, parsed=None):
+    if parsed is None:
+        parsed = urlparse(source)
     if parsed.scheme == "file":
         if parsed.netloc not in ("", "localhost"):
             return None
@@ -295,8 +298,8 @@ def local_appimage_path(source):
     return None
 
 
-def resolve_local_source(module, source, catalog_name=None):
-    path = local_appimage_path(source)
+def resolve_local_source(module, source, parsed=None, catalog_name=None):
+    path = local_appimage_path(source, parsed)
     if path is None:
         return None
     if module.params["state"] == "latest":
@@ -322,11 +325,12 @@ def resolve_local_source(module, source, catalog_name=None):
 
 
 def resolve_url_source(module, url, catalog_name=None):
-    local_source = resolve_local_source(module, url, catalog_name=catalog_name)
+    parsed = urlparse(url)
+    local_source = resolve_local_source(module, url, parsed=parsed, catalog_name=catalog_name)
     if local_source is not None:
         return local_source
 
-    if is_github_releases_url(url):
+    if is_github_releases_url(url, parsed):
         if module.params["state"] == "latest" and module.params["version"]:
             module.fail_json(msg="state=latest cannot be combined with version")
         headers = {}
@@ -334,7 +338,7 @@ def resolve_url_source(module, url, catalog_name=None):
             headers["Authorization"] = f"Bearer {module.params['github_token']}"
         release = fetch_json(
             module,
-            github_api_url_from_releases_url(url, module.params["state"], module.params["version"]),
+            github_api_url_from_releases_url(url, module.params["state"], module.params["version"], parsed),
             headers,
         )
         asset = select_release_asset(module, release, module.params["asset_name"])
@@ -347,7 +351,7 @@ def resolve_url_source(module, url, catalog_name=None):
             source["catalog_name"] = catalog_name
         return source
 
-    if not urlparse(url).path.lower().endswith(".appimage"):
+    if not parsed.path.lower().endswith(".appimage"):
         module.fail_json(
             msg=(
                 f"Resolved URL {url!r} is not a direct AppImage URL or GitHub releases page. "
@@ -359,7 +363,7 @@ def resolve_url_source(module, url, catalog_name=None):
 
     source = {
         "source_url": url,
-        "asset_name": os.path.basename(urlparse(url).path),
+        "asset_name": os.path.basename(parsed.path),
         "version": None,
     }
     if catalog_name:
@@ -417,10 +421,10 @@ def needs_install(path, state, source):
     )
 
 
-def atomic_install(module, write_source, dest):
+def atomic_install(module, source_file, dest):
     fd, tmp_path = tempfile.mkstemp(prefix=".ansible-appimage-", dir=module.tmpdir)
     with os.fdopen(fd, "wb") as tmp_file:
-        write_source(tmp_file)
+        shutil.copyfileobj(source_file, tmp_file)
     module.atomic_move(tmp_path, dest, unsafe_writes=module.params["unsafe_writes"])
 
 
@@ -435,15 +439,12 @@ def download_appimage(module, source_url, dest):
     if status != 200:
         module.fail_json(msg=f"Failed to download AppImage from {source_url}", status=status, details=info.get("msg"))
 
-    atomic_install(module, lambda tmp_file: shutil.copyfileobj(response, tmp_file), dest)
+    atomic_install(module, response, dest)
 
 
 def copy_appimage(module, source_path, dest):
-    def write_source(tmp_file):
-        with open(source_path, "rb") as source_file:
-            shutil.copyfileobj(source_file, tmp_file)
-
-    atomic_install(module, write_source, dest)
+    with open(source_path, "rb") as source_file:
+        atomic_install(module, source_file, dest)
 
 
 def install_appimage(module, source, dest):

--- a/plugins/modules/appimage.py
+++ b/plugins/modules/appimage.py
@@ -232,10 +232,14 @@ def select_release_asset(module, release, asset_name):
             matches.append(asset)
 
     if not matches:
-        module.fail_json(msg=f"No AppImage asset matching {asset_name!r} was found in GitHub release {release.get('tag_name')}")
+        module.fail_json(
+            msg=f"No AppImage asset matching {asset_name!r} was found in GitHub release {release.get('tag_name')}"
+        )
     if len(matches) > 1:
         names = [asset["name"] for asset in matches]
-        module.fail_json(msg=f"Multiple AppImage assets match {asset_name!r}; make asset_name more specific", assets=names)
+        module.fail_json(
+            msg=f"Multiple AppImage assets match {asset_name!r}; make asset_name more specific", assets=names
+        )
 
     return matches[0]
 
@@ -252,7 +256,9 @@ def select_catalog_item(module, feed, name):
         module.fail_json(msg=f"No AppImage named {name!r} was found in the appimage.github.io catalog")
     if len(normalized_matches) > 1:
         names = [item["name"] for item in normalized_matches]
-        module.fail_json(msg=f"Multiple AppImage catalog entries match {name!r}; use the exact catalog name", catalog_names=names)
+        module.fail_json(
+            msg=f"Multiple AppImage catalog entries match {name!r}; use the exact catalog name", catalog_names=names
+        )
 
     return normalized_matches[0]
 
@@ -279,7 +285,7 @@ def resolve_url_source(module, url, catalog_name=None):
         tag = module.params["version"] or tag_from_url
         headers = {}
         if module.params["github_token"]:
-            headers["Authorization"] = "Bearer %s" % module.params["github_token"]
+            headers["Authorization"] = f"Bearer {module.params['github_token']}"
         release = fetch_json(module, github_api_url(owner, repo, tag), headers)
         asset = select_release_asset(module, release, module.params["asset_name"])
         source = {
@@ -387,14 +393,7 @@ def desktop_file_path(name):
 
 
 def desired_desktop_file(name, executable):
-    return (
-        "[Desktop Entry]\n"
-        "Type=Application\n"
-        f"Name={name}\n"
-        f"Exec={executable}\n"
-        "Terminal=false\n"
-        "Categories=Utility;\n"
-    )
+    return f"[Desktop Entry]\nType=Application\nName={name}\nExec={executable}\nTerminal=false\nCategories=Utility;\n"
 
 
 def ensure_desktop_file(path, content, check_mode):

--- a/plugins/modules/appimage.py
+++ b/plugins/modules/appimage.py
@@ -11,7 +11,7 @@ short_description: Manage AppImage packages
 description:
   - Install, update, and remove applications distributed as AppImage files.
   - The module installs AppImage files into a user-controlled directory and can optionally create a desktop launcher.
-  - Sources can be direct AppImage URLs or GitHub release pages containing AppImage assets.
+  - Sources can be direct AppImage URLs, GitHub release pages containing AppImage assets, or appimage.github.io catalog entries.
 author:
   - Ansible Community (@ansible-collections)
 extends_documentation_fragment:
@@ -26,6 +26,7 @@ options:
     description:
       - Name of the managed AppImage.
       - This is used as the installed executable filename and as the desktop file basename.
+      - When O(url) is omitted, this is also used to look up the AppImage in the appimage.github.io catalog.
     type: str
     required: true
   url:
@@ -33,7 +34,7 @@ options:
       - URL used to install the AppImage.
       - This can point directly to an AppImage file, or to a GitHub releases page such as
         V(https://github.com/OWNER/REPO/releases) or V(https://github.com/OWNER/REPO/releases/tag/TAG).
-      - Required when O(state=present) or O(state=latest).
+      - When omitted with O(state=present) or O(state=latest), the module looks up O(name) in the appimage.github.io catalog.
     type: str
   state:
     description:
@@ -71,6 +72,11 @@ options:
       - GitHub token used when querying GitHub releases.
       - This can be useful for private repositories or higher API rate limits.
     type: str
+  catalog_url:
+    description:
+      - URL of the appimage.github.io-compatible JSON feed used when O(url) is omitted.
+    type: str
+    default: https://appimage.github.io/feed.json
   validate_certs:
     description:
       - If V(false), SSL certificates are not validated.
@@ -88,6 +94,10 @@ EXAMPLES = r"""
   community.general.appimage:
     name: example
     url: https://example.com/downloads/example-x86_64.AppImage
+
+- name: Install an AppImage from the appimage.github.io catalog
+  community.general.appimage:
+    name: appimagetool
 
 - name: Install the latest x86_64 AppImage from GitHub releases
   community.general.appimage:
@@ -135,6 +145,16 @@ version:
   returned: when installing from a GitHub release
   type: str
   sample: v1.2.3
+catalog_name:
+  description: AppImage catalog entry name used to resolve the source.
+  returned: when installing from the appimage.github.io catalog
+  type: str
+  sample: appimagetool
+catalog_url:
+  description: AppImage catalog page used to resolve the source.
+  returned: when installing from the appimage.github.io catalog
+  type: str
+  sample: https://appimage.github.io/appimagetool/
 """
 
 import fnmatch
@@ -145,6 +165,10 @@ from urllib.parse import urlparse
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
+
+
+def normalized_catalog_name(name):
+    return "".join(c for c in name.lower() if c.isalnum())
 
 
 def is_github_releases_url(url):
@@ -170,6 +194,10 @@ def github_api_url(owner, repo, tag):
     if tag:
         return f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag}"
     return f"https://api.github.com/repos/{owner}/{repo}/releases/latest"
+
+
+def appimage_catalog_name_url(catalog_name):
+    return f"https://appimage.github.io/{catalog_name}/"
 
 
 def response_body(response):
@@ -212,8 +240,40 @@ def select_release_asset(module, release, asset_name):
     return matches[0]
 
 
-def resolve_source(module):
-    url = module.params["url"]
+def select_catalog_item(module, feed, name):
+    items = feed.get("items") or []
+    exact_matches = [item for item in items if item.get("name") == name]
+    if exact_matches:
+        return exact_matches[0]
+
+    normalized_name = normalized_catalog_name(name)
+    normalized_matches = [item for item in items if normalized_catalog_name(item.get("name", "")) == normalized_name]
+    if not normalized_matches:
+        module.fail_json(msg=f"No AppImage named {name!r} was found in the appimage.github.io catalog")
+    if len(normalized_matches) > 1:
+        names = [item["name"] for item in normalized_matches]
+        module.fail_json(msg=f"Multiple AppImage catalog entries match {name!r}; use the exact catalog name", catalog_names=names)
+
+    return normalized_matches[0]
+
+
+def select_catalog_download_url(module, item):
+    links = item.get("links") or []
+    download_links = [link for link in links if link.get("type") == "Download" and link.get("url")]
+    github_links = [link for link in links if link.get("type") == "GitHub" and link.get("url")]
+
+    if download_links:
+        return download_links[0]["url"]
+    if github_links:
+        github_url = github_links[0]["url"]
+        if github_url.startswith("http://") or github_url.startswith("https://"):
+            return github_url.rstrip("/") + "/releases"
+        return f"https://github.com/{github_url.strip('/')}/releases"
+
+    module.fail_json(msg=f"AppImage catalog entry {item.get('name')!r} does not contain a supported download link")
+
+
+def resolve_url_source(module, url, catalog_name=None):
     if is_github_releases_url(url):
         owner, repo, tag_from_url = parse_github_releases_url(url)
         tag = module.params["version"] or tag_from_url
@@ -222,13 +282,47 @@ def resolve_source(module):
             headers["Authorization"] = "Bearer %s" % module.params["github_token"]
         release = fetch_json(module, github_api_url(owner, repo, tag), headers)
         asset = select_release_asset(module, release, module.params["asset_name"])
-        return {
+        source = {
             "source_url": asset["browser_download_url"],
             "asset_name": asset.get("name"),
             "version": release.get("tag_name"),
         }
+        if catalog_name:
+            source["catalog_name"] = catalog_name
+        return source
 
-    return {"source_url": url, "asset_name": os.path.basename(urlparse(url).path), "version": None}
+    if not urlparse(url).path.lower().endswith(".appimage"):
+        module.fail_json(
+            msg=(
+                f"Resolved URL {url!r} is not a direct AppImage URL or GitHub releases page. "
+                "Use url to provide a supported AppImage source explicitly."
+            )
+        )
+
+    source = {
+        "source_url": url,
+        "asset_name": os.path.basename(urlparse(url).path),
+        "version": None,
+    }
+    if catalog_name:
+        source["catalog_name"] = catalog_name
+    return source
+
+
+def resolve_catalog_source(module):
+    feed = fetch_json(module, module.params["catalog_url"], {})
+    item = select_catalog_item(module, feed, module.params["name"])
+    download_url = select_catalog_download_url(module, item)
+    source = resolve_url_source(module, download_url, catalog_name=item.get("name"))
+    source["catalog_url"] = appimage_catalog_name_url(item.get("name"))
+    return source
+
+
+def resolve_source(module):
+    url = module.params["url"]
+    if url:
+        return resolve_url_source(module, url)
+    return resolve_catalog_source(module)
 
 
 def metadata_path(path):
@@ -334,10 +428,10 @@ def main():
             version=dict(type="str"),
             asset_name=dict(type="str", default="*.AppImage"),
             github_token=dict(type="str", no_log=True),
+            catalog_url=dict(type="str", default="https://appimage.github.io/feed.json"),
             validate_certs=dict(type="bool", default=True),
             timeout=dict(type="int", default=30),
         ),
-        required_if=[("state", "present", ["url"]), ("state", "latest", ["url"])],
         supports_check_mode=True,
     )
 

--- a/plugins/modules/appimage.py
+++ b/plugins/modules/appimage.py
@@ -10,12 +10,14 @@ module: appimage
 short_description: Manage AppImage packages
 description:
   - Install, update, and remove applications distributed as AppImage files.
-  - The module installs AppImage files into a user-controlled directory and can optionally create a desktop launcher.
-  - Sources can be direct AppImage URLs, GitHub release pages containing AppImage assets, or appimage.github.io catalog entries.
+  - The module installs AppImage files into a user-controlled directory.
+  - Sources can be local AppImage files, direct AppImage URLs, GitHub release pages containing AppImage assets,
+    or U(https://appimage.github.io) catalog entries.
 author:
   - Travis Beale (@travisbeale)
 extends_documentation_fragment:
   - community.general._attributes
+  - ansible.builtin.files
 attributes:
   check_mode:
     support: full
@@ -25,23 +27,26 @@ options:
   name:
     description:
       - Name of the managed AppImage.
-      - This is used as the installed executable filename and as the desktop file basename.
-      - When O(url) is omitted, this is also used to look up the AppImage in the appimage.github.io catalog.
+      - This is used as the installed executable filename.
+      - When O(url) is omitted, this is also used to look up the AppImage in the U(https://appimage.github.io) catalog.
     type: str
     required: true
   url:
     description:
-      - URL used to install the AppImage.
-      - This can point directly to an AppImage file, or to a GitHub releases page such as
-        V(https://github.com/OWNER/REPO/releases) or V(https://github.com/OWNER/REPO/releases/tag/TAG).
-      - When omitted with O(state=present) or O(state=latest), the module looks up O(name) in the appimage.github.io catalog.
+      - Source used to install the AppImage.
+      - This can point directly to an AppImage URL, a local AppImage file path, a V(file://) AppImage URL,
+        or to a GitHub releases page such as V(https://github.com/OWNER/REPO/releases)
+        or V(https://github.com/OWNER/REPO/releases/tag/TAG).
+      - When omitted with O(state=present) or O(state=latest), the module looks up O(name) in the U(https://appimage.github.io) catalog.
     type: str
   state:
     description:
       - Desired state of the AppImage.
       - When O(state=present), the AppImage is installed if missing.
-      - When O(state=latest), GitHub releases pages are resolved to the latest release unless O(version) is set.
-        Direct AppImage URLs are installed when missing or when the recorded source URL differs.
+      - When O(state=latest), sources that support multiple versions, such as GitHub releases pages,
+        are resolved to the latest release and updated when the recorded version differs.
+      - O(state=latest) cannot be combined with O(version), and is not supported for fixed sources such
+        as direct AppImage URLs or local files.
     type: str
     choices: [absent, present, latest]
     default: present
@@ -50,12 +55,6 @@ options:
       - Directory where the AppImage executable is installed.
     type: path
     default: "~/.local/bin"
-  desktop_integration:
-    description:
-      - Whether to create a desktop launcher for the installed AppImage.
-      - The launcher is written to C($HOME/.local/share/applications/).
-    type: bool
-    default: false
   version:
     description:
       - GitHub release tag to install when O(url) points to a GitHub releases page.
@@ -74,7 +73,7 @@ options:
     type: str
   catalog_url:
     description:
-      - URL of the appimage.github.io-compatible JSON feed used when O(url) is omitted.
+      - URL of the U(https://appimage.github.io)-compatible JSON feed used when O(url) is omitted.
     type: str
     default: https://appimage.github.io/feed.json
   validate_certs:
@@ -95,6 +94,11 @@ EXAMPLES = r"""
     name: example
     url: https://example.com/downloads/example-x86_64.AppImage
 
+- name: Install an AppImage from a local file
+  community.general.appimage:
+    name: example
+    url: /tmp/example-x86_64.AppImage
+
 - name: Install an AppImage from the appimage.github.io catalog
   community.general.appimage:
     name: appimagetool
@@ -111,12 +115,6 @@ EXAMPLES = r"""
     name: example
     url: https://github.com/example/example/releases
     version: v1.2.3
-
-- name: Install an AppImage and create a desktop launcher
-  community.general.appimage:
-    name: example
-    url: https://example.com/downloads/example.AppImage
-    desktop_integration: true
 
 - name: Remove an AppImage
   community.general.appimage:
@@ -135,11 +133,11 @@ source_url:
   returned: when O(state) is V(present) or V(latest)
   type: str
   sample: https://github.com/example/example/releases/download/v1.2.3/example-x86_64.AppImage
-desktop_file:
-  description: Path to the managed desktop launcher.
-  returned: when O(desktop_integration=true) or O(state=absent)
+source_path:
+  description: Local AppImage source path.
+  returned: when installing from a local path or V(file://) source
   type: str
-  sample: /home/user/.local/share/applications/example.desktop
+  sample: /tmp/example-x86_64.AppImage
 version:
   description: GitHub release tag that was installed.
   returned: when installing from a GitHub release
@@ -160,8 +158,9 @@ catalog_url:
 import fnmatch
 import json
 import os
+import shutil
 import tempfile
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
@@ -196,14 +195,20 @@ def github_api_url(owner, repo, tag):
     return f"https://api.github.com/repos/{owner}/{repo}/releases/latest"
 
 
+def github_api_url_from_releases_url(url, state, version):
+    owner, repo, tag_from_url = parse_github_releases_url(url)
+    tag = None if state == "latest" else version or tag_from_url
+    return github_api_url(owner, repo, tag)
+
+
 def appimage_catalog_name_url(catalog_name):
     return f"https://appimage.github.io/{catalog_name}/"
 
 
-def response_body(response):
+def response_text(response):
     if response is None:
-        return b""
-    return response.read()
+        return ""
+    return response.read().decode("utf-8")
 
 
 def fetch_json(module, url, headers):
@@ -218,7 +223,7 @@ def fetch_json(module, url, headers):
     if status != 200:
         module.fail_json(msg=f"Failed to fetch {url}", status=status, details=info.get("msg"))
     try:
-        return json.loads(response_body(response).decode("utf-8"))
+        return json.loads(response_text(response))
     except (TypeError, ValueError) as e:
         module.fail_json(msg=f"Failed to parse JSON from {url}: {e}")
 
@@ -279,14 +284,59 @@ def select_catalog_download_url(module, item):
     module.fail_json(msg=f"AppImage catalog entry {item.get('name')!r} does not contain a supported download link")
 
 
+def local_appimage_path(source):
+    parsed = urlparse(source)
+    if parsed.scheme == "file":
+        if parsed.netloc not in ("", "localhost"):
+            return None
+        return unquote(parsed.path)
+    if parsed.scheme == "":
+        return os.path.expanduser(source)
+    return None
+
+
+def resolve_local_source(module, source, catalog_name=None):
+    path = local_appimage_path(source)
+    if path is None:
+        return None
+    if module.params["state"] == "latest":
+        module.fail_json(msg="state=latest is only supported for sources that provide release versions, such as GitHub releases pages")
+    if not path.lower().endswith(".appimage"):
+        module.fail_json(
+            msg=(
+                f"Local source {source!r} is not an AppImage file. "
+                "Use `url` to provide a supported AppImage source explicitly."
+            )
+        )
+    if not os.path.isfile(path):
+        module.fail_json(msg=f"Local AppImage source {path!r} does not exist or is not a file")
+    resolved_path = os.path.abspath(path)
+    result = {
+        "source_path": resolved_path,
+        "asset_name": os.path.basename(resolved_path),
+        "version": None,
+    }
+    if catalog_name:
+        result["catalog_name"] = catalog_name
+    return result
+
+
 def resolve_url_source(module, url, catalog_name=None):
+    local_source = resolve_local_source(module, url, catalog_name=catalog_name)
+    if local_source is not None:
+        return local_source
+
     if is_github_releases_url(url):
-        owner, repo, tag_from_url = parse_github_releases_url(url)
-        tag = module.params["version"] or tag_from_url
+        if module.params["state"] == "latest" and module.params["version"]:
+            module.fail_json(msg="state=latest cannot be combined with version")
         headers = {}
         if module.params["github_token"]:
             headers["Authorization"] = f"Bearer {module.params['github_token']}"
-        release = fetch_json(module, github_api_url(owner, repo, tag), headers)
+        release = fetch_json(
+            module,
+            github_api_url_from_releases_url(url, module.params["state"], module.params["version"]),
+            headers,
+        )
         asset = select_release_asset(module, release, module.params["asset_name"])
         source = {
             "source_url": asset["browser_download_url"],
@@ -301,9 +351,11 @@ def resolve_url_source(module, url, catalog_name=None):
         module.fail_json(
             msg=(
                 f"Resolved URL {url!r} is not a direct AppImage URL or GitHub releases page. "
-                "Use url to provide a supported AppImage source explicitly."
+                "Use `url` to provide a supported AppImage source explicitly."
             )
         )
+    if module.params["state"] == "latest":
+        module.fail_json(msg="state=latest is only supported for sources that provide release versions, such as GitHub releases pages")
 
     source = {
         "source_url": url,
@@ -340,7 +392,7 @@ def load_metadata(path):
     if not os.path.exists(meta_path):
         return {}
     try:
-        with open(meta_path, "r", encoding="utf-8") as f:
+        with open(meta_path, "r") as f:
             return json.load(f)
     except (OSError, ValueError):
         return {}
@@ -358,7 +410,18 @@ def needs_install(path, state, source):
     if state != "latest":
         return False
     metadata = load_metadata(path)
-    return metadata.get("source_url") != source.get("source_url") or metadata.get("version") != source.get("version")
+    return (
+        metadata.get("source_url") != source.get("source_url")
+        or metadata.get("source_path") != source.get("source_path")
+        or metadata.get("version") != source.get("version")
+    )
+
+
+def atomic_install(module, write_source, dest):
+    fd, tmp_path = tempfile.mkstemp(prefix=".ansible-appimage-", dir=module.tmpdir)
+    with os.fdopen(fd, "wb") as tmp_file:
+        write_source(tmp_file)
+    module.atomic_move(tmp_path, dest, unsafe_writes=module.params["unsafe_writes"])
 
 
 def download_appimage(module, source_url, dest):
@@ -372,40 +435,30 @@ def download_appimage(module, source_url, dest):
     if status != 200:
         module.fail_json(msg=f"Failed to download AppImage from {source_url}", status=status, details=info.get("msg"))
 
-    install_dir = os.path.dirname(dest)
-    fd, tmp_path = tempfile.mkstemp(prefix=".ansible-appimage-", dir=install_dir)
-    try:
-        with os.fdopen(fd, "wb") as tmp_file:
-            tmp_file.write(response_body(response))
-        os.chmod(tmp_path, 0o755)
-        module.atomic_move(tmp_path, dest)
-    except Exception:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
+    atomic_install(module, lambda tmp_file: shutil.copyfileobj(response, tmp_file), dest)
 
 
-def desktop_file_path(name):
-    base_dir = os.path.join(os.environ["HOME"], ".local", "share", "applications")
-    return os.path.join(base_dir, f"{name}.desktop")
+def copy_appimage(module, source_path, dest):
+    def write_source(tmp_file):
+        with open(source_path, "rb") as source_file:
+            shutil.copyfileobj(source_file, tmp_file)
+
+    atomic_install(module, write_source, dest)
 
 
-def desired_desktop_file(name, executable):
-    return f"[Desktop Entry]\nType=Application\nName={name}\nExec={executable}\nTerminal=false\nCategories=Utility;\n"
+def install_appimage(module, source, dest):
+    if source.get("source_path"):
+        copy_appimage(module, source["source_path"], dest)
+    else:
+        download_appimage(module, source["source_url"], dest)
 
 
-def ensure_desktop_file(path, content, check_mode):
-    if os.path.exists(path):
-        with open(path, "r", encoding="utf-8") as f:
-            if f.read() == content:
-                return False
-    if not check_mode:
-        os.makedirs(os.path.dirname(path), mode=0o755, exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(content)
-    return True
+def apply_file_attributes(module, path, changed):
+    file_params = module.params.copy()
+    if file_params.get("mode") is None:
+        file_params["mode"] = "0755"
+    file_args = module.load_file_common_arguments(file_params, path=path)
+    return module.set_fs_attributes_if_different(file_args, changed)
 
 
 def remove_file(path, check_mode):
@@ -423,7 +476,6 @@ def main():
             url=dict(type="str"),
             state=dict(type="str", default="present", choices=["absent", "present", "latest"]),
             install_dir=dict(type="path", default="~/.local/bin"),
-            desktop_integration=dict(type="bool", default=False),
             version=dict(type="str"),
             asset_name=dict(type="str", default="*.AppImage"),
             github_token=dict(type="str", no_log=True),
@@ -431,6 +483,7 @@ def main():
             validate_certs=dict(type="bool", default=True),
             timeout=dict(type="int", default=30),
         ),
+        add_file_common_args=True,
         supports_check_mode=True,
     )
 
@@ -438,14 +491,12 @@ def main():
     name = module.params["name"]
     install_dir = module.params["install_dir"]
     path = os.path.join(install_dir, name)
-    desktop_path = desktop_file_path(name)
     result = {"changed": False, "path": path}
 
     if state == "absent":
-        result["changed"] = remove_file(path, module.check_mode)
-        result["changed"] = remove_file(metadata_path(path), module.check_mode) or result["changed"]
-        result["changed"] = remove_file(desktop_path, module.check_mode) or result["changed"]
-        result["desktop_file"] = desktop_path
+        removed_appimage = remove_file(path, module.check_mode)
+        removed_metadata = remove_file(metadata_path(path), module.check_mode)
+        result["changed"] = removed_appimage or removed_metadata
         module.exit_json(**result)
 
     source = resolve_source(module)
@@ -454,14 +505,12 @@ def main():
     if needs_install(path, state, source):
         result["changed"] = True
         if not module.check_mode:
-            os.makedirs(install_dir, mode=0o755, exist_ok=True)
-            download_appimage(module, source["source_url"], path)
+            os.makedirs(install_dir, exist_ok=True)
+            install_appimage(module, source, path)
             write_metadata(path, source)
 
-    if module.params["desktop_integration"]:
-        result["desktop_file"] = desktop_path
-        content = desired_desktop_file(name, path)
-        result["changed"] = ensure_desktop_file(desktop_path, content, module.check_mode) or result["changed"]
+    if os.path.exists(path):
+        result["changed"] = apply_file_attributes(module, path, result["changed"])
 
     module.exit_json(**result)
 

--- a/plugins/modules/appimage.py
+++ b/plugins/modules/appimage.py
@@ -13,7 +13,7 @@ description:
   - The module installs AppImage files into a user-controlled directory and can optionally create a desktop launcher.
   - Sources can be direct AppImage URLs, GitHub release pages containing AppImage assets, or appimage.github.io catalog entries.
 author:
-  - Ansible Community (@ansible-collections)
+  - Travis Beale (@travisbeale)
 extends_documentation_fragment:
   - community.general._attributes
 attributes:

--- a/plugins/modules/appimage.py
+++ b/plugins/modules/appimage.py
@@ -79,7 +79,7 @@ options:
     default: https://appimage.github.io/feed.json
   validate_certs:
     description:
-      - If V(false), SSL certificates are not validated.
+      - If V(false), TLS certificates are not validated.
     type: bool
     default: true
   timeout:

--- a/plugins/modules/appimage.py
+++ b/plugins/modules/appimage.py
@@ -303,7 +303,9 @@ def resolve_local_source(module, source, parsed=None, catalog_name=None):
     if path is None:
         return None
     if module.params["state"] == "latest":
-        module.fail_json(msg="state=latest is only supported for sources that provide release versions, such as GitHub releases pages")
+        module.fail_json(
+            msg="state=latest is only supported for sources that provide release versions, such as GitHub releases pages"
+        )
     if not path.lower().endswith(".appimage"):
         module.fail_json(
             msg=(
@@ -359,7 +361,9 @@ def resolve_url_source(module, url, catalog_name=None):
             )
         )
     if module.params["state"] == "latest":
-        module.fail_json(msg="state=latest is only supported for sources that provide release versions, such as GitHub releases pages")
+        module.fail_json(
+            msg="state=latest is only supported for sources that provide release versions, such as GitHub releases pages"
+        )
 
     source = {
         "source_url": url,

--- a/plugins/modules/appimage.py
+++ b/plugins/modules/appimage.py
@@ -388,7 +388,7 @@ def download_appimage(module, source_url, dest):
 
 
 def desktop_file_path(name):
-    base_dir = os.path.expanduser("~/.local/share/applications")
+    base_dir = os.path.join(os.environ["HOME"], ".local", "share", "applications")
     return os.path.join(base_dir, f"{name}.desktop")
 
 
@@ -436,7 +436,7 @@ def main():
 
     state = module.params["state"]
     name = module.params["name"]
-    install_dir = os.path.expanduser(module.params["install_dir"])
+    install_dir = module.params["install_dir"]
     path = os.path.join(install_dir, name)
     desktop_path = desktop_file_path(name)
     result = {"changed": False, "path": path}

--- a/plugins/modules/appimage.py
+++ b/plugins/modules/appimage.py
@@ -33,7 +33,7 @@ options:
     required: true
   url:
     description:
-      - Source used to install the AppImage.
+      - Source used to obtain the AppImage.
       - This can point directly to an AppImage URL, a local AppImage file path, a V(file://) AppImage URL,
         or to a GitHub releases page such as V(https://github.com/OWNER/REPO/releases)
         or V(https://github.com/OWNER/REPO/releases/tag/TAG).
@@ -58,6 +58,7 @@ options:
   version:
     description:
       - GitHub release tag to install when O(url) points to a GitHub releases page.
+      - This can only be used with sources that provide release versions, such as GitHub releases pages.
       - By default, GitHub release pages use the latest release.
     type: str
   asset_name:
@@ -164,6 +165,10 @@ from urllib.parse import unquote, urlparse
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
+
+
+class NoLocalImagePath(Exception):
+    pass
 
 
 def normalized_catalog_name(name):
@@ -289,22 +294,20 @@ def select_catalog_download_url(module, item):
 def local_appimage_path(source, parsed=None):
     if parsed is None:
         parsed = urlparse(source)
+    if parsed.scheme == "file" and parsed.netloc not in ("", "localhost"):
+        raise NoLocalImagePath
     if parsed.scheme == "file":
-        if parsed.netloc not in ("", "localhost"):
-            return None
         return unquote(parsed.path)
     if parsed.scheme == "":
         return source
-    return None
+    raise NoLocalImagePath
 
 
 def resolve_local_source(module, source, parsed=None, catalog_name=None):
     path = local_appimage_path(source, parsed)
-    if path is None:
-        return None
     if module.params["state"] == "latest":
         module.fail_json(
-            msg="state=latest is only supported for sources that provide release versions, such as GitHub releases pages"
+            msg="`state=latest` is only supported for sources that provide release versions, such as GitHub releases pages"
         )
     if not path.lower().endswith(".appimage"):
         module.fail_json(
@@ -328,9 +331,10 @@ def resolve_local_source(module, source, parsed=None, catalog_name=None):
 
 def resolve_url_source(module, url, catalog_name=None):
     parsed = urlparse(url)
-    local_source = resolve_local_source(module, url, parsed=parsed, catalog_name=catalog_name)
-    if local_source is not None:
-        return local_source
+    try:
+        return resolve_local_source(module, url, parsed=parsed, catalog_name=catalog_name)
+    except NoLocalImagePath:
+        pass
 
     if is_github_releases_url(url, parsed):
         if module.params["state"] == "latest" and module.params["version"]:
@@ -362,7 +366,7 @@ def resolve_url_source(module, url, catalog_name=None):
         )
     if module.params["state"] == "latest":
         module.fail_json(
-            msg="state=latest is only supported for sources that provide release versions, such as GitHub releases pages"
+            msg="`state=latest` is only supported for sources that provide release versions, such as GitHub releases pages"
         )
 
     source = {

--- a/plugins/modules/appimage.py
+++ b/plugins/modules/appimage.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 DOCUMENTATION = r"""
 module: appimage
 short_description: Manage AppImage packages
+version_added: 13.4.0
 description:
   - Install, update, and remove applications distributed as AppImage files.
   - The module installs AppImage files into a user-controlled directory.

--- a/plugins/modules/appimage.py
+++ b/plugins/modules/appimage.py
@@ -1,0 +1,377 @@
+#!/usr/bin/python
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+DOCUMENTATION = r"""
+module: appimage
+short_description: Manage AppImage packages
+description:
+  - Install, update, and remove applications distributed as AppImage files.
+  - The module installs AppImage files into a user-controlled directory and can optionally create a desktop launcher.
+  - Sources can be direct AppImage URLs or GitHub release pages containing AppImage assets.
+author:
+  - Ansible Community (@ansible-collections)
+extends_documentation_fragment:
+  - community.general._attributes
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
+options:
+  name:
+    description:
+      - Name of the managed AppImage.
+      - This is used as the installed executable filename and as the desktop file basename.
+    type: str
+    required: true
+  url:
+    description:
+      - URL used to install the AppImage.
+      - This can point directly to an AppImage file, or to a GitHub releases page such as
+        V(https://github.com/OWNER/REPO/releases) or V(https://github.com/OWNER/REPO/releases/tag/TAG).
+      - Required when O(state=present) or O(state=latest).
+    type: str
+  state:
+    description:
+      - Desired state of the AppImage.
+      - When O(state=present), the AppImage is installed if missing.
+      - When O(state=latest), GitHub releases pages are resolved to the latest release unless O(version) is set.
+        Direct AppImage URLs are installed when missing or when the recorded source URL differs.
+    type: str
+    choices: [absent, present, latest]
+    default: present
+  install_dir:
+    description:
+      - Directory where the AppImage executable is installed.
+    type: path
+    default: "~/.local/bin"
+  desktop_integration:
+    description:
+      - Whether to create a desktop launcher for the installed AppImage.
+      - The launcher is written to C($HOME/.local/share/applications/).
+    type: bool
+    default: false
+  version:
+    description:
+      - GitHub release tag to install when O(url) points to a GitHub releases page.
+      - By default, GitHub release pages use the latest release.
+    type: str
+  asset_name:
+    description:
+      - Glob pattern used to select the AppImage asset from a GitHub release.
+      - If the pattern matches multiple assets, the module fails and asks for a more specific pattern.
+    type: str
+    default: "*.AppImage"
+  github_token:
+    description:
+      - GitHub token used when querying GitHub releases.
+      - This can be useful for private repositories or higher API rate limits.
+    type: str
+  validate_certs:
+    description:
+      - If V(false), SSL certificates are not validated.
+    type: bool
+    default: true
+  timeout:
+    description:
+      - Timeout in seconds for HTTP requests.
+    type: int
+    default: 30
+"""
+
+EXAMPLES = r"""
+- name: Install an AppImage from a direct URL
+  community.general.appimage:
+    name: example
+    url: https://example.com/downloads/example-x86_64.AppImage
+
+- name: Install the latest x86_64 AppImage from GitHub releases
+  community.general.appimage:
+    name: example
+    url: https://github.com/example/example/releases
+    state: latest
+    asset_name: "*x86_64.AppImage"
+
+- name: Install a specific GitHub release tag
+  community.general.appimage:
+    name: example
+    url: https://github.com/example/example/releases
+    version: v1.2.3
+
+- name: Install an AppImage and create a desktop launcher
+  community.general.appimage:
+    name: example
+    url: https://example.com/downloads/example.AppImage
+    desktop_integration: true
+
+- name: Remove an AppImage
+  community.general.appimage:
+    name: example
+    state: absent
+"""
+
+RETURN = r"""
+path:
+  description: Path to the managed AppImage executable.
+  returned: always
+  type: str
+  sample: /home/user/.local/bin/example
+source_url:
+  description: Resolved AppImage download URL.
+  returned: when O(state) is V(present) or V(latest)
+  type: str
+  sample: https://github.com/example/example/releases/download/v1.2.3/example-x86_64.AppImage
+desktop_file:
+  description: Path to the managed desktop launcher.
+  returned: when O(desktop_integration=true) or O(state=absent)
+  type: str
+  sample: /home/user/.local/share/applications/example.desktop
+version:
+  description: GitHub release tag that was installed.
+  returned: when installing from a GitHub release
+  type: str
+  sample: v1.2.3
+"""
+
+import fnmatch
+import json
+import os
+import tempfile
+from urllib.parse import urlparse
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import fetch_url
+
+
+def is_github_releases_url(url):
+    parsed = urlparse(url)
+    path_parts = [part for part in parsed.path.split("/") if part]
+    return parsed.netloc.lower() == "github.com" and len(path_parts) >= 3 and path_parts[2] == "releases"
+
+
+def parse_github_releases_url(url):
+    parsed = urlparse(url)
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if not is_github_releases_url(url):
+        raise ValueError("URL is not a GitHub releases page")
+    owner = path_parts[0]
+    repo = path_parts[1]
+    tag = None
+    if len(path_parts) >= 5 and path_parts[3] == "tag":
+        tag = path_parts[4]
+    return owner, repo, tag
+
+
+def github_api_url(owner, repo, tag):
+    if tag:
+        return f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag}"
+    return f"https://api.github.com/repos/{owner}/{repo}/releases/latest"
+
+
+def response_body(response):
+    if response is None:
+        return b""
+    return response.read()
+
+
+def fetch_json(module, url, headers):
+    response, info = fetch_url(
+        module,
+        url,
+        headers=headers,
+        method="GET",
+        timeout=module.params["timeout"],
+    )
+    status = info.get("status", 0)
+    if status != 200:
+        module.fail_json(msg=f"Failed to fetch {url}", status=status, details=info.get("msg"))
+    try:
+        return json.loads(response_body(response).decode("utf-8"))
+    except (TypeError, ValueError) as e:
+        module.fail_json(msg=f"Failed to parse JSON from {url}: {e}")
+
+
+def select_release_asset(module, release, asset_name):
+    matches = []
+    for asset in release.get("assets", []):
+        name = asset.get("name", "")
+        download_url = asset.get("browser_download_url")
+        if download_url and fnmatch.fnmatchcase(name, asset_name):
+            matches.append(asset)
+
+    if not matches:
+        module.fail_json(msg=f"No AppImage asset matching {asset_name!r} was found in GitHub release {release.get('tag_name')}")
+    if len(matches) > 1:
+        names = [asset["name"] for asset in matches]
+        module.fail_json(msg=f"Multiple AppImage assets match {asset_name!r}; make asset_name more specific", assets=names)
+
+    return matches[0]
+
+
+def resolve_source(module):
+    url = module.params["url"]
+    if is_github_releases_url(url):
+        owner, repo, tag_from_url = parse_github_releases_url(url)
+        tag = module.params["version"] or tag_from_url
+        headers = {}
+        if module.params["github_token"]:
+            headers["Authorization"] = "Bearer %s" % module.params["github_token"]
+        release = fetch_json(module, github_api_url(owner, repo, tag), headers)
+        asset = select_release_asset(module, release, module.params["asset_name"])
+        return {
+            "source_url": asset["browser_download_url"],
+            "asset_name": asset.get("name"),
+            "version": release.get("tag_name"),
+        }
+
+    return {"source_url": url, "asset_name": os.path.basename(urlparse(url).path), "version": None}
+
+
+def metadata_path(path):
+    return f"{path}.appimage.json"
+
+
+def load_metadata(path):
+    meta_path = metadata_path(path)
+    if not os.path.exists(meta_path):
+        return {}
+    try:
+        with open(meta_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return {}
+
+
+def write_metadata(path, metadata):
+    with open(metadata_path(path), "w", encoding="utf-8") as f:
+        json.dump(metadata, f, sort_keys=True, indent=2)
+        f.write("\n")
+
+
+def needs_install(path, state, source):
+    if not os.path.exists(path):
+        return True
+    if state != "latest":
+        return False
+    metadata = load_metadata(path)
+    return metadata.get("source_url") != source.get("source_url") or metadata.get("version") != source.get("version")
+
+
+def download_appimage(module, source_url, dest):
+    response, info = fetch_url(
+        module,
+        source_url,
+        method="GET",
+        timeout=module.params["timeout"],
+    )
+    status = info.get("status", 0)
+    if status != 200:
+        module.fail_json(msg=f"Failed to download AppImage from {source_url}", status=status, details=info.get("msg"))
+
+    install_dir = os.path.dirname(dest)
+    fd, tmp_path = tempfile.mkstemp(prefix=".ansible-appimage-", dir=install_dir)
+    try:
+        with os.fdopen(fd, "wb") as tmp_file:
+            tmp_file.write(response_body(response))
+        os.chmod(tmp_path, 0o755)
+        module.atomic_move(tmp_path, dest)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def desktop_file_path(name):
+    base_dir = os.path.expanduser("~/.local/share/applications")
+    return os.path.join(base_dir, f"{name}.desktop")
+
+
+def desired_desktop_file(name, executable):
+    return (
+        "[Desktop Entry]\n"
+        "Type=Application\n"
+        f"Name={name}\n"
+        f"Exec={executable}\n"
+        "Terminal=false\n"
+        "Categories=Utility;\n"
+    )
+
+
+def ensure_desktop_file(path, content, check_mode):
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            if f.read() == content:
+                return False
+    if not check_mode:
+        os.makedirs(os.path.dirname(path), mode=0o755, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+    return True
+
+
+def remove_file(path, check_mode):
+    if not os.path.exists(path):
+        return False
+    if not check_mode:
+        os.unlink(path)
+    return True
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(type="str", required=True),
+            url=dict(type="str"),
+            state=dict(type="str", default="present", choices=["absent", "present", "latest"]),
+            install_dir=dict(type="path", default="~/.local/bin"),
+            desktop_integration=dict(type="bool", default=False),
+            version=dict(type="str"),
+            asset_name=dict(type="str", default="*.AppImage"),
+            github_token=dict(type="str", no_log=True),
+            validate_certs=dict(type="bool", default=True),
+            timeout=dict(type="int", default=30),
+        ),
+        required_if=[("state", "present", ["url"]), ("state", "latest", ["url"])],
+        supports_check_mode=True,
+    )
+
+    state = module.params["state"]
+    name = module.params["name"]
+    install_dir = os.path.expanduser(module.params["install_dir"])
+    path = os.path.join(install_dir, name)
+    desktop_path = desktop_file_path(name)
+    result = {"changed": False, "path": path}
+
+    if state == "absent":
+        result["changed"] = remove_file(path, module.check_mode)
+        result["changed"] = remove_file(metadata_path(path), module.check_mode) or result["changed"]
+        result["changed"] = remove_file(desktop_path, module.check_mode) or result["changed"]
+        result["desktop_file"] = desktop_path
+        module.exit_json(**result)
+
+    source = resolve_source(module)
+    result.update(source)
+
+    if needs_install(path, state, source):
+        result["changed"] = True
+        if not module.check_mode:
+            os.makedirs(install_dir, mode=0o755, exist_ok=True)
+            download_appimage(module, source["source_url"], path)
+            write_metadata(path, source)
+
+    if module.params["desktop_integration"]:
+        result["desktop_file"] = desktop_path
+        content = desired_desktop_file(name, path)
+        result["changed"] = ensure_desktop_file(desktop_path, content, module.check_mode) or result["changed"]
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/appimage.py
+++ b/plugins/modules/appimage.py
@@ -291,7 +291,7 @@ def local_appimage_path(source):
             return None
         return unquote(parsed.path)
     if parsed.scheme == "":
-        return os.path.expanduser(source)
+        return source
     return None
 
 

--- a/tests/unit/plugins/modules/test_appimage.py
+++ b/tests/unit/plugins/modules/test_appimage.py
@@ -64,6 +64,53 @@ def test_select_release_asset_fails_on_multiple_matches():
     assert module.fail["assets"] == ["tool-x86_64.AppImage", "tool-aarch64.AppImage"]
 
 
+def test_select_catalog_item_prefers_exact_match():
+    feed = {
+        "items": [
+            {"name": "Tool_App"},
+            {"name": "tool-app"},
+        ],
+    }
+
+    item = appimage.select_catalog_item(FakeModule(), feed, "Tool_App")
+
+    assert item["name"] == "Tool_App"
+
+
+def test_select_catalog_item_normalizes_name():
+    feed = {"items": [{"name": "AppImageUpdate"}]}
+
+    item = appimage.select_catalog_item(FakeModule(), feed, "appimage-update")
+
+    assert item["name"] == "AppImageUpdate"
+
+
+def test_select_catalog_download_url_prefers_download_link():
+    item = {
+        "name": "tool",
+        "links": [
+            {"type": "GitHub", "url": "example/tool"},
+            {"type": "Download", "url": "https://github.com/example/tool/releases"},
+        ],
+    }
+
+    assert appimage.select_catalog_download_url(FakeModule(), item) == "https://github.com/example/tool/releases"
+
+
+def test_select_catalog_download_url_uses_github_fallback():
+    item = {"name": "tool", "links": [{"type": "GitHub", "url": "example/tool"}]}
+
+    assert appimage.select_catalog_download_url(FakeModule(), item) == "https://github.com/example/tool/releases"
+
+
+def test_resolve_url_source_rejects_unsupported_catalog_url():
+    module = FakeModule()
+    module.params = {"version": None, "github_token": None, "asset_name": "*.AppImage"}
+
+    with pytest.raises(RuntimeError, match="not a direct AppImage URL or GitHub releases page"):
+        appimage.resolve_url_source(module, "https://example.com/download")
+
+
 def test_needs_install_uses_metadata_for_latest(tmp_path):
     path = tmp_path / "tool"
     path.write_text("appimage", encoding="utf-8")

--- a/tests/unit/plugins/modules/test_appimage.py
+++ b/tests/unit/plugins/modules/test_appimage.py
@@ -166,14 +166,14 @@ def test_resolve_url_source_rejects_latest_for_local_path(tmp_path):
     path = tmp_path / "tool.AppImage"
     path.write_bytes(b"appimage")
 
-    with pytest.raises(RuntimeError, match="state=latest is only supported"):
+    with pytest.raises(RuntimeError, match=r"`state=latest` is only supported"):
         appimage.resolve_url_source(FakeModule({"state": "latest"}), str(path))
 
 
 def test_resolve_url_source_rejects_latest_for_direct_url():
     module = FakeModule({"state": "latest"})
 
-    with pytest.raises(RuntimeError, match="state=latest is only supported"):
+    with pytest.raises(RuntimeError, match=r"`state=latest` is only supported"):
         appimage.resolve_url_source(module, "https://example.com/tool.AppImage")
 
 

--- a/tests/unit/plugins/modules/test_appimage.py
+++ b/tests/unit/plugins/modules/test_appimage.py
@@ -136,3 +136,9 @@ def test_desktop_file_content():
 
     assert "Name=tool\n" in content
     assert "Exec=/home/user/.local/bin/tool\n" in content
+
+
+def test_desktop_file_path_uses_home(monkeypatch):
+    monkeypatch.setenv("HOME", "/home/user")
+
+    assert appimage.desktop_file_path("tool") == "/home/user/.local/share/applications/tool.desktop"

--- a/tests/unit/plugins/modules/test_appimage.py
+++ b/tests/unit/plugins/modules/test_appimage.py
@@ -119,6 +119,29 @@ def test_resolve_url_source_rejects_unsupported_catalog_url():
         appimage.resolve_url_source(module, "https://example.com/download")
 
 
+def test_local_appimage_path_rejects_non_local_sources():
+    with pytest.raises(appimage.NoLocalImagePath):
+        appimage.local_appimage_path("https://example.com/tool.AppImage")
+
+
+def test_resolve_url_source_continues_after_non_local_source(monkeypatch):
+    fetched_urls = []
+
+    def fake_fetch_json(module, url, headers):
+        fetched_urls.append(url)
+        return {
+            "tag_name": "v1.2.3",
+            "assets": [{"name": "tool.AppImage", "browser_download_url": "https://example.com/tool.AppImage"}],
+        }
+
+    monkeypatch.setattr(appimage, "fetch_json", fake_fetch_json)
+
+    source = appimage.resolve_url_source(FakeModule(), "https://github.com/example/project/releases")
+
+    assert fetched_urls == ["https://api.github.com/repos/example/project/releases/latest"]
+    assert source["source_url"] == "https://example.com/tool.AppImage"
+
+
 def test_resolve_url_source_accepts_local_path(tmp_path):
     path = tmp_path / "tool.AppImage"
     path.write_bytes(b"appimage")

--- a/tests/unit/plugins/modules/test_appimage.py
+++ b/tests/unit/plugins/modules/test_appimage.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+import io
+import os
+
 import pytest
 
 from ansible_collections.community.general.plugins.modules import appimage
@@ -221,6 +224,64 @@ def test_response_text_decodes_body():
             return b'{"ok": true}'
 
     assert appimage.response_text(Response()) == '{"ok": true}'
+
+
+def test_atomic_install_copies_source_file(tmp_path):
+    class InstallModule(FakeModule):
+        def __init__(self):
+            super().__init__({"unsafe_writes": False})
+            self.tmpdir = str(tmp_path)
+            self.atomic_move_args = None
+
+        def atomic_move(self, tmp_path, dest, unsafe_writes=False):
+            self.atomic_move_args = (tmp_path, dest, unsafe_writes)
+            os.replace(tmp_path, dest)
+
+    module = InstallModule()
+    dest = tmp_path / "tool"
+
+    appimage.atomic_install(module, io.BytesIO(b"appimage"), str(dest))
+
+    assert dest.read_bytes() == b"appimage"
+    assert module.atomic_move_args[1:] == (str(dest), False)
+
+
+def test_copy_appimage_installs_local_file(tmp_path):
+    class InstallModule(FakeModule):
+        def __init__(self):
+            super().__init__({"unsafe_writes": False})
+            self.tmpdir = str(tmp_path)
+
+        def atomic_move(self, tmp_path, dest, unsafe_writes=False):
+            os.replace(tmp_path, dest)
+
+    source = tmp_path / "source.AppImage"
+    dest = tmp_path / "tool"
+    source.write_bytes(b"local appimage")
+
+    appimage.copy_appimage(InstallModule(), str(source), str(dest))
+
+    assert dest.read_bytes() == b"local appimage"
+
+
+def test_download_appimage_installs_response_body(monkeypatch, tmp_path):
+    class InstallModule(FakeModule):
+        def __init__(self):
+            super().__init__({"timeout": 30, "unsafe_writes": False})
+            self.tmpdir = str(tmp_path)
+
+        def atomic_move(self, tmp_path, dest, unsafe_writes=False):
+            os.replace(tmp_path, dest)
+
+    def fake_fetch_url(module, source_url, method=None, timeout=None):
+        return io.BytesIO(b"downloaded appimage"), {"status": 200}
+
+    monkeypatch.setattr(appimage, "fetch_url", fake_fetch_url)
+    dest = tmp_path / "tool"
+
+    appimage.download_appimage(InstallModule(), "https://example.com/tool.AppImage", str(dest))
+
+    assert dest.read_bytes() == b"downloaded appimage"
 
 
 def test_apply_file_attributes_defaults_to_executable_mode(tmp_path):

--- a/tests/unit/plugins/modules/test_appimage.py
+++ b/tests/unit/plugins/modules/test_appimage.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import pytest
+
+from ansible_collections.community.general.plugins.modules import appimage
+
+
+class FakeModule:
+    def __init__(self):
+        self.fail = None
+
+    def fail_json(self, **kwargs):
+        self.fail = kwargs
+        raise RuntimeError(kwargs["msg"])
+
+
+def test_parse_github_releases_url_latest():
+    owner, repo, tag = appimage.parse_github_releases_url("https://github.com/example/project/releases")
+
+    assert owner == "example"
+    assert repo == "project"
+    assert tag is None
+
+
+def test_parse_github_releases_url_tag():
+    owner, repo, tag = appimage.parse_github_releases_url("https://github.com/example/project/releases/tag/v1.2.3")
+
+    assert owner == "example"
+    assert repo == "project"
+    assert tag == "v1.2.3"
+
+
+def test_select_release_asset_single_match():
+    release = {
+        "tag_name": "v1.2.3",
+        "assets": [
+            {"name": "tool.tar.gz", "browser_download_url": "https://example.com/tool.tar.gz"},
+            {"name": "tool-x86_64.AppImage", "browser_download_url": "https://example.com/tool.AppImage"},
+        ],
+    }
+
+    asset = appimage.select_release_asset(FakeModule(), release, "*.AppImage")
+
+    assert asset["name"] == "tool-x86_64.AppImage"
+
+
+def test_select_release_asset_fails_on_multiple_matches():
+    release = {
+        "tag_name": "v1.2.3",
+        "assets": [
+            {"name": "tool-x86_64.AppImage", "browser_download_url": "https://example.com/tool-x86_64.AppImage"},
+            {"name": "tool-aarch64.AppImage", "browser_download_url": "https://example.com/tool-aarch64.AppImage"},
+        ],
+    }
+    module = FakeModule()
+
+    with pytest.raises(RuntimeError, match="Multiple AppImage assets"):
+        appimage.select_release_asset(module, release, "*.AppImage")
+
+    assert module.fail["assets"] == ["tool-x86_64.AppImage", "tool-aarch64.AppImage"]
+
+
+def test_needs_install_uses_metadata_for_latest(tmp_path):
+    path = tmp_path / "tool"
+    path.write_text("appimage", encoding="utf-8")
+    appimage.write_metadata(
+        str(path),
+        {"source_url": "https://example.com/tool-v1.AppImage", "version": "v1"},
+    )
+
+    assert not appimage.needs_install(
+        str(path),
+        "latest",
+        {"source_url": "https://example.com/tool-v1.AppImage", "version": "v1"},
+    )
+    assert appimage.needs_install(
+        str(path),
+        "latest",
+        {"source_url": "https://example.com/tool-v2.AppImage", "version": "v2"},
+    )
+
+
+def test_desktop_file_content():
+    content = appimage.desired_desktop_file("tool", "/home/user/.local/bin/tool")
+
+    assert "Name=tool\n" in content
+    assert "Exec=/home/user/.local/bin/tool\n" in content

--- a/tests/unit/plugins/modules/test_appimage.py
+++ b/tests/unit/plugins/modules/test_appimage.py
@@ -10,8 +10,14 @@ from ansible_collections.community.general.plugins.modules import appimage
 
 
 class FakeModule:
-    def __init__(self):
+    def __init__(self, params=None):
         self.fail = None
+        self.params = params or {
+            "state": "present",
+            "version": None,
+            "github_token": None,
+            "asset_name": "*.AppImage",
+        }
 
     def fail_json(self, **kwargs):
         self.fail = kwargs
@@ -105,10 +111,79 @@ def test_select_catalog_download_url_uses_github_fallback():
 
 def test_resolve_url_source_rejects_unsupported_catalog_url():
     module = FakeModule()
-    module.params = {"version": None, "github_token": None, "asset_name": "*.AppImage"}
 
     with pytest.raises(RuntimeError, match="not a direct AppImage URL or GitHub releases page"):
         appimage.resolve_url_source(module, "https://example.com/download")
+
+
+def test_resolve_url_source_accepts_local_path(tmp_path):
+    path = tmp_path / "tool.AppImage"
+    path.write_bytes(b"appimage")
+
+    source = appimage.resolve_url_source(FakeModule(), str(path))
+
+    assert source["source_path"] == str(path)
+    assert source["asset_name"] == "tool.AppImage"
+
+
+def test_resolve_url_source_accepts_file_url(tmp_path):
+    path = tmp_path / "tool.AppImage"
+    path.write_bytes(b"appimage")
+
+    source = appimage.resolve_url_source(FakeModule(), path.as_uri())
+
+    assert source["source_path"] == str(path)
+    assert source["asset_name"] == "tool.AppImage"
+
+
+def test_resolve_url_source_rejects_latest_for_local_path(tmp_path):
+    path = tmp_path / "tool.AppImage"
+    path.write_bytes(b"appimage")
+
+    with pytest.raises(RuntimeError, match="state=latest is only supported"):
+        appimage.resolve_url_source(FakeModule({"state": "latest"}), str(path))
+
+
+def test_resolve_url_source_rejects_latest_for_direct_url():
+    module = FakeModule({"state": "latest"})
+
+    with pytest.raises(RuntimeError, match="state=latest is only supported"):
+        appimage.resolve_url_source(module, "https://example.com/tool.AppImage")
+
+
+def test_resolve_url_source_rejects_latest_with_version():
+    module = FakeModule(
+        {
+            "state": "latest",
+            "version": "v1.2.3",
+            "github_token": None,
+            "asset_name": "*.AppImage",
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="state=latest cannot be combined with version"):
+        appimage.resolve_url_source(module, "https://github.com/example/project/releases")
+
+
+def test_resolve_url_source_uses_latest_github_release_for_state_latest(monkeypatch):
+    fetched_urls = []
+
+    def fake_fetch_json(module, url, headers):
+        fetched_urls.append(url)
+        return {
+            "tag_name": "v2.0.0",
+            "assets": [{"name": "tool.AppImage", "browser_download_url": "https://example.com/tool.AppImage"}],
+        }
+
+    monkeypatch.setattr(appimage, "fetch_json", fake_fetch_json)
+
+    source = appimage.resolve_url_source(
+        FakeModule({"state": "latest", "version": None, "github_token": None, "asset_name": "*.AppImage"}),
+        "https://github.com/example/project/releases/tag/v1.0.0",
+    )
+
+    assert fetched_urls == ["https://api.github.com/repos/example/project/releases/latest"]
+    assert source["version"] == "v2.0.0"
 
 
 def test_needs_install_uses_metadata_for_latest(tmp_path):
@@ -131,14 +206,41 @@ def test_needs_install_uses_metadata_for_latest(tmp_path):
     )
 
 
-def test_desktop_file_content():
-    content = appimage.desired_desktop_file("tool", "/home/user/.local/bin/tool")
+def test_needs_install_uses_source_path_metadata_for_latest(tmp_path):
+    path = tmp_path / "tool"
+    path.write_text("appimage", encoding="utf-8")
+    appimage.write_metadata(str(path), {"source_path": "/tmp/tool-v1.AppImage", "version": None})
 
-    assert "Name=tool\n" in content
-    assert "Exec=/home/user/.local/bin/tool\n" in content
+    assert not appimage.needs_install(str(path), "latest", {"source_path": "/tmp/tool-v1.AppImage", "version": None})
+    assert appimage.needs_install(str(path), "latest", {"source_path": "/tmp/tool-v2.AppImage", "version": None})
 
 
-def test_desktop_file_path_uses_home(monkeypatch):
-    monkeypatch.setenv("HOME", "/home/user")
+def test_response_text_decodes_body():
+    class Response:
+        def read(self):
+            return b'{"ok": true}'
 
-    assert appimage.desktop_file_path("tool") == "/home/user/.local/share/applications/tool.desktop"
+    assert appimage.response_text(Response()) == '{"ok": true}'
+
+
+def test_apply_file_attributes_defaults_to_executable_mode(tmp_path):
+    class AttrModule(FakeModule):
+        def __init__(self):
+            super().__init__({"mode": None})
+            self.loaded = None
+
+        def load_file_common_arguments(self, params, path=None):
+            self.loaded = (params, path)
+            return {"mode": params["mode"], "path": path}
+
+        def set_fs_attributes_if_different(self, file_args, changed):
+            return changed
+
+    path = tmp_path / "tool"
+    path.write_text("appimage", encoding="utf-8")
+    module = AttrModule()
+
+    appimage.apply_file_attributes(module, str(path), False)
+
+    assert module.loaded[0]["mode"] == "0755"
+    assert module.loaded[1] == str(path)


### PR DESCRIPTION
##### SUMMARY

Adds a new `community.general.appimage` module for managing AppImage packages. The module can install and remove AppImage files, install from direct AppImage URLs, resolve AppImage assets from GitHub releases, look up entries from the appimage.github.io catalog by name, install to `~/.local/bin` by default, and optionally create a user desktop launcher.

The implementation keeps AppImage management file-based because AppImage does not provide a standard package database. A small sidecar metadata file records the resolved source so `state=latest` can detect changes for GitHub release and catalog-backed installs.

No changelog fragment is included because this is a new module/plugin contribution, which `community.general` contribution guidance says must not include one.

Assisted-by: OpenAI Codex / GPT-5

##### ISSUE TYPE

- New Module/Plugin Pull Request

##### COMPONENT NAME

`plugins/modules/appimage.py`
`tests/unit/plugins/modules/test_appimage.py`

##### ADDITIONAL INFORMATION

Validation performed:

- `python -m py_compile plugins/modules/appimage.py tests/unit/plugins/modules/test_appimage.py`
- `ansible-test sanity --venv --test validate-modules plugins/modules/appimage.py`
- `ansible-test sanity --venv --test import plugins/modules/appimage.py tests/unit/plugins/modules/test_appimage.py`
- `ansible-test units --venv tests/unit/plugins/modules/test_appimage.py`

The unit command ran the broader unit groups selected by `ansible-test` on Python 3.12:

- module unit tests: `1623 passed, 7 skipped`
- module_utils unit tests: `403 passed`
- controller unit tests: `358 passed`

The branch was rebased onto current upstream `main` before opening this PR.
