### PR TITLE
git_config: allow empty values

### DIFF
--- a/changelogs/fragments/12502-git-config-empty-value.yml
+++ b/changelogs/fragments/12502-git-config-empty-value.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - 'git_config - allow to set a setting to an empty string, the way ``git config user.email ""`` does. Passing an
+    empty ``value`` failed with ``If state=present, a value must be specified``, and once a setting had an empty
+    value the module was no longer idempotent for it
+    (https://github.com/ansible-collections/community.general/issues/12502).'

--- a/plugins/modules/git_config.py
+++ b/plugins/modules/git_config.py
@@ -63,6 +63,7 @@ options:
       - When specifying the name of a single setting, supply a value to set that setting to the given value.
       - From community.general 11.0.0 on, O(value) is required if O(state=present). To read values, use the M(community.general.git_config_info)
         module instead.
+      - An empty string is a valid value; it sets the setting to an empty value, like C(git config user.email "") does.
     type: str
   add_mode:
     description:
@@ -167,10 +168,10 @@ def main():
 
     name = params["name"] or ""
     unset = params["state"] == "absent"
-    new_value = params["value"] or ""
+    new_value = params["value"]
     add_mode = params["add_mode"]
 
-    if not unset and not new_value:
+    if not unset and new_value is None:
         module.fail_json(
             msg="If state=present, a value must be specified. Use the community.general.git_config_info module to read a config value."
         )
@@ -197,7 +198,11 @@ def main():
         # If the return code is 1, it just means the option hasn't been set yet, which is fine.
         module.fail_json(rc=rc, msg=err, cmd=" ".join(list_args))
 
-    old_values = out.rstrip().splitlines()
+    # 'git config --get-all' terminates every value with a newline, so splitting always yields a
+    # trailing empty element which must not be mistaken for a configured empty value.
+    old_values = out.split("\n")
+    if old_values and old_values[-1] == "":
+        old_values.pop()
 
     if unset and not out:
         module.exit_json(changed=False, msg="no setting to unset")

--- a/tests/integration/targets/git_config/tasks/main.yml
+++ b/tests/integration/targets/git_config/tasks/main.yml
@@ -30,6 +30,8 @@
     - ansible.builtin.import_tasks: unset_check_mode.yml
     # testing for case in issue #1776
     - ansible.builtin.import_tasks: set_value_with_tilde.yml
+    # testing for case in issue #12502
+    - ansible.builtin.import_tasks: set_empty_value.yml
     - ansible.builtin.import_tasks: set_multi_value.yml
     - ansible.builtin.import_tasks: unset_multi_value.yml
   when: git_installed is succeeded and git_version.stdout is version(git_version_supporting_includes, ">=")

--- a/tests/integration/targets/git_config/tasks/set_empty_value.yml
+++ b/tests/integration/targets/git_config/tasks/set_empty_value.yml
@@ -1,0 +1,61 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- ansible.builtin.import_tasks: setup_no_value.yml
+
+- name: setting an empty value
+  community.general.git_config:
+    name: user.email
+    value: ""
+    scope: global
+  register: set_result1
+
+- name: setting the same empty value again
+  community.general.git_config:
+    name: user.email
+    value: ""
+    scope: global
+  register: set_result2
+
+- name: getting value
+  community.general.git_config_info:
+    name: user.email
+    scope: global
+  register: get_result
+
+- name: replacing the empty value
+  community.general.git_config:
+    name: user.email
+    value: foo
+    scope: global
+  register: set_result3
+
+- name: assert the empty value was set idempotently
+  ansible.builtin.assert:
+    that:
+      - set_result1 is changed
+      - set_result2 is not changed
+      - 'get_result.config_values == {"user.email": [""]}'
+      - set_result3 is changed
+      - set_result3.diff.after == "foo\n"
+
+- name: setting another empty value to unset it afterwards
+  community.general.git_config:
+    name: user.name
+    value: ""
+    scope: global
+
+- name: unsetting an empty value
+  community.general.git_config:
+    name: user.name
+    state: absent
+    scope: global
+  register: unset_result
+
+- name: assert the empty value was unset
+  ansible.builtin.assert:
+    that:
+      - unset_result is changed
+...


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible-collections/community.general/issues/12502

`git config user.email ""` is valid, but `git_config` refused it: `value` was normalized with `params["value"] or ""` and then checked with `if not unset and not new_value`, so an empty string was indistinguishable from a missing value and the task failed with `If state=present, a value must be specified.`

As suggested by @felixfontein in the issue, the check is now `new_value is None`. `value: null` therefore still fails (the message is the intended one, and `required_if` already covers the case where the option is omitted entirely), while `value: ""` is accepted.

There was a second empty-string bug behind that one. The current value was read as `out.rstrip().splitlines()`, and since `git config --get-all` prints an empty line for an empty value, `rstrip()` reduced it to `""` and `splitlines()` to `[]` — exactly what an unset setting looks like. A setting with an empty value would therefore never compare equal to the requested empty value and the module would report a change on every run. The output is now split on the value separator instead, dropping only the single trailing newline that `git config --get-all` always emits.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

git_config

##### ADDITIONAL INFORMATION

The `git_config` integration target is not `unsupported`, so the new `set_empty_value.yml` tasks run in CI: they set an empty value, set it again to assert idempotency, read it back through `git_config_info` (`config_values == {"user.email": [""]}`, which distinguishes an empty value from an unset one, unlike `config_value`), overwrite it with a non-empty value, and finally unset a setting that holds an empty value.

The parsing change is behavior-preserving for non-empty values: `git config --get-all` terminates each value with a newline, so the only difference against `rstrip().splitlines()` is that trailing whitespace of the last value is no longer silently dropped.