### PR TITLE
keycloak_user: fix attributes always reporting changed=True

### DIFF
--- a/changelogs/fragments/12629-keycloak-user-attributes-fix.yml
+++ b/changelogs/fragments/12629-keycloak-user-attributes-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_user - fix attributes always reporting changed=True due to a type mismatch between the raw Keycloak representation and the module's list representation (https://github.com/ansible-collections/community.general/pull/12629).

--- a/plugins/modules/keycloak_user.py
+++ b/plugins/modules/keycloak_user.py
@@ -542,10 +542,19 @@ def main():
                 "groups",
                 "clientConsents",
                 "federatedIdentities",
+                "state",
             ]
+
+            before_user_for_compare = before_user
+            if "attributes" in changeset and "attributes" in before_user:
+                before_user_for_compare = before_user.copy()
+                before_user_for_compare["attributes"] = kc.convert_keycloak_user_attributes_dict_to_module_list(
+                    attributes=before_user["attributes"]
+                )
+
             # Compare users
             if not (
-                is_struct_included(desired_user, before_user, excludes, empty_list_result=False)
+                is_struct_included(desired_user, before_user_for_compare, excludes, empty_list_result=False)
             ):  # If the new user introduces a change to the existing user
                 # Update the user
                 if not module.check_mode:


### PR DESCRIPTION
##### SUMMARY
Hi everyone! I am opening this tiny PR because while I was using the `keycloak_user` module I realized that when specifying the `attributes` field, the task always returns the `changed` status `true`, even if nothing have actually changed.

Looking at the code, it seems to me that this happens because `desired_user['attributes']` is always a *list* of `{name, values, state}` dicts, but `before_user['attributes']` is left as the *raw dict* Keycloak returns (e.g. `{"foo": ["bar"]}`). However comparing a list to a dict will always fail the check in `is_struct_included`, thus the module reports `changed=True` on every run once a user has any attributes.

My proposed fix is to convert `before_user` to a list before the check, but using a copy of the variable instead of the original one, in order not to break other parts of the code that use it. Also, the `state` must be excluded from the comparison since this field is not present in Keycloak's response.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
keycloak_user

#### REFERENCE PR
https://github.com/ansible-middleware/keycloak/pull/399