### PR TITLE
proton_pass lookup: update pass-cli handling

### DIFF
--- a/changelogs/fragments/12639-proton-pass-cli.yml
+++ b/changelogs/fragments/12639-proton-pass-cli.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proton_pass lookup plugin - use ``pass-cli info`` instead of the removed ``pass-cli test`` command when checking for an active session, restoring session detection with ``pass-cli`` 2.2.4 and later (https://github.com/ansible-collections/community.general/pull/12639).

--- a/plugins/lookup/proton_pass.py
+++ b/plugins/lookup/proton_pass.py
@@ -360,7 +360,7 @@ class ProtonPassClient:
 
     def test_session(self) -> bool:
         """Return True when an active pass-cli session exists."""
-        rc, *_ignored = self._run(["test"])
+        rc, *_ignored = self._run(["info"])
         return rc == 0
 
     def login_with_pat(self, pat: str) -> None:
@@ -442,17 +442,19 @@ class ProtonPassClient:
 def _raise_item_error(title: str, vault: str, field: str | None, stderr: str) -> None:
     """Translate pass-cli stderr into a descriptive AnsibleLookupError."""
     msg = stderr.strip()
+    msg_lower = msg.lower()
     vault_hint = f" in vault '{vault}'" if vault else ""
     field_hint = f", field '{field}'" if field else ""
 
-    lower = msg.lower()
-    if "not found" in lower or "no items found" in lower:
-        raise AnsibleLookupError(
+    if "not found" in msg_lower or "no items found" in msg_lower:
+        error_msg = (
             f"Item '{title}'{vault_hint} not found in Proton Pass{field_hint}. Verify the item title and vault name."
         )
-    if "unauthorized" in lower or "unauthenticated" in lower:
-        raise AnsibleLookupError(f"pass-cli authentication error: {msg}. Re-run 'pass-cli login' or refresh your PAT.")
-    raise AnsibleLookupError(f"pass-cli failed for item '{title}'{vault_hint}{field_hint}: {msg}")
+    elif "unauthorized" in msg_lower or "unauthenticated" in msg_lower:
+        error_msg = f"pass-cli authentication error: {msg}. Re-run 'pass-cli login' or refresh your PAT."
+    else:
+        error_msg = f"pass-cli failed for item '{title}'{vault_hint}{field_hint}: {msg}"
+    raise AnsibleLookupError(error_msg)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/plugins/lookup/test_proton_pass.py
+++ b/tests/unit/plugins/lookup/test_proton_pass.py
@@ -293,11 +293,12 @@ class TestRaiseItemError(unittest.TestCase):
         with self.assertRaises(AnsibleLookupError) as ctx:
             _raise_item_error("vm", "vault", None, "Error: unauthorized access")
         self.assertIn("authentication", str(ctx.exception).lower())
+        self.assertIn("Error: unauthorized access", str(ctx.exception))
 
     def test_generic_error(self):
         with self.assertRaises(AnsibleLookupError) as ctx:
-            _raise_item_error("vm", "vault", "api_key", "unexpected failure")
-        self.assertIn("unexpected failure", str(ctx.exception))
+            _raise_item_error("vm", "vault", "api_key", "Unexpected Failure")
+        self.assertIn("Unexpected Failure", str(ctx.exception))
         self.assertIn("api_key", str(ctx.exception))
 
 
@@ -370,6 +371,7 @@ class TestProtonPassClientAuth(unittest.TestCase):
         mock_popen.return_value = _make_popen_mock(0, b"", b"")
         client = ProtonPassClient(cli_path="pass-cli", timeout=30, agent_reason="")
         self.assertTrue(client.test_session())
+        self.assertEqual(mock_popen.call_args.args[0], ["pass-cli", "info"])
 
     @patch("ansible_collections.community.general.plugins.lookup.proton_pass.Popen")
     def test_test_session_returns_false_on_nonzero(self, mock_popen):


### PR DESCRIPTION
Summary:

  - Replace the removed pass-cli test command with pass-cli info when checking for an active session.
  - Add a regression assertion for the session-check command.
  - Simplify pass-cli error handling by constructing the appropriate message before raising AnsibleLookupError.

  Testing:

  - Targeted unit tests: 47 passed.