### PR TITLE
Prepare use of Secrets API

### DIFF
--- a/plugins/module_utils/_secrets.py
+++ b/plugins/module_utils/_secrets.py
@@ -8,6 +8,7 @@ import typing as t
 from collections.abc import Mapping, Sequence
 
 try:
+    from ansible.module_utils.secrets import mask_secrets as _mask_secrets  # type: ignore[import-not-found]
     from ansible.module_utils.secrets import register_secret  # type: ignore[import-not-found]
 
     HAS_SECRETS_API = True
@@ -28,7 +29,7 @@ def _mark_recursively(value: t.Any, *, int_to_string: bool = False) -> t.Any:
 
 
 def mark_values_as_secrets(value: t.Any, *, int_to_string: bool = False) -> t.Any:
-    """Register all strings appearing in the (potentially nested) data structure value secrets."""
+    """Register all strings appearing in the (potentially nested) data structure ``value`` as secrets."""
     if HAS_SECRETS_API:
         value = _mark_recursively(value)
     return value
@@ -38,4 +39,28 @@ def mark_as_secret(value: str) -> str:
     """Register a string as a secret."""
     if HAS_SECRETS_API:
         value = register_secret(value)
+    return value
+
+
+def mask_secrets(value: str, *, mask_placeholder="$REDACTED$") -> str:
+    """Mask secrets in value."""
+    if HAS_SECRETS_API:
+        return _mask_secrets(value, mask_placeholder=mask_placeholder)
+    return value
+
+
+def _mask_recursively(value: t.Any, *, mask_placeholder: str) -> t.Any:
+    if isinstance(value, Mapping):
+        return {k: _mask_recursively(v, mask_placeholder=mask_placeholder) for k, v in value.items()}
+    if isinstance(value, str):
+        return _mask_secrets(value, mask_placeholder=mask_placeholder)
+    if isinstance(value, Sequence):
+        return [_mask_recursively(v, mask_placeholder=mask_placeholder) for v in value]
+    return value
+
+
+def mask_secret_values(value: t.Any, *, mask_placeholder="$REDACTED$") -> t.Any:
+    """Mask secrets in the (potentially nested) data structure ``value``."""
+    if HAS_SECRETS_API:
+        return _mask_recursively(value, mask_placeholder=mask_placeholder)
     return value

--- a/plugins/module_utils/_secrets.py
+++ b/plugins/module_utils/_secrets.py
@@ -15,6 +15,8 @@ try:
 except ImportError:
     HAS_SECRETS_API = False
 
+_T = t.TypeVar("_T")
+
 
 def _collect_recursively(value: t.Any, collected_values: list[str], *, int_to_string: bool = False) -> None:
     if isinstance(value, Mapping):
