### PR TITLE
apache2_module: fix false failures with `ignore_configcheck`

### DIFF
--- a/changelogs/fragments/12597-apache2-module-ignore-configcheck.yml
+++ b/changelogs/fragments/12597-apache2-module-ignore-configcheck.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apache2_module - fix false failures when ``ignore_configcheck`` is set and the configuration is broken for a reason unrelated to the module being changed (https://github.com/ansible-collections/community.general/issues/4592, https://github.com/ansible-collections/community.general/pull/12597).

--- a/plugins/modules/apache2_module.py
+++ b/plugins/modules/apache2_module.py
@@ -135,6 +135,13 @@ def _get_ctl_binary(module):
 
 
 def _module_is_enabled(module):
+    """
+    Returns a tuple (enabled, configcheck_failed).
+
+    configcheck_failed is True when `apache2ctl -M` itself failed and
+    ignore_configcheck absorbed the error, meaning enabled could not
+    actually be confirmed one way or another.
+    """
     control_binary = _get_ctl_binary(module)
     result, stdout, stderr = module.run_command([control_binary, "-M"])
 
@@ -149,12 +156,12 @@ def _module_is_enabled(module):
                     )
             else:
                 module.warn(error_msg)
-            return False
+            return False, True
         else:
             module.fail_json(msg=error_msg)
 
     searchstring = f" {module.params['identifier']}"
-    return searchstring in stdout
+    return searchstring in stdout, False
 
 
 def create_apache_identifier(name):
@@ -201,7 +208,8 @@ def _set_state(module, state):
     a2mod_binary = {"present": "a2enmod", "absent": "a2dismod"}[state]
     success_msg = f"Module {name} {state_string}"
 
-    if _module_is_enabled(module) != want_enabled:
+    currently_enabled, _configcheck_failed = _module_is_enabled(module)
+    if currently_enabled != want_enabled:
         if module.check_mode:
             module.exit_json(changed=True, result=success_msg)
 
@@ -219,8 +227,24 @@ def _set_state(module, state):
 
         result, stdout, stderr = module.run_command(a2mod_binary_cmd + [name])
 
