### PR TITLE
npm: fix `JSONDecodeError` from stdout warnings

### DIFF
--- a/changelogs/fragments/12665-npm-json-decode-error.yml
+++ b/changelogs/fragments/12665-npm-json-decode-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - npm - fix ``JSONDecodeError`` when npm's stdout output contains warnings or notices alongside the JSON payload (https://github.com/ansible-collections/community.general/pull/12665, https://github.com/ansible-collections/community.general/issues/4960).

--- a/plugins/modules/npm.py
+++ b/plugins/modules/npm.py
@@ -231,14 +231,13 @@ class Npm:
         data = {}
         out = self._exec(cmd, True, False, False) or "{}"
         # npm may print warnings/notices to stdout ahead of (or after) the JSON
-        # payload, which breaks strict JSON parsing. Extract the outermost
-        # object so such noise does not cause a spurious failure.
-        start = out.find("{")
-        end = out.rfind("}")
-        if start != -1 and end != -1 and end > start:
-            out = out[start : end + 1]
+        # payload, which breaks strict JSON parsing. Skip to the first '{'
+        # that starts a line (ignoring leading whitespace), then decode only
+        # the JSON value found there, ignoring any trailing noise npm appends.
+        start_match = re.search(r"^[ \t]*(\{)", out, re.MULTILINE)
+        start = start_match.start(1) if start_match else 0
         try:
-            data = json.loads(out)
+            data, _end = json.JSONDecoder().raw_decode(out, start)
         except getattr(json, "JSONDecodeError", ValueError) as e:
             self.module.fail_json(msg=f"Failed to parse NPM output with error {e}")
         if "dependencies" in data:

--- a/plugins/modules/npm.py
+++ b/plugins/modules/npm.py
@@ -229,8 +229,16 @@ class Npm:
         installed = list()
         missing = list()
         data = {}
+        out = self._exec(cmd, True, False, False) or "{}"
+        # npm may print warnings/notices to stdout ahead of (or after) the JSON
+        # payload, which breaks strict JSON parsing. Extract the outermost
+        # object so such noise does not cause a spurious failure.
+        start = out.find("{")
+        end = out.rfind("}")
+        if start != -1 and end != -1 and end > start:
+            out = out[start : end + 1]
         try:
-            data = json.loads(self._exec(cmd, True, False, False) or "{}")
+            data = json.loads(out)
         except getattr(json, "JSONDecodeError", ValueError) as e:
             self.module.fail_json(msg=f"Failed to parse NPM output with error {e}")
         if "dependencies" in data:

--- a/tests/unit/plugins/modules/test_npm.yaml
+++ b/tests/unit/plugins/modules/test_npm.yaml
@@ -189,6 +189,35 @@ test_cases:
           out: '{}'
           err: ''
 
+  - id: present_missing_with_brace_in_warning
+    input:
+      name: coffee-script
+      global: true
+      state: present
+    output:
+      changed: true
+    mocks:
+      run_command:
+        - command: [/testbin/npm, list, --json, --long, --global]
+          environ: *env-list
+          rc: 0
+          out: |
+            npm warn using {legacy} config
+            {
+              "dependencies": {
+                "coffee-script": {
+                  "missing": true
+                }
+              }
+            }
+            npm notice new version available {details here}
+          err: ''
+        - command: [/testbin/npm, install, --global, coffee-script]
+          environ: *env-exec
+          rc: 0
+          out: '{}'
+          err: ''
+
   - id: present_package_json
     input:
       global: true

--- a/tests/unit/plugins/modules/test_npm.yaml
+++ b/tests/unit/plugins/modules/test_npm.yaml
@@ -169,6 +169,26 @@ test_cases:
           out: '{}'
           err: ''
 
+  - id: present_missing_with_stdout_noise
+    input:
+      name: coffee-script
+      global: true
+      state: present
+    output:
+      changed: true
+    mocks:
+      run_command:
+        - command: [/testbin/npm, list, --json, --long, --global]
+          environ: *env-list
+          rc: 0
+          out: "npm warn config global \n{\"dependencies\": {\"coffee-script\": {\"missing\": true}}}\n"
+          err: ''
+        - command: [/testbin/npm, install, --global, coffee-script]
+          environ: *env-exec
+          rc: 0
+          out: '{}'
+          err: ''
+
   - id: present_package_json
     input:
       global: true


### PR DESCRIPTION
##### SUMMARY
`npm list --json` can have warnings or notices printed to stdout ahead of (or after) the JSON payload, depending on the npm version and environment. This breaks strict JSON parsing and causes the module to fail with a `JSONDecodeError`. The fix extracts the outermost JSON object from the command output before parsing, tolerating such noise regardless of npm version.

Fixes #4960

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
npm

##### ADDITIONAL INFORMATION
```paste below

```