### PR TITLE
Added more options to lvm_pv module

### DIFF
--- a/changelogs/fragments/lvm_pv-add-more-options.yml
+++ b/changelogs/fragments/lvm_pv-add-more-options.yml
@@ -2,4 +2,4 @@
 minor_changes:
   - lvm_pv - add ``zero``, ``metadatasize``, ``dataalignment``, and ``pvmetadatacopies`` options to control ``pvcreate``
     behavior, and ``allocatable``, ``metadataignore``, and ``tags`` options to manage existing physical volume attributes
-    with ``pvchange``.
+    with ``pvchange`` (https://github.com/ansible-collections/community.general/pull/12701).

--- a/changelogs/fragments/lvm_pv-add-more-options.yml
+++ b/changelogs/fragments/lvm_pv-add-more-options.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - lvm_pv - add ``zero``, ``metadatasize``, ``dataalignment``, and ``pvmetadatacopies`` options to control ``pvcreate``
+    behavior, and ``allocatable``, ``metadataignore``, and ``tags`` options to manage existing physical volume attributes
+    with ``pvchange``.

--- a/plugins/module_utils/_lvm.py
+++ b/plugins/module_utils/_lvm.py
@@ -54,9 +54,12 @@ def pvcreate_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
     Runner for C(pvcreate). Used by: community.general.lvg, community.general.lvm_pv,
     community.general.filesystem.
 
-    Suggested arg_formats keys: pv_options force yes device
+    Suggested arg_formats keys: pv_options force yes zero metadatasize dataalignment
+    pvmetadatacopies metadataignore device
 
     Note: C(pv_options) accepts a pre-split list (e.g. from C(shlex.split())).
+    C(zero) and C(metadataignore) are passed as booleans and map to C(-Z y/n)
+    and C(--metadataignore y/n) respectively.
     """
     return CmdRunner(
         module,
@@ -65,6 +68,13 @@ def pvcreate_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
             pv_options=cmd_runner_fmt.as_list(),
             force=cmd_runner_fmt.as_bool("-f"),
             yes=cmd_runner_fmt.as_bool("--yes"),
+            zero=cmd_runner_fmt.as_bool(["-Z", "y"], ["-Z", "n"], ignore_none=True),
+            metadatasize=cmd_runner_fmt.as_opt_val("--metadatasize"),
+            dataalignment=cmd_runner_fmt.as_opt_val("--dataalignment"),
+            pvmetadatacopies=cmd_runner_fmt.as_opt_val("--pvmetadatacopies"),
+            metadataignore=cmd_runner_fmt.as_bool(
+                ["--metadataignore", "y"], ["--metadataignore", "n"], ignore_none=True
+            ),
             device=cmd_runner_fmt.as_list(),
         ),
         **kwargs,
@@ -73,9 +83,14 @@ def pvcreate_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
 
 def pvchange_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
     """
-    Runner for C(pvchange). Used by: community.general.lvg, community.general.filesystem.
+    Runner for C(pvchange). Used by: community.general.lvg, community.general.filesystem,
+    community.general.lvm_pv.
 
-    Suggested arg_formats keys: uuid yes device
+    Suggested arg_formats keys: uuid yes allocatable metadataignore addtag deltag device
+
+    Note: C(allocatable) and C(metadataignore) are passed as booleans and map to
+    C(-x y/n) and C(--metadataignore y/n) respectively. C(addtag) and C(deltag)
+    each accept a list of tag strings.
     """
     return CmdRunner(
         module,
@@ -83,6 +98,16 @@ def pvchange_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
         arg_formats=dict(
             uuid=cmd_runner_fmt.as_bool("-u"),
             yes=cmd_runner_fmt.as_bool("--yes"),
+            allocatable=cmd_runner_fmt.as_bool(["-x", "y"], ["-x", "n"], ignore_none=True),
+            metadataignore=cmd_runner_fmt.as_bool(
+                ["--metadataignore", "y"], ["--metadataignore", "n"], ignore_none=True
+            ),
+            addtag=cmd_runner_fmt.as_func(
+                lambda tags: [x for t in tags for x in ("--addtag", t)], ignore_none=True
+            ),
+            deltag=cmd_runner_fmt.as_func(
+                lambda tags: [x for t in tags for x in ("--deltag", t)], ignore_none=True
+            ),
             device=cmd_runner_fmt.as_list(),
         ),
         **kwargs,

--- a/plugins/module_utils/_lvm.py
+++ b/plugins/module_utils/_lvm.py
@@ -102,12 +102,8 @@ def pvchange_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
             metadataignore=cmd_runner_fmt.as_bool(
                 ["--metadataignore", "y"], ["--metadataignore", "n"], ignore_none=True
             ),
-            addtag=cmd_runner_fmt.as_func(
-                lambda tags: [x for t in tags for x in ("--addtag", t)], ignore_none=True
-            ),
-            deltag=cmd_runner_fmt.as_func(
-                lambda tags: [x for t in tags for x in ("--deltag", t)], ignore_none=True
-            ),
+            addtag=cmd_runner_fmt.as_func(lambda tags: [x for t in tags for x in ("--addtag", t)], ignore_none=True),
+            deltag=cmd_runner_fmt.as_func(lambda tags: [x for t in tags for x in ("--deltag", t)], ignore_none=True),
             device=cmd_runner_fmt.as_list(),
         ),
         **kwargs,

--- a/plugins/module_utils/_lvm.py
+++ b/plugins/module_utils/_lvm.py
@@ -102,8 +102,8 @@ def pvchange_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
             metadataignore=cmd_runner_fmt.as_bool(
                 ["--metadataignore", "y"], ["--metadataignore", "n"], ignore_none=True
             ),
-            addtag=cmd_runner_fmt.as_func(lambda tags: [x for t in tags for x in ("--addtag", t)]),
-            deltag=cmd_runner_fmt.as_func(lambda tags: [x for t in tags for x in ("--deltag", t)]),
+            addtag=cmd_runner_fmt.stack(cmd_runner_fmt.as_opt_val)("--addtag"),
+            deltag=cmd_runner_fmt.stack(cmd_runner_fmt.as_opt_val)("--deltag"),
             device=cmd_runner_fmt.as_list(),
         ),
         **kwargs,
@@ -111,7 +111,7 @@ def pvchange_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
 
 
 def pvresize_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
-    """s
+    """
     Runner for C(pvresize). Used by: community.general.lvg, community.general.lvm_pv,
     community.general.filesystem.
 

--- a/plugins/module_utils/_lvm.py
+++ b/plugins/module_utils/_lvm.py
@@ -102,8 +102,8 @@ def pvchange_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
             metadataignore=cmd_runner_fmt.as_bool(
                 ["--metadataignore", "y"], ["--metadataignore", "n"], ignore_none=True
             ),
-            addtag=cmd_runner_fmt.as_func(lambda tags: [x for t in tags for x in ("--addtag", t)], ignore_none=True),
-            deltag=cmd_runner_fmt.as_func(lambda tags: [x for t in tags for x in ("--deltag", t)], ignore_none=True),
+            addtag=cmd_runner_fmt.as_func(lambda tags: [x for t in tags for x in ("--addtag", t)]),
+            deltag=cmd_runner_fmt.as_func(lambda tags: [x for t in tags for x in ("--deltag", t)]),
             device=cmd_runner_fmt.as_list(),
         ),
         **kwargs,
@@ -111,7 +111,7 @@ def pvchange_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
 
 
 def pvresize_runner(module: AnsibleModule, **kwargs) -> CmdRunner:
-    """
+    """s
     Runner for C(pvresize). Used by: community.general.lvg, community.general.lvm_pv,
     community.general.filesystem.
 

--- a/plugins/modules/lvm_pv.py
+++ b/plugins/modules/lvm_pv.py
@@ -38,9 +38,60 @@ options:
       - Resize PV to device size when O(state=present).
     type: bool
     default: false
+  zero:
+    description:
+      - Control whether the first 4 sectors of the device are wiped when creating the PV.
+      - Only applied when creating a new PV; has no effect on a PV that already exists.
+    type: bool
+    version_added: 13.5.0
+  metadatasize:
+    description:
+      - Approximate amount of space to reserve for VG metadata on the PV, for example V(128k) or V(1m).
+      - Only applied when creating a new PV; the metadata area size cannot be changed afterwards.
+    type: str
+    version_added: 13.5.0
+  dataalignment:
+    description:
+      - Align the start of the PV data area to a multiple of this value, for example V(1m).
+      - Only applied when creating a new PV; cannot be changed afterwards.
+    type: str
+    version_added: 13.5.0
+  pvmetadatacopies:
+    description:
+      - Number of metadata areas to reserve on the PV for storing VG metadata.
+      - Only applied when creating a new PV; cannot be changed afterwards.
+    type: int
+    choices: [0, 1, 2]
+    version_added: 13.5.0
+  metadataignore:
+    description:
+      - Whether metadata areas on the PV are ignored, meaning LVM does not store VG metadata on it.
+      - Applied when creating a new PV, and enforced on existing PVs using C(pvchange).
+    type: bool
+    version_added: 13.5.0
+  allocatable:
+    description:
+      - Whether the PV can be used for allocation of physical extents.
+      - Managed using C(pvchange). LVM only supports this once the PV is part of a volume group; the module fails if
+        the PV is still an orphan (not yet part of any volume group).
+    type: bool
+    version_added: 13.5.0
+  tags:
+    description:
+      - List of tags that must be set on the PV.
+      - Tags present on the PV but not listed here are removed; tags listed here but not yet present are added.
+      - Managed using C(pvchange). LVM only supports tags once the PV is part of a volume group; the module fails if
+        the PV is still an orphan (not yet part of any volume group).
+    type: list
+    elements: str
+    version_added: 13.5.0
 notes:
   - Requires LVM2 utilities installed on the target system.
   - Device path must exist when creating a PV.
+  - O(zero), O(metadatasize), O(dataalignment), and O(pvmetadatacopies) only take effect when the PV is created; they
+    are ignored for a PV that already exists.
+  - O(metadataignore) detection on an existing PV relies on comparing the number of metadata areas on the PV with the
+    number in use, so it is only meaningful when the PV has at least one metadata area.
 """
 
 EXAMPLES = r"""
@@ -63,6 +114,27 @@ EXAMPLES = r"""
     device: /dev/sdb
     force: true
     state: absent
+
+- name: Creating a physical volume with custom metadata layout
+  community.general.lvm_pv:
+    device: /dev/sdb
+    metadatasize: 128m
+    dataalignment: 1m
+    pvmetadatacopies: 2
+
+- name: Creating a physical volume without wiping existing signatures and with no metadata areas
+  community.general.lvm_pv:
+    device: /dev/sdb
+    zero: false
+    pvmetadatacopies: 0
+
+- name: Setting tags and excluding a physical volume from allocation (PV must already be part of a VG)
+  community.general.lvm_pv:
+    device: /dev/sdb
+    allocatable: false
+    tags:
+      - fast_disks
+      - site_a
 """
 
 RETURN = r"""
@@ -74,6 +146,7 @@ import os
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.community.general.plugins.module_utils._lvm import (
+    pvchange_runner,
     pvcreate_runner,
     pvremove_runner,
     pvresize_runner,
@@ -117,6 +190,13 @@ def main():
             state=dict(type="str", default="present", choices=["present", "absent"]),
             force=dict(type="bool", default=False),
             resize=dict(type="bool", default=False),
+            zero=dict(type="bool"),
+            metadatasize=dict(type="str"),
+            dataalignment=dict(type="str"),
+            pvmetadatacopies=dict(type="int", choices=[0, 1, 2]),
+            metadataignore=dict(type="bool"),
+            allocatable=dict(type="bool"),
+            tags=dict(type="list", elements="str"),
         ),
         supports_check_mode=True,
     )
