### PR TITLE
sefcontext: fix idempotence of <<none>> file contexts

### DIFF
--- a/changelogs/fragments/12561-sefcontext-none-idempotence.yml
+++ b/changelogs/fragments/12561-sefcontext-none-idempotence.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sefcontext - fix idempotence of ``<<none>>`` file contexts (https://github.com/ansible-collections/community.general/pull/12561)

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -47,6 +47,8 @@ options:
   setype:
     description:
       - SELinux type for the specified O(target).
+      - V(<<none>>) maps the O(target) to no context at all, marking paths that should not be relabeled.
+        Such a mapping stores no SELinux user or range, so O(seuser) and O(selevel) are reported as V(none) for it.
     type: str
   substitute:
     description:
@@ -170,6 +172,9 @@ if HAVE_SEOBJECT:
         s=seobject.SEMANAGE_FCONTEXT_SOCK,
     )
 
+# semanage spelling for "map this target to no context at all"
+SETYPE_NONE = "<<none>>"
+
 # Make backward compatible
 option_to_file_type_str = dict(
     a="all files",
@@ -187,16 +192,23 @@ def get_runtime_status(ignore_selinux_state=False):
     return True if ignore_selinux_state is True else selinux.is_selinux_enabled()
 
 
+def is_setype_none(setype):
+    """Whether setype is the special "no context at all" mapping, which semanage spells case-insensitively."""
+
+    return setype is not None and setype.lower() == SETYPE_NONE
+
+
 def semanage_fcontext_exists(sefcontext, target, ftype):
     """Get the SELinux file context mapping definition from policy. Return None if it does not exist."""
 
     # Beware that records comprise of a string representation of the file_type
     record = (target, option_to_file_type_str[ftype])
     records = sefcontext.get_all()
-    try:
-        return records[record]
-    except KeyError:
+    if record not in records:
         return None
+    # A "<<none>>" mapping carries no context, and seobject represents it as a None value.
+    # Return a synthetic record instead so callers can tell it apart from a missing one.
+    return records[record] or (None, None, SETYPE_NONE, None)
 
 
 def semanage_fcontext_substitute_exists(sefcontext, target):
@@ -216,7 +228,7 @@ def semanage_fcontext_modify(module, result, target, ftype, setype, substitute, 
         sefcontext.set_reload(do_reload)
         if substitute is None:
             exists = semanage_fcontext_exists(sefcontext, target, ftype)
-            if exists:
+            if exists is not None:
                 # Modify existing entry
                 orig_seuser, orig_serole, orig_setype, orig_serange = exists
 
@@ -225,9 +237,21 @@ def semanage_fcontext_modify(module, result, target, ftype, setype, substitute, 
                 if serange is None:
                     serange = orig_serange
 
-                if setype != orig_setype or seuser != orig_seuser or serange != orig_serange:
+                # A "<<none>>" mapping stores no user or range, so only the type can differ
+                setype_differs = (
+                    not is_setype_none(setype) or not is_setype_none(orig_setype)
+                ) and setype != orig_setype
+
+                if setype_differs or seuser != orig_seuser or serange != orig_serange:
                     if not module.check_mode:
-                        sefcontext.modify(target, setype, ftype, serange, seuser)
+                        # serange/seuser are None if the existing mapping was "<<none>>"
+                        sefcontext.modify(
+                            target,
+                            setype,
+                            ftype,
+                            "s0" if serange is None else serange,
+                            "system_u" if seuser is None else seuser,
+                        )
                     changed = True
 
                     if module._diff:
@@ -298,7 +322,7 @@ def semanage_fcontext_delete(module, result, target, ftype, setype, substitute, 
         sefcontext.set_reload(do_reload)
         exists = semanage_fcontext_exists(sefcontext, target, ftype)
         substitute_exists = semanage_fcontext_substitute_exists(sefcontext, target)
-        if exists and substitute is None:
+        if exists is not None and substitute is None:
             # Remove existing entry
             orig_seuser, orig_serole, orig_setype, orig_serange = exists
 

--- a/tests/integration/targets/sefcontext/tasks/sefcontext.yml
+++ b/tests/integration/targets/sefcontext/tasks/sefcontext.yml
@@ -231,3 +231,97 @@
 - ansible.builtin.assert:
     that:
       - subst_tenth is not changed
+
+- name: Ensure we start with a clean state for "<<none>>"
+  community.general.sefcontext:
+    path: '/tmp/foo/none(/.*)?'
+    state: absent
+    reload: false
+
+- name: Set SELinux file context of foo/none to "<<none>>"
+  community.general.sefcontext:
+    path: '/tmp/foo/none(/.*)?'
+    setype: '<<none>>'
+    state: present
+    reload: false
+  register: none_first
+
+- ansible.builtin.assert:
+    that:
+      - none_first is changed
+      - none_first.setype == '<<none>>'
+
+- name: Set SELinux file context of foo/none to "<<none>>" (again)
+  community.general.sefcontext:
+    path: '/tmp/foo/none(/.*)?'
+    setype: '<<none>>'
+    state: present
+    reload: false
+  register: none_second
+
+- ansible.builtin.assert:
+    that:
+      - none_second is not changed
+      - none_second.setype == '<<none>>'
+
+- name: Set SELinux file context of foo/none to "<<None>>" (semanage spelling is case-insensitive)
+  community.general.sefcontext:
+    path: '/tmp/foo/none(/.*)?'
+    setype: '<<None>>'
+    state: present
+    reload: false
+  register: none_third
+
+- ansible.builtin.assert:
+    that:
+      - none_third is not changed
+
+- name: Change SELinux file context of foo/none to a real type
+  community.general.sefcontext:
+    path: '/tmp/foo/none(/.*)?'
+    setype: httpd_sys_content_t
+    state: present
+    reload: false
+  register: none_fourth
+
+- ansible.builtin.assert:
+    that:
+      - none_fourth is changed
+      - none_fourth.setype == 'httpd_sys_content_t'
+
+- name: Change SELinux file context of foo/none back to "<<none>>"
+  community.general.sefcontext:
+    path: '/tmp/foo/none(/.*)?'
+    setype: '<<none>>'
+    state: present
+    reload: false
+  register: none_fifth
+
+- ansible.builtin.assert:
+    that:
+      - none_fifth is changed
+      - none_fifth.setype == '<<none>>'
+
+- name: Delete SELinux file context of foo/none
+  community.general.sefcontext:
+    path: '/tmp/foo/none(/.*)?'
+    setype: '<<none>>'
+    state: absent
+    reload: false
+  register: none_sixth
+
+- ansible.builtin.assert:
+    that:
+      - none_sixth is changed
+
+- name: Delete SELinux file context of foo/none (again)
+  community.general.sefcontext:
+    path: '/tmp/foo/none(/.*)?'
+    setype: '<<none>>'
+    state: absent
+    reload: false
+  register: none_seventh
+
+- ansible.builtin.assert:
+    that:
+      - none_seventh is not changed


### PR DESCRIPTION
##### SUMMARY

SELinux supports `<<none>>` as a context value, marking paths that should not be relabeled.
The module cannot handle mappings that use it.

`seobject` represents such a record with a Python `None` **value** rather than by omitting the key,
so `semanage_fcontext_exists()` returned something indistinguishable from "record missing".
Both call sites test it for truthiness, which gives two bugs:

- `state: present` reports `changed` on every run.
  The add branch is taken, and it sets `changed = True` unconditionally without comparing anything.
  The mapping itself ends up correct, so the task never converges but is otherwise harmless.
- `state: absent` silently does nothing.
  The delete is skipped and `changed: false` is reported while the mapping stays in place.

Changes:

- `semanage_fcontext_exists()` detects absence by key lookup, and returns a synthetic record for a `<<none>>` mapping so callers can tell the two apart.
- Both call sites test `if exists is not None:`.
- `sefcontext.modify()` is given the `system_u` / `s0` defaults when the existing mapping carried no SELinux user or range.
  Per the `seuser` and `selevel` descriptions, an unspecified value is inherited from the existing mapping,
  which a `<<none>>` record cannot provide, so the new-context defaults apply.
  Reached only when a `<<none>>` mapping changes to a real type.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

sefcontext

##### ADDITIONAL INFORMATION

On AlmaLinux 9, `<<none>>` is what the shipped policy uses for the contents of poly-instantiated directories, so that instance content keeps the label its creating process gave it.
Both `/tmp-inst/.*` and `/var/tmp/tmp-inst/.*` ship this way.
Which mappings a distribution ships will differ, but the record shape below does not.
This was found while adding the equivalent mapping for a custom instance parent, where the policy ships no rule.

This task reports `changed` on every run, indefinitely:

```yaml
- community.general.sefcontext:
    target: '/var/tmp-inst/.*'
    setype: '<<none>>'
    state: present
```

Running it with `state: absent` afterwards reports `changed: false`, and `semanage fcontext -l -C` still lists the mapping.

The cause is visible directly in `seobject`: The key is present, the value is `None`:

```paste below
# semanage fcontext -a -t "<<none>>" "/var/tmp-inst/.*"

# python3 -c "
import seobject
for k, v in seobject.fcontextRecords('').get_all().items():
    if 'tmp-inst' in k[0]: print(k, '->', repr(v))
"
### OS defaults, shiped by selinux-policy
('/tmp-inst/.*', 'all files') -> None
('/var/tmp/tmp-inst/.*', 'all files') -> None
('/tmp-inst', 'all files') -> ('system_u', 'object_r', 'tmp_t', 's0')
('/var/tmp-inst', 'directory') -> ('system_u', 'object_r', 'tmp_t', 's0')
('/var/tmp/tmp-inst', 'directory') -> ('system_u', 'object_r', 'tmp_t', 's0')
### Added by ansible
('/var/tmp-inst/.*', 'all files') -> None
```

The first two entries shipped by `selinux-policy` have the same shape, so this affects reading the policy's own mappings and not only ones created by this module.
