### PR TITLE
ufw: skip default policy command when already set

### DIFF
--- a/changelogs/fragments/12590-ufw-default-idempotent.yml
+++ b/changelogs/fragments/12590-ufw-default-idempotent.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ufw - do not reload the default policy when it is already set to the requested value (https://github.com/ansible-collections/community.general/issues/1843, https://github.com/ansible-collections/community.general/pull/12590).

--- a/plugins/modules/ufw.py
+++ b/plugins/modules/ufw.py
@@ -495,20 +495,22 @@ def main():
                 module.fail_json(
                     msg='For default, direction must be one of "outgoing", "incoming" and "routed", or direction must not be specified.'
                 )
-            if module.check_mode:
-                regexp = r"Default: (deny|allow|reject) \(incoming\), (deny|allow|reject) \(outgoing\), (deny|allow|reject|disabled) \(routed\)"
-                extract = re.search(regexp, pre_state)
-                if extract is not None:
-                    current_default_values = {}
-                    current_default_values["incoming"] = extract.group(1)
-                    current_default_values["outgoing"] = extract.group(2)
-                    current_default_values["routed"] = extract.group(3)
-                    v = current_default_values[params["direction"] or "incoming"]
-                    if v not in (value, "disabled"):
-                        changed = True
-                else:
-                    changed = True
+            regexp = r"Default: (deny|allow|reject) \(incoming\), (deny|allow|reject) \(outgoing\), (deny|allow|reject|disabled) \(routed\)"
+            extract = re.search(regexp, pre_state)
+            if extract is not None:
+                current_default_values = {}
+                current_default_values["incoming"] = extract.group(1)
+                current_default_values["outgoing"] = extract.group(2)
+                current_default_values["routed"] = extract.group(3)
+                v = current_default_values[params["direction"] or "incoming"]
+                already_set = v in (value, "disabled")
             else:
+                already_set = False
+
+            if module.check_mode:
+                if not already_set:
+                    changed = True
+            elif not already_set:
                 execute(cmd + [[command], [value], [params["direction"]]])
 
         elif command == "rule":

--- a/tests/unit/plugins/modules/test_ufw.py
+++ b/tests/unit/plugins/modules/test_ufw.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import unittest
 from unittest.mock import patch
 
+import pytest
 from ansible.module_utils import basic
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
     AnsibleExitJson,
@@ -49,6 +50,14 @@ ufw_status_verbose_with_ipv6 = (
 )
 
 ufw_status_verbose_nothing = ufw_verbose_header
+
+ufw_status_verbose_default_allow_incoming = """Status: active
+Logging: on (low)
+Default: allow (incoming), allow (outgoing), deny (routed)
+New profiles: skip
+
+To                         Action      From
+--                         ------      ----"""
 
 skippg_adding_existing_rules = "Skipping adding existing rule\nSkipping adding existing rule (v6)\n"
 
@@ -113,6 +122,31 @@ def do_nothing_func_port_7000(*args, **kwarg):
 def get_bin_path(self, arg, required=False):
     """Mock AnsibleModule.get_bin_path"""
     return arg
+
+
+def default_command_run_command(post_status_verbose):
+    """Build a run_command side_effect for real-mode "default" command tests.
+
+    The first "ufw status verbose" call reports the pre-change state (deny incoming,
+    allow outgoing); later calls report post_status_verbose, simulating the effect
+    (or lack thereof) of running "ufw default ...".
+    """
+    calls = {"status_verbose": 0}
+
+    def _run_command(*args, **kwarg):
+        cmd = args[0]
+        if cmd == "ufw status verbose":
+            calls["status_verbose"] += 1
+            if calls["status_verbose"] == 1:
+                return 0, ufw_verbose_header, ""
+            return 0, post_status_verbose, ""
+        if cmd == grep_config_cli:
+            return 0, "", ""
+        if cmd.startswith("ufw default "):
+            return 0, "Default incoming policy changed to 'allow'\n", ""
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    return _run_command
 
 
 class TestUFW(unittest.TestCase):
@@ -430,3 +464,35 @@ class TestUFW(unittest.TestCase):
             with self.assertRaises(AnsibleExitJson) as result:
                 module.main()
         return result
+
+
+@pytest.fixture
+def patch_ansible_module():
+    with patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json, get_bin_path=get_bin_path):
+        yield
+
+
+def test_default_real_mode_not_changed(patch_ansible_module):
+    # policy already matches the desired value: "ufw default ..." must not run
+    with set_module_args({"default": "deny", "direction": "incoming"}):
+        with patch.object(basic.AnsibleModule, "run_command") as mock_run_command:
+            mock_run_command.side_effect = default_command_run_command(ufw_verbose_header)
+            with pytest.raises(AnsibleExitJson) as exc:
+                module.main()
+
+    payload = exc.value.args[0]
+    assert payload["changed"] is False
+    assert "ufw default deny incoming" not in payload["commands"]
+
+
+def test_default_real_mode_changed(patch_ansible_module):
+    # policy differs from the desired value: "ufw default ..." must run
+    with set_module_args({"default": "allow", "direction": "incoming"}):
+        with patch.object(basic.AnsibleModule, "run_command") as mock_run_command:
+            mock_run_command.side_effect = default_command_run_command(ufw_status_verbose_default_allow_incoming)
+            with pytest.raises(AnsibleExitJson) as exc:
+                module.main()
+
+    payload = exc.value.args[0]
+    assert payload["changed"] is True
+    assert "ufw default allow incoming" in payload["commands"]


### PR DESCRIPTION
##### SUMMARY
When setting a `default` policy with `community.general.ufw`, the module always ran `ufw default <policy> <direction>` in normal (non-check) mode, even when the policy was already set to the desired value. Running that command reloads the firewall's default policy and can briefly drop active connections (including the SSH connection used to manage the host), causing task failures across a fleet of hosts even though nothing needed to change.

The module already had logic to detect whether the default policy would change, used only for check mode. This PR reuses that same state comparison in normal mode to skip running `ufw default ...` when the current policy already matches the desired value.

Fixes #1843

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ufw

##### ADDITIONAL INFORMATION
Added unit tests covering the real (non-check) execution path for the `default` command, asserting the `ufw default ...` command is skipped when idempotent and run when not.