### PR TITLE
[stable-11] CI: Remove Debian Bullseye (#12703)

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -207,12 +207,6 @@ stages:
               test: ansible-test-integration-2.21-debian-bookworm-3.11-azp-posix-2
             - name: Debian 12 + py3.11 + group 3
               test: ansible-test-integration-2.21-debian-bookworm-3.11-azp-posix-3
-            - name: Debian 11 + py3.9 + group 1
-              test: ansible-test-integration-2.21-debian-bullseye-3.9-azp-posix-1
-            - name: Debian 11 + py3.9 + group 2
-              test: ansible-test-integration-2.21-debian-bullseye-3.9-azp-posix-2
-            - name: Debian 11 + py3.9 + group 3
-              test: ansible-test-integration-2.21-debian-bullseye-3.9-azp-posix-3
             - name: Fedora 43 + group 1
               test: ansible-test-integration-2.21-fedora43-azp-posix-1
             - name: Fedora 43 + group 2

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -125,7 +125,6 @@ retry_on_error = "in-ci"
 "azp/posix/vm/" = "extra VMs"
 
 [sessions.ansible_test_integration.nice_docker_names]
-"quay.io/ansible-community/test-image:debian-bullseye" = "Debian 11"
 "quay.io/ansible-community/test-image:debian-bookworm" = "Debian 12"
 "quay.io/ansible-community/test-image:debian-13-trixie" = "Debian 13"
 "quay.io/ansible-community/test-image:archlinux" = "Arch Linux"
@@ -220,12 +219,6 @@ description = "Meta session for running all ansible-test-integration-2.21-* sess
 ansible_core = "2.21"
 target = [ "azp/posix/1/", "azp/posix/2/", "azp/posix/3/" ]
 docker = [ "fedora43", "alpine323", "ubuntu2204", "ubuntu2404" ]
-
-[[sessions.ansible_test_integration.groups.sessions]]
-ansible_core = "2.21"
-target = [ "azp/posix/1/", "azp/posix/2/", "azp/posix/3/" ]
-python_version = "3.9"
-docker = "quay.io/ansible-community/test-image:debian-bullseye"
 
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "2.21"


### PR DESCRIPTION
##### SUMMARY
Backport of #12703 to stable-11.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
