### PR TITLE
supervisorctl: handle `BACKOFF` process state

### DIFF
--- a/changelogs/fragments/12688-supervisorctl-backoff.yml
+++ b/changelogs/fragments/12688-supervisorctl-backoff.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - supervisorctl - treat the ``BACKOFF`` process state as active so that ``state=started`` does not fail on a program still being retried by ``supervisord`` (https://github.com/ansible-collections/community.general/issues/5599, https://github.com/ansible-collections/community.general/pull/12688).

--- a/plugins/modules/supervisorctl.py
+++ b/plugins/modules/supervisorctl.py
@@ -118,7 +118,7 @@ from ansible.module_utils.basic import AnsibleModule, is_executable
 
 
 def _is_active(status):
-    return status in ("RUNNING", "STARTING")
+    return status in ("RUNNING", "STARTING", "BACKOFF")
 
 
 def _is_not_active(status):


### PR DESCRIPTION
##### SUMMARY
`supervisorctl` treated only `RUNNING` and `STARTING` as active. A program in the
transient `BACKOFF` state (supervisord retrying a start after the process exited
before `startsecs`) was seen as inactive, so `state=started` ran
`supervisorctl start` on it and failed with `ERROR (already started)`, and
`state=stopped` left the retry cycle running. `BACKOFF` is now treated as active.

Addresses only the `BACKOFF` handling from the issue; the "wait until
RUNNING/FATAL" behavior for retries is left for a separate feature PR. No
automated test is added, as `BACKOFF` is timing-dependent and hard to reproduce
deterministically.

Relates to #5599

Co-authored-by: Claude (Anthropic) <noreply@anthropic.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
supervisorctl
