### PR TITLE
Fix description for pvresize task

### DIFF
--- a/plugins/modules/lvg.py
+++ b/plugins/modules/lvg.py
@@ -132,7 +132,7 @@ EXAMPLES = r"""
     vg: vg.services
     state: absent
 
-- name: Create a volume group on top of /dev/sda3 and resize the volume group /dev/sda3 to the maximum possible
+- name: Create a volume group on top of /dev/sda3 and resize the physical volume /dev/sda3 to the maximum possible
   community.general.lvg:
     vg: resizableVG
     pvs: /dev/sda3


### PR DESCRIPTION
##### SUMMARY

Doc-Only Fix  - **LVG module**

Replace volume group by physical volume for the following example in `community.general.lvg`.

From :

```
- name: Create a volume group on top of /dev/sda3 and resize the volume group /dev/sda3 to the maximum possible
  community.general.lvg:
    vg: resizableVG
    pvs: /dev/sda3
    pvresize: true
```

To :

```
- name: Create a volume group on top of /dev/sda3 and resize the physical volume /dev/sda3 to the maximum possible
  community.general.lvg:
    vg: resizableVG
    pvs: /dev/sda3
    pvresize: true
```

Explanation : /dev/sda3 is not a **vg** but a **pv**.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
community.general.lvg