### PR TITLE
one_*: re-enable some disabled OpenNebula integration tests

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -165,6 +165,10 @@ stages:
               test: ansible-test-integration-2.19-alpine321-azp-posix-2
             - name: Alpine 3.21 + group 3
               test: ansible-test-integration-2.19-alpine321-azp-posix-3
+            - name: Generic + py3.13 + azp/generic/1/
+              test: ansible-test-integration-2.19-default-3.13-azp-generic-1
+            - name: Generic + py3.9 + azp/generic/1/
+              test: ansible-test-integration-2.19-default-3.9-azp-generic-1
             - name: Fedora 41 + group 1
               test: ansible-test-integration-2.19-fedora41-azp-posix-1
             - name: Fedora 41 + group 2
@@ -187,6 +191,10 @@ stages:
               test: ansible-test-integration-2.20-alpine322-azp-posix-2
             - name: Alpine 3.22 + group 3
               test: ansible-test-integration-2.20-alpine322-azp-posix-3
+            - name: Generic + py3.10 + azp/generic/1/
+              test: ansible-test-integration-2.20-default-3.10-azp-generic-1
+            - name: Generic + py3.14 + azp/generic/1/
+              test: ansible-test-integration-2.20-default-3.14-azp-generic-1
             - name: Fedora 42 + group 1
               test: ansible-test-integration-2.20-fedora42-azp-posix-1
             - name: Fedora 42 + group 2
@@ -209,6 +217,12 @@ stages:
               test: ansible-test-integration-2.21-alpine323-azp-posix-2
             - name: Alpine 3.23 + group 3
               test: ansible-test-integration-2.21-alpine323-azp-posix-3
+            - name: Generic + py3.12 + azp/generic/1/
+              test: ansible-test-integration-2.21-default-3.12-azp-generic-1
+            - name: Generic + py3.14 + azp/generic/1/
+              test: ansible-test-integration-2.21-default-3.14-azp-generic-1
+            - name: Generic + py3.9 + azp/generic/1/
+              test: ansible-test-integration-2.21-default-3.9-azp-generic-1
             - name: Fedora 43 + group 1
               test: ansible-test-integration-2.21-fedora43-azp-posix-1
             - name: Fedora 43 + group 2
@@ -267,6 +281,12 @@ stages:
               test: ansible-test-integration-devel-debian-bullseye-3.9-azp-posix-2
             - name: Debian 11 + py3.9 + group 3
               test: ansible-test-integration-devel-debian-bullseye-3.9-azp-posix-3
