### PR TITLE
ipa_dnsrecord: clarify PTR record_value must be a trailing-dot FQDN

### DIFF
--- a/plugins/modules/ipa_dnsrecord.py
+++ b/plugins/modules/ipa_dnsrecord.py
@@ -47,7 +47,7 @@ options:
       - In the case of V(CNAME) record type, this is the hostname.
       - In the case of V(DNAME) record type, this is the DNAME target.
       - In the case of V(NS) record type, this is the name server hostname. Hostname must already have a valid A or AAAA record.
-      - In the case of V(PTR) record type, this is the hostname.
+      - In the case of V(PTR) record type, this is the hostname. It must be a fully qualified domain name ending with a dot.
       - In the case of V(TXT) record type, this is a text.
       - In the case of V(SRV) record type, this is a service record.
       - In the case of V(MX) record type, this is a mail exchanger record.
@@ -62,7 +62,7 @@ options:
       - In the case of V(CNAME) record type, this is the hostname.
       - In the case of V(DNAME) record type, this is the DNAME target.
       - In the case of V(NS) record type, this is the name server hostname. Hostname must already have a valid A or AAAA record.
-      - In the case of V(PTR) record type, this is the hostname.
+      - In the case of V(PTR) record type, this is the hostname. It must be a fully qualified domain name ending with a dot.
       - In the case of V(TXT) record type, this is a text.
       - In the case of V(SRV) record type, this is a service record.
       - In the case of V(MX) record type, this is a mail exchanger record.
@@ -129,7 +129,7 @@ EXAMPLES = r"""
     zone_name: 2.168.192.in-addr.arpa
     record_name: 5
     record_type: 'PTR'
-    record_value: 'internal.ipa.example.com'
+    record_value: 'internal.ipa.example.com.'
 
 - name: Ensure a TXT record is present
   community.general.ipa_dnsrecord:


### PR DESCRIPTION
##### SUMMARY
Clarify in the documentation that, for `record_type=PTR`, `record_value`/`record_values` must be a fully qualified domain name ending with a dot. Also fix the `EXAMPLES` block, which showed a PTR value without the trailing dot.

Relates to #3947

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ipa_dnsrecord

##### ADDITIONAL INFORMATION
This only documents the existing (RFC 1034/1035-compliant) behavior; it does not change module behavior.