### PR TITLE
archive: use context managers for tarfile checksum reads

### DIFF
--- a/changelogs/fragments/12569-archive-tar-checksum-context-manager.yml
+++ b/changelogs/fragments/12569-archive-tar-checksum-context-manager.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - archive - use context managers when reading tar checksums (https://github.com/ansible-collections/community.general/pull/12569).

--- a/plugins/modules/archive.py
+++ b/plugins/modules/archive.py
@@ -593,17 +593,15 @@ class TarArchive(Archive):
         try:
             if self.format == "xz":
                 with lzma.open(_to_native_ascii(path), "r") as f:
-                    archive = tarfile.open(fileobj=f)
-                    checksums = {(info.name, info.chksum) for info in archive.getmembers()}
-                    archive.close()
+                    with tarfile.open(fileobj=f) as archive:
+                        checksums = {(info.name, info.chksum) for info in archive.getmembers()}
             elif self.format == "zstd":
                 with zstandard.open(_to_native_ascii(path), "rb") as f:
                     with tarfile.open(fileobj=f, mode="r|") as archive:
                         checksums = {(info.name, info.chksum) for info in archive.getmembers()}
             else:
-                archive = tarfile.open(_to_native_ascii(path), f"r|{self.format}")
-                checksums = {(info.name, info.chksum) for info in archive.getmembers()}
-                archive.close()
+                with tarfile.open(_to_native_ascii(path), f"r|{self.format}") as archive:
+                    checksums = {(info.name, info.chksum) for info in archive.getmembers()}
         except compression_errors:
             try:
                 # The python implementations of gzip, bz2, and lzma do not support restoring compressed files


### PR DESCRIPTION
##### SUMMARY
Replace manual open/close of `tarfile` objects in the `xz` and generic
tar checksum-reading paths of `TarArchive` with `with` statements,
matching the pattern already used for the `zstd` branch.

##### ISSUE TYPE
- Refactoring Pull Request

##### COMPONENT NAME
archive

##### ADDITIONAL INFORMATION