### PR TITLE
odbc: add `autocommit` option

### DIFF
--- a/changelogs/fragments/12595-odbc-autocommit.yml
+++ b/changelogs/fragments/12595-odbc-autocommit.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - odbc - add ``autocommit`` option to support statements that must run outside of a transaction (https://github.com/ansible-collections/community.general/issues/4173, https://github.com/ansible-collections/community.general/issues/8577, https://github.com/ansible-collections/community.general/pull/12595).

--- a/plugins/modules/odbc.py
+++ b/plugins/modules/odbc.py
@@ -44,6 +44,15 @@ options:
     type: bool
     default: true
     version_added: 1.3.0
+  autocommit:
+    description:
+      - Enable autocommit on the connection.
+      - Some databases and drivers execute an implicit transaction as soon as a statement runs unless autocommit
+        is enabled, which some statements (for example, C(ALTER SERVER AUDIT) on SQL Server) do not allow.
+      - This is independent of O(commit), which only controls whether an explicit commit is issued after the query.
+    type: bool
+    default: false
+    version_added: 13.4.0
 requirements:
   - "pyodbc"
 
@@ -60,6 +69,14 @@ EXAMPLES = r"""
     query: "Select * from table_a where column1 = ?"
     params:
       - "value1"
+    commit: false
+  changed_when: false
+
+- name: Run a statement that cannot execute inside a transaction
+  community.general.odbc:
+    dsn: "DRIVER={ODBC Driver 17 for SQL Server};Server=db.ansible.com;Database=master;UID=admin;PWD=password;"
+    query: "ALTER SERVER AUDIT my_audit WITH (STATE=ON)"
+    autocommit: true
     commit: false
   changed_when: false
 """
@@ -100,6 +117,7 @@ def main():
             query=dict(type="str", required=True),
             params=dict(type="list", elements="str"),
             commit=dict(type="bool", default=True),
+            autocommit=dict(type="bool", default=False),
         ),
     )
 
@@ -107,6 +125,7 @@ def main():
     query = module.params.get("query")
     params = module.params.get("params")
     commit = module.params.get("commit")
+    autocommit = module.params.get("autocommit")
 
     if not HAS_PYODBC:
         module.fail_json(msg=missing_required_lib("pyodbc"))
@@ -114,7 +133,7 @@ def main():
     # Try to make a connection with the DSN
     connection = None
     try:
-        connection = pyodbc.connect(dsn)
+        connection = pyodbc.connect(dsn, autocommit=autocommit)
     except Exception as e:
         module.fail_json(msg=f"Failed to connect to DSN: {e}")
 

--- a/tests/integration/targets/odbc/tasks/main.yml
+++ b/tests/integration/targets/odbc/tasks/main.yml
@@ -157,6 +157,32 @@
           - results is successful
           - results.row_count == 2
 
+    - name: Insert a record with autocommit enabled
+      community.general.odbc:
+        dsn: "{{ dsn }}"
+        query: "INSERT INTO films (code, title, did, date_prod, kind, len) VALUES ('zxcvb', 'My Third Movie', 3, '2019-01-12', 'Drama', '01:45')"
+        autocommit: true
+        commit: false
+      become_user: "{{ pg_user }}"
+      become: true
+      register: results
+
+    - ansible.builtin.assert:
+        that:
+          - results is changed
+
+    - name: Perform select to confirm autocommit record was persisted
+      community.general.odbc:
+        dsn: "{{ dsn }}"
+        query: "SELECT * FROM films WHERE code='zxcvb'"
+      register: results
+      changed_when: false
+
+    - ansible.builtin.assert:
+        that:
+          - results is successful
+          - results.row_count == 1
+
     - name: Drop the table
       community.general.odbc:
         dsn: "{{ dsn }}"


### PR DESCRIPTION
##### SUMMARY
The `odbc` module always connects via `pyodbc.connect(dsn)`, which defaults to `autocommit=False`. Some databases and drivers implicitly open a transaction as soon as a statement runs unless autocommit is enabled on the connection — for example, SQL Server rejects `ALTER SERVER AUDIT` inside any transaction, and some Simba/Databricks ODBC drivers reject `SQL_ATTR_AUTOCOMMIT=False` outright. The existing `commit` option only controls whether `cursor.commit()` is called after the query; it does not affect whether the connection itself is transactional, so there was previously no way to avoid the implicit transaction.

This adds a new `autocommit` option (default `false`, preserving current behavior) that is passed through to `pyodbc.connect()`.

Fixes #4173
Fixes #8577

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
odbc

##### ADDITIONAL INFORMATION
```yaml
- name: Run a statement that cannot execute inside a transaction
  community.general.odbc:
    dsn: "DRIVER={ODBC Driver 17 for SQL Server};Server=db.ansible.com;Database=master;UID=admin;PWD=password;"
    query: "ALTER SERVER AUDIT my_audit WITH (STATE=ON)"
    autocommit: true
    commit: false
  changed_when: false
```