@@ -124,11 +204,19 @@ def main():
     device = module.params["device"]
     state = module.params["state"]
     resize = module.params["resize"]
+    zero = module.params["zero"]
+    metadatasize = module.params["metadatasize"]
+    dataalignment = module.params["dataalignment"]
+    pvmetadatacopies = module.params["pvmetadatacopies"]
+    metadataignore = module.params["metadataignore"]
+    allocatable = module.params["allocatable"]
+    tags = module.params["tags"]
     changed = False
     actions = []
 
     pvs = pvs_runner(module)
     pvcreate = pvcreate_runner(module)
+    pvchange = pvchange_runner(module)
     pvresize = pvresize_runner(module)
     pvremove = pvremove_runner(module)
 
@@ -142,11 +230,23 @@ def main():
             dummy, out, dummy = ctx.run(units="b", fields="pv_size", devices=[device])
         return int(out.strip())
 
+    def get_pv_attrs():
+        fields = "pv_attr,pv_tags,pv_mda_count,pv_mda_used_count"
+        with pvs("noheadings nosuffix readonly units fields separator devices") as ctx:
+            dummy, out, dummy = ctx.run(units="b", fields=fields, separator="|", devices=[device])
+        attr, tags_str, mda_count, mda_used_count = (p.strip() for p in out.strip().split("|"))
+        return dict(
+            allocatable=attr[:1] == "a",
+            tags=[t for t in tags_str.split(",") if t],
+            metadataignore=int(mda_count) > 0 and int(mda_used_count) == 0,
+        )
+
     # Validate device existence for present state
     if state == "present" and not os.path.exists(device):
         module.fail_json(msg=f"Device {device} not found")
 
     is_pv = get_pv_status()
