### PR TITLE
consul_kv lookup: drop py-consul dependency

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -39,6 +39,8 @@ exclude_paths:
   - tests/integration/targets/filter_jc/runme.yml
   - tests/integration/targets/filter_json_patch/runme.yml
   - tests/integration/targets/filter_json_query/runme.yml
+  - tests/integration/targets/lookup_consul_kv/dependencies.yml
+  - tests/integration/targets/lookup_consul_kv/test_lookup_consul_kv.yml
   - tests/integration/targets/lookup_etcd3/dependencies.yml
   - tests/integration/targets/lookup_etcd3/test_lookup_etcd3.yml
   - tests/integration/targets/test_fqdn_valid/runme.yml

--- a/changelogs/fragments/12659-consul_kv-lookup-drop-py-consul.yml
+++ b/changelogs/fragments/12659-consul_kv-lookup-drop-py-consul.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - consul_kv lookup plugin - the plugin no longer requires the ``py-consul`` Python library, it now uses ``ansible.module_utils.urls.open_url`` directly (https://github.com/ansible-collections/community.general/issues/5251, https://github.com/ansible-collections/community.general/pull/12659).

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -12,8 +12,6 @@ description:
   - Lookup metadata for a playbook from the key value store in a Consul cluster. Values can be easily set in the kv store
     with simple rest commands.
   - C(curl -X PUT -d 'some-value' http://localhost:8500/v1/kv/ansible/somedata).
-requirements:
-  - 'py-consul python library U(https://github.com/criteo/py-consul?tab=readme-ov-file#installation)'
 options:
   _terms:
     description: List of key(s) to retrieve.
@@ -130,21 +128,17 @@ _raw:
   type: dict
 """
 
-from urllib.parse import urlparse
+import base64
+import json
+from urllib.error import HTTPError
+from urllib.parse import quote, urlencode, urlparse
 
 from ansible.errors import AnsibleAssertionError, AnsibleError
 from ansible.module_utils.common.text.converters import to_text
+from ansible.module_utils.urls import open_url
 from ansible.plugins.lookup import LookupBase
 
 from ansible_collections.community.general.plugins.plugin_utils._lookup import check_for_wrong_terms
-
-try:
-    import consul
-
-    HAS_CONSUL = True
-except ImportError:
-    HAS_CONSUL = False
-
 
 _EMPTY_VALUE_MAP = {
     "textual_none": "None",
@@ -155,11 +149,6 @@ _EMPTY_VALUE_MAP = {
 
 class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
-        if not HAS_CONSUL:
-            raise AnsibleError(
-                "py-consul is required for consul_kv lookup. see https://github.com/criteo/py-consul?tab=readme-ov-file#installation"
-            )
-
         # get options
         self.set_options(direct=kwargs)
         check_for_wrong_terms(self, direct=kwargs)
@@ -180,35 +169,70 @@ class LookupModule(LookupBase):
         ca_path = self.get_option("ca_path")
         client_cert = self.get_option("client_cert")
 
-        verify = (ca_path or validate_certs) if validate_certs else False
-
         empty_value = _EMPTY_VALUE_MAP[self.get_option("empty_value")]
         values = []
         try:
             for term in terms:
                 params = self.parse_params(term)
-                consul_api = consul.Consul(host=host, port=port, scheme=scheme, verify=verify, cert=client_cert)
-
-                results = consul_api.kv.get(
-                    params["key"],
+                entries = self._kv_get(
+                    scheme=scheme,
+                    host=host,
+                    port=port,
+                    key=params["key"],
                     token=params["token"],
                     index=params["index"],
                     recurse=params["recurse"],
-                    dc=params["datacenter"],
+                    datacenter=params["datacenter"],
+                    validate_certs=validate_certs,
+                    ca_path=ca_path,
+                    client_cert=client_cert,
                 )
-                if results[1]:
-                    # responds with a single or list of result maps
-                    if isinstance(results[1], list):
-                        for r in results[1]:
-                            v = r["Value"]
-                            values.append(to_text(v) if v is not None else empty_value)
-                    else:
-                        v = results[1]["Value"]
-                        values.append(to_text(v) if v is not None else empty_value)
+                for entry in entries or []:
+                    v = entry["Value"]
+                    values.append(to_text(v) if v is not None else empty_value)
         except Exception as e:
             raise AnsibleError(f"Error locating '{term}' in kv store. Error was {e}") from e
 
         return values
+
+    @staticmethod
+    def _kv_get(scheme, host, port, key, token, index, recurse, datacenter, validate_certs, ca_path, client_cert):
+        query = {}
+        if recurse:
+            query["recurse"] = "true"
+        if datacenter:
+            query["dc"] = datacenter
+        if index is not None:
+            query["index"] = index
+
+        url = f"{scheme}://{host}:{port}/v1/kv/{quote(key, safe='/')}"
+        if query:
+            url = f"{url}?{urlencode(query)}"
+
+        headers = {"X-Consul-Token": token} if token else {}
+
+        try:
+            response = open_url(
+                url,
+                headers=headers,
+                validate_certs=validate_certs,
+                ca_path=ca_path,
+                client_cert=client_cert,
+            )
+        except HTTPError as e:
+            if e.code == 404:
+                return None
+            raise
+
+        body = response.read()
+        if not body:
+            return None
+
+        entries = json.loads(body)
+        for entry in entries:
+            if entry.get("Value") is not None:
+                entry["Value"] = base64.b64decode(entry["Value"])
+        return entries
 
     def parse_params(self, term):
         params = term.split(" ")

--- a/tests/integration/targets/consul/tasks/consul_kv.yml
+++ b/tests/integration/targets/consul/tasks/consul_kv.yml
@@ -15,10 +15,10 @@
       - result is changed
       - result.data.Value == 'somevalue'
 
-# - name: Test the lookup
-#   ansible.builtin.assert:
-#     that:
-#       - lookup('community.general.consul_kv', 'somekey', token=consul_management_token) == 'somevalue'
+- name: Test the lookup
+  ansible.builtin.assert:
+    that:
+      - lookup('community.general.consul_kv', 'somekey', token=consul_management_token) == 'somevalue'
 
 - name: Update a key with the same data
   community.general.consul_kv:

--- a/tests/integration/targets/consul/tasks/consul_kv.yml
+++ b/tests/integration/targets/consul/tasks/consul_kv.yml
@@ -15,10 +15,13 @@
       - result is changed
       - result.data.Value == 'somevalue'
 
-- name: Test the lookup
-  ansible.builtin.assert:
-    that:
-      - lookup('community.general.consul_kv', 'somekey', token=consul_management_token) == 'somevalue'
+# The lookup plugin always runs on the controller, but the dev-mode Consul
+# agent used by this integration test target is only reachable from the
+# target host, so this can't be exercised here.
+# - name: Test the lookup
+#   ansible.builtin.assert:
+#     that:
+#       - lookup('community.general.consul_kv', 'somekey', token=consul_management_token) == 'somevalue'
 
 - name: Update a key with the same data
   community.general.consul_kv:

--- a/tests/integration/targets/consul/tasks/consul_kv.yml
+++ b/tests/integration/targets/consul/tasks/consul_kv.yml
@@ -15,14 +15,6 @@
       - result is changed
       - result.data.Value == 'somevalue'
 
-# The lookup plugin always runs on the controller, but the dev-mode Consul
-# agent used by this integration test target is only reachable from the
-# target host, so this can't be exercised here.
-# - name: Test the lookup
-#   ansible.builtin.assert:
-#     that:
-#       - lookup('community.general.consul_kv', 'somekey', token=consul_management_token) == 'somevalue'
-
 - name: Update a key with the same data
   community.general.consul_kv:
     key: somekey

--- a/tests/integration/targets/consul/tasks/main.yml
+++ b/tests/integration/targets/consul/tasks/main.yml
@@ -14,14 +14,6 @@
     consul_uri: https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version }}_{{ ansible_facts.system | lower }}_{{ consul_arch }}.zip
     consul_cmd: '{{ remote_tmp_dir }}/consul'
   block:
-    - name: Install py-consul
-      ansible.builtin.pip:
-        name: py-consul
-        extra_args: "-c {{ remote_constraints }}"
-      register: result
-      retries: 3
-      delay: 5
-      until: result is success
     - name: Generate privatekey
       community.crypto.openssl_privatekey:
         path: '{{ remote_tmp_dir }}/privatekey.pem'

--- a/tests/integration/targets/lookup_consul_kv/aliases
+++ b/tests/integration/targets/lookup_consul_kv/aliases
@@ -1,0 +1,6 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+azp/posix/1
+destructive

--- a/tests/integration/targets/lookup_consul_kv/defaults/main.yml
+++ b/tests/integration/targets/lookup_consul_kv/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+consul_version: "1.22.6"
+consul_download_location: /tmp/consul-download-test
+consul_download_url: "https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version }}_{{ ansible_facts.system | lower }}_{{ consul_arch }}.zip"
+consul_cmd: "{{ consul_download_location }}/consul"
+
+consul_kv_prefix: "lookup_consul_kv_test/"

--- a/tests/integration/targets/lookup_consul_kv/dependencies.yml
+++ b/tests/integration/targets/lookup_consul_kv/dependencies.yml
@@ -1,0 +1,11 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- hosts: localhost
+  tasks:
+    - name: Set up Consul
+      ansible.builtin.import_role:
+        name: lookup_consul_kv
+        tasks_from: setup

--- a/tests/integration/targets/lookup_consul_kv/meta/main.yml
+++ b/tests/integration/targets/lookup_consul_kv/meta/main.yml
@@ -1,0 +1,7 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependencies:
+  - setup_pkg_mgr

--- a/tests/integration/targets/lookup_consul_kv/runme.sh
+++ b/tests/integration/targets/lookup_consul_kv/runme.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Copyright (c) Ansible project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+set -eux
+
+# The consul_kv lookup plugin always runs on the controller, so both the
+# Consul agent and the test that queries it are run against localhost here,
+# rather than relying on ansible-test's usual (possibly separate) target host.
+
+ANSIBLE_ROLES_PATH=../ \
+    ansible-playbook dependencies.yml -v "$@"
+
+ANSIBLE_ROLES_PATH=../ \
+    ansible-playbook test_lookup_consul_kv.yml -v "$@"

--- a/tests/integration/targets/lookup_consul_kv/tasks/main.yml
+++ b/tests/integration/targets/lookup_consul_kv/tasks/main.yml
@@ -36,7 +36,8 @@
 
 - name: Test the lookup with recurse
   ansible.builtin.set_fact:
-    consul_kv_recurse_result: "{{ lookup('community.general.consul_kv', consul_kv_prefix, recurse=true) }}"
+    # query() (unlike lookup()) always returns a list, even with 2+ string results.
+    consul_kv_recurse_result: "{{ query('community.general.consul_kv', consul_kv_prefix, recurse=true) }}"
 
 - ansible.builtin.assert:
     that:

--- a/tests/integration/targets/lookup_consul_kv/tasks/main.yml
+++ b/tests/integration/targets/lookup_consul_kv/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Create a key
+  community.general.consul_kv:
+    key: somekey
+    value: somevalue
+  register: result
+
+- ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.data.Value == 'somevalue'
+
+- name: Test the lookup
+  ansible.builtin.assert:
+    that:
+      - lookup('community.general.consul_kv', 'somekey') == 'somevalue'
+
+- name: Create keys under a common prefix
+  community.general.consul_kv:
+    key: "{{ consul_kv_prefix }}{{ item.key }}"
+    value: "{{ item.value }}"
+  loop:
+    - key: a
+      value: vala
+    - key: b
+      value: valb
+
+- name: Test the lookup with recurse
+  ansible.builtin.set_fact:
+    consul_kv_recurse_result: "{{ lookup('community.general.consul_kv', consul_kv_prefix, recurse=true) }}"
+
+- ansible.builtin.assert:
+    that:
+      - consul_kv_recurse_result | length == 2
+      - consul_kv_recurse_result[0] == 'vala'
+      - consul_kv_recurse_result[1] == 'valb'
+
+- name: Test the lookup for a missing key
+  ansible.builtin.assert:
+    that:
+      - lookup('community.general.consul_kv', 'nonexistent-key') == []

--- a/tests/integration/targets/lookup_consul_kv/tasks/setup.yml
+++ b/tests/integration/targets/lookup_consul_kv/tasks/setup.yml
@@ -1,0 +1,70 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Check if Consul is already usable
+  ansible.builtin.command: "{{ consul_cmd }} kv get somekey"
+  changed_when: false
+  failed_when: false
+  register: consul_health_check
+
+- name: Set up Consul binary
+  when: consul_health_check.rc != 0
+  block:
+    - name: Install unzip
+      ansible.builtin.package:
+        name: unzip
+      register: result
+      until: result is success
+      when: ansible_facts.distribution != "MacOSX"
+
+    - name: Ensure clean download directory
+      ansible.builtin.file:
+        path: "{{ consul_download_location }}"
+        state: absent
+
+    - name: Create download directory
+      ansible.builtin.file:
+        path: "{{ consul_download_location }}"
+        state: directory
+
+    - ansible.builtin.assert:
+        that: ansible_facts.architecture in ['i386', 'x86_64', 'amd64', 'arm64', 'aarch64']
+
+    - ansible.builtin.set_fact:
+        consul_arch: '386'
+      when: ansible_facts.architecture == 'i386'
+    - ansible.builtin.set_fact:
+        consul_arch: amd64
+      when: ansible_facts.architecture in ['x86_64', 'amd64']
+    - ansible.builtin.set_fact:
+        consul_arch: arm64
+      when: ansible_facts.architecture in ['arm64', 'aarch64']
+
+    - name: Download consul binary
+      ansible.builtin.unarchive:
+        src: "{{ consul_download_url }}"
+        dest: "{{ consul_download_location }}"
+        remote_src: true
+
+    - name: Remove macOS quarantine attribute from consul binary
+      ansible.builtin.command: xattr -d com.apple.quarantine {{ consul_cmd }}
+      when: ansible_facts.system == 'Darwin'
+      ignore_errors: true
+
+    - name: Start Consul (dev mode enabled)
+      ansible.builtin.shell: "nohup {{ consul_cmd }} agent -dev -pid-file={{ consul_download_location }}/consul.pid >{{ consul_download_location }}/consul.log 2>&1 &"
+      changed_when: true
+
+    - name: Wait for Consul HTTP API to be ready
+      ansible.builtin.wait_for:
+        host: localhost
+        port: 8500
+        delay: 1
+        timeout: 60

--- a/tests/integration/targets/lookup_consul_kv/test_lookup_consul_kv.yml
+++ b/tests/integration/targets/lookup_consul_kv/test_lookup_consul_kv.yml
@@ -1,0 +1,10 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- hosts: localhost
+  tasks:
+    - name: Test consul_kv lookup
+      ansible.builtin.import_role:
+        name: lookup_consul_kv

--- a/tests/unit/plugins/lookup/test_consul_kv.py
+++ b/tests/unit/plugins/lookup/test_consul_kv.py
@@ -1,0 +1,98 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError
+
+from ansible.plugins.loader import lookup_loader
+
+
+def _entry(value, key="somekey"):
+    return {"Key": key, "Value": None if value is None else _b64(value)}
+
+
+def _b64(value):
+    import base64
+
+    return base64.b64encode(value.encode("utf-8")).decode("utf-8")
+
+
+def _response(entries):
+    response = MagicMock()
+    response.read.return_value = json.dumps(entries).encode("utf-8")
+    return response
+
+
+def _not_found():
+    return HTTPError("http://localhost:8500/v1/kv/somekey", 404, "Not Found", {}, None)
+
+
+class TestLookupModule(unittest.TestCase):
+    def setUp(self):
+        self.lookup = lookup_loader.get("community.general.consul_kv")
+
+    def test_simple_lookup(self):
+        with patch(
+            "ansible_collections.community.general.plugins.lookup.consul_kv.open_url",
+            return_value=_response([_entry("somevalue")]),
+        ) as open_url:
+            result = self.lookup.run(["somekey"])
+        self.assertEqual(result, ["somevalue"])
+        args, kwargs = open_url.call_args
+        self.assertEqual(args[0], "http://localhost:8500/v1/kv/somekey")
+        self.assertEqual(kwargs["headers"], {})
+
+    def test_token_sets_header(self):
+        with patch(
+            "ansible_collections.community.general.plugins.lookup.consul_kv.open_url",
+            return_value=_response([_entry("somevalue")]),
+        ) as open_url:
+            self.lookup.run(["somekey token=mytoken"])
+        self.assertEqual(open_url.call_args.kwargs["headers"], {"X-Consul-Token": "mytoken"})
+
+    def test_recurse_returns_multiple_values(self):
+        entries = [_entry("v1", "prefix/a"), _entry("v2", "prefix/b")]
+        with patch(
+            "ansible_collections.community.general.plugins.lookup.consul_kv.open_url",
+            return_value=_response(entries),
+        ) as open_url:
+            result = self.lookup.run(["prefix recurse=true"])
+        self.assertEqual(result, ["v1", "v2"])
+        self.assertIn("recurse=true", open_url.call_args.args[0])
+
+    def test_missing_key_returns_empty_list(self):
+        with patch(
+            "ansible_collections.community.general.plugins.lookup.consul_kv.open_url",
+            side_effect=_not_found(),
+        ):
+            result = self.lookup.run(["somekey"])
+        self.assertEqual(result, [])
+
+    def test_null_value_default_empty_value(self):
+        with patch(
+            "ansible_collections.community.general.plugins.lookup.consul_kv.open_url",
+            return_value=_response([_entry(None)]),
+        ):
+            result = self.lookup.run(["somekey"])
+        self.assertEqual(result, ["None"])
+
+    def test_null_value_python_none(self):
+        with patch(
+            "ansible_collections.community.general.plugins.lookup.consul_kv.open_url",
+            return_value=_response([_entry(None)]),
+        ):
+            result = self.lookup.run(["somekey"], empty_value="python_none")
+        self.assertEqual(result, [None])
+
+    def test_url_option_overrides_host_port_scheme(self):
+        with patch(
+            "ansible_collections.community.general.plugins.lookup.consul_kv.open_url",
+            return_value=_response([_entry("somevalue")]),
+        ) as open_url:
+            self.lookup.run(["somekey"], url="https://consul.example.com:9500")
+        self.assertEqual(open_url.call_args.args[0], "https://consul.example.com:9500/v1/kv/somekey")

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -14,6 +14,4 @@ pyfmg == 0.6.1 # newer versions do not pass current unit tests
 pytest-mock >= 1.4.0 # needed for mock_use_standalone_module pytest option
 pyone < 7 # newer versions fail early
 cffi >= 1.14.2, != 1.14.3 # Yanked version which older versions of pip will still install:
-py-consul < 1.3.0 ; python_version < '3.8'  # 1.3.0 dropped support for Python 3.5, 3.6, 3.7
-py-consul < 1.5.4 ; python_version < '3.9'  # 1.5.4 dropped support for Python 3.8
 argcomplete < 3.7.1 ; python_version < '3.10'  # 3.7.1 uses Python 3.10+ syntax


### PR DESCRIPTION
##### SUMMARY
The `consul_kv` lookup plugin required the third-party `py-consul` library, which could be hard to install in some environments (for example AWX/Tower execution environments on RHEL8, as reported in the linked issue). The `consul_kv` module was already migrated off this dependency in #12221; this does the equivalent for the lookup plugin, reimplementing the KV read with `ansible.module_utils.urls.open_url` instead of `import consul`.

Behavior (options, blocking `index` queries, per-key `token`, `recurse`, `datacenter`, TLS options, `empty_value` handling) is unchanged. The now-unused `py-consul` pip install step and version constraints are removed from the test suite. A new dedicated integration test target, `lookup_consul_kv`, exercises the lookup end to end against a real Consul agent started on the controller (the lookup always runs there, unlike modules, so it can't share the existing `consul` target's agent, which runs on a separate target host).

Fixes #5251

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/lookup/consul_kv.py

##### ADDITIONAL INFORMATION
New unit tests added in `tests/unit/plugins/lookup/test_consul_kv.py` covering simple lookup, per-key token header, `recurse`, missing-key (404) handling, both `empty_value` modes, and the `url` option override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
