### PR TITLE
vmadm: add `bootrom` option

### DIFF
--- a/changelogs/fragments/12601-vmadm-bootrom.yml
+++ b/changelogs/fragments/12601-vmadm-bootrom.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmadm - add ``bootrom`` option to support UEFI boot for ``bhyve`` VMs (https://github.com/ansible-collections/community.general/pull/12601, https://github.com/ansible-collections/community.general/issues/4282).

--- a/plugins/modules/vmadm.py
+++ b/plugins/modules/vmadm.py
@@ -32,12 +32,19 @@ options:
     choices: [joyent, joyent-minimal, lx, kvm, bhyve]
     default: joyent
     description:
-      - Type of virtual machine. The V(bhyve) option was added in community.general 0.2.0.
+      - Type of virtual machine.
+      - The V(bhyve) option was added in community.general 0.2.0.
     type: str
   boot:
     description:
       - Set the boot order for KVM VMs.
     type: str
+  bootrom:
+    description:
+      - Sets the boot ROM used for a bhyve VM. Valid values are V(bios), V(uefi), or a path to a custom bootrom binary relative
+        to the guest zone root.
+    type: str
+    version_added: 13.4.0
   cpu_cap:
     description:
       - Sets a limit on the amount of CPU time that can be used by a VM. Use V(0) for no cap.
@@ -577,6 +584,7 @@ def main():
     properties = {
         "str": [
             "boot",
+            "bootrom",
             "disk_driver",
             "dns_domain",
             "fs_allowed",


### PR DESCRIPTION
##### SUMMARY
Adds the `bootrom` option to the `vmadm` module, allowing the boot ROM to be set for `bhyve` VMs (e.g. `uefi` for UEFI boot, `bios` for the default, or a path to a custom boot ROM).

Relates to #4282

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmadm

##### ADDITIONAL INFORMATION

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>