### PR TITLE
hashids, unicode_normalize - import AnsibleTypeError directly instead of deprecated AnsibleFilterTypeError fallback

### DIFF
--- a/changelogs/fragments/12609-ansible-type-error-import.yml
+++ b/changelogs/fragments/12609-ansible-type-error-import.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - unicode_normalize filter - fix spurious deprecation warnings by importing ``AnsibleTypeError`` directly instead of falling back to the deprecated ``AnsibleFilterTypeError`` (https://github.com/ansible-collections/community.general/issues/12609).
+  - hashids filter - fix spurious deprecation warnings by importing ``AnsibleTypeError`` directly instead of falling back to the deprecated ``AnsibleFilterTypeError`` (https://github.com/ansible-collections/community.general/issues/12609).

--- a/plugins/filter/hashids.py
+++ b/plugins/filter/hashids.py
@@ -9,11 +9,7 @@ from ansible.errors import (
     AnsibleFilterError,
 )
 from ansible.module_utils.common.collections import is_sequence
-
-try:
-    from ansible.errors import AnsibleTypeError
-except ImportError:
-    from ansible.errors import AnsibleFilterTypeError as AnsibleTypeError  # type: ignore
+from ansible.errors import AnsibleTypeError
 
 try:
     from hashids import Hashids

--- a/plugins/filter/unicode_normalize.py
+++ b/plugins/filter/unicode_normalize.py
@@ -47,11 +47,7 @@ _value:
 from unicodedata import normalize
 
 from ansible.errors import AnsibleFilterError
-
-try:
-    from ansible.errors import AnsibleTypeError
-except ImportError:
-    from ansible.errors import AnsibleFilterTypeError as AnsibleTypeError  # type: ignore
+from ansible.errors import AnsibleTypeError
 
 
 def unicode_normalize(data, form="NFC"):

--- a/tests/unit/plugins/filter/test_hashids.py
+++ b/tests/unit/plugins/filter/test_hashids.py
@@ -1,0 +1,21 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+import unittest
+import warnings
+
+from ansible_collections.community.general.plugins.filter.hashids import hashids_encode, hashids_decode
+
+
+class TestHashids(unittest.TestCase):
+    def test_encode_decode_no_warnings(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            hashed = hashids_encode([1, 2, 3], salt="salt")
+            self.assertEqual(hashids_decode(hashed, salt="salt"), [1, 2, 3])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/plugins/filter/test_unicode_normalize.py
+++ b/tests/unit/plugins/filter/test_unicode_normalize.py
@@ -1,0 +1,20 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+import unittest
+import warnings
+
+from ansible_collections.community.general.plugins.filter.unicode_normalize import unicode_normalize
+
+
+class TestUnicodeNormalize(unittest.TestCase):
+    def test_normalize_no_warnings(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            self.assertEqual(unicode_normalize("é"), "é")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
Fixes #12609

- Bugfix Pull Request

The `unicode_normalize` and `hashids` filters imported `AnsibleTypeError` via a fallback:

```python
try:
    from ansible.errors import AnsibleTypeError
except ImportError:
    from ansible.errors import AnsibleFilterTypeError as AnsibleTypeError  # type: ignore
```

`AnsibleFilterTypeError` is deprecated since ansible-core 2.19 and slated for removal in ansible-core 2.23, so on current ansible-core every use of these filters emits a deprecation warning (see issue #12609). The collection already requires ansible-core >= 2.18 (`meta/runtime.yml`), where `AnsibleTypeError` always exists, so the fallback is dead code.

This PR imports `AnsibleTypeError` directly in both filters and drops the try/except fallback. Nothing else changes.

Co-authored: Claude (ox-alpha)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/filter/hashids.py
plugins/filter/unicode_normalize.py

##### ADDITIONAL INFORMATION
Verified locally with ansible-core 2.19.12:

```
python3 -m pytest tests/unit/plugins/filter/test_hashids.py \
                  tests/unit/plugins/filter/test_unicode_normalize.py -v
# 2 passed
```

New unit tests run each filter with warnings promoted to errors (`warnings.simplefilter("error")`) to assert no DeprecationWarning is emitted.