### PR TITLE
homebrew_cask: fix brew --version parsing for versions with more than three segments

### DIFF
--- a/changelogs/fragments/homebrew_cask-version-regex-multisegment.yml
+++ b/changelogs/fragments/homebrew_cask-version-regex-multisegment.yml
@@ -3,4 +3,4 @@ bugfixes:
     three dot-separated segments (for example, some vendor Homebrew builds report a fourth
     segment). The previous regex could silently drop the leading segment, misjudging whether
     the deprecated ``brew cask`` command syntax is still required and causing installs to fail
-    with an unknown-command error."
+    with an unknown-command error (https://github.com/ansible-collections/community.general/pull/12559)."

--- a/changelogs/fragments/homebrew_cask-version-regex-multisegment.yml
+++ b/changelogs/fragments/homebrew_cask-version-regex-multisegment.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - "homebrew_cask - fix ``brew --version`` parsing to handle version strings with more than
+    three dot-separated segments (for example, some vendor Homebrew builds report a fourth
+    segment). The previous regex could silently drop the leading segment, misjudging whether
+    the deprecated ``brew cask`` command syntax is still required and causing installs to fail
+    with an unknown-command error."

--- a/plugins/modules/homebrew_cask.py
+++ b/plugins/modules/homebrew_cask.py
@@ -446,7 +446,7 @@ class HomebrewCask:
         # later substring of the output; ``\d+(?:\.\d+)+`` accepts any number of dot-separated
         # segments rather than assuming exactly three (some Homebrew builds report more, e.g.
         # "Homebrew 4.6.13.1-custom-...").
-        pattern = r"Homebrew\s+(>=)?\s*(\d+(?:\.\d+)+)"
+        pattern = r"Homebrew\s+(>=)?(\d+(?:\.\d+)+)"
         rematch = re.search(pattern, out)
         if not rematch:
             self.module.fail_json(msg="Failed to match regex to get brew version", stdout=out)

--- a/plugins/modules/homebrew_cask.py
+++ b/plugins/modules/homebrew_cask.py
@@ -442,13 +442,17 @@ class HomebrewCask:
         cmd = [self.brew_path, "--version"]
         dummy, out, dummy = self.module.run_command(cmd, check_rc=True)
 
-        pattern = r"Homebrew (.*)(\d+\.\d+\.\d+)(-dirty)?"
+        # Anchored immediately after "Homebrew " so the version group can't drift onto a
+        # later substring of the output; ``\d+(?:\.\d+)+`` accepts any number of dot-separated
+        # segments rather than assuming exactly three (some Homebrew builds report more, e.g.
+        # "Homebrew 4.6.13.1-custom-...").
+        pattern = r"Homebrew\s+(>=)?\s*(\d+(?:\.\d+)+)"
         rematch = re.search(pattern, out)
         if not rematch:
             self.module.fail_json(msg="Failed to match regex to get brew version", stdout=out)
 
-        prefix, version, dummy = rematch.groups()
-        if ">=" in prefix:
+        placeholder, version = rematch.groups()
+        if placeholder:
             version = "99.0.0"
 
         self.brew_version = version

--- a/tests/unit/plugins/modules/test_homebrew_cask.py
+++ b/tests/unit/plugins/modules/test_homebrew_cask.py
@@ -19,10 +19,11 @@ def test_valid_cask_names():
 
 
 def test_homebrew_version(mocker):
-    # NB: HomebrewCask._get_brew_version() caches its result on the instance, so each case
-    # below needs its own instance -- otherwise every iteration after the first would just
-    # return the first case's cached value without actually exercising the regex (as the
-    # previous version of this test did: it only ever verified the first case below).
+    # NB: HomebrewCask._get_brew_version() caches its result on the instance, so
+    # brew_version is reset before each case below -- otherwise every iteration after
+    # the first would just return the first case's cached value without actually
+    # exercising the regex (as the previous version of this test did: it only ever
+    # verified the first case below).
     brew_versions = {
         "Homebrew 4.1.0": "4.1.0",
         # A placeholder version (e.g. a shallow git clone) is deliberately treated as
@@ -38,7 +39,8 @@ def test_homebrew_version(mocker):
     mocker.patch.object(HomebrewValidate, "valid_path", return_value=True)
     mocker.patch.object(HomebrewValidate, "valid_brew_path", return_value=True)
 
+    homebrewcask = HomebrewCask(module=module)
     for version, expected in brew_versions.items():
-        homebrewcask = HomebrewCask(module=module)
+        homebrewcask.brew_version = None
         module.run_command.return_value = (0, version, "")
         assert homebrewcask._get_brew_version() == expected

--- a/tests/unit/plugins/modules/test_homebrew_cask.py
+++ b/tests/unit/plugins/modules/test_homebrew_cask.py
@@ -19,18 +19,26 @@ def test_valid_cask_names():
 
 
 def test_homebrew_version(mocker):
-    brew_versions = [
-        "Homebrew 4.1.0",
-        "Homebrew >=4.1.0 (shallow or no git repository)",
-        "Homebrew 4.1.0-dirty",
-    ]
+    # NB: HomebrewCask._get_brew_version() caches its result on the instance, so each case
+    # below needs its own instance -- otherwise every iteration after the first would just
+    # return the first case's cached value without actually exercising the regex (as the
+    # previous version of this test did: it only ever verified the first case below).
+    brew_versions = {
+        "Homebrew 4.1.0": "4.1.0",
+        # A placeholder version (e.g. a shallow git clone) is deliberately treated as
+        # "newer than anything we'd otherwise compare against" -- see _get_brew_version.
+        "Homebrew >=4.1.0 (shallow or no git repository)": "99.0.0",
+        "Homebrew 4.1.0-dirty": "4.1.0",
+        # Some Homebrew builds report more than three dot-separated version segments.
+        "Homebrew 4.6.13.1-custom-18-gabcdef0": "4.6.13.1",
+    }
     module = mocker.Mock()
 
     mocker.patch.object(HomebrewCask, "valid_module", return_value=True)
     mocker.patch.object(HomebrewValidate, "valid_path", return_value=True)
     mocker.patch.object(HomebrewValidate, "valid_brew_path", return_value=True)
 
-    homebrewcask = HomebrewCask(module=module)
-    for version in brew_versions:
+    for version, expected in brew_versions.items():
+        homebrewcask = HomebrewCask(module=module)
         module.run_command.return_value = (0, version, "")
-        assert homebrewcask._get_brew_version() == "4.1.0"
+        assert homebrewcask._get_brew_version() == expected


### PR DESCRIPTION
## Summary

`_get_brew_version()` uses a regex to parse `brew --version` output so it can decide whether the deprecated `brew cask` command syntax is still needed. The regex has a greedy `.*` before the version-number group:

```python
pattern = r"Homebrew (.*)(\d+\.\d+\.\d+)(-dirty)?"
```

Because `.*` is greedy, it backtracks from the *end* of the string to find wherever a 3-number run happens to fit, rather than matching the version that actually follows "Homebrew ". This works fine as long as the real version has exactly three dot-separated segments, but Homebrew builds that report a fourth segment (e.g. a build/patch number, such as `Homebrew 6.0.17.1-apple-18-g...`) get mis-parsed: the leading segment is silently dropped (`6.0.17.1` → `0.17.1`), which can flip the `_brew_cask_command_is_deprecated()` >= 2.6.0 check and make the module fall back to the removed `brew cask` subcommand — a hard failure (`Unknown command: brew cask`) instead of a successful install.

This PR:
- Anchors the match immediately after `"Homebrew "` and accepts any number of dot-separated segments (`\d+(?:\.\d+)+`) instead of assuming exactly three, so the version group can no longer drift onto a later substring of the output.
- Keeps the existing placeholder-version handling (`Homebrew >=X.Y.Z (shallow or no git repository)` → treated as `99.0.0`), just expressed as an explicit capture group instead of an `if ">=" in prefix` substring check.
- Fixes `tests/unit/plugins/modules/test_homebrew_cask.py::test_homebrew_version`, which reused a single `HomebrewCask` instance across all three existing version strings. Since `_get_brew_version()` caches its result on the instance, only the *first* string in the list was ever actually exercised — the other two silently passed on the cached value. Each case now gets its own instance, so all cases are genuinely tested (this also caught that the placeholder case's real expected output is `99.0.0`, not `4.1.0` as the original assertion implied). A fourth, 4-segment case is added as a regression test for this fix.
- Adds a changelog fragment.

All 4 version-string cases (the original 3 plus the new one) pass against the fixed regex; the new 4-segment case fails against the original regex with the exact mis-parse described above (`6.13.1` instead of `4.6.13.1`), confirming this is a genuine regression test and not a tautology.

No behavior change for any currently-passing case — `LooseVersion` comparison against `2.6.0` is unaffected by extra trailing segments, since it compares component-by-component and short-circuits on the first difference.

## Issue Type

Bugfix Pull Request

## Component Name

homebrew_cask

## Additional Information

Related community discussion on the module's long-term future: #8709. This fix doesn't expand the module's scope or lifetime — it's a minimal, contained parsing fix for a module that's still shipped and default-recommended today, independent of any future deprecation decision.

## Code of Conduct

- [x] I agree to follow the Ansible Code of Conduct