### PR TITLE
xenserver_guest: skip provisioning when existing VM is used as a template, fixes #12576

### DIFF
--- a/changelogs/fragments/12717-xenserver-skip-provisioning-on-existing-vm-as-template.yml
+++ b/changelogs/fragments/12717-xenserver-skip-provisioning-on-existing-vm-as-template.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - xenserver_guest - skip provisioning when existing VM is used as a template (https://github.com/ansible-collections/community.general/issues/12576, https://github.com/ansible-collections/community.general/pull/12717).

--- a/plugins/modules/xenserver_guest.py
+++ b/plugins/modules/xenserver_guest.py
@@ -707,8 +707,11 @@ class XenServerVM(XenServerObject):
 
                 self.xapi_session.xenapi.VM.set_other_config(self.vm_ref, vm_other_config)
 
-            # At this point we have VM ready for provisioning.
-            self.xapi_session.xenapi.VM.provision(self.vm_ref)
+            # At this point we have a template clone or copy that is ready
+            # for provisioning. Provisioning is done for real templates and
+            # snapshots and skipped for existing VMs used as templates.
+            if self.xapi_session.xenapi.VM.get_is_a_template(templ_ref):
+                self.xapi_session.xenapi.VM.provision(self.vm_ref)
 
             # After provisioning we can prepare vm_params for reconfigure().
             self.gather_params()


### PR DESCRIPTION
##### SUMMARY
`VM.provision()` method is only applicable to real VM templates and VM snapshots (when used as templates). It cannot be called on an existing VM when used as a template. Existing VMs are already provisioned in XenAPI sense so calling `VM.provision()` fails with the error `PROVISION_ONLY_ALLOWED_ON_TEMPLATE`. Thus, provisioning can be safely skipped when existing VMs are used as templates.

Fixes #12576

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
xenserver_guest

##### ADDITIONAL INFORMATION
None