### PR TITLE
new filter plugin: version_sort_natural sorts lists using natural version order

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -246,6 +246,10 @@ files:
     maintainers: Ajpantuso
   $filters/version_sort.py:
     maintainers: ericzolf
+  $filters/version_sort.yml:
+    maintainers: ericzolf
+  $filters/version_sort_natural.yml:
+    maintainers: ericzolf russoz
   $inventories/:
     labels: inventories
   $inventories/cobbler.py:

--- a/plugins/filter/version_sort.py
+++ b/plugins/filter/version_sort.py
@@ -4,36 +4,11 @@
 
 from __future__ import annotations
 
-DOCUMENTATION = r"""
-name: version_sort
-short_description: Sort a list according to version order instead of pure alphabetical one
-version_added: 2.2.0
-author: Eric L. (@ericzolf)
-description:
-  - Sort a list according to version order instead of pure alphabetical one.
-options:
-  _input:
-    description: A list of strings to sort.
-    type: list
-    elements: string
-    required: true
-"""
-
-EXAMPLES = r"""
-- name: Sort a list of strings by version
-  ansible.builtin.set_fact:
-    sorted_list: "{{ ['2.1', '2.10', '2.9'] | community.general.version_sort }}"
-    # Result is ['2.1', '2.9', '2.10']
-"""
-
-RETURN = r"""
-_value:
-  description: The list of strings sorted by version.
-  type: list
-  elements: string
-"""
+import re
 
 from ansible_collections.community.general.plugins.module_utils._version import LooseVersion
+
+_NATURAL_SORT_RE = re.compile(r"(\d+)")
 
 
 def version_sort(value, reverse=False):
@@ -41,8 +16,20 @@ def version_sort(value, reverse=False):
     return sorted(value, key=LooseVersion, reverse=reverse)
 
 
+def _natural_sort_key(value: str) -> list[int | str]:
+    return [int(chunk) if chunk.isdigit() else chunk for chunk in _NATURAL_SORT_RE.split(value)]
+
+
+def version_sort_natural(value: list[str], reverse: bool = False) -> list[str]:
+    """Sort a list of strings by natural version order, tolerating differing numbers of version components."""
+    return sorted(value, key=_natural_sort_key, reverse=reverse)
+
+
 class FilterModule:
     """Version sort filter"""
 
     def filters(self):
-        return {"version_sort": version_sort}
+        return {
+            "version_sort": version_sort,
+            "version_sort_natural": version_sort_natural,
+        }

--- a/plugins/filter/version_sort.yml
+++ b/plugins/filter/version_sort.yml
@@ -1,0 +1,30 @@
+---
+# Copyright (C) 2021 Eric Lavarde <elavarde@redhat.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+DOCUMENTATION:
+  name: version_sort
+  short_description: Sort a list according to version order instead of pure alphabetical one
+  version_added: 2.2.0
+  author: Eric L. (@ericzolf)
+  description:
+    - Sort a list according to version order instead of pure alphabetical one.
+  options:
+    _input:
+      description: A list of strings to sort.
+      type: list
+      elements: string
+      required: true
+
+EXAMPLES: |
+  - name: Sort a list of strings by version
+    ansible.builtin.set_fact:
+      sorted_list: "{{ ['2.1', '2.10', '2.9'] | community.general.version_sort }}"
+      # Result is ['2.1', '2.9', '2.10']
+
+RETURN:
+  _value:
+    description: The list of strings sorted by version.
+    type: list
+    elements: string

