### PR TITLE
archive: clarify that tar and gzip archives are not byte-for-byte reproducible

### DIFF
--- a/plugins/modules/archive.py
+++ b/plugins/modules/archive.py
@@ -75,6 +75,10 @@ notes:
   - Can produce C(gzip), C(bzip2), C(lzma), C(zstd), and C(zip) compressed files or archives.
   - This module uses C(tarfile), C(zipfile), C(gzip), C(bz2), and C(lzma) packages on the target host to create archives. These are
     part of the Python standard library.
+  - Tar and gzip based archives embed per-entry metadata, such as modification time, ownership, and permissions, and this module
+    does not guarantee a stable order in which files are added to an archive. As a result, running this module against the
+    same source content more than once, or on different hosts, is not guaranteed to produce a byte-for-byte identical archive,
+    even when the file contents themselves are unchanged.
 requirements:
   - zstandard for O(format=zstd)
 seealso:


### PR DESCRIPTION
##### SUMMARY
Adds a note to the `archive` module's documentation clarifying that tar and gzip based
archives embed per-entry metadata (modification time, ownership, permissions) and that
file ordering is not guaranteed stable across runs. As a result, archiving the same
source content more than once, or on different hosts, is not guaranteed to produce a
byte-for-byte identical archive, even though the file contents themselves are unchanged.

Fixes #1994
Fixes #3888 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
archive

##### ADDITIONAL INFORMATION
Related to #3888, which reports the same underlying non-determinism, and to #12086,
which proposes granular options (fixed entry timestamps/ownership, sorted entries, fixed
gzip metadata) to make output reproducible when that is desired.