### PR TITLE
jabber: don't send muc#user tag on groupchat message

### DIFF
--- a/changelogs/fragments/12658-jabber-muc-user-tag.yml
+++ b/changelogs/fragments/12658-jabber-muc-user-tag.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - jabber - do not send an unnecessary ``muc#user`` tag on groupchat messages (https://github.com/ansible-collections/community.general/pull/12658, https://github.com/ansible-collections/community.general/issues/5343).

--- a/plugins/modules/jabber.py
+++ b/plugins/modules/jabber.py
@@ -143,7 +143,6 @@ def main():
 
         if nick:  # sending to room instead of user, need to join
             msg.setType("groupchat")
-            msg.setTag("x", namespace="http://jabber.org/protocol/muc#user")
             join = xmpp.Presence(to=module.params["to"])
             join.setTag("x", namespace="http://jabber.org/protocol/muc")
             conn.send(join)


### PR DESCRIPTION
##### SUMMARY
The `jabber` module tags outgoing groupchat messages with `<x xmlns="http://jabber.org/protocol/muc#user"/>`. Per XEP-0045, that element is only needed on the join presence (which already carries its own `<x xmlns="http://jabber.org/protocol/muc"/>`), not on the message stanza itself. This removes the extraneous tag from the message.

Fixes #5343

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
jabber

##### ADDITIONAL INFORMATION