--- a/plugins/filter/version_sort_natural.yml
+++ b/plugins/filter/version_sort_natural.yml
@@ -1,0 +1,41 @@
+---
+# Copyright (c) 2026, Alexei Znamensky <russoz@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+DOCUMENTATION:
+  name: version_sort_natural
+  short_description: Sort a list of strings by natural version order
+  version_added: 13.4.0
+  author: Alexei Znamensky (@russoz)
+  description:
+    - Sort a list of strings by natural version order, comparing runs of digits numerically and everything else as text.
+    - Unlike P(community.general.version_sort#filter), this does not require the compared versions to have the same
+      number of components, so for example C(1.1-SNAPSHOT) and C(1.1.0-SNAPSHOT) can be compared without errors.
+  options:
+    _input:
+      description: A list of strings to sort.
+      type: list
+      elements: string
+      required: true
+    reverse:
+      description: Set to V(true) to sort in descending order instead of the default ascending order.
+      type: boolean
+      default: false
+
+EXAMPLES: |
+  - name: Sort a list of strings by natural version order
+    ansible.builtin.set_fact:
+      sorted_list: "{{ ['1.1.0-SNAPSHOT', '1.1-SNAPSHOT'] | community.general.version_sort_natural }}"
+      # Result is ['1.1-SNAPSHOT', '1.1.0-SNAPSHOT']
+
+  - name: Sort a list of strings by natural version order, descending
+    ansible.builtin.set_fact:
+      sorted_list: "{{ ['2.1', '2.10', '2.9'] | community.general.version_sort_natural(reverse=true) }}"
+      # Result is ['2.10', '2.9', '2.1']
+
+RETURN:
+  _value:
+    description: The list of strings sorted by natural version order.
+    type: list
+    elements: string

--- a/tests/integration/targets/filter_version_sort/tasks/main.yml
+++ b/tests/integration/targets/filter_version_sort/tasks/main.yml
@@ -12,3 +12,19 @@
   ansible.builtin.assert:
     that:
       - "['a-1.9.rpm', 'a-1.10-1.rpm', 'a-1.09.rpm', 'b-1.01.rpm', 'a-2.1-0.rpm', 'a-1.10-0.rpm'] | community.general.version_sort == ['a-1.9.rpm', 'a-1.09.rpm', 'a-1.10-0.rpm', 'a-1.10-1.rpm', 'a-2.1-0.rpm', 'b-1.01.rpm']"
+
+- name: validate that version_sort_natural sorts the same stable-sort case as version_sort
+  ansible.builtin.assert:
+    that:
+      - "['a-1.9.rpm', 'a-1.10-1.rpm', 'a-1.09.rpm', 'b-1.01.rpm', 'a-2.1-0.rpm', 'a-1.10-0.rpm'] | community.general.version_sort_natural == ['a-1.9.rpm', 'a-1.09.rpm', 'a-1.10-0.rpm', 'a-1.10-1.rpm', 'a-2.1-0.rpm', 'b-1.01.rpm']"
+
+- name: validate that version_sort_natural handles versions with differing numbers of components
+  ansible.builtin.assert:
+    that:
+      - "['1.1.0-SNAPSHOT', '1.1-SNAPSHOT'] | community.general.version_sort_natural == ['1.1-SNAPSHOT', '1.1.0-SNAPSHOT']"
+      - "['1.1.0', '1.1'] | community.general.version_sort_natural == ['1.1', '1.1.0']"
+
+- name: validate that version_sort_natural supports reverse sorting
+  ansible.builtin.assert:
+    that:
+      - "['2.1', '2.10', '2.9'] | community.general.version_sort_natural(reverse=true) == ['2.10', '2.9', '2.1']"


### PR DESCRIPTION
##### SUMMARY
`version_sort` (backed by `LooseVersion`) can raise an unhandled `TypeError` when comparing version strings that have different numbers of components, for example `"1.1.0-SNAPSHOT"` and `"1.1-SNAPSHOT"` (see #4451). This happens because `LooseVersion`'s tokenizer splits differently depending on string content, so the same positional slot can end up holding an `int` in one version and a `str` in the other.

Rather than changing `version_sort`'s behavior (which could be a backwards-compatibility break for existing users relying on `LooseVersion` semantics), this PR adds a new, separate filter, `version_sort_natural`, that sorts using a natural-sort key (splitting on runs of digits, converting them to `int`, comparing everything else as text). That approach is structurally immune to the original bug: the key always alternates non-digit/digit chunks, so position parity fixes the type regardless of how many components either string has.

Verified against the exact example from #4451:
```
["1.1.0-SNAPSHOT", "1.1-SNAPSHOT"] | community.general.version_sort_natural
# => ["1.1-SNAPSHOT", "1.1.0-SNAPSHOT"]
```

Note this does not close #4451: the existing `version_sort` filter is unchanged and still has the reported bug. This adds an alternative for users who want a filter that will not raise on mismatched version shapes.

`version_sort`'s `DOCUMENTATION`/`EXAMPLES`/`RETURN` were moved out to a `version_sort.yml` sidecar (content unchanged), following this collection's existing convention for filter files that host more than one filter (see `lists.py`, `hashids.py`, `json_patch.py`).

##### ISSUE TYPE
- New Module/Plugin Pull Request

##### COMPONENT NAME
version_sort_natural filter

##### ADDITIONAL INFORMATION
Related to #4451