+    just_created = False
 
     if state == "present":
         # Create PV if needed
@@ -154,8 +254,21 @@ def main():
             if module.check_mode:
                 changed = True
                 actions.append("would be created")
+                just_created = True
             else:
-                pvcreate("force device", check_rc=True).run()
+                create_args = ["force"]
+                if zero is not None:
+                    create_args.append("zero")
+                if metadatasize:
+                    create_args.append("metadatasize")
+                if dataalignment:
+                    create_args.append("dataalignment")
+                if pvmetadatacopies is not None:
+                    create_args.append("pvmetadatacopies")
+                if metadataignore is not None:
+                    create_args.append("metadataignore")
+                create_args.append("device")
+                pvcreate(" ".join(create_args), check_rc=True).run()
                 changed = True
                 actions.append("created")
             is_pv = True
@@ -176,6 +289,44 @@ def main():
                 if new_size != original_size:
                     changed = True
                     actions.append("resized")
+
+        # Manage live attributes (allocatable, metadataignore, tags) via pvchange
+        if is_pv and (allocatable is not None or metadataignore is not None or tags is not None):
+            if module.check_mode and just_created:
+                # The PV does not exist yet in check mode, so its current attributes cannot be queried
+                actions.append("attributes would be set")
+            else:
+                current = get_pv_attrs()
+                change_args = []
+                run_kwargs = {}
+
+                if allocatable is not None and current["allocatable"] != allocatable:
+                    change_args.append("allocatable")
+
+                if metadataignore is not None and current["metadataignore"] != metadataignore:
+                    change_args.append("metadataignore")
+
+                if tags is not None:
+                    current_tags = set(current["tags"])
+                    desired_tags = set(tags)
+                    to_add = sorted(desired_tags - current_tags)
+                    to_del = sorted(current_tags - desired_tags)
+                    if to_add:
+                        change_args.append("addtag")
+                        run_kwargs["addtag"] = to_add
+                    if to_del:
+                        change_args.append("deltag")
+                        run_kwargs["deltag"] = to_del
+
+                if change_args:
+                    if module.check_mode:
+                        changed = True
+                        actions.append("attributes would be changed")
+                    else:
+                        change_args.append("device")
+                        pvchange(" ".join(change_args), check_rc=True).run(**run_kwargs)
+                        changed = True
+                        actions.append("attributes changed")
 
     elif state == "absent":
         if is_pv:

