### PR TITLE
capabilities: fix idempotency across libcap versions and multi-cap input

### DIFF
--- a/changelogs/fragments/12650-capabilities-idempotent.yml
+++ b/changelogs/fragments/12650-capabilities-idempotent.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - capabilities - fix idempotency when the installed ``libcap`` normalizes capability operators or flags, or when
+    multiple capabilities are set at once (https://github.com/ansible-collections/community.general/issues/4067,
+    https://github.com/ansible-collections/community.general/pull/12650).

--- a/plugins/modules/capabilities.py
+++ b/plugins/modules/capabilities.py
@@ -28,6 +28,8 @@ options:
   capability:
     description:
       - Desired capability to set (with operator and flags, if O(state=present)) or remove (if O(state=absent)).
+      - The value is passed to C(setcap) as is, so it accepts the same syntax, including setting several capabilities
+        at once (for example V(cap_chown,cap_fowner+ep)).
     type: str
     required: true
     aliases: [cap]
@@ -38,10 +40,10 @@ options:
     choices: [absent, present]
     default: present
 notes:
-  - The capabilities system automatically transforms operators and flags into the effective set, so for example, C(cap_foo=ep)
-    probably becomes C(cap_foo+ep).
-  - This module does not attempt to determine the final operator and flags to compare, so you want to ensure that your capabilities
-    argument matches the final capabilities.
+  - Whether a change is required is determined with C(setcap --verify), so a task is reported as changed only when
+    the capabilities on O(path) actually differ from the request, regardless of how the local C(libcap) version
+    normalizes operators and flags (some versions turn C(cap_foo+ep) into C(cap_foo=ep)).
+  - When O(state=present), capabilities already set on O(path) that are not listed in O(capability) are left untouched.
 author:
   - Nate Coraor (@natefoo)
 """
@@ -76,37 +78,48 @@ class CapabilitiesModule:
         self.state = module.params["state"]
         self.getcap_cmd = module.get_bin_path("getcap", required=True)
         self.setcap_cmd = module.get_bin_path("setcap", required=True)
-        self.capability_tup = self._parse_cap(self.capability, op_required=self.state == "present")
+
+        if self.state == "present" and not any(op in self.capability for op in OPS):
+            self.module.fail_json(msg=f"Couldn't find operator (one of: {OPS})")
 
         self.run()
 
     def run(self):
         current = self.getcap(self.path)
-        caps = [cap[0] for cap in current]
+        current_names = [cap[0] for cap in current]
+        requested_names = self._requested_cap_names()
 
-        if self.state == "present" and self.capability_tup not in current:
-            # need to add capability
-            if self.module.check_mode:
-                self.module.exit_json(changed=True, msg="capabilities changed")
-            else:
-                # remove from current cap list if it is already set (but op/flags differ)
-                current = [x for x in current if x[0] != self.capability_tup[0]]
-                # add new cap with correct op/flags
-                current.append(self.capability_tup)
-                self.module.exit_json(
-                    changed=True, state=self.state, msg="capabilities changed", stdout=self.setcap(self.path, current)
-                )
-        elif self.state == "absent" and self.capability_tup[0] in caps:
-            # need to remove capability
-            if self.module.check_mode:
-                self.module.exit_json(changed=True, msg="capabilities changed")
-            else:
-                # remove from current cap list and then set current list
-                current = [x for x in current if x[0] != self.capability_tup[0]]
-                self.module.exit_json(
-                    changed=True, state=self.state, msg="capabilities changed", stdout=self.setcap(self.path, current)
-                )
-        self.module.exit_json(changed=False, state=self.state)
+        # Preserve capabilities already on the file that the user did not mention.
+        kept = [self._cap_str(cap) for cap in current if cap[0] not in requested_names]
+
+        if self.state == "present":
+            clauses = " ".join(kept + [self.capability])
+        else:
+            if not any(name in current_names for name in requested_names):
+                self.module.exit_json(changed=False, state=self.state)
+            clauses = " ".join(kept)
+
+        if clauses:
+            already_set = self._verify(clauses)
+        else:
+            # Desired state is "no capabilities": it already matches only if the file has none.
+            already_set = not current
+
+        if already_set:
+            self.module.exit_json(changed=False, state=self.state)
+
+        if self.module.check_mode:
+            # setcap --verify can report a difference that setcap would not actually apply
+            # (for example an effective-only flag without the matching permitted flag), but
+            # check mode cannot run setcap to find out for sure without mutating the file, so
+            # a reported difference is taken at face value here.
+            self.module.exit_json(changed=True, state=self.state, msg="capabilities changed")
+
+        stdout = self.setcap(self.path, clauses)
+        # Now that setcap has actually run, confirm the change by re-reading the
+        # capabilities instead of trusting the --verify result from above.
+        changed = sorted(current) != sorted(self.getcap(self.path))
+        self.module.exit_json(changed=changed, state=self.state, msg="capabilities changed", stdout=stdout)
 
     def getcap(self, path):
         rval = []
@@ -143,14 +156,35 @@ class CapabilitiesModule:
                     rval.append(self._parse_cap(cap))
         return rval
 
-    def setcap(self, path, caps):
-        caps = " ".join(["".join(cap) for cap in caps])
-        cmd = [self.setcap_cmd, caps, path]
+    def setcap(self, path, clauses):
+        cmd = [self.setcap_cmd, clauses, path]
         rc, stdout, stderr = self.module.run_command(cmd)
         if rc != 0:
             self.module.fail_json(msg=f"Unable to set capabilities of {path}", stdout=stdout, stderr=stderr)
-        else:
-            return stdout
+        return stdout
+
+    def _verify(self, clauses):
+        """Return True when setcap does not need to run because the file already matches clauses."""
+        cmd = [self.setcap_cmd, "-v", clauses, self.path]
+        rc, dummy, dummy2 = self.module.run_command(cmd)
+        return rc == 0
+
+    def _requested_cap_names(self):
+        """Return the capability names referenced by the capability parameter, ignoring operators and flags."""
+        names = []
+        for clause in self.capability.split():
+            cut = len(clause)
+            for op in OPS:
+                pos = clause.find(op)
+                if pos != -1:
+                    cut = min(cut, pos)
+            names.extend(name for name in clause[:cut].split(",") if name)
+        return names
+
+    @staticmethod
+    def _cap_str(cap):
+        name, op, flags = cap
+        return f"{name}{op}{flags}"
 
     def _parse_cap(self, cap, op_required=True):
         opind = -1

--- a/tests/unit/plugins/modules/test_capabilities.py
+++ b/tests/unit/plugins/modules/test_capabilities.py
@@ -1,0 +1,11 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from ansible_collections.community.general.plugins.modules import capabilities
+
+from .uthelper import RunCommandMock, UTHelper
+
+UTHelper.from_module(capabilities, __name__, mocks=[RunCommandMock])

--- a/tests/unit/plugins/modules/test_capabilities.yaml
+++ b/tests/unit/plugins/modules/test_capabilities.yaml
@@ -1,0 +1,283 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+---
+test_cases:
+  - id: present_set_on_file_without_caps
+    input:
+      path: /tmp/foo
+      capability: cap_sys_chroot+ep
+      state: present
+    output:
+      changed: true
+      state: present
+    mocks:
+      run_command:
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo\n"
+          err: ''
+        - command: [/testbin/setcap, -v, cap_sys_chroot+ep, /tmp/foo]
+          rc: 1
+          out: "/tmp/foo differs in [ep]\n"
+          err: ''
+        - command: [/testbin/setcap, cap_sys_chroot+ep, /tmp/foo]
+          rc: 0
+          out: ''
+          err: ''
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo cap_sys_chroot=ep\n"
+          err: ''
+
+  # Second run of the task above: newer libcap prints the capability with '='
+  # even though it was set with '+'. Must be reported as not changed.
+  - id: present_idempotent_new_libcap
+    input:
+      path: /tmp/foo
+      capability: cap_sys_chroot+ep
+      state: present
+    output:
+      changed: false
+      state: present
+    mocks:
+      run_command:
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo cap_sys_chroot=ep\n"
+          err: ''
+        - command: [/testbin/setcap, -v, cap_sys_chroot+ep, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo: OK\n"
+          err: ''
+
+  # Same, but with the output format of an older libcap ('/foo = cap...+ep').
+  - id: present_idempotent_old_libcap
+    input:
+      path: /tmp/foo
+      capability: cap_sys_chroot+ep
+      state: present
+    output:
+      changed: false
+      state: present
+    mocks:
+      run_command:
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo = cap_sys_chroot+ep\n"
+          err: ''
+        - command: [/testbin/setcap, -v, cap_sys_chroot+ep, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo: OK\n"
+          err: ''
+
+  # Several capabilities set at once, passed in a different order than getcap
+  # reports them back. Must still be idempotent.
+  - id: present_idempotent_multiple_caps
+    input:
+      path: /tmp/foo
+      capability: "cap_chown,cap_fowner,cap_dac_override=ip"
+      state: present
+    output:
+      changed: false
+      state: present
+    mocks:
+      run_command:
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo cap_chown,cap_dac_override,cap_fowner=ip\n"
+          err: ''
+        - command: [/testbin/setcap, -v, "cap_chown,cap_fowner,cap_dac_override=ip", /tmp/foo]
+          rc: 0
+          out: "/tmp/foo: OK\n"
+          err: ''
+
+  - id: present_preserves_other_capabilities
+    input:
+      path: /tmp/foo
+      capability: cap_sys_chroot+ep
+      state: present
+    output:
+      changed: true
+      state: present
+    mocks:
+      run_command:
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo cap_net_raw=ep\n"
+          err: ''
+        - command: [/testbin/setcap, -v, "cap_net_raw=ep cap_sys_chroot+ep", /tmp/foo]
+          rc: 1
+          out: "/tmp/foo differs in [ep]\n"
+          err: ''
+        - command: [/testbin/setcap, "cap_net_raw=ep cap_sys_chroot+ep", /tmp/foo]
+          rc: 0
+          out: ''
+          err: ''
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo cap_net_raw,cap_sys_chroot=ep\n"
+          err: ''
+
+  # setcap --verify claims a difference, but setcap does not actually change
+  # anything (effective flag without permitted flag). Re-reading the caps shows
+  # no change, so the task must be reported as not changed.
+  - id: present_setcap_verify_false_positive
+    input:
+      path: /tmp/foo
+      capability: cap_sys_chroot+ep
+      state: present
+    output:
+      changed: false
+      state: present
+    mocks:
+      run_command:
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo cap_sys_chroot=ep\n"
+          err: ''
+        - command: [/testbin/setcap, -v, cap_sys_chroot+ep, /tmp/foo]
+          rc: 1
+          out: "/tmp/foo differs in [e]\n"
+          err: ''
+        - command: [/testbin/setcap, cap_sys_chroot+ep, /tmp/foo]
+          rc: 0
+          out: ''
+          err: ''
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo cap_sys_chroot=ep\n"
+          err: ''
+
+  - id: present_check_mode_reports_change
+    flags:
+      check: true
+    input:
+      path: /tmp/foo
+      capability: cap_sys_chroot+ep
+      state: present
+    output:
+      changed: true
+      state: present
+    mocks:
+      run_command:
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo\n"
+          err: ''
+        - command: [/testbin/setcap, -v, cap_sys_chroot+ep, /tmp/foo]
+          rc: 1
+          out: "/tmp/foo differs in [ep]\n"
+          err: ''
+
+  - id: present_check_mode_idempotent
+    flags:
+      check: true
+    input:
+      path: /tmp/foo
+      capability: cap_sys_chroot+ep
+      state: present
+    output:
+      changed: false
+      state: present
+    mocks:
+      run_command:
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo cap_sys_chroot=ep\n"
+          err: ''
+        - command: [/testbin/setcap, -v, cap_sys_chroot+ep, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo: OK\n"
+          err: ''
+
+  - id: absent_removes_capability
+    input:
+      path: /tmp/foo
+      capability: cap_sys_chroot
+      state: absent
+    output:
+      changed: true
+      state: absent
+    mocks:
+      run_command:
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo cap_sys_chroot=ep\n"
+          err: ''
+        - command: [/testbin/setcap, '', /tmp/foo]
+          rc: 0
+          out: ''
+          err: ''
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo\n"
+          err: ''
+
+  - id: absent_keeps_other_capabilities
+    input:
+      path: /tmp/foo
+      capability: cap_sys_chroot
+      state: absent
+    output:
+      changed: true
+      state: absent
+    mocks:
+      run_command:
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo cap_net_raw,cap_sys_chroot=ep\n"
+          err: ''
+        - command: [/testbin/setcap, -v, "cap_net_raw=ep", /tmp/foo]
+          rc: 1
+          out: "/tmp/foo differs in [ep]\n"
+          err: ''
+        - command: [/testbin/setcap, "cap_net_raw=ep", /tmp/foo]
+          rc: 0
+          out: ''
+          err: ''
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo cap_net_raw=ep\n"
+          err: ''
+
+  - id: absent_noop_when_capability_missing
+    input:
+      path: /tmp/foo
+      capability: cap_sys_chroot
+      state: absent
+    output:
+      changed: false
+      state: absent
+    mocks:
+      run_command:
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo cap_net_raw=ep\n"
+          err: ''
+
+  - id: fail_when_file_missing
+    input:
+      path: /tmp/does-not-exist
+      capability: cap_sys_chroot+ep
+      state: present
+    output:
+      failed: true
+      msg: Unable to get capabilities of /tmp/does-not-exist
+    mocks:
+      run_command:
+        - command: [/testbin/getcap, -v, /tmp/does-not-exist]
+          rc: 0
+          out: "/tmp/does-not-exist (No such file or directory)\n"
+          err: ''
+
+  - id: fail_present_without_operator
+    input:
+      path: /tmp/foo
+      capability: cap_sys_chroot
+      state: present
+    output:
+      failed: true
+    mocks:
+      run_command: []

--- a/tests/unit/plugins/modules/test_capabilities.yaml
+++ b/tests/unit/plugins/modules/test_capabilities.yaml
@@ -120,6 +120,35 @@ test_cases:
           out: "/tmp/foo cap_net_raw,cap_sys_chroot=ep\n"
           err: ''
 
+  # Using '=' on a capability that is already set with extra flags must clear
+  # the flags not mentioned in the request, not merge/OR them in.
+  - id: present_equals_clears_nonmatching_flags
+    input:
+      path: /tmp/foo
+      capability: cap_sys_chroot=ep
+      state: present
+    output:
+      changed: true
+      state: present
+    mocks:
+      run_command:
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo cap_sys_chroot=eip\n"
+          err: ''
+        - command: [/testbin/setcap, -v, cap_sys_chroot=ep, /tmp/foo]
+          rc: 1
+          out: "/tmp/foo differs in [i]\n"
+          err: ''
+        - command: [/testbin/setcap, cap_sys_chroot=ep, /tmp/foo]
+          rc: 0
+          out: ''
+          err: ''
+        - command: [/testbin/getcap, -v, /tmp/foo]
+          rc: 0
+          out: "/tmp/foo cap_sys_chroot=ep\n"
+          err: ''
+
   # setcap --verify claims a difference, but setcap does not actually change
   # anything (effective flag without permitted flag). Re-reading the caps shows
   # no change, so the task must be reported as not changed.


### PR DESCRIPTION
##### SUMMARY
The `capabilities` module compared the raw user-supplied `capability` string against parsed
`getcap` output to decide whether a change was needed. That comparison always mismatched
when the local `libcap` version normalizes operators/flags differently from what was passed
in (for example `cap_foo+ep` becoming `cap_foo=ep`), and it never worked correctly when
several capabilities were set in one string — so the module reported `changed` on every run.

The module now determines whether a change is needed with `setcap --verify`, then confirms
the actual result by re-reading `getcap` after `setcap` runs (guarding against `verify`
false positives, for example an effective-only flag without the matching permitted flag).
`state=present` still preserves capabilities already on the file that are not mentioned in
the task.

Unit tests using `uthelper` were added, covering idempotency across old/new `libcap` output
formats, multiple capabilities in one string, preserving unrelated capabilities, check mode,
and both `present`/`absent` states.

Fixes #4067

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
capabilities

##### ADDITIONAL INFORMATION
See the discussion in #4067 for the various non-idempotent cases reported (operator
normalization differences across distros, and multiple capabilities passed at once).
