### PR TITLE
opennebula inventory plugin: add set_name_variable option

### DIFF
--- a/changelogs/fragments/opennebula-set_name_variable.yml
+++ b/changelogs/fragments/opennebula-set_name_variable.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - "opennebula inventory plugin - add ``set_name_variable`` option to allow disabling
+     the ``name`` host variable, avoiding the ``Found variable using reserved name 'name'``
+     warning. ``inventory_hostname`` is unaffected
+     (https://github.com/ansible-collections/community.general/pull/12695)."

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -79,6 +79,15 @@ options:
     type: bool
     default: false
     version_added: 13.3.0
+  set_name_variable:
+    description:
+      - Set the C(name) variable for each host, taken from the VM's OpenNebula name.
+      - When V(true), sets the C(name) variable which may trigger a warning about using a reserved name.
+      - Set to V(false) to avoid the warning when C(name) is not needed as a variable. The value is always available
+        as C(inventory_hostname).
+    type: bool
+    default: true
+    version_added: 13.4.0
   filters:
     # This option is provided by the community.library_inventory_filtering_v1.inventory_filter doc fragment
     version_added: 13.2.0
@@ -120,6 +129,15 @@ group_by_labels: false
 plugin: community.general.opennebula
 api_url: https://opennebula:2633/RPC2
 prefer_existing_ansible_host: true
+
+---
+# Connect by VM name without setting the 'name' host variable, to avoid the
+# "Found variable using reserved name 'name'" warning. inventory_hostname
+# is unaffected and still equals the VM's OpenNebula name.
+plugin: community.general.opennebula
+api_url: https://opennebula:2633/RPC2
+hostname: name
+set_name_variable: false
 
 ---
 # Group VMs by their OpenNebula owner and group (UNAME/GNAME).
@@ -305,6 +323,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         hostname_preference = self.get_option("hostname")
         prefer_existing_ansible_host = self.get_option("prefer_existing_ansible_host")
         group_by_labels = self.get_option("group_by_labels")
+        set_name_variable = self.get_option("set_name_variable")
         strict = self.get_option("strict")
         filters = parse_filters(self.get_option("filters"))
 
@@ -329,6 +348,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             self.inventory.add_host(host=hostname, group="all")
 
             for attribute, value in server.items():
+                if attribute == "name" and not set_name_variable:
+                    continue
                 self.inventory.set_variable(hostname, attribute, value)
 
             if hostname_preference != "name":

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -87,7 +87,7 @@ options:
         as C(inventory_hostname).
     type: bool
     default: true
-    version_added: 13.4.0
+    version_added: 13.5.0
   filters:
     # This option is provided by the community.library_inventory_filtering_v1.inventory_filter doc fragment
     version_added: 13.2.0

--- a/tests/unit/plugins/inventory/test_opennebula.py
+++ b/tests/unit/plugins/inventory/test_opennebula.py
@@ -300,6 +300,7 @@ options_base_test = {
     "api_authfile": "~/.one/one_auth",
     "hostname": "v4_first_ip",
     "prefer_existing_ansible_host": False,
+    "set_name_variable": True,
     "group_by_labels": True,
     "filter_by_label": None,
     "filters": None,
@@ -432,6 +433,9 @@ def test_populate(inventory, mocker):
     # check for custom ssh port
     assert host_gitlab.get_vars()["ansible_port"] == 8822
 
+    # check that the 'name' variable is set by default
+    assert host_sam.get_vars()["name"] == "sam-691-sam"
+
 
 def test_coerce_ssh_port():
     coerce = InventoryModule._coerce_ssh_port
@@ -471,6 +475,19 @@ def test_populate_hostname_name(inventory, mocker):
 
     host_sam = inventory.inventory.get_host("sam-691-sam")
     assert "ansible_host" not in host_sam.get_vars()
+
+
+def test_populate_set_name_variable_false(inventory, mocker):
+    opts = options_base_test.copy()
+    opts["set_name_variable"] = False
+    inventory._get_vm_pool = mocker.MagicMock(side_effect=get_vm_pool)
+    inventory.get_option = mocker.MagicMock(side_effect=mk_get_options(opts))
+    inventory._populate()
+
+    host_sam = inventory.inventory.get_host("sam-691-sam")
+    assert "name" not in host_sam.get_vars()
+    # inventory_hostname is unaffected by set_name_variable
+    assert host_sam.name == "sam-691-sam"
 
 
 def test_populate_respects_existing_ansible_host(inventory, mocker):


### PR DESCRIPTION
## Summary

The `opennebula` inventory plugin always sets a `name` host variable (the VM's OpenNebula name), which triggers Ansible's reserved-name warning on every run:

```
[WARNING]: Found variable using reserved name 'name'.
```

This is the same class of problem fixed for the `nmap` inventory plugin in #11893, and follows the same fix pattern: a `set_name_variable` option (default `true`, matching current behavior) that can be set to `false` to skip setting `name`. `inventory_hostname` already equals the VM's OpenNebula name regardless of this option, so nothing else changes.

## Details

- `set_name_variable` option added, `bool`, default `true`, `version_added: 13.4.0`
- `_populate()` skips the `name` key in the `set_variable` loop when the option is `false`
- New EXAMPLES entry showing `hostname: name` + `set_name_variable: false`
- Unit tests: default (`name` var present, `13.4.0` default) and `set_name_variable: false` (var absent, `inventory_hostname` unaffected)
- Changelog fragment added

## Test plan

- [x] `ruff check` / `ruff format --check` pass on changed files
- [x] `pytest tests/unit/plugins/inventory/test_opennebula.py` — all relevant tests pass (one pre-existing test, `test_populate_constructable_templating`, fails in my local ad hoc collection-path setup independent of this change; verified it fails identically on unmodified `main`)
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)