--- a/plugins/modules/lvm_pv.py
+++ b/plugins/modules/lvm_pv.py
@@ -204,10 +204,6 @@ def main():
     device = module.params["device"]
     state = module.params["state"]
     resize = module.params["resize"]
-    zero = module.params["zero"]
-    metadatasize = module.params["metadatasize"]
-    dataalignment = module.params["dataalignment"]
-    pvmetadatacopies = module.params["pvmetadatacopies"]
     metadataignore = module.params["metadataignore"]
     allocatable = module.params["allocatable"]
     tags = module.params["tags"]
@@ -256,19 +252,9 @@ def main():
                 actions.append("would be created")
                 just_created = True
             else:
-                create_args = ["force"]
-                if zero is not None:
-                    create_args.append("zero")
-                if metadatasize:
-                    create_args.append("metadatasize")
-                if dataalignment:
-                    create_args.append("dataalignment")
-                if pvmetadatacopies is not None:
-                    create_args.append("pvmetadatacopies")
-                if metadataignore is not None:
-                    create_args.append("metadataignore")
-                create_args.append("device")
-                pvcreate(" ".join(create_args), check_rc=True).run()
+                pvcreate(
+                    "force zero metadatasize dataalignment pvmetadatacopies metadataignore device", check_rc=True
+                ).run()
                 changed = True
                 actions.append("created")
             is_pv = True

