### PR TITLE
xen_orchestra inventory plugin: add `XO_*` environment variable aliases

### DIFF
--- a/changelogs/fragments/12656-xen-orchestra-xo-env-vars.yml
+++ b/changelogs/fragments/12656-xen-orchestra-xo-env-vars.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - xen_orchestra inventory plugin - add ``XO_HOST``, ``XO_USER``, and ``XO_PASSWORD`` as alternative environment variables for the ``api_host``, ``user``, and ``password`` options, respectively (https://github.com/ansible-collections/community.general/issues/4501, https://github.com/ansible-collections/community.general/pull/12656).

--- a/plugins/inventory/xen_orchestra.py
+++ b/plugins/inventory/xen_orchestra.py
@@ -30,28 +30,34 @@ options:
     description:
       - API host to XOA API.
       - If the value is not specified in the inventory configuration, the value of environment variable E(ANSIBLE_XO_HOST)
-        is used instead.
+        or E(XO_HOST) is used instead.
     type: str
     env:
       - name: ANSIBLE_XO_HOST
+      - name: XO_HOST
+        version_added: 13.4.0
   user:
     description:
       - Xen Orchestra user.
       - If the value is not specified in the inventory configuration, the value of environment variable E(ANSIBLE_XO_USER)
-        is used instead.
+        or E(XO_USER) is used instead.
     required: true
     type: str
     env:
       - name: ANSIBLE_XO_USER
+      - name: XO_USER
+        version_added: 13.4.0
   password:
     description:
       - Xen Orchestra password.
       - If the value is not specified in the inventory configuration, the value of environment variable E(ANSIBLE_XO_PASSWORD)
-        is used instead.
+        or E(XO_PASSWORD) is used instead.
     required: true
     type: str
     env:
       - name: ANSIBLE_XO_PASSWORD
+      - name: XO_PASSWORD
+        version_added: 13.4.0
   validate_certs:
     description: Verify TLS certificate if using HTTPS.
     type: boolean


### PR DESCRIPTION
##### SUMMARY
Adds `XO_HOST`, `XO_USER`, and `XO_PASSWORD` as alternative environment variables for the `api_host`, `user`, and `password` options, alongside the existing `ANSIBLE_XO_*` names. Tools such as AWX/AAP refuse to inject credential environment variables prefixed with `ANSIBLE_`, which made it impossible to supply Xen Orchestra credentials through AWX credential injection.

Fixes #4501

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
xen_orchestra

##### ADDITIONAL INFORMATION
The existing `ANSIBLE_XO_*` environment variables are kept for backwards compatibility.