### PR TITLE
passwordstore lookup: add keep_trailing_newline option

### DIFF
--- a/changelogs/fragments/12589-passwordstore-keep-trailing-newline.yml
+++ b/changelogs/fragments/12589-passwordstore-keep-trailing-newline.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - passwordstore lookup plugin - add ``keep_trailing_newline`` option to preserve the trailing newline when ``returnall=true`` (https://github.com/ansible-collections/community.general/pull/12589, https://github.com/ansible-collections/community.general/issues/3616).

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -53,6 +53,13 @@ options:
     description: Return all the content of the password, not only the first line.
     type: bool
     default: false
+  keep_trailing_newline:
+    description:
+      - Keep the trailing newline in the password file content when O(returnall=true).
+      - Only used when O(returnall=true), ignored otherwise.
+    type: bool
+    default: false
+    version_added: 13.4.0
   subkey:
     description:
       - By default return a specific subkey of the password. When set to V(password), always returns the first line.
@@ -233,6 +240,10 @@ tasks.yml: |-
   - name: Return the entire password file content
     ansible.builtin.set_fact:
       passfilecontent: "{{ lookup('community.general.passwordstore', 'example/test', returnall=true)}}"
+
+  - name: Return the entire password file content, keeping its trailing newline
+    ansible.builtin.set_fact:
+      passfilecontent: "{{ lookup('community.general.passwordstore', 'example/test', returnall=true, keep_trailing_newline=true)}}"
 """
 
 RETURN = r"""
@@ -319,7 +330,7 @@ class LookupModule(LookupBase):
                 raise AnsibleError(e) from e
             # check and convert values
             try:
-                for key in ["create", "returnall", "overwrite", "backup", "nosymbols"]:
+                for key in ["create", "returnall", "keep_trailing_newline", "overwrite", "backup", "nosymbols"]:
                     if not isinstance(self.paramvals[key], bool):
                         self.paramvals[key] = boolean(self.paramvals[key])
             except (ValueError, AssertionError) as e:
@@ -358,9 +369,11 @@ class LookupModule(LookupBase):
 
     def check_pass(self):
         try:
-            self.passoutput = to_text(
+            raw_output = to_text(
                 run_backend_cmd([self.pass_cmd, "show"] + [self.passname], env=self.env), errors="surrogate_or_strict"
-            ).splitlines()
+            )
+            self.passoutput_had_trailing_newline = raw_output.endswith("\n")
+            self.passoutput = raw_output.splitlines()
             self.password = self.passoutput[0]
             self.passdict = {}
             try:
@@ -473,7 +486,10 @@ class LookupModule(LookupBase):
 
     def get_passresult(self):
         if self.paramvals["returnall"]:
-            return os.linesep.join(self.passoutput)
+            result = os.linesep.join(self.passoutput)
+            if self.paramvals["keep_trailing_newline"] and self.passoutput_had_trailing_newline:
+                result += os.linesep
+            return result
         if self.paramvals["subkey"] == "password":
             return self.password
         else:
@@ -531,6 +547,7 @@ class LookupModule(LookupBase):
             "directory": directory,
             "create": self.get_option("create"),
             "returnall": self.get_option("returnall"),
+            "keep_trailing_newline": self.get_option("keep_trailing_newline"),
             "overwrite": self.get_option("overwrite"),
             "nosymbols": self.get_option("nosymbols"),
             "userpass": self.get_option("userpass") or "",

--- a/tests/integration/targets/lookup_passwordstore/tasks/password_tests.yml
+++ b/tests/integration/targets/lookup_passwordstore/tasks/password_tests.yml
@@ -105,7 +105,7 @@
 
 - name: Fetch all from multiline file, keeping trailing newline ({{ backend }})
   ansible.builtin.set_fact:
-    readyamlpass_keep_newline: "{{ lookup('community.general.passwordstore', 'test-multiline-pass', returnall='yes', keep_trailing_newline='yes', backend=backend) }}"
+    readyamlpass_keep_newline: "{{ lookup('community.general.passwordstore', 'test-multiline-pass', returnall='true', keep_trailing_newline='true', backend=backend) }}"
 
 - name: Multiline pass returnall with keep_trailing_newline adds exactly one trailing newline on top of the default result ({{ backend }})
   ansible.builtin.assert:

--- a/tests/integration/targets/lookup_passwordstore/tasks/password_tests.yml
+++ b/tests/integration/targets/lookup_passwordstore/tasks/password_tests.yml
@@ -103,6 +103,15 @@
     that:
       - readyamlpass == 'testpassword\nrandom additional line\n'
 
+- name: Fetch all from multiline file, keeping trailing newline ({{ backend }})
+  ansible.builtin.set_fact:
+    readyamlpass_keep_newline: "{{ lookup('community.general.passwordstore', 'test-multiline-pass', returnall='yes', keep_trailing_newline='yes', backend=backend) }}"
+
+- name: Multiline pass returnall with keep_trailing_newline adds exactly one trailing newline on top of the default result ({{ backend }})
+  ansible.builtin.assert:
+    that:
+      - readyamlpass_keep_newline == readyamlpass ~ "\n"
+
 - name: Create a password in a folder ({{ backend }})
   ansible.builtin.set_fact:
     newpass: "{{ lookup('community.general.passwordstore', 'folder/test-pass', length=8, create=true, backend=backend) }}"

--- a/tests/integration/targets/lookup_passwordstore/tasks/password_tests.yml
+++ b/tests/integration/targets/lookup_passwordstore/tasks/password_tests.yml
@@ -105,7 +105,7 @@
 
 - name: Fetch all from multiline file, keeping trailing newline ({{ backend }})
   ansible.builtin.set_fact:
-    readyamlpass_keep_newline: "{{ lookup('community.general.passwordstore', 'test-multiline-pass', returnall='true', keep_trailing_newline='true', backend=backend) }}"
+    readyamlpass_keep_newline: "{{ lookup('community.general.passwordstore', 'test-multiline-pass', returnall=true, keep_trailing_newline=true, backend=backend) }}"
 
 - name: Multiline pass returnall with keep_trailing_newline adds exactly one trailing newline on top of the default result ({{ backend }})
   ansible.builtin.assert:


### PR DESCRIPTION
##### SUMMARY
Adds a new `keep_trailing_newline` option to the `passwordstore` lookup plugin. When combined with `returnall=true`, it preserves the trailing newline from the pass file content instead of stripping it. Defaults to `false` to preserve existing behavior.

Fixes #3616

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
passwordstore

##### ADDITIONAL INFORMATION
Previously, `lookup('community.general.passwordstore', 'foo', returnall=true)` never returned a trailing newline even when the underlying `pass show` output had one, because the plugin reconstructs the content via `splitlines()` + `os.linesep.join()`. Since changing the default would be a breaking change, this adds an opt-in option instead.

```yaml
- name: Return the entire password file content, keeping its trailing newline
  ansible.builtin.set_fact:
    passfilecontent: "{{ lookup('community.general.passwordstore', 'example/test', returnall=true, keep_trailing_newline=true)}}"
```