--- a/plugins/modules/lvm_pv.py
+++ b/plugins/modules/lvm_pv.py
@@ -14,6 +14,13 @@ description:
   - Creates, resizes or removes LVM Physical Volumes.
 author:
   - Klention Mali (@klention)
+extends_documentation_fragment:
+  - community.general._attributes
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
 options:
   device:
     description:
@@ -283,34 +290,33 @@ def main():
                 actions.append("attributes would be set")
             else:
                 current = get_pv_attrs()
-                change_args = []
-                run_kwargs = {}
 
+                change_allocatable = None
                 if allocatable is not None and current["allocatable"] != allocatable:
-                    change_args.append("allocatable")
+                    change_allocatable = allocatable
 
+                change_metadataignore = None
                 if metadataignore is not None and current["metadataignore"] != metadataignore:
-                    change_args.append("metadataignore")
+                    change_metadataignore = metadataignore
 
+                to_add = to_del = None
                 if tags is not None:
                     current_tags = set(current["tags"])
                     desired_tags = set(tags)
-                    to_add = sorted(desired_tags - current_tags)
-                    to_del = sorted(current_tags - desired_tags)
-                    if to_add:
-                        change_args.append("addtag")
-                        run_kwargs["addtag"] = to_add
-                    if to_del:
-                        change_args.append("deltag")
-                        run_kwargs["deltag"] = to_del
+                    to_add = sorted(desired_tags - current_tags) or None
+                    to_del = sorted(current_tags - desired_tags) or None
 
-                if change_args:
+                if change_allocatable is not None or change_metadataignore is not None or to_add or to_del:
                     if module.check_mode:
                         changed = True
                         actions.append("attributes would be changed")
                     else:
-                        change_args.append("device")
-                        pvchange(" ".join(change_args), check_rc=True).run(**run_kwargs)
+                        pvchange("allocatable metadataignore addtag deltag device", check_rc=True).run(
+                            allocatable=change_allocatable,
+                            metadataignore=change_metadataignore,
+                            addtag=to_add,
+                            deltag=to_del,
+                        )
                         changed = True
                         actions.append("attributes changed")
 

