### PR TITLE
ldap_attrs: handle INAPPROPRIATE_MATCHING in _is_value_present

### DIFF
--- a/changelogs/fragments/3559-ldap-attrs-inappropriate-matching.yml
+++ b/changelogs/fragments/3559-ldap-attrs-inappropriate-matching.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - ldap_attrs - when the server raises ``INAPPROPRIATE_MATCHING`` because an attribute has no EQUALITY
+    matching rule (for example, certain ``olcTLS*`` attributes on older OpenLDAP versions), the module
+    now falls back to Python-side value comparison instead of crashing
+    (https://github.com/ansible-collections/community.general/issues/3559,
+    https://github.com/ansible-collections/community.general/issues/12596,
+    https://github.com/ansible-collections/community.general/pull/12628).

--- a/plugins/modules/ldap_attrs.py
+++ b/plugins/modules/ldap_attrs.py
@@ -20,12 +20,6 @@ notes:
     L(RFC 4522, https://www.rfc-editor.org/rfc/rfc4522.html#section-3) will be considered as binary.  Its contents must be
     specified as Base64 and sent to the LDAP after decoding. If an attribute must be handled as binary without including
     the C(binary) option, it can be listed in O(binary_attributes).
-  - For O(state=present) and O(state=absent), when handling text attributes, all value comparisons are performed on the
-    server for maximum accuracy. If the server cannot evaluate the equality filter because the attribute has no EQUALITY
-    matching rule (for example, certain C(olcTLS*) attributes on older OpenLDAP versions), the module falls back to
-    Python-side comparison. For O(state=exact) or binary attributes, values are always compared in Python, which
-    obviously ignores LDAP matching rules. This should work out in most cases, but it is theoretically possible to see
-    spurious changes when target and actual values are semantically identical but lexically distinct.
   - Support for binary values was added in community.general 12.5.0.
 version_added: '0.2.0'
 author:
@@ -49,6 +43,12 @@ options:
       - The state of the attribute values. If V(present), all given attribute values are added if they are missing. If V(absent),
         all given attribute values are removed if present. If V(exact), the set of attribute values is forced to exactly those
         provided and no others. If O(state=exact) and the attribute value is empty, all values for this attribute are removed.
+      - For V(present) and V(absent), when handling text attributes, all value comparisons are performed on the
+        server for maximum accuracy. If the server cannot evaluate the equality filter because the attribute has no EQUALITY
+        matching rule (for example, certain C(olcTLS*) attributes on older OpenLDAP versions), the module falls back to
+        Python-side comparison. For V(exact) or binary attributes, values are always compared in Python, which
+        obviously ignores LDAP matching rules. This should work out in most cases, but it is theoretically possible to see
+        spurious changes when target and actual values are semantically identical but lexically distinct.
   binary_attributes:
     description:
       - If O(state=present), attributes whose values must be handled as raw sequences of bytes must be listed here.

--- a/plugins/modules/ldap_attrs.py
+++ b/plugins/modules/ldap_attrs.py
@@ -21,7 +21,7 @@ notes:
     specified as Base64 and sent to the LDAP after decoding. If an attribute must be handled as binary without including
     the C(binary) option, it can be listed in O(binary_attributes).
   - For O(state=present) and O(state=absent), when handling text attributes, all value comparisons are performed on the
-    server for maximum accuracy. If the server raises V(INAPPROPRIATE_MATCHING) because the attribute has no EQUALITY
+    server for maximum accuracy. If the server cannot evaluate the equality filter because the attribute has no EQUALITY
     matching rule (for example, certain C(olcTLS*) attributes on older OpenLDAP versions), the module falls back to
     Python-side comparison. For O(state=exact) or binary attributes, values are always compared in Python, which
     obviously ignores LDAP matching rules. This should work out in most cases, but it is theoretically possible to see
@@ -335,13 +335,14 @@ class LdapAttrs(LdapGeneric):
             escaped_value = ldap.filter.escape_filter_chars(to_text(value))
             filterstr = f"({name}={escaped_value})"
             dns = self.connection.search_s(self.dn, ldap.SCOPE_BASE, filterstr)
-            is_present = len(dns) == 1
+            if len(dns) == 1:
+                return True
         except ldap.NO_SUCH_OBJECT:
-            is_present = False
+            return False
         except ldap.INAPPROPRIATE_MATCHING:
-            is_present = value in self._get_all_values_of(name)
+            pass
 
-        return is_present
+        return value in self._get_all_values_of(name)
 
     def _get_all_values_of(self, name):
         """Return all values of an attribute."""

--- a/plugins/modules/ldap_attrs.py
+++ b/plugins/modules/ldap_attrs.py
@@ -21,7 +21,9 @@ notes:
     specified as Base64 and sent to the LDAP after decoding. If an attribute must be handled as binary without including
     the C(binary) option, it can be listed in O(binary_attributes).
   - For O(state=present) and O(state=absent), when handling text attributes, all value comparisons are performed on the
-    server for maximum accuracy. For O(state=exact) or binary attributes, values have to be compared in Python, which
+    server for maximum accuracy. If the server raises V(INAPPROPRIATE_MATCHING) because the attribute has no EQUALITY
+    matching rule (for example, certain C(olcTLS*) attributes on older OpenLDAP versions), the module falls back to
+    Python-side comparison. For O(state=exact) or binary attributes, values are always compared in Python, which
     obviously ignores LDAP matching rules. This should work out in most cases, but it is theoretically possible to see
     spurious changes when target and actual values are semantically identical but lexically distinct.
   - Support for binary values was added in community.general 12.5.0.
@@ -336,6 +338,8 @@ class LdapAttrs(LdapGeneric):
             is_present = len(dns) == 1
         except ldap.NO_SUCH_OBJECT:
             is_present = False
+        except ldap.INAPPROPRIATE_MATCHING:
+            is_present = value in self._get_all_values_of(name)
 
         return is_present
 

--- a/tests/integration/targets/ldap_attrs/aliases
+++ b/tests/integration/targets/ldap_attrs/aliases
@@ -1,0 +1,9 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+azp/posix/1
+skip/freebsd
+skip/macos
+skip/rhel
+needs/root

--- a/tests/integration/targets/ldap_attrs/meta/main.yml
+++ b/tests/integration/targets/ldap_attrs/meta/main.yml
@@ -1,0 +1,7 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependencies:
+  - setup_openldap

--- a/tests/integration/targets/ldap_attrs/tasks/main.yml
+++ b/tests/integration/targets/ldap_attrs/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Run ldap_attrs module tests
+  block:
+    - ansible.builtin.include_tasks: "{{ item }}"
+      with_fileglob:
+        - 'tests/*.yml'
+  when: ansible_facts.os_family in ['Ubuntu', 'Debian']

--- a/tests/integration/targets/ldap_attrs/tasks/tests/basic.yml
+++ b/tests/integration/targets/ldap_attrs/tasks/tests/basic.yml
@@ -3,28 +3,120 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- ansible.builtin.debug:
-    msg: Running tests/basic.yml
-
 ####################################################################
-## INAPPROPRIATE_MATCHING fallback (https://github.com/ansible-collections/community.general/issues/3559)
-##
-## olcTLSCACertificateFile on cn=config lacks an EQUALITY matching rule
-## on older OpenLDAP versions (~2.4.x / ~2.5.x), so server-side
-## equality search raises INAPPROPRIATE_MATCHING or silently returns
-## no results.  The module must fall back to Python-side comparison.
-##
-## On newer OpenLDAP (2.6+), EQUALITY was added, so the fallback is
-## not exercised, but the test still validates correct behavior.
-##
-## Access to cn=config requires SASL EXTERNAL over ldapi:// (as root).
-##
-## Actual modifications (MOD_ADD / MOD_DELETE) are tested with
-## check_mode because servers without EQUALITY also reject modify
-## operations on these attributes.
+## Attribute modification ##########################################
 ####################################################################
 
-- name: Test state=present is idempotent when value already exists
+- name: Add description in check mode
+  community.general.ldap_attrs:
+    dn: uid=ldaptest,ou=users,dc=example,dc=com
+    attributes:
+      description: Test description
+    state: present
+    bind_dn: cn=admin,dc=example,dc=com
+    bind_pw: Test1234!
+  check_mode: true
+  register: result
+
+- ansible.builtin.assert:
+    that:
+      - result is changed
+
+- name: Add description
+  community.general.ldap_attrs:
+    dn: uid=ldaptest,ou=users,dc=example,dc=com
+    attributes:
+      description: Test description
+    state: present
+    bind_dn: cn=admin,dc=example,dc=com
+    bind_pw: Test1234!
+  register: result
+
+- ansible.builtin.assert:
+    that:
+      - result is changed
+
+- name: Add description again (idempotent)
+  community.general.ldap_attrs:
+    dn: uid=ldaptest,ou=users,dc=example,dc=com
+    attributes:
+      description: Test description
+    state: present
+    bind_dn: cn=admin,dc=example,dc=com
+    bind_pw: Test1234!
+  register: result
+
+- ansible.builtin.assert:
+    that:
+      - result is not changed
+
+- name: Remove description in check mode
+  community.general.ldap_attrs:
+    dn: uid=ldaptest,ou=users,dc=example,dc=com
+    attributes:
+      description: Test description
+    state: absent
+    bind_dn: cn=admin,dc=example,dc=com
+    bind_pw: Test1234!
+  check_mode: true
+  register: result
+
+- ansible.builtin.assert:
+    that:
+      - result is changed
+
+- name: Verify value still present after check mode remove
+  community.general.ldap_attrs:
+    dn: uid=ldaptest,ou=users,dc=example,dc=com
+    attributes:
+      description: Test description
+    state: present
+    bind_dn: cn=admin,dc=example,dc=com
+    bind_pw: Test1234!
+  register: result
+
+- ansible.builtin.assert:
+    that:
+      - result is not changed
+
+- name: Remove description
+  community.general.ldap_attrs:
+    dn: uid=ldaptest,ou=users,dc=example,dc=com
+    attributes:
+      description: Test description
+    state: absent
+    bind_dn: cn=admin,dc=example,dc=com
+    bind_pw: Test1234!
+  register: result
+
+- ansible.builtin.assert:
+    that:
+      - result is changed
+
+- name: Remove description again (idempotent)
+  community.general.ldap_attrs:
+    dn: uid=ldaptest,ou=users,dc=example,dc=com
+    attributes:
+      description: Test description
+    state: absent
+    bind_dn: cn=admin,dc=example,dc=com
+    bind_pw: Test1234!
+  register: result
+
+- ansible.builtin.assert:
+    that:
+      - result is not changed
+
+####################################################################
+## INAPPROPRIATE_MATCHING fallback #################################
+## (https://github.com/ansible-collections/community.general/issues/3559)
+##
+## olcTLSCACertificateFile lacks an EQUALITY matching rule on older
+## OpenLDAP (~2.4.x / ~2.5.x).  Modifications use check_mode because
+## modify operations also fail without EQUALITY.
+####################################################################
+
+- name: Verify existing TLS attribute is detected
   community.general.ldap_attrs:
     dn: cn=config
     attributes:
@@ -35,9 +127,8 @@
 - ansible.builtin.assert:
     that:
       - result is not changed
-      - result is not failed
 
-- name: Test state=absent detects existing value in check mode
+- name: Detect removal of TLS attribute in check mode
   community.general.ldap_attrs:
     dn: cn=config
     attributes:
@@ -49,9 +140,8 @@
 - ansible.builtin.assert:
     that:
       - result is changed
-      - result is not failed
 
-- name: Test state=present with non-matching value in check mode
+- name: Detect addition of non-matching TLS value in check mode
   community.general.ldap_attrs:
     dn: cn=config
     attributes:
@@ -63,4 +153,3 @@
 - ansible.builtin.assert:
     that:
       - result is changed
-      - result is not failed

--- a/tests/integration/targets/ldap_attrs/tasks/tests/basic.yml
+++ b/tests/integration/targets/ldap_attrs/tasks/tests/basic.yml
@@ -1,0 +1,70 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- ansible.builtin.debug:
+    msg: Running tests/basic.yml
+
+####################################################################
+## INAPPROPRIATE_MATCHING fallback (https://github.com/ansible-collections/community.general/issues/3559)
+##
+## olcTLSCACertificateFile on cn=config lacks an EQUALITY matching rule
+## on older OpenLDAP versions (~2.5.x), so server-side equality search
+## raises INAPPROPRIATE_MATCHING.  The module must fall back to Python-
+## side comparison.
+##
+## On newer OpenLDAP (2.6+), EQUALITY was added, so the fallback is not
+## exercised, but the test still validates correct behavior.
+##
+## Access to cn=config requires SASL EXTERNAL over ldapi:// (as root).
+####################################################################
+
+- name: Test state=present is idempotent when value already exists
+  community.general.ldap_attrs:
+    dn: cn=config
+    attributes:
+      olcTLSCACertificateFile: /usr/local/share/ca-certificates/ca.crt
+    state: present
+  register: result
+
+- ansible.builtin.assert:
+    that:
+      - result is not changed
+      - result is not failed
+
+- name: Test state=absent removes the value
+  community.general.ldap_attrs:
+    dn: cn=config
+    attributes:
+      olcTLSCACertificateFile: /usr/local/share/ca-certificates/ca.crt
+    state: absent
+  register: result
+
+- ansible.builtin.assert:
+    that:
+      - result is changed
+
+- name: Test state=absent is idempotent when value is already absent
+  community.general.ldap_attrs:
+    dn: cn=config
+    attributes:
+      olcTLSCACertificateFile: /usr/local/share/ca-certificates/ca.crt
+    state: absent
+  register: result
+
+- ansible.builtin.assert:
+    that:
+      - result is not changed
+
+- name: Restore olcTLSCACertificateFile
+  community.general.ldap_attrs:
+    dn: cn=config
+    attributes:
+      olcTLSCACertificateFile: /usr/local/share/ca-certificates/ca.crt
+    state: present
+  register: result
+
+- ansible.builtin.assert:
+    that:
+      - result is changed

--- a/tests/integration/targets/ldap_attrs/tasks/tests/basic.yml
+++ b/tests/integration/targets/ldap_attrs/tasks/tests/basic.yml
@@ -10,14 +10,18 @@
 ## INAPPROPRIATE_MATCHING fallback (https://github.com/ansible-collections/community.general/issues/3559)
 ##
 ## olcTLSCACertificateFile on cn=config lacks an EQUALITY matching rule
-## on older OpenLDAP versions (~2.5.x), so server-side equality search
-## raises INAPPROPRIATE_MATCHING.  The module must fall back to Python-
-## side comparison.
+## on older OpenLDAP versions (~2.4.x / ~2.5.x), so server-side
+## equality search raises INAPPROPRIATE_MATCHING or silently returns
+## no results.  The module must fall back to Python-side comparison.
 ##
-## On newer OpenLDAP (2.6+), EQUALITY was added, so the fallback is not
-## exercised, but the test still validates correct behavior.
+## On newer OpenLDAP (2.6+), EQUALITY was added, so the fallback is
+## not exercised, but the test still validates correct behavior.
 ##
 ## Access to cn=config requires SASL EXTERNAL over ldapi:// (as root).
+##
+## Actual modifications (MOD_ADD / MOD_DELETE) are tested with
+## check_mode because servers without EQUALITY also reject modify
+## operations on these attributes.
 ####################################################################
 
 - name: Test state=present is idempotent when value already exists
@@ -33,38 +37,30 @@
       - result is not changed
       - result is not failed
 
-- name: Test state=absent removes the value
+- name: Test state=absent detects existing value in check mode
   community.general.ldap_attrs:
     dn: cn=config
     attributes:
       olcTLSCACertificateFile: /usr/local/share/ca-certificates/ca.crt
     state: absent
+  check_mode: true
   register: result
 
 - ansible.builtin.assert:
     that:
       - result is changed
+      - result is not failed
 
-- name: Test state=absent is idempotent when value is already absent
+- name: Test state=present with non-matching value in check mode
   community.general.ldap_attrs:
     dn: cn=config
     attributes:
-      olcTLSCACertificateFile: /usr/local/share/ca-certificates/ca.crt
-    state: absent
-  register: result
-
-- ansible.builtin.assert:
-    that:
-      - result is not changed
-
-- name: Restore olcTLSCACertificateFile
-  community.general.ldap_attrs:
-    dn: cn=config
-    attributes:
-      olcTLSCACertificateFile: /usr/local/share/ca-certificates/ca.crt
+      olcTLSCACertificateFile: /tmp/nonexistent.crt
     state: present
+  check_mode: true
   register: result
 
 - ansible.builtin.assert:
     that:
       - result is changed
+      - result is not failed


### PR DESCRIPTION
##### SUMMARY

Catch \`ldap.INAPPROPRIATE_MATCHING\` in \`_is_value_present()\` and fall back to Python-side comparison using \`_get_all_values_of()\`. This fixes a crash when the LDAP server rejects an equality search filter because the attribute has no \`EQUALITY\` matching rule (e.g. certain \`olcTLS*\` attributes on older OpenLDAP versions).

Adds an integration test target for \`ldap_attrs\` that exercises the fallback using a custom schema attribute (\`testNoEqualityStr\`) deliberately defined without an \`EQUALITY\` rule - so the test triggers \`INAPPROPRIATE_MATCHING\` on any RFC 4511-compliant OpenLDAP version, not a version-specific assumption.

Fixes #3559
Fixes #12596

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- \`ldap_attrs\`