### PR TITLE
haproxy: fix the drain guard for servers that are already down

### DIFF
--- a/changelogs/fragments/9020-haproxy-drain-down-guard.yml
+++ b/changelogs/fragments/9020-haproxy-drain-down-guard.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - haproxy - fix ``state=disabled`` with ``drain=true`` timing out instead of putting a server that is already down into maintenance mode (https://github.com/ansible-collections/community.general/issues/9020, https://github.com/ansible-collections/community.general/pull/12640).

--- a/plugins/modules/haproxy.py
+++ b/plugins/modules/haproxy.py
@@ -334,7 +334,7 @@ class HAProxy:
 
             if state is not None:
                 self.execute(Template(cmd).substitute(pxname=backend, svname=svname))
-                if self.wait and not (wait_for_status == "DRAIN" and state == "DOWN"):
+                if self.wait and not (wait_for_status == "DRAIN" and "DOWN" in state[0]["status"]):
                     self.wait_until_status(backend, svname, wait_for_status)
 
     def get_state_for(self, pxname, svname):

--- a/tests/unit/plugins/modules/test_haproxy.py
+++ b/tests/unit/plugins/modules/test_haproxy.py
@@ -6,13 +6,14 @@ from __future__ import annotations
 
 from unittest import mock
 
-from ansible_collections.community.general.plugins.modules import haproxy
-from ansible_collections.community.general.tests.unit.plugins.modules.utils import (
+from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
     AnsibleExitJson,
     AnsibleFailJson,
     ModuleTestCase,
     set_module_args,
 )
+
+from ansible_collections.community.general.plugins.modules import haproxy
 
 STAT_HEADER = (
     "# pxname,svname,qcur,qmax,scur,smax,slim,stot,bin,bout,dreq,dresp,ereq,econ,"

--- a/tests/unit/plugins/modules/test_haproxy.py
+++ b/tests/unit/plugins/modules/test_haproxy.py
@@ -1,0 +1,95 @@
+# Copyright (c) Ansible project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from unittest import mock
+
+from ansible_collections.community.general.plugins.modules import haproxy
+from ansible_collections.community.general.tests.unit.plugins.modules.utils import (
+    AnsibleExitJson,
+    AnsibleFailJson,
+    ModuleTestCase,
+    set_module_args,
+)
+
+STAT_HEADER = (
+    "# pxname,svname,qcur,qmax,scur,smax,slim,stot,bin,bout,dreq,dresp,ereq,econ,"
+    "eresp,wretr,wredis,status,weight,act,bck,chkfail,chkdown,lastchg,downtime,"
+    "qlimit,pid,iid,sid,throttle,lbtot,tracked,type,rate,rate_lim,rate_max,"
+)
+
+
+class FakeSocket:
+    def __init__(self, status, scur=0):
+        self.status = status
+        self.scur = scur
+        self.commands = []
+
+    def __call__(self, cmd, timeout=200, capture_output=True):
+        self.commands.append(cmd)
+
+        if cmd == "show info":
+            return "Name: HAProxy\nVersion: 2.8.0\n"
+
+        if cmd == "show stat":
+            rows = [
+                STAT_HEADER,
+                f"bk_test,srv,0,0,{self.scur},0,,0,0,0,,0,,0,0,0,0,{self.status},1,1,0,0,0,0,0,,1,3,1,,0,,2,0,,0,,,",
+                f"bk_test,BACKEND,0,0,{self.scur},0,200,0,0,0,0,0,,0,0,0,0,UP,1,1,0,,0,0,0,,1,3,0,,0,,1,0,,0,,,",
+            ]
+            return "\n".join(rows) + "\n"
+
+        if "state drain" in cmd and not self.status.startswith("DOWN"):
+            self.status = "DRAIN"
+        if "disable server" in cmd:
+            self.status = "MAINT"
+        return ""
+
+
+class TestHAProxyDrain(ModuleTestCase):
+    def run_disable(self, status, scur=0):
+        fake = FakeSocket(status, scur)
+        args = {
+            "state": "disabled",
+            "backend": "bk_test",
+            "host": "srv",
+            "socket": "/var/run/haproxy.sock",
+            "drain": True,
+            "wait": True,
+            "wait_retries": 3,
+            "wait_interval": 1,
+            "fail_on_not_found": True,
+        }
+        with set_module_args(args), mock.patch.object(haproxy.HAProxy, "execute", fake):
+            try:
+                haproxy.main()
+            except (AnsibleExitJson, AnsibleFailJson) as exc:
+                return fake, exc
+            raise AssertionError("the module neither succeeded nor failed")
+
+    def test_down_server_goes_to_maintenance_without_waiting_for_drain(self):
+        fake, exc = self.run_disable("DOWN")
+
+        self.assertIsInstance(exc, AnsibleExitJson)
+        self.assertEqual(fake.status, "MAINT")
+
+    def test_composite_down_status_is_recognized_as_down(self):
+        fake, exc = self.run_disable("DOWN 2/3")
+
+        self.assertIsInstance(exc, AnsibleExitJson)
+        self.assertEqual(fake.status, "MAINT")
+
+    def test_running_server_is_still_drained(self):
+        fake, exc = self.run_disable("UP")
+
+        self.assertIsInstance(exc, AnsibleExitJson)
+        self.assertEqual(fake.status, "MAINT")
+        self.assertTrue(any("state drain" in cmd for cmd in fake.commands))
+
+    def test_sessions_in_flight_still_exhaust_the_retries(self):
+        fake, exc = self.run_disable("UP", scur=4)
+
+        self.assertIsInstance(exc, AnsibleFailJson)
+        self.assertIn("not status 'DRAIN'", exc.args[0]["msg"])


### PR DESCRIPTION
##### SUMMARY

Fixes #9020.

`execute_for_backends()` is supposed to skip waiting for the `DRAIN` status when the
server is already down:

```python
if self.wait and not (wait_for_status == "DRAIN" and state == "DOWN"):
```

`state` comes from `get_state_for()`, which returns a **tuple of dicts**
(`({'status': 'DOWN', 'weight': '1', 'scur': '0'},)`). Comparing that tuple to the string
`"DOWN"` is always false, so the guard never triggers.

The wait then cannot succeed: HAProxy reports the *operational* status, so a server whose
health check fails stays `DOWN` and never reaches `DRAIN`. The module exhausts
`wait_retries` and fails, leaving the server neither drained nor in maintenance — while
`MAINT` is an administrative state it would have reached immediately.

This guard was added in #8100 to fix #8092, but `get_state_for()` already returned a tuple
at the time, so it has never had any effect.

The fix compares the status field, using substring matching rather than equality: HAProxy
reports composite statuses such as `DOWN 2/3` while a server is rising, and
`MAINT (via pxname/svname)` for tracked servers. `wait_until_status()` already matches on
substrings for that exact reason.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

haproxy

##### ADDITIONAL INFORMATION

Reproduction: a backend with a server whose health check fails, then

```yaml
- community.general.haproxy:
    state: disabled
    backend: bk_test
    host: srv_down
    socket: /var/run/haproxy/admin.sock
    drain: true
    wait: true
    wait_retries: 5
    wait_interval: 2
```

```paste below
fatal: [localhost]: FAILED! => {"changed": false, "msg": "server bk_test/srv_down not status 'DRAIN' after 5 retries. Aborting."}
```

Measured against a real HAProxy over its admin socket, running the same call with the
module as shipped, with the `==` fix suggested in #9020, and with the substring fix in
this PR:

| scenario | reported status | current | `== "DOWN"` | this PR |
|---|---|---|---|---|
| down, no sessions | `DOWN` | **fails, 8.2s** | ok, 0.3s | ok, 0.3s |
| down, rising | `DOWN 12/60` | **fails, 8.2s** | **fails, 8.3s** | ok, 0.3s |
| up, sessions in flight | `UP` scur=3 | fails, 8.3s | fails, 8.3s | fails, 8.3s |
| up, no session | `UP` | ok, 0.3s | ok, 0.4s | ok, 0.4s |

The last two rows are the non-regression: on a running server, with or without traffic,
behaviour is unchanged — a legitimate drain is still waited for. The second row is why
this PR matches on a substring instead of comparing for equality.

Same results on HAProxy 2.2, 2.6, 2.8, 3.0 and 3.2, so this does not depend on the HAProxy
version.

There were no unit tests for this module; this PR adds four, covering the two rows fixed
here and the two that must keep their current behaviour. They fail on the first two cases
without the one-line change.

Note that #12286 reports a related but distinct problem in `wait_until_status()` (the
`scur` check being nested under the status check). This PR does not address it.