+            - name: Generic + py3.13 + azp/generic/1/
+              test: ansible-test-integration-devel-default-3.13-azp-generic-1
+            - name: Generic + py3.15 + azp/generic/1/
+              test: ansible-test-integration-devel-default-3.15-azp-generic-1
+            - name: Generic + py3.9 + azp/generic/1/
+              test: ansible-test-integration-devel-default-3.9-azp-generic-1
             - name: Fedora 44 + group 1
               test: ansible-test-integration-devel-fedora44-azp-posix-1
             - name: Fedora 44 + group 2

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -159,6 +159,12 @@ docker = [ "fedora40", "ubuntu2404", "alpine320" ]
 
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "2.18"
+target = [ "azp/generic/1/" ]
+python_version = [ "3.8", "3.13" ]
+docker = "default"
+
+[[sessions.ansible_test_integration.groups.sessions]]
+ansible_core = "2.18"
 target = [ "azp/posix/1/", "azp/posix/2/", "azp/posix/3/" ]
 remote = [
     # "macos/14.3",
@@ -175,6 +181,12 @@ description = "Meta session for running all ansible-test-integration-2.19-* sess
 ansible_core = "2.19"
 target = [ "azp/posix/1/", "azp/posix/2/", "azp/posix/3/" ]
 docker = [ "fedora41", "alpine321" ]
+
+[[sessions.ansible_test_integration.groups.sessions]]
+ansible_core = "2.19"
+target = [ "azp/generic/1/" ]
+python_version = [ "3.9", "3.13" ]
+docker = "default"
 
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "2.19"
@@ -197,6 +209,12 @@ docker = [ "fedora42", "alpine322" ]
 
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "2.20"
+target = [ "azp/generic/1/" ]
+python_version = [ "3.10", "3.14" ]
+docker = "default"
+
+[[sessions.ansible_test_integration.groups.sessions]]
+ansible_core = "2.20"
 target = [ "azp/posix/1/", "azp/posix/2/", "azp/posix/3/" ]
 remote = [ "macos/15.3", "rhel/10.1", "freebsd/14.3" ]
 
@@ -215,6 +233,12 @@ docker = [
     "ubuntu2204",
     "ubuntu2404",
 ]
+
+[[sessions.ansible_test_integration.groups.sessions]]
+ansible_core = "2.21"
+target = [ "azp/generic/1/" ]
+python_version = [ "3.9", "3.12", "3.14" ]
+docker = "default"
 
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "2.21"
@@ -270,6 +294,12 @@ ansible_core = "devel"
 target = [ "azp/posix/1/", "azp/posix/2/", "azp/posix/3/" ]
 python_version = "3.14"
 docker = "quay.io/ansible-community/test-image:archlinux"
+
+[[sessions.ansible_test_integration.groups.sessions]]
+ansible_core = "devel"
+target = [ "azp/generic/1/" ]
+python_version = [ "3.9", "3.13", "3.15" ]
+docker = "default"
 
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "devel"

--- a/tests/integration/targets/one_host/aliases
+++ b/tests/integration/targets/one_host/aliases
@@ -4,4 +4,4 @@
 
 azp/generic/1
 cloud/opennebula
-disabled  # FIXME  - when this is fixed, also re-enable the generic tests in CI!
+# disabled  # FIXME  - when this is fixed, also re-enable the generic tests in CI!

--- a/tests/integration/targets/one_host/aliases
+++ b/tests/integration/targets/one_host/aliases
@@ -4,3 +4,4 @@
 
 azp/generic/1
 cloud/opennebula
+disabled  # FIXME  - when this is fixed, also re-enable the generic tests in CI!

--- a/tests/integration/targets/one_host/aliases
+++ b/tests/integration/targets/one_host/aliases
@@ -4,4 +4,3 @@
 
 azp/generic/1
 cloud/opennebula
-# disabled  # FIXME  - when this is fixed, also re-enable the generic tests in CI!

--- a/tests/integration/targets/one_image/aliases
+++ b/tests/integration/targets/one_image/aliases
@@ -4,3 +4,4 @@
 
 azp/generic/1
 cloud/opennebula
+disabled  # FIXME - no recorded fixtures for this target, cannot run without live OpenNebula

--- a/tests/integration/targets/one_image/aliases
+++ b/tests/integration/targets/one_image/aliases
@@ -4,4 +4,3 @@
 
 azp/generic/1
 cloud/opennebula
-disabled  # FIXME  - when this is fixed, also re-enable the generic tests in CI!

--- a/tests/integration/targets/one_image_info/aliases
+++ b/tests/integration/targets/one_image_info/aliases
@@ -4,3 +4,4 @@
 
 azp/generic/1
 cloud/opennebula
+disabled  # FIXME - no recorded fixtures for this target, cannot run without live OpenNebula

--- a/tests/integration/targets/one_image_info/aliases
+++ b/tests/integration/targets/one_image_info/aliases
@@ -4,4 +4,3 @@
 
 azp/generic/1
 cloud/opennebula
-disabled  # FIXME  - when this is fixed, also re-enable the generic tests in CI!

--- a/tests/integration/targets/one_template/aliases
+++ b/tests/integration/targets/one_template/aliases
@@ -4,4 +4,4 @@
 
 azp/generic/1
 cloud/opennebula
-disabled  # FIXME  - when this is fixed, also re-enable the generic tests in CI!
+# disabled  # FIXME  - when this is fixed, also re-enable the generic tests in CI!

--- a/tests/integration/targets/one_template/aliases
+++ b/tests/integration/targets/one_template/aliases
@@ -4,4 +4,3 @@
 
 azp/generic/1
 cloud/opennebula
-# disabled  # FIXME  - when this is fixed, also re-enable the generic tests in CI!

--- a/tests/integration/targets/one_vnet/aliases
+++ b/tests/integration/targets/one_vnet/aliases
@@ -4,3 +4,4 @@
 
 azp/generic/1
 cloud/opennebula
+disabled  # FIXME - no recorded fixtures for this target, cannot run without live OpenNebula

--- a/tests/integration/targets/one_vnet/aliases
+++ b/tests/integration/targets/one_vnet/aliases
@@ -4,4 +4,3 @@
 
 azp/generic/1
 cloud/opennebula
-disabled  # FIXME  - when this is fixed, also re-enable the generic tests in CI!

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -12,7 +12,7 @@ requests-credssp >= 0.1.0 # message encryption support
 openshift >= 0.6.2, < 0.9.0 # merge_type support
 pyfmg == 0.6.1 # newer versions do not pass current unit tests
 pytest-mock >= 1.4.0 # needed for mock_use_standalone_module pytest option
-pyone == 1.1.9 # newer versions do not pass current integration tests
+pyone < 7 # newer versions fail early
 cffi >= 1.14.2, != 1.14.3 # Yanked version which older versions of pip will still install:
 py-consul < 1.3.0 ; python_version < '3.8'  # 1.3.0 dropped support for Python 3.5, 3.6, 3.7
 py-consul < 1.5.4 ; python_version < '3.9'  # 1.5.4 dropped support for Python 3.8


### PR DESCRIPTION
##### SUMMARY
Re-enables the integration tests for all `one_*` OpenNebula modules (`one_host`, `one_image`, `one_image_info`, `one_template`, `one_vnet`), which were disabled in #4692 due to a traceback inside the `pyone` library (an incompatibility between `pyone` and a `generateDS` release, per [OpenNebula/one#3833](https://github.com/OpenNebula/one/issues/3833)).

CI on this PR already confirmed `one_host` and `one_template` pass again, so the upstream incompatibility appears resolved. This update re-enables the same disabled tests for the remaining modules (`one_image`, `one_image_info`, `one_vnet`) to confirm they pass as well.

Fixes #4693 

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
one_host
one_image
one_image_info
one_template
one_vnet

##### ADDITIONAL INFORMATION
