### PR TITLE
onepassword: decode secret reference lookup output

### DIFF
--- a/changelogs/fragments/onepassword-secret-reference-bytes.yml
+++ b/changelogs/fragments/onepassword-secret-reference-bytes.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - onepassword - the ``op://`` secret reference lookup returned raw bytes instead of a string, which broke passing the value into other modules (https://github.com/ansible-collections/community.general/pull/11958).
+  - onepassword lookup plugin - the ``op://`` secret reference lookup returned raw bytes instead of a string, which broke passing the value into other modules (https://github.com/ansible-collections/community.general/pull/11958).

--- a/changelogs/fragments/onepassword-secret-reference-bytes.yml
+++ b/changelogs/fragments/onepassword-secret-reference-bytes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - onepassword - the ``op://`` secret reference lookup returned raw bytes instead of a string, which broke passing the value into other modules (https://github.com/ansible-collections/community.general/pull/11958).

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -579,7 +579,7 @@ class OnePass:
             raise AnsibleLookupError("Not a valid secret reference")
 
         rc, out, err = self._cli.get_secret_reference(reference, self.token)
-        return out.strip()
+        return to_text(out).strip()
 
 
 class LookupModule(LookupBase):

--- a/tests/unit/plugins/lookup/test_onepassword.py
+++ b/tests/unit/plugins/lookup/test_onepassword.py
@@ -212,6 +212,17 @@ def test_op_get_field(mocker, op_fixture, output, expected, request):
 # This test sometimes fails on older Python versions because the gathered tests mismatch.
 # Sort the fixture data to make this reliable
 # https://github.com/pytest-dev/pytest-xdist/issues/432
+@pytest.mark.parametrize("op_fixture", OP_VERSION_FIXTURES)
+def test_op_get_secret_reference_decodes_bytes(mocker, op_fixture, request):
+    op = request.getfixturevalue(op_fixture)
+    mocker.patch.object(op._cli, "get_secret_reference", return_value=(0, b"hunter2\n", ""))
+
+    result = op.get_secret_reference("op://vault/item/field")
+
+    assert result == "hunter2"
+    assert isinstance(result, str)
+
+
 @pytest.mark.parametrize(
     ("cli_class", "vault", "queries", "kwargs", "output", "expected"),
     (


### PR DESCRIPTION
get_secret_reference() returned the raw subprocess bytes instead of a decoded string, unlike the rest of the lookup. This broke passing the result into modules with strictly-typed string arguments.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
onepassword

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
