### PR TITLE
zypper: allow non-numeric characters in version specifier

### DIFF
--- a/changelogs/fragments/12588-zypper-version-specifier-regex.yml
+++ b/changelogs/fragments/12588-zypper-version-specifier-regex.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - zypper - fix version specifier parsing when the version contains non-numeric characters, which caused packages to
+    not be removed or installed (https://github.com/ansible-collections/community.general/pull/12588, https://github.com/ansible-collections/community.general/issues/6564).

--- a/plugins/modules/zypper.py
+++ b/plugins/modules/zypper.py
@@ -276,9 +276,10 @@ def split_name_version(name):
     example formats:
         - docker>=1.10
         - apache=2.4
+        - crash-kmp-default<7.2.1_k4.12.14_122.127
 
     Allowed version specifiers: <, >, <=, >=, =
-    Allowed version format: [0-9.-]*
+    Allowed version format: [\\w.:+~-]*
 
     Also allows a prefix indicating remove "-", "~" or install "+"
     """
@@ -290,7 +291,7 @@ def split_name_version(name):
     if prefix == "~":
         prefix = "-"
 
-    version_check = re.compile("^(.*?)((?:<|>|<=|>=|=)[0-9.-]*)?$")
+    version_check = re.compile(r"^(.*?)((?:<=|>=|<|>|=)[\w.:+~-]*)?$")
     try:
         reres = version_check.match(name)
         name, version = reres.groups()

--- a/tests/unit/plugins/modules/test_zypper.py
+++ b/tests/unit/plugins/modules/test_zypper.py
@@ -1,0 +1,39 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import pytest
+
+from ansible_collections.community.general.plugins.modules.zypper import split_name_version
+
+NAME_VERSION = [
+    ("nmap", ("nmap", "")),
+    ("docker>=1.10", ("docker", ">=1.10")),
+    ("apache=2.4", ("apache", "=2.4")),
+    ("foo>1", ("foo", ">1")),
+    # https://github.com/ansible-collections/community.general/issues/6564
+    ("crash-kmp-default<7.2.1_k4.12.14_122.127", ("crash-kmp-default", "<7.2.1_k4.12.14_122.127")),
+    ("crash-kmp-default<=7.2.1_k4.12.14_122.127-8.19.2", ("crash-kmp-default", "<=7.2.1_k4.12.14_122.127-8.19.2")),
+    ("pkg=1:2.3.4-5.el8", ("pkg", "=1:2.3.4-5.el8")),
+]
+
+
+@pytest.mark.parametrize("name, expected", NAME_VERSION, ids=lambda x: x if isinstance(x, str) else "")
+def test_split_name_version(name, expected):
+    prefix, pname, version = split_name_version(name)
+    assert (pname, version) == expected
+    assert prefix == ""
+
+
+PREFIXED_NAME_VERSION = [
+    ("-nmap", ("-", "nmap", "")),
+    ("~nmap", ("-", "nmap", "")),
+    ("+docker>=1.10", ("+", "docker", ">=1.10")),
+]
+
+
+@pytest.mark.parametrize("name, expected", PREFIXED_NAME_VERSION, ids=lambda x: x if isinstance(x, str) else "")
+def test_split_name_version_with_prefix(name, expected):
+    assert split_name_version(name) == expected


### PR DESCRIPTION
##### SUMMARY

The version part of a versioned package specifier (for example `name<1.2.3`) was matched by a regex that only allowed `[0-9.-]` characters. Real-world RPM versions/releases frequently include letters and underscores (for example kernel-module package versions like `7.2.1_k4.12.14_122.127`), so such specifiers failed to be split from the package name. The `<`/`>`/`=` operator stayed glued to the name, the resulting literal name never matched anything in `zypper search`, and O(state=absent) silently reported `changed: false` without removing the package or raising any error.

The version character class was broadened to `[\w.:+~-]*` (covers RPM version/release characters including epoch `:` and version suffixes `+`/`~`), and the operator alternation was reordered so the two-character operators (`<=`, `>=`) are tried before the single-character ones.

Fixes #6564

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zypper

##### ADDITIONAL INFORMATION

Before the fix:
```
>>> split_name_version("crash-kmp-default<7.2.1_k4.12.14_122.127")
('', 'crash-kmp-default<7.2.1_k4.12.14_122.127', '')
```

After the fix:
```
>>> split_name_version("crash-kmp-default<7.2.1_k4.12.14_122.127")
('', 'crash-kmp-default', '<7.2.1_k4.12.14_122.127')
```