-        if _module_is_enabled(module) == want_enabled:
+        if result != 0:
+            module.fail_json(
+                msg=f"Failed to run {a2mod_binary} for module {name}:\n{stdout}\n{stderr}",
+                rc=result,
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+        now_enabled, configcheck_failed = _module_is_enabled(module)
+        if now_enabled == want_enabled:
             module.exit_json(changed=True, result=success_msg)
+        elif configcheck_failed:
+            # apache2ctl -M could not confirm the new state because the configuration
+            # is broken for a reason unrelated to this module. Since a2mod_binary
+            # itself succeeded above, fall back to its own wording to tell whether
+            # this was a real change.
+            changed = f"already {state_string}" not in stdout
+            module.exit_json(changed=changed, result=success_msg)
         else:
             msg = (
                 f"Failed to set module {name} to {state_string}:\n"

--- a/tests/integration/targets/apache2_module/tasks/4592-ignore-configcheck-unrelated-broken-config.yml
+++ b/tests/integration/targets/apache2_module/tasks/4592-ignore-configcheck-unrelated-broken-config.yml
@@ -1,0 +1,82 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# This test represents the behavior described in
+# https://github.com/ansible-collections/community.general/issues/4592:
+# with ignore_configcheck, a module change that itself succeeds (a2enmod/a2dismod
+# returns success) must not be reported as failed just because apache2ctl -M keeps
+# failing afterwards, for a reason unrelated to the module being changed.
+
+- name: disable headers module, recording its original state
+  community.general.apache2_module:
+    name: headers
+    state: absent
+  register: headers_first_disable
+
+- name: disable rewrite module, recording its original state
+  community.general.apache2_module:
+    name: rewrite
+    state: absent
+    force: true
+  register: rewrite_first_disable
+
+- name: add a site that requires rewrite, breaking the config for reasons unrelated to headers
+  ansible.builtin.copy:
+    dest: /etc/apache2/sites-enabled/999-4592-broken.conf
+    content: |
+      RewriteEngine On
+    mode: "0644"
+
+- name: confirm the config is indeed broken
+  ansible.builtin.command: apache2ctl -M
+  register: broken_check
+  failed_when: false
+  changed_when: false
+
+- name: sanity check that the injected site really broke the config
+  ansible.builtin.assert:
+    that:
+      - broken_check.rc != 0
+
+- name: enable headers module while the config is broken for an unrelated reason
+  community.general.apache2_module:
+    name: headers
+    state: present
+    ignore_configcheck: true
+  register: enable_headers_broken_config
+
+- name: ensure enabling headers succeeded despite the unrelated broken config
+  ansible.builtin.assert:
+    that:
+      - enable_headers_broken_config is succeeded
+      - enable_headers_broken_config is changed
+
+- name: enable headers module again, idempotency check
+  community.general.apache2_module:
+    name: headers
+    state: present
+    ignore_configcheck: true
+  register: enable_headers_broken_config_again
+
+- name: ensure idempotency holds despite the unrelated broken config
+  ansible.builtin.assert:
+    that:
+      - enable_headers_broken_config_again is succeeded
+      - enable_headers_broken_config_again is not changed
+
+- name: remove the injected broken site
+  ansible.builtin.file:
+    path: /etc/apache2/sites-enabled/999-4592-broken.conf
+    state: absent
+
+- name: restore headers module to its original state
+  community.general.apache2_module:
+    name: headers
+    state: "{{ 'present' if headers_first_disable is changed else 'absent' }}"
+
+- name: restore rewrite module to its original state
+  community.general.apache2_module:
+    name: rewrite
+    state: present
+  when: rewrite_first_disable is changed

--- a/tests/integration/targets/apache2_module/tasks/main.yml
+++ b/tests/integration/targets/apache2_module/tasks/main.yml
@@ -9,6 +9,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: test apache2_module
+  when: ansible_facts.os_family in ['Debian', 'Suse']
+  # CentOS/RHEL does not have a2enmod/a2dismod
   block:
     - name: get list of enabled modules
       ansible.builtin.shell: apache2ctl -M | sort
@@ -28,10 +30,14 @@
     - name: ensure that all test modules are disabled again
       ansible.builtin.assert:
         that: modules_before.stdout == modules_after.stdout
-  when: ansible_facts.os_family in ['Debian', 'Suse']
-  # CentOS/RHEL does not have a2enmod/a2dismod
 
-- name: include misleading warning test
-  ansible.builtin.include_tasks: 635-apache2-misleading-warning.yml
-  when: ansible_facts.os_family in ['Debian']
-  # Suse has mpm_event module compiled within the base apache2
+- name: Debian-only tests
+  when: ansible_facts.os_family == 'Debian'
+  # Suse has mpm_event module compiled within the base apache2,
+  # and its sites-enabled layout differs from Debian's
+  block:
+    - name: include misleading warning test
+      ansible.builtin.include_tasks: 635-apache2-misleading-warning.yml
+
+    - name: include unrelated broken config test
+      ansible.builtin.include_tasks: 4592-ignore-configcheck-unrelated-broken-config.yml


### PR DESCRIPTION
##### SUMMARY
With `ignore_configcheck: true`, a module change that succeeded via `a2enmod`/`a2dismod` could still be reported as failed, if `apache2ctl -M` kept erroring out afterwards for a reason unrelated to the module being changed (e.g. an unrelated site referencing a directive from a different, not-yet-loaded module). The post-action check now falls back to the exit code and wording of `a2enmod`/`a2dismod` when `apache2ctl -M` cannot confirm the new state.

Fixes #4592

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apache2_module

##### ADDITIONAL INFORMATION
Added an integration test target reproducing the scenario: an unrelated broken site config (`RewriteEngine On` while `rewrite` is disabled) is injected, then a different module (`headers`) is enabled with `ignore_configcheck: true`, asserting both the change and its idempotency.