@@ -29,7 +31,7 @@ def _collect_recursively(value: t.Any, collected_values: list[str], *, int_to_st
         collected_values.append(str(value))
 
 
-def mark_values_as_secrets(value: t.Any, *, int_to_string: bool = False) -> t.Any:
+def mark_values_as_secrets(value: _T, *, int_to_string: bool = False) -> _T:
     """Register all strings appearing in the (potentially nested) data structure ``value`` as secrets."""
     if HAS_SECRETS_API:
         collected_values: list[str] = []
@@ -61,6 +63,18 @@ def _mask_recursively(value: t.Any, *, mask_placeholder: str) -> t.Any:
     if isinstance(value, Sequence):
         return [_mask_recursively(v, mask_placeholder=mask_placeholder) for v in value]
     return value
+
+
+@t.overload
+def mask_secret_values(value: dict[str, t.Any], *, mask_placeholder="$REDACTED$") -> dict[str, t.Any]: ...
+
+
+@t.overload
+def mask_secret_values(value: list[t.Any], *, mask_placeholder="$REDACTED$") -> list[t.Any]: ...
+
+
+@t.overload
+def mask_secret_values(value: t.Any, *, mask_placeholder="$REDACTED$") -> t.Any: ...
 
 
 def mask_secret_values(value: t.Any, *, mask_placeholder="$REDACTED$") -> t.Any:

--- a/plugins/module_utils/_secrets.py
+++ b/plugins/module_utils/_secrets.py
@@ -9,29 +9,33 @@ from collections.abc import Mapping, Sequence
 
 try:
     from ansible.module_utils.secrets import mask_secrets as _mask_secrets  # type: ignore[import-not-found]
-    from ansible.module_utils.secrets import register_secret  # type: ignore[import-not-found]
+    from ansible.module_utils.secrets import register_secret, register_secrets  # type: ignore[import-not-found]
 
     HAS_SECRETS_API = True
 except ImportError:
     HAS_SECRETS_API = False
 
 
-def _mark_recursively(value: t.Any, *, int_to_string: bool = False) -> t.Any:
+def _collect_recursively(value: t.Any, collected_values: list[str], *, int_to_string: bool = False) -> None:
     if isinstance(value, Mapping):
-        return {k: _mark_recursively(v, int_to_string=int_to_string) for k, v in value.items()}
-    if isinstance(value, str):
-        return register_secret(value)
-    if isinstance(value, Sequence):
-        return [_mark_recursively(v, int_to_string=int_to_string) for v in value]
-    if int_to_string and isinstance(value, int):
-        register_secret(str(value))
-    return value
+        for v in value.items():
+            _collect_recursively(v, collected_values, int_to_string=int_to_string)
+    elif isinstance(value, str):
+        collected_values.append(value)
+    elif isinstance(value, Sequence):
+        for v in value:
+            _collect_recursively(v, collected_values, int_to_string=int_to_string)
+    elif int_to_string and isinstance(value, int):
+        collected_values.append(str(value))
 
 
 def mark_values_as_secrets(value: t.Any, *, int_to_string: bool = False) -> t.Any:
     """Register all strings appearing in the (potentially nested) data structure ``value`` as secrets."""
     if HAS_SECRETS_API:
-        value = _mark_recursively(value)
+        collected_values: list[str] = []
+        _collect_recursively(value, collected_values, int_to_string=int_to_string)
+        if collected_values:
+            register_secrets(collected_values)
     return value
 
 

--- a/plugins/module_utils/_secrets.py
+++ b/plugins/module_utils/_secrets.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import typing as t
+from collections.abc import Mapping, Sequence
+
+try:
+    from ansible.module_utils.secrets import register_secret  # type: ignore[import-not-found]
+
+    HAS_SECRETS_API = True
+except ImportError:
+    HAS_SECRETS_API = False
+
+
+def _mark_recursively(value: t.Any, *, int_to_string: bool = False) -> t.Any:
+    if isinstance(value, Mapping):
+        return {k: _mark_recursively(v, int_to_string=int_to_string) for k, v in value.items()}
+    if isinstance(value, str):
+        return register_secret(value)
+    if isinstance(value, Sequence):
+        return [_mark_recursively(v, int_to_string=int_to_string) for v in value]
+    if int_to_string and isinstance(value, int):
+        register_secret(str(value))
+    return value
+
+
+def mark_values_as_secrets(value: t.Any, *, int_to_string: bool = False) -> t.Any:
+    """Register all strings appearing in the (potentially nested) data structure value secrets."""
+    if HAS_SECRETS_API:
+        value = _mark_recursively(value)
+    return value
+
+
+def mark_as_secret(value: str) -> str:
+    """Register a string as a secret."""
+    if HAS_SECRETS_API:
+        value = register_secret(value)
+    return value

--- a/plugins/modules/consul_acl_bootstrap.py
+++ b/plugins/modules/consul_acl_bootstrap.py
@@ -47,8 +47,10 @@ RETURN = r"""
 result:
   description:
     - The bootstrap result as returned by the Consul HTTP API.
-    - B(Note:) If O(bootstrap_secret) has been specified the C(SecretID) and C(ID) do not contain the secret but C(VALUE_SPECIFIED_IN_NO_LOG_PARAMETER).
+    - B(Note:) (ansible-core 2.21 and before) If O(bootstrap_secret) has been specified,
+      the C(SecretID) and C(ID) do not contain the secret but C(VALUE_SPECIFIED_IN_NO_LOG_PARAMETER).
       If you pass O(bootstrap_secret), make sure your playbook/role does not depend on this return value!
+      On ansible-core 2.22+, this is no longer a problem.
   returned: changed
   type: dict
   sample:

--- a/tests/integration/targets/gitlab_instance_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_instance_variable/tasks/main.yml
@@ -437,7 +437,7 @@
       - gitlab_instance_variable_state.instance_variable.untouched|length == 0
       - gitlab_instance_variable_state.instance_variable.removed|length == 0
       - gitlab_instance_variable_state.instance_variable.updated|length == 0
-      # VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
+      # VALUE_SPECIFIED_IN_NO_LOG_PARAMETER - this is only a problem for ansible-core < 2.22
       # - gitlab_instance_variable_state.instance_variable.added[0] == "my_test_var"
 
 - name: change variable_type attribute

--- a/tests/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -478,7 +478,7 @@
       - gitlab_project_variable_state.project_variable.untouched|length == 0
       - gitlab_project_variable_state.project_variable.removed|length == 0
       - gitlab_project_variable_state.project_variable.updated|length == 0
-      # VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
+      # VALUE_SPECIFIED_IN_NO_LOG_PARAMETER - this is only a problem for ansible-core < 2.22
       # - gitlab_project_variable_state.project_variable.added[0] == "my_test_var"
 
 - name: change variable_type attribute

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,5 +1,6 @@
 plugins/module_utils/_crypt.py import-3.11  # Uses deprecated stdlib library 'crypt'
 plugins/module_utils/_crypt.py import-3.12  # Uses deprecated stdlib library 'crypt'
+plugins/module_utils/_secrets.py pep8:E704
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice


### PR DESCRIPTION
##### SUMMARY
The Secrets API is being introduced for ansible-core 2.22 and allows modules and plugins to mark secret values for redaction. As opposed to the rudimentary `no_log` handling up until ansible-core 2.21, this improves masking of secret values.

More infos:
* https://forum.ansible.com/t/46291
* https://github.com/ansible/ansible/pull/87457
* https://github.com/ansible/ansible-documentation/pull/3934

This PR updates documentation of consul_acl_bootstrap (which mentions the old masking mechanism) and adds a `_secrets` module utils (taken from https://github.com/ansible-collections/community.crypto/pull/1076 / https://github.com/ansible-collections/community.docker/pull/1312 / https://github.com/ansible-collections/community.sops/pull/304) that can be used for modules / plugins to register secrets without having to care about the ansible-core version in use.

I'm creating a separate PR for this since this is something that needs to be used in quite a few lookup plugins and modules for secret managers. I'll push some more enhancements soon that will be useful for callback plugins. To avoid having to create a monster PR with everything, I'd prefer to get the helper merged first, and then have separate PRs for individual plugins / groups of plugins.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/consul_acl_bootstrap.py
plugins/module_utils/_secrets.py
