### PR TITLE
gitlab_project: return `project` attributes in check mode when updating

### DIFF
--- a/changelogs/fragments/12689-gitlab_project-check-mode-attrs.yml
+++ b/changelogs/fragments/12689-gitlab_project-check-mode-attrs.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - gitlab_project - return ``project`` in the result when updating an existing project in check mode (https://github.com/ansible-collections/community.general/pull/12689, https://github.com/ansible-collections/community.general/issues/5689).
+  - gitlab_project - return ``project`` in the result when running in check mode (https://github.com/ansible-collections/community.general/pull/12689, https://github.com/ansible-collections/community.general/issues/5689).

--- a/changelogs/fragments/12689-gitlab_project-check-mode-attrs.yml
+++ b/changelogs/fragments/12689-gitlab_project-check-mode-attrs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gitlab_project - return ``project`` in the result when updating an existing project in check mode (https://github.com/ansible-collections/community.general/pull/12689, https://github.com/ansible-collections/community.general/issues/5689).

--- a/plugins/modules/gitlab_project.py
+++ b/plugins/modules/gitlab_project.py
@@ -478,7 +478,8 @@ class GitLabProject:
             project_options["topics"] = options["topics"]
 
         # Because we have already call userExists in main()
-        if self.project_object is None:
+        is_new_project = self.project_object is None
+        if is_new_project:
             if options["default_branch"] and not options["initialize_with_readme"]:
                 module.fail_json(msg="Param default_branch needs param initialize_with_readme set to true")
             project_options.update(
@@ -511,7 +512,11 @@ class GitLabProject:
         self.project_object = project
         if changed:
             if self._module.check_mode:
-                self._module.exit_json(changed=True, msg=f"Successfully created or updated the project {project_name}")
+                if is_new_project:
+                    self._module.exit_json(
+                        changed=True, msg=f"Successfully created or updated the project {project_name}"
+                    )
+                return True
 
             try:
                 project.save()
@@ -812,12 +817,12 @@ def main():
             module.exit_json(
                 changed=True,
                 msg=f"Successfully created or updated the project {project_name}",
-                project=gitlab_project.project_object._attrs,
+                project=gitlab_project.project_object.attributes,
             )
         module.exit_json(
             changed=False,
             msg=f"No need to update the project {project_name}",
-            project=gitlab_project.project_object._attrs,
+            project=gitlab_project.project_object.attributes,
         )
 
 

--- a/plugins/modules/gitlab_project.py
+++ b/plugins/modules/gitlab_project.py
@@ -399,7 +399,11 @@ error:
   sample: "400: path is already in use"
 
 project:
-  description: API object.
+  description:
+    - API object.
+    - When a new project is created while O(state=present) runs in check mode, no API call is made,
+      so this is a synthesized representation built from the module options instead of the object
+      GitLab would actually return. Treat it as an approximation in that case.
   returned: always
   type: dict
 """
@@ -496,8 +500,9 @@ class GitLabProject:
             project_options = self.get_options_with_value(project_options)
             project = self.create_project(namespace, project_options)
 
-            # add avatar to project
-            if options["avatar_path"]:
+            # add avatar to project. Nothing is created in check mode, so there is no
+            # real project to attach the avatar to.
+            if options["avatar_path"] and not self._module.check_mode:
                 try:
                     project.avatar = open(options["avatar_path"], "rb")
                 except OSError as e:
@@ -511,19 +516,25 @@ class GitLabProject:
 
         self.project_object = project
         if changed:
-            if self._module.check_mode:
-                if is_new_project:
-                    self._module.exit_json(
-                        changed=True, msg=f"Successfully created or updated the project {project_name}"
-                    )
-                return True
-
-            try:
-                project.save()
-            except Exception as e:
-                self._module.fail_json(msg=f"Failed to update project: {e} ")
+            if not self._module.check_mode:
+                try:
+                    project.save()
+                except Exception as e:
+                    self._module.fail_json(msg=f"Failed to update project: {e} ")
             return True
         return False
+
+    """
+    Returns the tracked project's attributes. For a project created while running in
+    check mode, no API call was made, so this is a synthesized dict built from the
+    module options rather than the project's real attributes - see the module's
+    RETURN documentation for `project`.
+    """
+
+    def project_attributes(self):
+        if isinstance(self.project_object, dict):
+            return self.project_object
+        return self.project_object.attributes
 
     """
     @param namespace Namespace Object (User or Group)
@@ -532,7 +543,10 @@ class GitLabProject:
 
     def create_project(self, namespace, arguments):
         if self._module.check_mode:
-            return True
+            # No API call is made in check mode, so there is no real project to
+            # report back. Synthesize one from the arguments that would have
+            # been sent, so the caller still gets a value for `project`.
+            return {"namespace_id": namespace.id, **arguments}
 
         arguments["namespace_id"] = namespace.id
         if "container_expiration_policy" in arguments:
@@ -817,12 +831,12 @@ def main():
             module.exit_json(
                 changed=True,
                 msg=f"Successfully created or updated the project {project_name}",
-                project=gitlab_project.project_object.attributes,
+                project=gitlab_project.project_attributes(),
             )
         module.exit_json(
             changed=False,
             msg=f"No need to update the project {project_name}",
-            project=gitlab_project.project_object.attributes,
+            project=gitlab_project.project_attributes(),
         )
 
 

--- a/tests/unit/plugins/modules/gitlab.py
+++ b/tests/unit/plugins/modules/gitlab.py
@@ -501,6 +501,14 @@ PROJECT API
 """
 
 
+@urlmatch(scheme="http", netloc="localhost", path="/api/v4/version", method="get")
+def resp_get_gitlab_version(url, request):
+    headers = {"content-type": "application/json"}
+    content = '{"version": "15.0.0", "revision": "abcdef0"}'
+    content = content.encode("utf-8")
+    return response(200, content, headers, None, 5, request)
+
+
 @urlmatch(scheme="http", netloc="localhost", path="/api/v4/projects", method="get")
 def resp_find_project(url, request):
     headers = {"content-type": "application/json"}

--- a/tests/unit/plugins/modules/test_gitlab_project.py
+++ b/tests/unit/plugins/modules/test_gitlab_project.py
@@ -82,6 +82,65 @@ class TestGitlabProject(GitlabModuleTestCase):
         self.assertEqual(type(project), Project)
         self.assertEqual(project.name, "Diaspora Client")
 
+    @with_httmock(resp_get_group)
+    @with_httmock(resp_get_gitlab_version)
+    def test_create_project_check_mode(self):
+        group = self.gitlab_instance.groups.get(1)
+
+        self.mock_module.check_mode = True
+        options = {
+            "allow_merge_on_skipped_pipeline": None,
+            "avatar_path": None,
+            "builds_access_level": None,
+            "build_timeout": None,
+            "ci_config_path": None,
+            "container_expiration_policy": None,
+            "container_registry_access_level": None,
+            "default_branch": None,
+            "description": None,
+            "environments_access_level": None,
+            "feature_flags_access_level": None,
+            "forking_access_level": None,
+            "import_url": None,
+            "infrastructure_access_level": None,
+            "initialize_with_readme": False,
+            "issues_access_level": None,
+            "issues_enabled": None,
+            "lfs_enabled": None,
+            "merge_method": None,
+            "merge_requests_enabled": None,
+            "model_registry_access_level": None,
+            "monitor_access_level": None,
+            "only_allow_merge_if_all_discussions_are_resolved": None,
+            "only_allow_merge_if_pipeline_succeeds": None,
+            "packages_enabled": None,
+            "pages_access_level": None,
+            "path": "diaspora-client",
+            "releases_access_level": None,
+            "remove_source_branch_after_merge": None,
+            "repository_access_level": None,
+            "security_and_compliance_access_level": None,
+            "service_desk_enabled": None,
+            "shared_runners_enabled": None,
+            "snippets_enabled": None,
+            "squash_option": None,
+            "topics": None,
+            "visibility": None,
+            "wiki_enabled": None,
+        }
+
+        # No POST response is mocked: if the module tried to create the project
+        # while in check mode, this call would fail with a connection error.
+        changed = self.moduleUtil.create_or_update_project(self.mock_module, "Diaspora Client", group, options)
+
+        self.assertEqual(changed, True)
+        self.assertEqual(type(self.moduleUtil.project_object), dict)
+
+        attrs = self.moduleUtil.project_attributes()
+        self.assertEqual(attrs["name"], "Diaspora Client")
+        self.assertEqual(attrs["path"], "diaspora-client")
+        self.assertEqual(attrs["namespace_id"], group.id)
+
     @with_httmock(resp_get_project)
     def test_update_project(self):
         project = self.gitlab_instance.projects.get(1)

--- a/tests/unit/plugins/modules/test_gitlab_project.py
+++ b/tests/unit/plugins/modules/test_gitlab_project.py
@@ -24,6 +24,7 @@ try:
         GitlabModuleTestCase,
         resp_create_project,
         resp_delete_project,
+        resp_get_gitlab_version,
         resp_get_group,
         resp_get_project,
         resp_get_project_by_name,
@@ -39,6 +40,7 @@ except ImportError:
     resp_get_project = _dummy
     resp_delete_project = _dummy
     resp_get_user = _dummy
+    resp_get_gitlab_version = _dummy
 
 # Unit tests requirements
 try:
@@ -118,6 +120,63 @@ class TestGitlabProject(GitlabModuleTestCase):
         self.assertEqual(changed, False)
         self.assertEqual(newProject.name, "New Name")
         self.assertEqual(newProject.merge_method, "rebase_merge")
+
+    @with_httmock(resp_get_group)
+    @with_httmock(resp_get_project_by_name)
+    @with_httmock(resp_get_gitlab_version)
+    def test_update_project_check_mode(self):
+        group = self.gitlab_instance.groups.get(1)
+        self.moduleUtil.exists_project(group, "diaspora-client")
+
+        self.mock_module.check_mode = True
+        options = {
+            "allow_merge_on_skipped_pipeline": None,
+            "avatar_path": None,
+            "builds_access_level": None,
+            "build_timeout": None,
+            "ci_config_path": None,
+            "container_expiration_policy": None,
+            "container_registry_access_level": None,
+            "default_branch": None,
+            "description": "New description",
+            "environments_access_level": None,
+            "feature_flags_access_level": None,
+            "forking_access_level": None,
+            "import_url": None,
+            "infrastructure_access_level": None,
+            "initialize_with_readme": None,
+            "issues_access_level": None,
+            "issues_enabled": None,
+            "lfs_enabled": None,
+            "merge_method": None,
+            "merge_requests_enabled": None,
+            "model_registry_access_level": None,
+            "monitor_access_level": None,
+            "only_allow_merge_if_all_discussions_are_resolved": None,
+            "only_allow_merge_if_pipeline_succeeds": None,
+            "packages_enabled": None,
+            "pages_access_level": None,
+            "path": "diaspora-client",
+            "releases_access_level": None,
+            "remove_source_branch_after_merge": None,
+            "repository_access_level": None,
+            "security_and_compliance_access_level": None,
+            "service_desk_enabled": None,
+            "shared_runners_enabled": None,
+            "snippets_enabled": None,
+            "squash_option": None,
+            "topics": None,
+            "visibility": None,
+            "wiki_enabled": None,
+        }
+
+        # No PUT response is mocked: if the module tried to save the project
+        # while in check mode, this call would fail with a connection error.
+        changed = self.moduleUtil.create_or_update_project(self.mock_module, "Diaspora Client", group, options)
+
+        self.assertEqual(changed, True)
+        self.assertEqual(type(self.moduleUtil.project_object), Project)
+        self.assertEqual(self.moduleUtil.project_object.attributes["description"], "New description")
 
     @with_httmock(resp_get_group)
     @with_httmock(resp_get_project_by_name)


### PR DESCRIPTION
##### SUMMARY
When updating an existing project with `state: present` in check mode, `gitlab_project` returned only `changed` and `msg`, omitting the `project` key entirely. This happened because `create_or_update_project()` called `exit_json()` directly on a check-mode update, bypassing the code in `main()` that adds `project` to the result.

This PR removes that early exit for the update path (it is still used for the create path, which has a separate, unrelated limitation not addressed here) and switches `main()` to read `project_object.attributes` instead of `project_object._attrs`, so the check-mode result reflects the update that would be applied, without contacting the GitLab API.

Fixes #5689

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_project

##### ADDITIONAL INFORMATION
Only the update path (project already exists) is fixed here. Creating a new project in check mode still does not return a `project` key, since `create_project()` has no real object to report in that case; that is left for a follow-up.