--- a/plugins/modules/lvm_pv.py
+++ b/plugins/modules/lvm_pv.py
@@ -235,8 +235,8 @@ def main():
 
     def get_pv_attrs():
         fields = "pv_attr,pv_tags,pv_mda_count,pv_mda_used_count"
-        with pvs("noheadings nosuffix readonly units fields separator devices") as ctx:
-            dummy, out, dummy = ctx.run(units="b", fields=fields, separator="|", devices=[device])
+        with pvs("noheadings readonly fields separator devices") as ctx:
+            dummy, out, dummy = ctx.run(fields=fields, separator="|", devices=[device])
         attr, tags_str, mda_count, mda_used_count = (p.strip() for p in out.strip().split("|"))
         return dict(
             allocatable=attr[:1] == "a",
@@ -303,8 +303,8 @@ def main():
                 if tags is not None:
                     current_tags = set(current["tags"])
                     desired_tags = set(tags)
-                    to_add = sorted(desired_tags - current_tags) or None
-                    to_del = sorted(current_tags - desired_tags) or None
+                    to_add = sorted(desired_tags - current_tags)
+                    to_del = sorted(current_tags - desired_tags)
 
                 if change_allocatable is not None or change_metadataignore is not None or to_add or to_del:
                     if module.check_mode:

--- a/tests/integration/targets/lvm_pv/tasks/main.yml
+++ b/tests/integration/targets/lvm_pv/tasks/main.yml
@@ -19,6 +19,8 @@
   block:
     - ansible.builtin.import_tasks: creation.yml
 
+    - ansible.builtin.import_tasks: options.yml
+
     - ansible.builtin.import_tasks: resizing.yml
 
     - ansible.builtin.import_tasks: removal.yml

--- a/tests/integration/targets/lvm_pv/tasks/options.yml
+++ b/tests/integration/targets/lvm_pv/tasks/options.yml
@@ -1,0 +1,139 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Removing physical volume before testing creation-time options
+  community.general.lvm_pv:
+    device: "{{ loop_device.stdout }}"
+    state: absent
+
+- name: Creating physical volume with metadata layout options
+  community.general.lvm_pv:
+    device: "{{ loop_device.stdout }}"
+    zero: false
+    metadatasize: 128m
+    dataalignment: 1m
+    pvmetadatacopies: 2
+  register: create_options_result
+
+- name: Re-creating physical volume with the same metadata layout options (idempotency check)
+  community.general.lvm_pv:
+    device: "{{ loop_device.stdout }}"
+    zero: false
+    metadatasize: 128m
+    dataalignment: 1m
+    pvmetadatacopies: 2
+  register: create_options_result_again
+
+- name: Checking physical volume metadata area count
+  ansible.builtin.command: pvs --noheadings -o pv_mda_count {{ loop_device.stdout }}
+  register: pv_mda_count_output
+
+- name: Asserting physical volume was created with the requested metadata layout
+  ansible.builtin.assert:
+    that:
+      - create_options_result.changed == true
+      - "'created' in create_options_result.msg"
+      - create_options_result_again.changed == false
+      - (pv_mda_count_output.stdout | trim | int) == 2
+
+- name: Setting metadataignore on the orphan physical volume
+  community.general.lvm_pv:
+    device: "{{ loop_device.stdout }}"
+    metadataignore: true
+  register: ignore_result
+
+- name: Re-applying the same metadataignore value (idempotency check)
+  community.general.lvm_pv:
+    device: "{{ loop_device.stdout }}"
+    metadataignore: true
+  register: ignore_result_again
+
+- name: Checking physical volume metadata area usage
+  ansible.builtin.command: pvs --noheadings -o pv_mda_used_count {{ loop_device.stdout }}
+  register: pv_mda_used_count_output
+
+- name: Asserting metadataignore was applied
+  ansible.builtin.assert:
+    that:
+      - ignore_result.changed == true
+      - "'attributes changed' in ignore_result.msg"
+      - ignore_result_again.changed == false
+      - (pv_mda_used_count_output.stdout | trim | int) == 0
+
+- name: Restoring metadataignore to false
+  community.general.lvm_pv:
+    device: "{{ loop_device.stdout }}"
+    metadataignore: false
+  register: unignore_result
+
+- name: Checking physical volume metadata area usage again
+  ansible.builtin.command: pvs --noheadings -o pv_mda_used_count {{ loop_device.stdout }}
+  register: pv_mda_used_count_output_again
+
+- name: Asserting metadataignore was reverted
+  ansible.builtin.assert:
+    that:
+      - unignore_result.changed == true
+      - (pv_mda_used_count_output_again.stdout | trim | int) == 2
+
+- name: Creating a volume group on the physical volume (allocatable/tags only apply to PVs in a VG)
+  ansible.builtin.command: vgcreate test_lvm_pv_vg {{ loop_device.stdout }}
+  args:
+    creates: /dev/test_lvm_pv_vg
+
+- name: Setting allocatable and tags on the physical volume
+  community.general.lvm_pv:
+    device: "{{ loop_device.stdout }}"
+    allocatable: false
+    tags:
+      - fast_disks
+      - site_a
+  register: attrs_result
+
+- name: Re-applying the same attributes (idempotency check)
+  community.general.lvm_pv:
+    device: "{{ loop_device.stdout }}"
+    allocatable: false
+    tags:
+      - fast_disks
+      - site_a
+  register: attrs_result_again
+
+- name: Checking physical volume attributes
+  ansible.builtin.command: pvs --noheadings -o pv_attr,pv_tags --separator | {{ loop_device.stdout }}
+  register: pv_attrs_output
+
+- name: Asserting physical volume attributes were changed
+  ansible.builtin.assert:
+    that:
+      - attrs_result.changed == true
+      - "'attributes changed' in attrs_result.msg"
+      - attrs_result_again.changed == false
+      - pv_attrs_output.stdout.split('|')[0].strip()[0:1] != 'a'
+      - "'fast_disks' in pv_attrs_output.stdout.split('|')[1]"
+      - "'site_a' in pv_attrs_output.stdout.split('|')[1]"
+
+- name: Changing tags and re-enabling allocation
+  community.general.lvm_pv:
+    device: "{{ loop_device.stdout }}"
+    allocatable: true
+    tags:
+      - site_a
+  register: attrs_update_result
+
+- name: Checking updated physical volume attributes
+  ansible.builtin.command: pvs --noheadings -o pv_attr,pv_tags --separator | {{ loop_device.stdout }}
+  register: pv_attrs_updated_output
+
+- name: Asserting physical volume attributes were updated
+  ansible.builtin.assert:
+    that:
+      - attrs_update_result.changed == true
+      - pv_attrs_updated_output.stdout.split('|')[0].strip()[0:1] == 'a'
+      - "'fast_disks' not in pv_attrs_updated_output.stdout.split('|')[1]"
+      - "'site_a' in pv_attrs_updated_output.stdout.split('|')[1]"
+
+- name: Removing the volume group so the physical volume becomes an orphan again
+  ansible.builtin.command: vgremove -f test_lvm_pv_vg


### PR DESCRIPTION
##### SUMMARY
Adds `pvcreate`/`pvchange` options to `lvm_pv`: `zero`, `metadatasize`, `dataalignment`, `pvmetadatacopies` (creation-time only); `allocatable`, `metadataignore`, `tags` (idempotent via `pvchange`, `allocatable`/`tags` need PV in a VG).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lvm_pv

##### ADDITIONAL INFORMATION
```yaml
- community.general.lvm_pv:
    device: /dev/sdb
    metadatasize: 128m
    pvmetadatacopies: 2

- community.general.lvm_pv:
    device: /dev/sdb
    allocatable: false
    tags: [fast_disks, site_a]