### PR TITLE
CI: Remove Debian Bullseye

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -275,12 +275,6 @@ stages:
               test: ansible-test-integration-devel-debian-bookworm-3.11-azp-posix-2
             - name: Debian 12 + py3.11 + group 3
               test: ansible-test-integration-devel-debian-bookworm-3.11-azp-posix-3
-            - name: Debian 11 + py3.9 + group 1
-              test: ansible-test-integration-devel-debian-bullseye-3.9-azp-posix-1
-            - name: Debian 11 + py3.9 + group 2
-              test: ansible-test-integration-devel-debian-bullseye-3.9-azp-posix-2
-            - name: Debian 11 + py3.9 + group 3
-              test: ansible-test-integration-devel-debian-bullseye-3.9-azp-posix-3
             - name: Generic + py3.13 + generic group 1
               test: ansible-test-integration-devel-default-3.13-azp-generic-1
             - name: Generic + py3.15 + generic group 1

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -139,7 +139,6 @@ retry_on_error = "in-ci"
 "azp/generic/1/" = "generic group 1"
 
 [sessions.ansible_test_integration.nice_docker_names]
-"quay.io/ansible-community/test-image:debian-bullseye" = "Debian 11"
 "quay.io/ansible-community/test-image:debian-bookworm" = "Debian 12"
 "quay.io/ansible-community/test-image:debian-13-trixie" = "Debian 13"
 "quay.io/ansible-community/test-image:archlinux" = "Arch Linux"
@@ -265,12 +264,6 @@ docker = [
     "ubuntu2404",
     "alpine324",
 ]
-
-[[sessions.ansible_test_integration.groups.sessions]]
-ansible_core = "devel"
-target = [ "azp/posix/1/", "azp/posix/2/", "azp/posix/3/" ]
-python_version = "3.9"
-docker = "quay.io/ansible-community/test-image:debian-bullseye"
 
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "devel"


### PR DESCRIPTION
##### SUMMARY
I don't think it's worth the effort to keep that image working, especially now that the public debian-security repos for Debian Bullseye expired. So let's remove it from CI.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
