### PR TITLE
gitlab_hook - add branch_filter_strategy option

### DIFF
--- a/changelogs/fragments/12618-gitlab_hook-branch-filter-strategy.yml
+++ b/changelogs/fragments/12618-gitlab_hook-branch-filter-strategy.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - gitlab_hook - add ``branch_filter_strategy`` option to control how ``push_events_branch_filter`` filters push events, which allows filtering branches by a regular expression (https://github.com/ansible-collections/community.general/pull/12618).

--- a/plugins/modules/gitlab_hook.py
+++ b/plugins/modules/gitlab_hook.py
@@ -55,10 +55,20 @@ options:
     default: true
   push_events_branch_filter:
     description:
-      - Branch name of wildcard to trigger hook on push events.
+      - Branch name, wildcard, or regular expression to trigger hook on push events.
+      - O(branch_filter_strategy) controls whether this is interpreted as a wildcard or as a regular expression.
     type: str
     version_added: '0.2.0'
     default: ''
+  branch_filter_strategy:
+    description:
+      - How O(push_events_branch_filter) is used to filter push events by branch.
+      - With V(wildcard) the filter is matched as a wildcard expression, with V(regex) as a regular expression.
+      - With V(all_branches) push events are not filtered by branch and O(push_events_branch_filter) is ignored.
+      - If not specified, GitLab uses V(wildcard) for new hooks, and the strategy of an existing hook is left unchanged.
+    type: str
+    choices: ["wildcard", "regex", "all_branches"]
+    version_added: 13.4.0
   issues_events:
     description:
       - Trigger hook on issues events.
@@ -139,6 +149,17 @@ EXAMPLES = r"""
     state: present
     push_events: true
     custom_webhook_template: !unsafe '{"event": "{{object_kind}}", "project": "{{project.name}}"}'
+
+- name: Add a project hook triggered by push events on branches matching a regular expression
+  community.general.gitlab_hook:
+    api_url: https://gitlab.example.com/
+    api_token: "{{ access_token }}"
+    project: "my_group/my_project"
+    hook_url: "https://my-ci-server.example.com/gitlab-hook"
+    state: present
+    push_events: true
+    push_events_branch_filter: '^(main|release/.*)$'
+    branch_filter_strategy: regex
 
 - name: "Delete the previous hook"
   community.general.gitlab_hook:
@@ -228,11 +249,14 @@ class GitLabHook:
         if self.hook_object is None:
             if options["releases_events"] is not None:
                 hook_arguments["releases_events"] = options["releases_events"]
+            if options["branch_filter_strategy"] is not None:
+                hook_arguments["branch_filter_strategy"] = options["branch_filter_strategy"]
             hook = self.create_hook(project, hook_arguments)
             changed = True
         else:
             update_arguments = hook_arguments.copy()
             update_arguments["releases_events"] = options["releases_events"]
+            update_arguments["branch_filter_strategy"] = options["branch_filter_strategy"]
             changed, hook = self.update_hook(self.hook_object, update_arguments)
 
         self.hook_object = hook
@@ -314,6 +338,7 @@ def main():
             hook_url=dict(type="str", required=True),
             push_events=dict(type="bool", default=True),
             push_events_branch_filter=dict(type="str", default=""),
+            branch_filter_strategy=dict(type="str", choices=["wildcard", "regex", "all_branches"]),
             issues_events=dict(type="bool", default=False),
             merge_requests_events=dict(type="bool", default=False),
             tag_push_events=dict(type="bool", default=False),
@@ -350,6 +375,7 @@ def main():
     hook_url = module.params["hook_url"]
     push_events = module.params["push_events"]
     push_events_branch_filter = module.params["push_events_branch_filter"]
+    branch_filter_strategy = module.params["branch_filter_strategy"]
     issues_events = module.params["issues_events"]
     merge_requests_events = module.params["merge_requests_events"]
     tag_push_events = module.params["tag_push_events"]
@@ -385,6 +411,7 @@ def main():
             {
                 "push_events": push_events,
                 "push_events_branch_filter": push_events_branch_filter,
+                "branch_filter_strategy": branch_filter_strategy,
                 "issues_events": issues_events,
                 "merge_requests_events": merge_requests_events,
                 "tag_push_events": tag_push_events,

--- a/tests/unit/plugins/modules/gitlab.py
+++ b/tests/unit/plugins/modules/gitlab.py
@@ -725,7 +725,8 @@ def resp_find_project_hook(url, request):
     headers = {"content-type": "application/json"}
     content = (
         '[{"id": 1,"url": "http://example.com/hook","project_id": 3,'
-        '"push_events": true,"push_events_branch_filter": "","issues_events": true,'
+        '"push_events": true,"push_events_branch_filter": "",'
+        '"branch_filter_strategy": "wildcard","issues_events": true,'
         '"confidential_issues_events": true,"merge_requests_events": true,'
         '"tag_push_events": true,"note_events": true,"job_events": true,'
         '"pipeline_events": true,"wiki_page_events": true,"enable_ssl_verification": true,'
@@ -740,7 +741,8 @@ def resp_get_project_hook(url, request):
     headers = {"content-type": "application/json"}
     content = (
         '{"id": 1,"url": "http://example.com/hook","project_id": 3,'
-        '"push_events": true,"push_events_branch_filter": "","issues_events": true,'
+        '"push_events": true,"push_events_branch_filter": "",'
+        '"branch_filter_strategy": "wildcard","issues_events": true,'
         '"confidential_issues_events": true,"merge_requests_events": true,'
         '"tag_push_events": true,"note_events": true,"job_events": true,'
         '"pipeline_events": true,"wiki_page_events": true,"enable_ssl_verification": true,'
@@ -755,7 +757,8 @@ def resp_create_project_hook(url, request):
     headers = {"content-type": "application/json"}
     content = (
         '{"id": 1,"url": "http://example.com/hook","project_id": 3,'
-        '"push_events": true,"push_events_branch_filter": "","issues_events": true,'
+        '"push_events": true,"push_events_branch_filter": "",'
+        '"branch_filter_strategy": "wildcard","issues_events": true,'
         '"confidential_issues_events": true,"merge_requests_events": true,'
         '"tag_push_events": true,"note_events": true,"job_events": true,'
         '"pipeline_events": true,"wiki_page_events": true,"enable_ssl_verification": true,'

--- a/tests/unit/plugins/modules/test_gitlab_hook.py
+++ b/tests/unit/plugins/modules/test_gitlab_hook.py
@@ -92,6 +92,28 @@ class TestGitlabHook(GitlabModuleTestCase):
 
     @with_httmock(resp_get_project)
     @with_httmock(resp_find_project_hook)
+    def test_update_hook_branch_filter_strategy(self):
+        project = self.gitlab_instance.projects.get(1)
+        hook = self.moduleUtil.find_hook(project, "http://example.com/hook")
+
+        self.assertEqual(hook.branch_filter_strategy, "wildcard")
+
+        changed, newHook = self.moduleUtil.update_hook(
+            hook, {"push_events_branch_filter": "^(main|release/.*)$", "branch_filter_strategy": "regex"}
+        )
+
+        self.assertEqual(changed, True)
+        self.assertEqual(newHook.push_events_branch_filter, "^(main|release/.*)$")
+        self.assertEqual(newHook.branch_filter_strategy, "regex")
+
+        # Not specifying the strategy must leave the one configured on the hook alone
+        changed, newHook = self.moduleUtil.update_hook(hook, {"branch_filter_strategy": None})
+
+        self.assertEqual(changed, False)
+        self.assertEqual(newHook.branch_filter_strategy, "regex")
+
+    @with_httmock(resp_get_project)
+    @with_httmock(resp_find_project_hook)
     @with_httmock(resp_delete_project_hook)
     def test_delete_hook(self):
         project = self.gitlab_instance.projects.get(1)


### PR DESCRIPTION
##### SUMMARY
The GitLab project webhook API decides how `push_events_branch_filter` is applied through the `branch_filter_strategy` field: as a wildcard (the GitLab default), as a regular expression, or not at all (`all_branches`). The module only ever sent the filter itself, so hooks matching branches by a regular expression could not be managed with Ansible.

Add a `branch_filter_strategy` option with those three choices. It has no default: when it is not set, nothing is sent when creating a hook and the strategy of an existing hook is left untouched, so playbooks that do not use the option cannot silently reset a hook configured with `regex` or `all_branches`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`gitlab_hook` module
