### PR TITLE
idrac_redfish_command: document CreateBiosConfigJob is not idempotent

### DIFF
--- a/plugins/modules/idrac_redfish_command.py
+++ b/plugins/modules/idrac_redfish_command.py
@@ -30,6 +30,8 @@ options:
     required: true
     description:
       - List of commands to execute on iDRAC.
+      - V(CreateBiosConfigJob) is not idempotent and creates a new configuration job on every execution. The user is
+        responsible for ensuring that no other equivalent job is already running before invoking this command.
     type: list
     elements: str
   baseuri:


### PR DESCRIPTION
##### SUMMARY
Documents, under the `command` option, that `CreateBiosConfigJob` is not idempotent: it creates a new configuration job on every execution, and the caller is responsible for ensuring no other equivalent job is already running before invoking it.

This is a documentation-only clarification related to #3826. It does not address the false-failure behavior also reported there (the module calling `fail_json` on an HTTP 400 response even when the BMC has already scheduled the job), which remains open.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
idrac_redfish_command

##### ADDITIONAL INFORMATION
No changelog fragment included, per contribution guidelines for docs-only PRs.