### PR TITLE
incus connection plugin: add remote_user_id_command option

### DIFF
--- a/changelogs/fragments/12646-incus-remote-user-id-command.yml
+++ b/changelogs/fragments/12646-incus-remote-user-id-command.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - incus connection plugin - add ``remote_user_id_command`` option to configure the command used to retrieve the UID and GID of the remote user (https://github.com/ansible-collections/community.general/pull/12646).

--- a/plugins/connection/incus.py
+++ b/plugins/connection/incus.py
@@ -67,6 +67,18 @@ options:
     keyword:
       - name: remote_user
     version_added: 10.4.0
+  remote_user_id_command:
+    description:
+      - Command used to retrieve the remote UID and GID of O(remote_user).
+      - Is used to set the ownership of files copied with C(put_file) when O(remote_user) is not V(root).
+      - The command is run inside the instance twice, once with the argument C(-u) to retrieve the UID and once with C(-g) to retrieve
+        the GID.
+      - In both cases the command must write the numeric ID, and nothing else, to standard output.
+    type: str
+    default: /bin/id
+    vars:
+      - name: ansible_incus_user_id_command
+    version_added: 13.4.0
   project:
     description:
       - The name of the Incus project to use (per C(incus project list)).
@@ -253,12 +265,14 @@ class Connection(ConnectionBase):
     def _get_remote_uid_gid(self) -> tuple[int, int]:
         """Get the user and group ID of 'remote_user' from the instance."""
 
-        rc, uid_out, err = self.exec_command("/bin/id -u")
+        id_cmd = self.get_option("remote_user_id_command")
+
+        rc, uid_out, err = self.exec_command(f"{id_cmd} -u")
         if rc != 0:
             raise AnsibleError(f"Failed to get remote uid for user {self.get_option('remote_user')}: {err}")
         uid = uid_out.strip()
 
-        rc, gid_out, err = self.exec_command("/bin/id -g")
+        rc, gid_out, err = self.exec_command(f"{id_cmd} -g")
         if rc != 0:
             raise AnsibleError(f"Failed to get remote gid for user {self.get_option('remote_user')}: {err}")
         gid = gid_out.strip()

--- a/tests/unit/plugins/connection/test_incus.py
+++ b/tests/unit/plugins/connection/test_incus.py
@@ -357,3 +357,36 @@ def test_fetch_file_transfer_success(mocker):
     mocker.patch("ansible_collections.community.general.plugins.connection.incus.Popen", return_value=process)
 
     conn.fetch_file("/tmp/src", "/tmp/dest")
+
+
+def test_get_remote_uid_gid_default_command(mocker):
+    """By default ``/bin/id`` is used to resolve the remote UID and GID."""
+    conn = _make_conn(mocker)
+
+    exec_command = mocker.patch.object(conn, "exec_command", side_effect=[(0, "1001\n", ""), (0, "2002\n", "")])
+
+    assert conn._get_remote_uid_gid() == (1001, 2002)
+    assert [call.args[0] for call in exec_command.call_args_list] == ["/bin/id -u", "/bin/id -g"]
+
+
+def test_get_remote_uid_gid_custom_command(mocker):
+    """``remote_user_id_command`` overrides the command used to resolve the remote UID and GID."""
+    conn = _make_conn(mocker)
+    conn.set_option("remote_user_id_command", "/usr/bin/id")
+
+    exec_command = mocker.patch.object(conn, "exec_command", side_effect=[(0, "1001\n", ""), (0, "2002\n", "")])
+
+    assert conn._get_remote_uid_gid() == (1001, 2002)
+    assert [call.args[0] for call in exec_command.call_args_list] == ["/usr/bin/id -u", "/usr/bin/id -g"]
+
+
+def test_get_remote_uid_gid_failure(mocker):
+    """A failing ``id`` command must raise instead of returning bogus IDs."""
+    conn = _make_conn(mocker)
+
+    mocker.patch.object(conn, "exec_command", return_value=(1, "", "id: command not found"))
+
+    with pytest.raises(AnsibleError) as exc:
+        conn._get_remote_uid_gid()
+
+    assert "Failed to get remote uid for user root" in str(exc.value)


### PR DESCRIPTION
##### SUMMARY

The command used to look up the UID and GID of `remote_user` was hardcoded to `/bin/id`, which does not exist on every instance image. The new `remote_user_id` option makes that command configurable, defaulting to `/bin/id` so existing behavior is unchanged.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

incus

##### ADDITIONAL INFORMATION

The lookup only happens when `remote_user` is not `root`, where it determines the ownership of files transferred by `put_file`.

```yaml
- hosts: my_instance
  vars:
    ansible_connection: community.general.incus
    ansible_user: someuser
    ansible_incus_user_id: /usr/bin/id
  tasks:
    - ansible.builtin.copy:
        src: payload.txt
        dest: /home/someuser/payload.txt
```
