### PR TITLE
zypper: add `install_recommends` option

### DIFF
--- a/changelogs/fragments/12648-zypper-install-recommends.yml
+++ b/changelogs/fragments/12648-zypper-install-recommends.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zypper - add ``install_recommends`` option to explicitly control installation of recommended packages (https://github.com/ansible-collections/community.general/issues/3497, https://github.com/ansible-collections/community.general/pull/12648).

--- a/plugins/modules/zypper.py
+++ b/plugins/modules/zypper.py
@@ -97,6 +97,7 @@ options:
       - If not set, neither option is passed to I(zypper) and its configured default applies (option C(solver.onlyRequires)
         in C(zypp.conf)).
       - Mutually exclusive with O(disable_recommends).
+      - This option is only used during installation and not for idempotency checks.
     type: bool
     version_added: 13.4.0
   force:

--- a/plugins/modules/zypper.py
+++ b/plugins/modules/zypper.py
@@ -85,8 +85,20 @@ options:
     description:
       - Corresponds to the C(--no-recommends) option for I(zypper). Default behavior (V(true)) modifies zypper's default behavior;
         V(false) does install recommended packages.
+      - Mutually exclusive with O(install_recommends).
+      - This option will be deprecated in the future in favor of O(install_recommends).
     default: true
     type: bool
+  install_recommends:
+    description:
+      - Corresponds to the C(--recommends) and C(--no-recommends) options for I(zypper).
+      - If set to V(true), recommended packages are installed (C(--recommends) is passed to I(zypper)).
+      - If set to V(false), recommended packages are not installed (C(--no-recommends) is passed to I(zypper)).
+      - If not set, neither option is passed to I(zypper) and its configured default applies (option C(solver.onlyRequires)
+        in C(zypp.conf)).
+      - Mutually exclusive with O(disable_recommends).
+    type: bool
+    version_added: 13.4.0
   force:
     description:
       - Adds C(--force) option to I(zypper). Allows to downgrade packages and change vendor or architecture.
@@ -171,7 +183,7 @@ EXAMPLES = r"""
   community.general.zypper:
     name: apache2
     state: present
-    disable_recommends: false
+    install_recommends: true
 
 - name: Apply a given patch
   community.general.zypper:
@@ -432,7 +444,9 @@ def get_cmd(m, subcommand):
         cmd.append("--dry-run")
     if is_install:
         cmd.append("--auto-agree-with-licenses")
-        if m.params["disable_recommends"]:
+        if m.params["install_recommends"] is not None:
+            cmd.append("--recommends" if m.params["install_recommends"] else "--no-recommends")
+        elif m.params["disable_recommends"]:
             cmd.append("--no-recommends")
         if m.params["force"]:
             cmd.append("--force")
@@ -609,6 +623,7 @@ def main():
             disable_gpg_check=dict(default=False, type="bool"),
             auto_import_keys=dict(default=False, type="bool"),
             disable_recommends=dict(default=True, type="bool"),
+            install_recommends=dict(type="bool"),
             force=dict(default=False, type="bool"),
             force_resolution=dict(default=False, type="bool"),
             update_cache=dict(aliases=["refresh"], default=False, type="bool"),
@@ -621,6 +636,7 @@ def main():
             quiet=dict(default=True, type="bool"),
             skip_post_errors=dict(default=False, type="bool"),
         ),
+        mutually_exclusive=[["disable_recommends", "install_recommends"]],
         supports_check_mode=True,
     )
 

--- a/tests/unit/plugins/modules/test_zypper.yaml
+++ b/tests/unit/plugins/modules/test_zypper.yaml
@@ -257,6 +257,52 @@ test_cases:
           out: *xml_install_nmap
           err: ''
 
+  - id: install_recommends_true
+    input:
+      name: nmap
+      state: present
+      install_recommends: true
+    output:
+      changed: true
+      rc: 0
+    mocks:
+      run_command:
+        - command: *search_nmap
+          environ: *env
+          rc: 104
+          out: *xml_search_not_installed
+          err: ''
+        - command:
+            [/testbin/zypper, --non-interactive, --xmlout, --quiet, install, --type, package,
+             --auto-agree-with-licenses, --recommends, '--', +nmap]
+          environ: *env
+          rc: 0
+          out: *xml_install_nmap
+          err: ''
+
+  - id: install_recommends_false
+    input:
+      name: nmap
+      state: present
+      install_recommends: false
+    output:
+      changed: true
+      rc: 0
+    mocks:
+      run_command:
+        - command: *search_nmap
+          environ: *env
+          rc: 104
+          out: *xml_search_not_installed
+          err: ''
+        - command:
+            [/testbin/zypper, --non-interactive, --xmlout, --quiet, install, --type, package,
+             --auto-agree-with-licenses, --no-recommends, '--', +nmap]
+          environ: *env
+          rc: 0
+          out: *xml_install_nmap
+          err: ''
+
   - id: install_quiet_false
     input:
       name: '*'


### PR DESCRIPTION
##### SUMMARY

Adds a new `install_recommends` option to the `zypper` module that maps directly to
zypper's `--recommends` / `--no-recommends` command-line flags:

- `true`: pass `--recommends` (recommended packages are installed)
- `false`: pass `--no-recommends` (recommended packages are not installed)
- unset: pass neither, so zypper's own configuration (`solver.onlyRequires` in
  `zypp.conf`) decides

The existing `disable_recommends` option only ever appends `--no-recommends` when
truthy, so setting `disable_recommends: false` does not guarantee that recommended
packages get installed - it silently relies on the system configuration. The new
option makes the intent explicit and mirrors `ansible.builtin.apt`'s
`install_recommends`.

`install_recommends` is mutually exclusive with `disable_recommends`. The default
behavior is unchanged: with `install_recommends` unset, `disable_recommends` still
defaults to `true` and `--no-recommends` is passed. 

The idea is that `disable_recommends` will be deprecated in favor of `install_recommends` in a
future release; the deprecation itself is left for a separate PR.

Ref #3497

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

zypper
