### PR TITLE
influxdb_retention_policy - fix TypeError when altering policy without shard_group_duration

### DIFF
--- a/changelogs/fragments/3897-influxdb-retention-policy-alter-shard-group-duration.yml
+++ b/changelogs/fragments/3897-influxdb-retention-policy-alter-shard-group-duration.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - influxdb_retention_policy - fix ``TypeError`` when altering a retention policy without ``shard_group_duration`` set (https://github.com/ansible-collections/community.general/issues/3897, https://github.com/ansible-collections/community.general/pull/12652).

--- a/plugins/modules/influxdb_retention_policy.py
+++ b/plugins/modules/influxdb_retention_policy.py
@@ -281,9 +281,12 @@ def alter_retention_policy(module, client, retention_policy):
     ):
         if not module.check_mode:
             try:
-                client.alter_retention_policy(
-                    policy_name, database_name, duration, replication, default, shard_group_duration
-                )
+                if shard_group_duration:
+                    client.alter_retention_policy(
+                        policy_name, database_name, duration, replication, default, shard_group_duration
+                    )
+                else:
+                    client.alter_retention_policy(policy_name, database_name, duration, replication, default)
             except exceptions.InfluxDBClientError as e:
                 module.fail_json(msg=e.content)
         changed = True


### PR DESCRIPTION
## Summary

`alter_retention_policy()` always passes `shard_group_duration` positionally to the `influxdb` Python client library's `alter_retention_policy()` method, even when the option is left unset (`None`). Client library versions older than 5.2.0 do not accept that parameter at all, so the call raises a `TypeError` such as:

```
TypeError: alter_retention_policy() takes from 2 to 6 positional arguments but 7 were given
```

`create_retention_policy()` already guards against this by only passing `shard_group_duration` when it is set. This PR applies the same conditional to `alter_retention_policy()`.

Fixes #3897

## Test plan

- [x] `ruff check` / `ruff format` pass
- [x] Sanity tests pass
- Note: no unit or integration tests currently exist for this module to extend

🤖 Generated with [Claude Code](https://claude.com/claude-code)