### PR TITLE
new module: sssd_config manages options in the SSSD section

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -437,6 +437,8 @@ files:
     maintainers: russoz
   $module_utils/_ssh.py:
     maintainers: russoz
+  $module_utils/_sssd_config.py:
+    maintainers: NicholasBrodersen
   $module_utils/_systemd.py:
     maintainers: NomakCooper
   $module_utils/_utm_utils.py:
@@ -1304,6 +1306,8 @@ files:
     maintainers: farhan7500 gautamphegde
   $modules/ssh_config.py:
     maintainers: gaqzi Akasurde
+  $modules/sssd_config.py:
+    maintainers: NicholasBrodersen
   $modules/sssd_info.py:
     maintainers: a-gabidullin
   $modules/stacki_host.py:

--- a/plugins/module_utils/_sssd_config.py
+++ b/plugins/module_utils/_sssd_config.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2026, Nicholas Brodersen <nicholasbrodersen01@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Note that this module util is **PRIVATE** to the collection. It can have breaking changes at any time.
+# Do not use this from other collections or standalone plugins/modules!
+
+from __future__ import annotations
+
+import traceback
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Optional, Union, cast
+
+HAS_SSSD_LIB = False
+SSSDCONFIG_IMPORT_ERROR = ""
+_SSSDConfig: Any = None
+
+try:
+    from SSSDConfig import SSSDConfig as _ImportedSSSDConfig  # type: ignore[import-not-found]
+
+    _SSSDConfig = _ImportedSSSDConfig
+    HAS_SSSD_LIB = True
+except ImportError:
+    SSSDCONFIG_IMPORT_ERROR = traceback.format_exc()
+
+
+@dataclass(frozen=True)
+class SSSDTarget:
+    path: str
+    section: str
+    name: Optional[str] = None
+
+    @property
+    def section_name(self) -> str:
+        if self.section == "domain":
+            return f"domain/{self.name}"
+
+        if self.section == "service":
+            return cast(str, self.name)
+
+        return "sssd"
+
+
+@dataclass(frozen=True)
+class EnsurePresent:
+    target: SSSDTarget
+    options: Mapping[str, Any]
+    must_exist: bool = False
+    active: Optional[bool] = None
+
+
+@dataclass(frozen=True)
+class RemoveOptions:
+    target: SSSDTarget
+    option_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RemoveSection:
+    target: SSSDTarget
+
+
+SSSDRequest = Union[EnsurePresent, RemoveOptions, RemoveSection]
+
+
+def create_sssd_config():
+    if _SSSDConfig is None:
+        raise ImportError("the SSSDConfig Python library is unavailable")
+
+    return _SSSDConfig()
+
+
+def get_explicit_options(sssd_config, section_name: str) -> dict:
+    if not sssd_config.has_section(section_name):
+        return {}
+
+    return {
+        option["name"]: option["value"]
+        for option in sssd_config.strip_comments_empty(sssd_config.options(section_name))
+    }
+
+
+def set_domain_options(domain, requested_options: Mapping[str, Any], explicit_options: Mapping[str, Any]) -> bool:
+    before = dict(domain.get_all_options())
+
+    provider_options = {name: value for name, value in requested_options.items() if name.endswith("_provider")}
+
+    regular_options = {name: value for name, value in requested_options.items() if not name.endswith("_provider")}
+
+    for option, value in provider_options.items():
+        current_value = domain.get_all_options().get(option)
+
+        if current_value is not None and current_value != value:
+            provider_type = option[: -len("_provider")]
+            domain.remove_provider(provider_type)
+
+        domain.set_option(option, value)
+
+    for option, value in regular_options.items():
+        domain.set_option(option, value)
+
+    after = domain.get_all_options()
+
+    return before != after or any(option not in explicit_options for option in requested_options)
+
+
+def set_service_options(service, requested_options: Mapping[str, Any], explicit_options: Mapping[str, Any]) -> bool:
+    before = dict(service.get_all_options())
+
+    for option, value in requested_options.items():
+        service.set_option(option, value)
+
+    after = service.get_all_options()
+
+    return before != after or any(option not in explicit_options for option in requested_options)
+
+
+def set_domain_active(domain, created: bool, requested: Optional[bool]) -> bool:
+    if requested is None:
+        if not created:
+            return False
+
+        requested = False
+
+    if domain.active == requested:
+        return False
+
+    domain.set_active(requested)
+    return True
+
+
+def set_service_active(sssd_config, name: str, created: bool, requested: Optional[bool]) -> bool:
+    if requested is None:
+        if not created:
+            return False
+
+        requested = False
+
+    currently_active = name in sssd_config.list_active_services()
+
+    if currently_active == requested:
+        return False
+
+    if requested:
+        sssd_config.activate_service(name)
+    else:
+        sssd_config.deactivate_service(name)
+
+    return True
+
+
+def delete_service(sssd_config, name: str) -> None:
+    if name in sssd_config.list_active_services():
+        sssd_config.deactivate_service(name)
+
+    sssd_config.delete_service(name)
+
+
+def serialize_option_value(option: str, value: Any) -> str:
+    if isinstance(value, list):
+        value = ", ".join(str(item) for item in value)
+
+    if option == "debug_level" and isinstance(value, int) and value > 16:
+        value = hex(value)
+
+    return str(value)
+
+
+def set_sssd_options(sssd_config, requested_options: Mapping[str, Any]) -> bool:
+    # the SSSDConfig class exposes the [sssd] section schema through its SSSDService class
+    # writing the [sssd] section itself requires SSSDConfig
+    sssd_section = sssd_config.get_service("sssd")
+    current_options = dict(sssd_section.get_all_options())
+
+    changed = False
+
+    for option, requested_value in requested_options.items():
+        explicitly_present = sssd_config.has_option("sssd", option)
+        current_value = current_options.get(option)
+
+        # SSSDConfig class validates and normalizes the requested value.
+        sssd_section.set_option(option, requested_value)
+        normalized_value = sssd_section.get_option(option)
+
+        if not explicitly_present or current_value != normalized_value:
+            sssd_config.set(
+                "sssd",
+                option,
+                serialize_option_value(option, normalized_value),
+            )
+            changed = True
+
+    return changed
+
+
+def remove_domain_options(domain, option_names: Iterable[str]) -> bool:
+    option_names = tuple(option_names)
+
+    for option in option_names:
+        if option.endswith("_provider"):
+            domain.remove_provider(option[: -len("_provider")])
+        else:
+            domain.remove_option(option)
+
+    return bool(option_names)
+
+
+def remove_service_options(service, option_names: Iterable[str]) -> bool:
+    option_names = tuple(option_names)
+
+    for option in option_names:
+        service.remove_option(option)
+
+    return bool(option_names)
+
+
+def remove_sssd_options(sssd_config, option_names: Iterable[str]) -> bool:
+    option_names = tuple(option_names)
+
+    if not option_names:
+        return False
+
+    sssd_section = sssd_config.findOpts(
+        sssd_config.opts,
+        "section",
+        "sssd",
+    )[1]
+
+    for option in option_names:
+        sssd_config.delete_option_subtree(
+            sssd_section["value"],
+            "option",
+            option,
+            True,
+        )
+
+    return True

--- a/plugins/modules/sssd_config.py
+++ b/plugins/modules/sssd_config.py
@@ -1,0 +1,336 @@
+#!/usr/bin/python
+# Copyright (c) 2026, Nicholas Brodersen <nicholasbrodersen01@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+DOCUMENTATION = r"""
+module: sssd_config
+short_description: Manage options in the SSSD configuration section
+version_added: "13.5.0"
+description:
+  - Manages options in the top-level C([sssd]) section of an SSSD
+    configuration file.
+  - Validates and normalizes option names and values according to the
+    SSSD schema present on the managed node.
+  - The configuration file and its C([sssd]) section must already exist.
+  - Unspecified options are preserved.
+  - This module does not manage domain or service sections of SSSD configuration files.
+author:
+  - Nicholas Brodersen (@NicholasBrodersen)
+requirements:
+  - The SSSDConfig Python library on managed nodes.
+  - SSSD configuration schema files on managed nodes.
+extends_documentation_fragment:
+  - community.general._attributes
+attributes:
+  check_mode:
+    support: full
+    details:
+      - Reports whether the requested options would result in a change
+        to the specified configuration file.
+  diff_mode:
+    support: full
+    details:
+      - Reports changes to configured option names.
+      - Option values are omitted because they can contain sensitive data.
+options:
+  state:
+    description:
+      - When V(present), the options are added or updated.
+      - When V(absent), the option names are removed. Values are ignored.
+      - The C([sssd]) section itself is never removed.
+    type: str
+    choices: [absent, present]
+    default: present
+
+  must_exist:
+    description:
+      - Controls whether options with O(state=present) must already be explicitly configured.
+      - When V(true), the module fails instead of adding an option that is not
+        currently defined in the C([sssd]) section.
+      - Existing option values can still be changed when this is V(true).
+      - No effect when O(state=absent).
+    type: bool
+    default: false
+
+  path:
+    description:
+      - Path to the SSSD configuration file.
+    type: path
+    default: /etc/sssd/sssd.conf
+
+  options:
+    description:
+      - Mapping of C([sssd]) option names to their desired values.
+      - Option names and values are validated using the SSSD schema.
+      - When O(state=present), options are added or updated while
+        unspecified options are preserved.
+      - List-valued options such as C(domains) and C(services) are ordered desired values.
+        Reordering or omitting a list item changes the final configured value.
+      - When O(state=absent), only the mapping keys are used and their values are ignored.
+      - Providing an empty mapping results in an idempotent no-operation.
+    type: dict
+    required: true
+
+notes:
+  - The SSSDConfig library and its schema data are normally supplied by operating-system packages.
+    Package names differ between distributions.
+  - The set of valid options is determined at runtime by the installed SSSD schema.
+  - Domain and service sections are outside this module's scope.
+  - Restart or reload SSSD separately when the running daemon must consume the updated configuration.
+  - Option values are not included in the module return data because an SSSD
+    configuration can contain sensitive values.
+
+seealso:
+  - module: community.general.sssd_info
+"""
+
+EXAMPLES = r"""
+- name: Configure top-level SSSD options
+  community.general.sssd_config:
+    options:
+      config_file_version: 2
+      services:
+        - nss
+        - pam
+      domains:
+        - example.com
+      debug_level: 6
+
+- name: Update options only when they are already explicitly configured
+  community.general.sssd_config:
+    must_exist: true
+    options:
+      services:
+        - nss
+        - pam
+      domains:
+        - example.com
+
+- name: Remove selected options from the sssd section
+  community.general.sssd_config:
+    state: absent
+    options:
+      debug_level:
+      default_domain_suffix:
+
+- name: Manage an alternate SSSD configuration file
+  community.general.sssd_config:
+    path: /etc/sssd/sssd-test.conf
+    options:
+      debug_level: 0x0270
+"""
+
+RETURN = r"""
+path:
+  description:
+    - Path to the specified SSSD configuration file.
+  returned: always
+  type: str
+  sample: /etc/sssd/sssd.conf
+
+section_name:
+  description:
+    - Name of the configuration section.
+  returned: always
+  type: str
+  sample: sssd
+
+exists:
+  description:
+    - Whether the C([sssd]) section exists after the operation.
+  returned: always
+  type: bool
+  sample: true
+
+option_names:
+  description:
+    - Names of options defined in the resulting C([sssd]) section.
+    - Option values are intentionally omitted because options can contain sensitive data.
+    - In check mode, these are the option names predicted if the operation were performed.
+  returned: always
+  type: list
+  elements: str
+  sample:
+    - config_file_version
+    - domains
+    - services
+"""
+
+from typing import Any, Mapping, Optional, Union, cast
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ansible_collections.community.general.plugins.module_utils._module_helper import StateModuleHelper
+from ansible_collections.community.general.plugins.module_utils._sssd_config import (
+    HAS_SSSD_LIB,
+    SSSDCONFIG_IMPORT_ERROR,
+    EnsurePresent,
+    RemoveOptions,
+    SSSDTarget,
+    create_sssd_config,
+    get_explicit_options,
+    remove_sssd_options,
+    set_sssd_options,
+)
+
+_SSSDRequest = Union[EnsurePresent, RemoveOptions]
+
+
+def _parse_request(*, state: str, path: str, options: Mapping[str, Any], must_exist: bool) -> _SSSDRequest:
+    target = SSSDTarget(path=path, section="sssd")
+
+    if state == "present":
+        return EnsurePresent(target=target, options=dict(options), must_exist=must_exist)
+
+    return RemoveOptions(target=target, option_names=tuple(options))
+
+
+class SSSDConfigModule(StateModuleHelper):
+    _result_diff: Optional[dict] = None
+
+    module = dict(
+        argument_spec=dict(
+            state=dict(
+                type="str",
+                choices=["present", "absent"],
+                default="present",
+            ),
+            must_exist=dict(
+                type="bool",
+                default=False,
+            ),
+            path=dict(
+                type="path",
+                default="/etc/sssd/sssd.conf",
+            ),
+            options=dict(
+                type="dict",
+                required=True,
+            ),
+        ),
+        supports_check_mode=True,
+    )
+
+    output_params = ("path",)
+
+    def __init_module__(self):
+        self.request = _parse_request(
+            state=self.vars.state,
+            path=self.vars.path,
+            options=self.vars.options,
+            must_exist=self.vars.must_exist,
+        )
+
+        if not HAS_SSSD_LIB:
+            self.module.fail_json(
+                msg=missing_required_lib("SSSDConfig"),
+                exception=SSSDCONFIG_IMPORT_ERROR,
+            )
+
+        self.sssd_config = create_sssd_config()
+        self.sssd_config.import_config(self.request.target.path)
+
+        if not self.sssd_config.has_section(self.request.target.section_name):
+            self.module.fail_json(msg="The sssd section does not exist")
+
+        if self.diff_mode:
+            self._diff_before, self._diff_before_options = self._get_diff_state()
+
+    def _get_explicit_options(self) -> dict:
+        return get_explicit_options(
+            self.sssd_config,
+            self.request.target.section_name,
+        )
+
+    def _get_diff_state(self):
+        options = self._get_explicit_options()
+
+        return {
+            "section_name": self.request.target.section_name,
+            "exists": True,
+            "option_names": sorted(options),
+        }, options
+
+    def _set_diff(self) -> None:
+        self._result_diff = None
+
+        if not self.diff_mode:
+            return
+
+        after, after_options = self._get_diff_state()
+        before = dict(self._diff_before)
+
+        changed_option_names = sorted(
+            option
+            for option in self._diff_before_options.keys() | after_options.keys()
+            if (
+                option not in self._diff_before_options
+                or option not in after_options
+                or self._diff_before_options[option] != after_options[option]
+            )
+        )
+
+        before["changed_option_names"] = []
+        after["changed_option_names"] = changed_option_names
+
+        if before != after:
+            self._result_diff = {
+                "before": before,
+                "after": after,
+            }
+
+    @property
+    def output(self):
+        result = super().output
+
+        if self._result_diff is not None:
+            result["diff"] = self._result_diff
+
+        return result
+
+    def state_present(self):
+        request = cast(EnsurePresent, self.request)
+        explicit_options = self._get_explicit_options()
+
+        if request.must_exist:
+            missing_options = [option for option in request.options if option not in explicit_options]
+
+            if missing_options:
+                self.do_raise(f"The following options must already exist: {', '.join(sorted(missing_options))}")
+
+        if set_sssd_options(self.sssd_config, request.options):
+            self.changed = True
+
+    def state_absent(self):
+        request = cast(RemoveOptions, self.request)
+        explicit_options = self._get_explicit_options()
+        options_to_remove = tuple(option for option in request.option_names if option in explicit_options)
+
+        if remove_sssd_options(self.sssd_config, options_to_remove):
+            self.changed = True
+
+    def _set_return_values(self) -> None:
+        self.update_output(
+            section_name=self.request.target.section_name,
+            exists=True,
+            option_names=sorted(self._get_explicit_options()),
+        )
+
+    def __quit_module__(self) -> None:
+        self._set_diff()
+
+        if self.changed and not self.check_mode:
+            self.sssd_config.write()
+
+        self._set_return_values()
+
+
+def main():
+    SSSDConfigModule().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/sssd_config/aliases
+++ b/tests/integration/targets/sssd_config/aliases
@@ -1,0 +1,10 @@
+# Copyright (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+azp/posix/3
+destructive
+needs/root
+skip/alpine
+skip/freebsd
+skip/macos

--- a/tests/integration/targets/sssd_config/defaults/main.yml
+++ b/tests/integration/targets/sssd_config/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# Copyright (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+sssd_config_test_package_map:
+  RedHat:
+    - python3-sssdconfig
+  Debian:
+    - python3-sss
+    - sssd-common
+  Suse:
+    - python3-sssd-config
+  Archlinux:
+    - sssd
+
+# Set this to a package list on a distro whose names differ from the map.
+sssd_config_test_packages_override: null
+
+sssd_config_test_baseline: |
+  [sssd]
+  config_file_version = 2
+  services =
+  domains =

--- a/tests/integration/targets/sssd_config/files/inspect_ini.py
+++ b/tests/integration/targets/sssd_config/files/inspect_ini.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Read an sssd.conf independently of SSSDConfig and emit JSON."""
+
+from __future__ import annotations
+
+import configparser
+import hashlib
+import json
+import os
+import stat
+import sys
+
+
+def main():
+    path = sys.argv[1]
+
+    with open(path, "rb") as stream:
+        raw = stream.read()
+
+    parser = configparser.RawConfigParser(interpolation=None, strict=False)
+    parser.optionxform = str
+    parser.read_string(raw.decode("utf-8"))
+
+    sections = {section: dict(parser.items(section, raw=True)) for section in parser.sections()}
+
+    result = {
+        "mode": format(stat.S_IMODE(os.stat(path).st_mode), "04o"),
+        "sha256": hashlib.sha256(raw).hexdigest(),
+        "sections": sections,
+    }
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/sssd_config/files/probe_sssdconfig.py
+++ b/tests/integration/targets/sssd_config/files/probe_sssdconfig.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Report capabilities from the SSSDConfig schema installed on the target."""
+
+from __future__ import annotations
+
+import json
+import platform
+import sys
+
+import SSSDConfig as sssdconfig_module  # type: ignore[import-not-found]
+from SSSDConfig import SSSDConfig  # type: ignore[import-not-found]
+
+
+def main():
+    config = SSSDConfig()
+    config.import_config(sys.argv[1])
+
+    sssd_options = sorted(config.get_service("sssd").list_options())
+
+    result = {
+        "module_file": sssdconfig_module.__file__,
+        "python": platform.python_version(),
+        "sssd_options": sssd_options,
+    }
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/sssd_config/tasks/inspect.yml
+++ b/tests/integration/targets/sssd_config/tasks/inspect.yml
@@ -1,0 +1,17 @@
+---
+# Copyright (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Inspect the temporary SSSD configuration independently
+  ansible.builtin.command:
+    argv:
+      - "{{ ansible_facts.python.executable }}"
+      - "{{ sssd_config_test_inspector }}"
+      - "{{ sssd_config_test_inspect_path }}"
+  register: sssd_config_test_inspect_command
+  changed_when: false
+
+- name: Store the independent configuration view
+  ansible.builtin.set_fact:
+    sssd_config_test_config: "{{ sssd_config_test_inspect_command.stdout | from_json }}"

--- a/tests/integration/targets/sssd_config/tasks/main.yml
+++ b/tests/integration/targets/sssd_config/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Run sssd_config integration tests
+  block:
+    - name: Prepare the target
+      ansible.builtin.import_tasks: setup.yml
+
+    - name: Test sssd configuration options
+      ansible.builtin.import_tasks: test_sssd.yml
+
+    - name: Test validation and failure paths
+      ansible.builtin.import_tasks: test_validation.yml
+
+  always:
+    - name: Remove the temporary test directory
+      ansible.builtin.file:
+        path: "{{ sssd_config_test_temp.path }}"
+        state: absent
+      when: sssd_config_test_temp is defined

--- a/tests/integration/targets/sssd_config/tasks/main.yml
+++ b/tests/integration/targets/sssd_config/tasks/main.yml
@@ -7,6 +7,9 @@
 # Copyright (c) 2026, Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
+- name: Skip Alpine because SSSDConfig is unavailable
+  ansible.builtin.meta: end_host
+  when: ansible_facts.os_family == "Alpine"
 
 - name: Run sssd_config integration tests
   block:

--- a/tests/integration/targets/sssd_config/tasks/setup.yml
+++ b/tests/integration/targets/sssd_config/tasks/setup.yml
@@ -1,0 +1,104 @@
+---
+# Copyright (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Gather target distribution and Python facts
+  ansible.builtin.setup:
+    gather_subset:
+      - "!all"
+      - min
+
+- name: Select the native SSSDConfig packages
+  ansible.builtin.set_fact:
+    sssd_config_test_packages: >-
+      {{
+        sssd_config_test_package_map.get(ansible_facts.os_family, [])
+        if sssd_config_test_packages_override is none
+        else sssd_config_test_packages_override
+      }}
+
+- name: Require a known package mapping
+  ansible.builtin.assert:
+    that:
+      - ansible_facts.system == 'Linux'
+      - sssd_config_test_packages | length > 0
+    fail_msg: >-
+      No SSSDConfig package mapping is defined for os_family={{ ansible_facts.os_family }}.
+      Add it to defaults/main.yml or set sssd_config_test_packages_override.
+
+- name: Install the native SSSDConfig library and schemas
+  ansible.builtin.package:
+    name: "{{ sssd_config_test_packages }}"
+    state: present
+
+- name: Verify that Ansible's module interpreter can import SSSDConfig
+  ansible.builtin.command:
+    argv:
+      - "{{ ansible_facts.python.executable }}"
+      - -c
+      - "import SSSDConfig; print(SSSDConfig.__file__)"
+  register: sssd_config_test_import
+  changed_when: false
+
+- name: Create a private temporary directory
+  ansible.builtin.tempfile:
+    state: directory
+    prefix: ansible-sssd-config-
+  register: sssd_config_test_temp
+
+- name: Define temporary test paths
+  ansible.builtin.set_fact:
+    sssd_config_test_inspector: "{{ sssd_config_test_temp.path }}/inspect_ini.py"
+    sssd_config_test_probe: "{{ sssd_config_test_temp.path }}/probe_sssdconfig.py"
+    sssd_config_test_probe_path: "{{ sssd_config_test_temp.path }}/probe.conf"
+    sssd_config_test_sssd_path: "{{ sssd_config_test_temp.path }}/sssd-section.conf"
+    sssd_config_test_validation_path: "{{ sssd_config_test_temp.path }}/validation.conf"
+
+- name: Install independent test helpers
+  ansible.builtin.copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: "0700"
+  loop:
+    - src: inspect_ini.py
+      dest: "{{ sssd_config_test_inspector }}"
+    - src: probe_sssdconfig.py
+      dest: "{{ sssd_config_test_probe }}"
+
+- name: Seed the capability-probe configuration
+  ansible.builtin.copy:
+    content: "{{ sssd_config_test_baseline }}"
+    dest: "{{ sssd_config_test_probe_path }}"
+    mode: "0600"
+
+- name: Probe the installed SSSDConfig schema
+  ansible.builtin.command:
+    argv:
+      - "{{ ansible_facts.python.executable }}"
+      - "{{ sssd_config_test_probe }}"
+      - "{{ sssd_config_test_probe_path }}"
+  register: sssd_config_test_probe_result
+  changed_when: false
+
+- name: Store runtime SSSDConfig capabilities
+  ansible.builtin.set_fact:
+    sssd_config_test_capabilities: "{{ sssd_config_test_probe_result.stdout | from_json }}"
+
+- name: Require the schema capabilities used by the core suite
+  ansible.builtin.assert:
+    that:
+      - "'services' in sssd_config_test_capabilities.sssd_options"
+      - "'domains' in sssd_config_test_capabilities.sssd_options"
+      - "'debug_level' in sssd_config_test_capabilities.sssd_options"
+    fail_msg: >-
+      The installed SSSDConfig schema lacks a baseline capability required to
+      exercise this module. Probe result: {{ sssd_config_test_capabilities }}
+
+- name: Report the tested runtime
+  ansible.builtin.debug:
+    msg:
+      distribution: "{{ ansible_facts.distribution }} {{ ansible_facts.distribution_version }}"
+      packages: "{{ sssd_config_test_packages }}"
+      python: "{{ sssd_config_test_capabilities.python }}"
+      sssdconfig_module: "{{ sssd_config_test_capabilities.module_file }}"

--- a/tests/integration/targets/sssd_config/tasks/test_sssd.yml
+++ b/tests/integration/targets/sssd_config/tasks/test_sssd.yml
@@ -1,0 +1,180 @@
+---
+# Copyright (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Seed the sssd-section test configuration
+  ansible.builtin.copy:
+    content: "{{ sssd_config_test_baseline }}"
+    dest: "{{ sssd_config_test_sssd_path }}"
+    mode: "0600"
+
+- name: Inspect the initial sssd-section configuration
+  ansible.builtin.include_tasks: inspect.yml
+  vars:
+    sssd_config_test_inspect_path: "{{ sssd_config_test_sssd_path }}"
+
+- name: Save the pre-check-mode hash
+  ansible.builtin.set_fact:
+    sssd_config_test_hash_before: "{{ sssd_config_test_config.sha256 }}"
+
+- name: Predict scalar and list changes to the sssd section
+  community.general.sssd_config:
+    path: "{{ sssd_config_test_sssd_path }}"
+    options:
+      debug_level: 31
+      services:
+        - nss
+        - pam
+  check_mode: true
+  diff: true
+  register: sssd_config_test_sssd_check
+
+- name: Inspect the sssd-section configuration after check mode
+  ansible.builtin.include_tasks: inspect.yml
+  vars:
+    sssd_config_test_inspect_path: "{{ sssd_config_test_sssd_path }}"
+
+- name: Verify sssd check mode predicts without writing
+  ansible.builtin.assert:
+    that:
+      - sssd_config_test_sssd_check is changed
+      - sssd_config_test_config.sha256 == sssd_config_test_hash_before
+      - sssd_config_test_sssd_check.diff.before.section_name == 'sssd'
+      - sssd_config_test_sssd_check.diff.before.exists
+      - sssd_config_test_sssd_check.diff.before.changed_option_names == []
+      - sssd_config_test_sssd_check.diff.after.changed_option_names == ['debug_level', 'services']
+      - sssd_config_test_sssd_check.diff.after.option_names == ['config_file_version', 'debug_level', 'domains', 'services']
+      - sssd_config_test_sssd_check.path == sssd_config_test_sssd_path
+      - sssd_config_test_sssd_check.section_name == 'sssd'
+      - sssd_config_test_sssd_check.exists
+      - sssd_config_test_sssd_check.option_names == ['config_file_version', 'debug_level', 'domains', 'services']
+
+- name: Set scalar and list options in the sssd section
+  community.general.sssd_config:
+    path: "{{ sssd_config_test_sssd_path }}"
+    options:
+      debug_level: 31
+      services:
+        - nss
+        - pam
+  register: sssd_config_test_sssd_create
+
+- name: Inspect the updated sssd-section configuration
+  ansible.builtin.include_tasks: inspect.yml
+  vars:
+    sssd_config_test_inspect_path: "{{ sssd_config_test_sssd_path }}"
+
+- name: Verify list and hexadecimal serialization
+  ansible.builtin.assert:
+    that:
+      - sssd_config_test_sssd_create is changed
+      - sssd_config_test_config.mode == '0600'
+      - sssd_config_test_config.sections.sssd.debug_level == '0x1f'
+      - sssd_config_test_config.sections.sssd.services == 'nss, pam'
+
+- name: Repeat the same sssd options
+  community.general.sssd_config:
+    path: "{{ sssd_config_test_sssd_path }}"
+    options:
+      debug_level: 31
+      services:
+        - nss
+        - pam
+  register: sssd_config_test_sssd_idempotent
+
+- name: Verify sssd option idempotence
+  ansible.builtin.assert:
+    that:
+      - sssd_config_test_sssd_idempotent is not changed
+
+- name: Update explicit sssd options with must_exist
+  community.general.sssd_config:
+    path: "{{ sssd_config_test_sssd_path }}"
+    must_exist: true
+    options:
+      debug_level: 32
+      services:
+        - nss
+        - pam
+  register: sssd_config_test_sssd_must_exist_update
+
+- name: Verify must_exist permits updates to explicit options
+  ansible.builtin.assert:
+    that:
+      - sssd_config_test_sssd_must_exist_update is changed
+
+- name: Reject a non-explicit sssd option with must_exist
+  community.general.sssd_config:
+    path: "{{ sssd_config_test_sssd_path }}"
+    must_exist: true
+    options:
+      re_expression: "(?P<name>[^@]+)"
+  register: sssd_config_test_sssd_missing_option
+  ignore_errors: true
+
+- name: Verify the missing sssd option failure
+  ansible.builtin.assert:
+    that:
+      - sssd_config_test_sssd_missing_option is failed
+      - "'must already exist' in sssd_config_test_sssd_missing_option.msg"
+
+- name: Selectively remove an existing and a missing sssd option
+  community.general.sssd_config:
+    path: "{{ sssd_config_test_sssd_path }}"
+    state: absent
+    options:
+      debug_level: ignored
+      re_expression: ignored
+  register: sssd_config_test_sssd_remove_options
+
+- name: Inspect the sssd section after selective removal
+  ansible.builtin.include_tasks: inspect.yml
+  vars:
+    sssd_config_test_inspect_path: "{{ sssd_config_test_sssd_path }}"
+
+- name: Verify selective sssd option removal
+  ansible.builtin.assert:
+    that:
+      - sssd_config_test_sssd_remove_options is changed
+      - "'debug_level' not in sssd_config_test_config.sections.sssd"
+      - sssd_config_test_config.sections.sssd.services == 'nss, pam'
+
+- name: Repeat selective removal of missing sssd options
+  community.general.sssd_config:
+    path: "{{ sssd_config_test_sssd_path }}"
+    state: absent
+    options:
+      debug_level: ignored
+      re_expression: ignored
+  register: sssd_config_test_sssd_remove_idempotent
+
+- name: Verify repeated sssd option absence is idempotent
+  ansible.builtin.assert:
+    that:
+      - sssd_config_test_sssd_remove_idempotent is not changed
+
+- name: Request selective removal of no sssd options
+  community.general.sssd_config:
+    path: "{{ sssd_config_test_sssd_path }}"
+    state: absent
+    options: {}
+  register: sssd_config_test_sssd_empty_absent
+
+- name: Verify options={} is a no-op for state=absent
+  ansible.builtin.assert:
+    that:
+      - sssd_config_test_sssd_empty_absent is not changed
+
+- name: Reject an absent request without option names
+  community.general.sssd_config:
+    path: "{{ sssd_config_test_sssd_path }}"
+    state: absent
+  register: sssd_config_test_absent_without_options
+  ignore_errors: true
+
+- name: Verify options are required
+  ansible.builtin.assert:
+    that:
+      - sssd_config_test_absent_without_options is failed
+      - "'options' in sssd_config_test_absent_without_options.msg"

--- a/tests/integration/targets/sssd_config/tasks/test_validation.yml
+++ b/tests/integration/targets/sssd_config/tasks/test_validation.yml
@@ -1,0 +1,102 @@
+---
+# Copyright (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Seed the validation test configuration
+  ansible.builtin.copy:
+    content: "{{ sssd_config_test_baseline }}"
+    dest: "{{ sssd_config_test_validation_path }}"
+    mode: "0600"
+
+- name: Inspect before option validation failures
+  ansible.builtin.include_tasks: inspect.yml
+  vars:
+    sssd_config_test_inspect_path: "{{ sssd_config_test_validation_path }}"
+
+- name: Save the hash before option validation failures
+  ansible.builtin.set_fact:
+    sssd_config_test_hash_before: "{{ sssd_config_test_config.sha256 }}"
+
+- name: Require a non-explicit option for state=present
+  community.general.sssd_config:
+    path: "{{ sssd_config_test_validation_path }}"
+    must_exist: true
+    options:
+      debug_level: 2
+  register: sssd_config_test_present_missing_explicit_option
+  ignore_errors: true
+
+- name: Reject an option that is absent from the runtime schema
+  community.general.sssd_config:
+    path: "{{ sssd_config_test_validation_path }}"
+    options:
+      ansible_test_option_that_does_not_exist: true
+  register: sssd_config_test_invalid_schema_option
+  ignore_errors: true
+
+- name: Verify present-state validation errors
+  ansible.builtin.assert:
+    that:
+      - sssd_config_test_present_missing_explicit_option is failed
+      - sssd_config_test_invalid_schema_option is failed
+      - "'must already exist' in sssd_config_test_present_missing_explicit_option.msg"
+
+- name: Confirm must_exist has no effect for state=absent
+  community.general.sssd_config:
+    path: "{{ sssd_config_test_validation_path }}"
+    state: absent
+    must_exist: true
+    options:
+      debug_level: ignored
+  register: sssd_config_test_absent_must_exist
+
+- name: Verify absent removal of a missing option is idempotent
+  ansible.builtin.assert:
+    that:
+      - sssd_config_test_absent_must_exist is not changed
+
+- name: Inspect after option validation failures
+  ansible.builtin.include_tasks: inspect.yml
+  vars:
+    sssd_config_test_inspect_path: "{{ sssd_config_test_validation_path }}"
+
+- name: Verify validation failures did not write the configuration
+  ansible.builtin.assert:
+    that:
+      - sssd_config_test_config.sha256 == sssd_config_test_hash_before
+
+- name: Seed a configuration without an sssd section
+  ansible.builtin.copy:
+    content: |
+      [nss]
+      debug_level = 2
+    dest: "{{ sssd_config_test_validation_path }}"
+    mode: "0600"
+
+- name: Reject a configuration without an sssd section
+  community.general.sssd_config:
+    path: "{{ sssd_config_test_validation_path }}"
+    options:
+      debug_level: 2
+  register: sssd_config_test_missing_sssd_section
+  ignore_errors: true
+
+- name: Verify a missing sssd section fails explicitly
+  ansible.builtin.assert:
+    that:
+      - sssd_config_test_missing_sssd_section is failed
+      - "'sssd section does not exist' in sssd_config_test_missing_sssd_section.msg"
+
+- name: Reject a nonexistent configuration path
+  community.general.sssd_config:
+    path: "{{ sssd_config_test_temp.path }}/does-not-exist.conf"
+    options:
+      debug_level: 2
+  register: sssd_config_test_missing_path
+  ignore_errors: true
+
+- name: Verify a nonexistent configuration path fails
+  ansible.builtin.assert:
+    that:
+      - sssd_config_test_missing_path is failed

--- a/tests/unit/plugins/module_utils/test__sssd_config.py
+++ b/tests/unit/plugins/module_utils/test__sssd_config.py
@@ -1,0 +1,586 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+from ansible_collections.community.general.plugins.module_utils import _sssd_config
+
+
+class FakeConfiguration:
+    def __init__(self, options=None, normalizers=None):
+        self._options = dict(options or {})
+        self._normalizers = dict(normalizers or {})
+        self.set_option_calls = []
+        self.remove_option_calls = []
+
+    def get_all_options(self):
+        return dict(self._options)
+
+    def get_option(self, option):
+        return self._options[option]
+
+    def set_option(self, option, value):
+        self.set_option_calls.append(call(option, value))
+        normalizer = self._normalizers.get(option, lambda item: item)
+        self._options[option] = normalizer(value)
+
+    def remove_option(self, option):
+        self.remove_option_calls.append(call(option))
+        self._options.pop(option, None)
+
+
+class FakeDomain(FakeConfiguration):
+    def __init__(self, options=None, active=False, normalizers=None):
+        super().__init__(options=options, normalizers=normalizers)
+        self.active = active
+        self.remove_provider_calls = []
+        self.set_active_calls = []
+
+    def remove_provider(self, provider_type):
+        self.remove_provider_calls.append(call(provider_type))
+        self._options.pop(f"{provider_type}_provider", None)
+
+    def set_active(self, active):
+        self.set_active_calls.append(call(active))
+        self.active = active
+
+
+class FakeService(FakeConfiguration):
+    pass
+
+
+class TestRequestDataClasses(unittest.TestCase):
+    def test_sssd_target_resolves_root_section_name(self):
+        target = _sssd_config.SSSDTarget(
+            path="/etc/sssd/sssd.conf",
+            section="sssd",
+        )
+
+        self.assertEqual(target.section_name, "sssd")
+        self.assertIsNone(target.name)
+
+    def test_domain_target_resolves_qualified_section_name(self):
+        target = _sssd_config.SSSDTarget(
+            path="/etc/sssd/sssd.conf",
+            section="domain",
+            name="example.com",
+        )
+
+        self.assertEqual(target.section_name, "domain/example.com")
+
+    def test_service_target_uses_service_name_as_section_name(self):
+        target = _sssd_config.SSSDTarget(
+            path="/etc/sssd/sssd.conf",
+            section="service",
+            name="pam",
+        )
+
+        self.assertEqual(target.section_name, "pam")
+
+    def test_ensure_present_defaults_optional_activation(self):
+        target = _sssd_config.SSSDTarget(
+            path="/etc/sssd/sssd.conf",
+            section="sssd",
+        )
+        request = _sssd_config.EnsurePresent(
+            target=target,
+            options={"services": ["nss", "pam"]},
+        )
+
+        self.assertFalse(request.must_exist)
+        self.assertIsNone(request.active)
+
+    def test_removal_requests_contain_only_actionable_data(self):
+        target = _sssd_config.SSSDTarget(
+            path="/etc/sssd/sssd.conf",
+            section="service",
+            name="pam",
+        )
+        remove_options = _sssd_config.RemoveOptions(
+            target=target,
+            option_names=("debug_level",),
+        )
+        remove_section = _sssd_config.RemoveSection(target=target)
+
+        self.assertEqual(remove_options.option_names, ("debug_level",))
+        self.assertIs(remove_section.target, target)
+        self.assertFalse(hasattr(remove_options, "must_exist"))
+        self.assertFalse(hasattr(remove_section, "must_exist"))
+
+
+class TestLibraryAdapter(unittest.TestCase):
+    def test_create_sssd_config_uses_imported_constructor(self):
+        config = object()
+
+        with patch.object(_sssd_config, "_SSSDConfig", return_value=config) as constructor:
+            result = _sssd_config.create_sssd_config()
+
+        self.assertIs(result, config)
+        constructor.assert_called_once_with()
+
+    def test_get_explicit_options_returns_empty_mapping_when_section_is_absent(self):
+        config = MagicMock()
+        config.has_section.return_value = False
+
+        result = _sssd_config.get_explicit_options(config, "sssd")
+
+        self.assertEqual(result, {})
+        config.options.assert_not_called()
+
+    def test_get_explicit_options_converts_records_to_mapping(self):
+        config = MagicMock()
+        raw_options = [object(), object()]
+        config.has_section.return_value = True
+        config.options.return_value = raw_options
+        config.strip_comments_empty.return_value = [
+            {"name": "services", "value": "nss, pam"},
+            {"name": "domains", "value": "example.com"},
+        ]
+
+        result = _sssd_config.get_explicit_options(config, "sssd")
+
+        self.assertEqual(
+            result,
+            {"services": "nss, pam", "domains": "example.com"},
+        )
+        config.options.assert_called_once_with("sssd")
+        config.strip_comments_empty.assert_called_once_with(raw_options)
+
+
+class TestSetServiceOptions(unittest.TestCase):
+    def test_sets_requested_options(self):
+        service = FakeService(options={"pam_verbosity": 1})
+
+        changed = _sssd_config.set_service_options(
+            service,
+            {"pam_verbosity": 2},
+            {"pam_verbosity": "1"},
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(service.get_all_options()["pam_verbosity"], 2)
+        self.assertEqual(service.set_option_calls, [call("pam_verbosity", 2)])
+
+    def test_is_idempotent_when_explicit_value_is_unchanged(self):
+        service = FakeService(options={"pam_verbosity": 2})
+
+        changed = _sssd_config.set_service_options(
+            service,
+            {"pam_verbosity": 2},
+            {"pam_verbosity": "2"},
+        )
+
+        self.assertFalse(changed)
+
+    def test_materializes_implicit_default_as_explicit_option(self):
+        service = FakeService(options={"pam_verbosity": 0})
+
+        changed = _sssd_config.set_service_options(
+            service,
+            {"pam_verbosity": 0},
+            {},
+        )
+
+        self.assertTrue(changed)
+
+    def test_empty_request_is_idempotent(self):
+        service = FakeService(options={"pam_verbosity": 1})
+
+        changed = _sssd_config.set_service_options(service, {}, {})
+
+        self.assertFalse(changed)
+        self.assertEqual(service.set_option_calls, [])
+
+
+class TestSetDomainOptions(unittest.TestCase):
+    def test_changed_provider_is_removed_before_replacement(self):
+        domain = FakeDomain(options={"id_provider": "ipa"})
+
+        changed = _sssd_config.set_domain_options(
+            domain,
+            {"id_provider": "ldap"},
+            {"id_provider": "ipa"},
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(domain.remove_provider_calls, [call("id")])
+        self.assertEqual(domain.set_option_calls, [call("id_provider", "ldap")])
+        self.assertEqual(domain.get_all_options()["id_provider"], "ldap")
+
+    def test_unchanged_provider_is_not_removed(self):
+        domain = FakeDomain(options={"id_provider": "ldap"})
+
+        changed = _sssd_config.set_domain_options(
+            domain,
+            {"id_provider": "ldap"},
+            {"id_provider": "ldap"},
+        )
+
+        self.assertFalse(changed)
+        self.assertEqual(domain.remove_provider_calls, [])
+
+    def test_new_provider_does_not_remove_nonexistent_provider(self):
+        domain = FakeDomain()
+
+        changed = _sssd_config.set_domain_options(
+            domain,
+            {"auth_provider": "ldap"},
+            {},
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(domain.remove_provider_calls, [])
+
+    def test_regular_option_does_not_remove_provider(self):
+        domain = FakeDomain(options={"cache_credentials": False})
+
+        changed = _sssd_config.set_domain_options(
+            domain,
+            {"cache_credentials": True},
+            {"cache_credentials": "false"},
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(domain.remove_provider_calls, [])
+
+    def test_provider_options_are_processed_before_regular_options(self):
+        domain = FakeDomain()
+
+        _sssd_config.set_domain_options(
+            domain,
+            {
+                "cache_credentials": True,
+                "id_provider": "ldap",
+            },
+            {},
+        )
+
+        self.assertEqual(
+            domain.set_option_calls,
+            [
+                call("id_provider", "ldap"),
+                call("cache_credentials", True),
+            ],
+        )
+
+
+class TestActivation(unittest.TestCase):
+    def test_domain_is_activated_when_requested(self):
+        domain = FakeDomain(active=False)
+
+        changed = _sssd_config.set_domain_active(
+            domain,
+            created=False,
+            requested=True,
+        )
+
+        self.assertTrue(changed)
+        self.assertTrue(domain.active)
+        self.assertEqual(domain.set_active_calls, [call(True)])
+
+    def test_domain_activation_is_idempotent(self):
+        domain = FakeDomain(active=True)
+
+        changed = _sssd_config.set_domain_active(
+            domain,
+            created=False,
+            requested=True,
+        )
+
+        self.assertFalse(changed)
+        self.assertEqual(domain.set_active_calls, [])
+
+    def test_existing_domain_activation_is_unmanaged_when_omitted(self):
+        domain = FakeDomain(active=True)
+
+        changed = _sssd_config.set_domain_active(
+            domain,
+            created=False,
+            requested=None,
+        )
+
+        self.assertFalse(changed)
+        self.assertTrue(domain.active)
+        self.assertEqual(domain.set_active_calls, [])
+
+    def test_new_domain_defaults_to_inactive_when_activation_is_omitted(self):
+        domain = FakeDomain(active=True)
+
+        changed = _sssd_config.set_domain_active(
+            domain,
+            created=True,
+            requested=None,
+        )
+
+        self.assertTrue(changed)
+        self.assertFalse(domain.active)
+        self.assertEqual(domain.set_active_calls, [call(False)])
+
+    def test_service_is_activated_when_requested(self):
+        config = MagicMock()
+        config.list_active_services.return_value = []
+
+        changed = _sssd_config.set_service_active(
+            config,
+            "pam",
+            created=False,
+            requested=True,
+        )
+
+        self.assertTrue(changed)
+        config.activate_service.assert_called_once_with("pam")
+        config.deactivate_service.assert_not_called()
+
+    def test_service_is_deactivated_when_requested(self):
+        config = MagicMock()
+        config.list_active_services.return_value = ["pam"]
+
+        changed = _sssd_config.set_service_active(
+            config,
+            "pam",
+            created=False,
+            requested=False,
+        )
+
+        self.assertTrue(changed)
+        config.deactivate_service.assert_called_once_with("pam")
+        config.activate_service.assert_not_called()
+
+    def test_service_activation_is_idempotent(self):
+        config = MagicMock()
+        config.list_active_services.return_value = ["pam"]
+
+        changed = _sssd_config.set_service_active(
+            config,
+            "pam",
+            created=False,
+            requested=True,
+        )
+
+        self.assertFalse(changed)
+        config.activate_service.assert_not_called()
+        config.deactivate_service.assert_not_called()
+
+    def test_new_service_defaults_to_inactive_when_activation_is_omitted(self):
+        config = MagicMock()
+        config.list_active_services.return_value = ["pam"]
+
+        changed = _sssd_config.set_service_active(
+            config,
+            "pam",
+            created=True,
+            requested=None,
+        )
+
+        self.assertTrue(changed)
+        config.deactivate_service.assert_called_once_with("pam")
+        config.activate_service.assert_not_called()
+
+
+class TestDeleteService(unittest.TestCase):
+    def test_active_service_is_deactivated_before_deletion(self):
+        config = MagicMock()
+        config.list_active_services.return_value = ["nss", "pam"]
+
+        _sssd_config.delete_service(config, "pam")
+
+        self.assertEqual(
+            config.method_calls,
+            [
+                call.list_active_services(),
+                call.deactivate_service("pam"),
+                call.delete_service("pam"),
+            ],
+        )
+
+    def test_inactive_service_is_deleted_without_deactivation(self):
+        config = MagicMock()
+        config.list_active_services.return_value = ["nss"]
+
+        _sssd_config.delete_service(config, "pam")
+
+        config.deactivate_service.assert_not_called()
+        config.delete_service.assert_called_once_with("pam")
+
+
+class TestRemoveOptions(unittest.TestCase):
+    def test_empty_domain_option_names_are_idempotent(self):
+        domain = FakeDomain(options={"id_provider": "ldap"})
+
+        changed = _sssd_config.remove_domain_options(domain, ())
+
+        self.assertFalse(changed)
+        self.assertEqual(domain.remove_provider_calls, [])
+        self.assertEqual(domain.remove_option_calls, [])
+
+    def test_domain_provider_uses_remove_provider(self):
+        domain = FakeDomain(options={"id_provider": "ldap"})
+
+        changed = _sssd_config.remove_domain_options(domain, ("id_provider",))
+
+        self.assertTrue(changed)
+        self.assertEqual(domain.remove_provider_calls, [call("id")])
+        self.assertEqual(domain.remove_option_calls, [])
+
+    def test_regular_domain_option_uses_remove_option(self):
+        domain = FakeDomain(options={"cache_credentials": True})
+
+        changed = _sssd_config.remove_domain_options(domain, ("cache_credentials",))
+
+        self.assertTrue(changed)
+        self.assertEqual(domain.remove_provider_calls, [])
+        self.assertEqual(domain.remove_option_calls, [call("cache_credentials")])
+
+    def test_service_provider_named_option_uses_remove_option(self):
+        service = FakeService(options={"id_provider": "ldap"})
+
+        changed = _sssd_config.remove_service_options(service, ("id_provider",))
+
+        self.assertTrue(changed)
+        self.assertEqual(service.remove_option_calls, [call("id_provider")])
+
+    def test_empty_service_option_names_are_idempotent(self):
+        service = FakeService(options={"pam_verbosity": 1})
+
+        changed = _sssd_config.remove_service_options(service, ())
+
+        self.assertFalse(changed)
+        self.assertEqual(service.remove_option_calls, [])
+
+    def test_empty_sssd_option_names_are_idempotent(self):
+        config = MagicMock()
+
+        changed = _sssd_config.remove_sssd_options(config, ())
+
+        self.assertFalse(changed)
+        config.findOpts.assert_not_called()
+        config.delete_option_subtree.assert_not_called()
+
+    def test_removes_requested_sssd_options(self):
+        config = MagicMock()
+        config.opts = object()
+        section_values = object()
+        config.findOpts.return_value = (
+            4,
+            {"type": "section", "name": "sssd", "value": section_values},
+        )
+
+        changed = _sssd_config.remove_sssd_options(
+            config,
+            ("services", "debug_level"),
+        )
+
+        self.assertTrue(changed)
+        config.findOpts.assert_called_once_with(config.opts, "section", "sssd")
+        self.assertEqual(
+            config.delete_option_subtree.call_args_list,
+            [
+                call(section_values, "option", "services", True),
+                call(section_values, "option", "debug_level", True),
+            ],
+        )
+
+
+class TestSSSDOptions(unittest.TestCase):
+    def test_serialize_list(self):
+        self.assertEqual(
+            _sssd_config.serialize_option_value("services", ["nss", "pam"]),
+            "nss, pam",
+        )
+
+    def test_serialize_large_debug_level_as_hexadecimal(self):
+        self.assertEqual(
+            _sssd_config.serialize_option_value("debug_level", 32),
+            "0x20",
+        )
+
+    def test_serialize_small_debug_level_as_decimal(self):
+        self.assertEqual(
+            _sssd_config.serialize_option_value("debug_level", 16),
+            "16",
+        )
+
+    def test_serialize_regular_scalar_as_string(self):
+        self.assertEqual(
+            _sssd_config.serialize_option_value("config_file_version", 2),
+            "2",
+        )
+
+    def test_set_sssd_options_is_idempotent_for_matching_explicit_value(self):
+        section = FakeService(options={"config_file_version": 2})
+        config = MagicMock()
+        config.get_service.return_value = section
+        config.has_option.return_value = True
+
+        changed = _sssd_config.set_sssd_options(
+            config,
+            {"config_file_version": 2},
+        )
+
+        self.assertFalse(changed)
+        config.set.assert_not_called()
+
+    def test_set_sssd_options_materializes_implicit_default(self):
+        section = FakeService(options={"config_file_version": 2})
+        config = MagicMock()
+        config.get_service.return_value = section
+        config.has_option.return_value = False
+
+        changed = _sssd_config.set_sssd_options(
+            config,
+            {"config_file_version": 2},
+        )
+
+        self.assertTrue(changed)
+        config.set.assert_called_once_with("sssd", "config_file_version", "2")
+
+    def test_set_sssd_options_writes_normalized_value(self):
+        section = FakeService(
+            options={"services": ["nss"]},
+            normalizers={"services": lambda value: [item.strip() for item in value.split(",")]},
+        )
+        config = MagicMock()
+        config.get_service.return_value = section
+        config.has_option.return_value = True
+
+        changed = _sssd_config.set_sssd_options(
+            config,
+            {"services": "nss, pam"},
+        )
+
+        self.assertTrue(changed)
+        config.set.assert_called_once_with("sssd", "services", "nss, pam")
+
+    def test_set_sssd_options_serializes_large_debug_level(self):
+        section = FakeService(options={"debug_level": 0})
+        config = MagicMock()
+        config.get_service.return_value = section
+        config.has_option.return_value = True
+
+        changed = _sssd_config.set_sssd_options(
+            config,
+            {"debug_level": 32},
+        )
+
+        self.assertTrue(changed)
+        config.set.assert_called_once_with("sssd", "debug_level", "0x20")
+
+    def test_set_sssd_options_propagates_schema_validation_error(self):
+        section = MagicMock()
+        section.get_all_options.return_value = {"config_file_version": 2}
+        section.set_option.side_effect = ValueError("invalid value")
+        config = MagicMock()
+        config.get_service.return_value = section
+        config.has_option.return_value = True
+
+        with self.assertRaisesRegex(ValueError, "invalid value"):
+            _sssd_config.set_sssd_options(
+                config,
+                {"config_file_version": "invalid"},
+            )
+
+        config.set.assert_not_called()

--- a/tests/unit/plugins/modules/test_sssd_config.py
+++ b/tests/unit/plugins/modules/test_sssd_config.py
@@ -1,0 +1,668 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from ansible_collections.community.general.plugins.module_utils import (
+    _sssd_config as sssd_config_utils,
+)
+from ansible_collections.community.general.plugins.modules import sssd_config
+
+
+class ModuleRaisedError(Exception):
+    """Stand-in exception used to stop execution after do_raise/fail_json."""
+
+
+def make_helper(
+    state="present",
+    options=None,
+    must_exist=False,
+    path="/etc/sssd/sssd.conf",
+    config=None,
+    diff_mode=False,
+):
+    parsed_options = {} if options is None else options
+    helper = object.__new__(sssd_config.SSSDConfigModule)
+    helper.vars = SimpleNamespace(
+        state=state,
+        options=parsed_options,
+        must_exist=must_exist,
+        path=path,
+    )
+    helper.request = sssd_config._parse_request(
+        state=state,
+        path=path,
+        options=parsed_options,
+        must_exist=must_exist,
+    )
+    helper.sssd_config = config if config is not None else MagicMock()
+    helper.module = MagicMock()
+    helper.module._diff = diff_mode
+    helper.changed = False
+    helper.check_mode = False
+    helper._result_diff = None
+    return helper
+
+
+class TestModuleDefinition(unittest.TestCase):
+    def test_argument_spec_is_limited_to_the_sssd_section(self):
+        argument_spec = sssd_config.SSSDConfigModule.module["argument_spec"]
+
+        self.assertEqual(
+            set(argument_spec),
+            {"state", "must_exist", "path", "options"},
+        )
+        self.assertEqual(argument_spec["state"]["choices"], ["present", "absent"])
+        self.assertEqual(argument_spec["state"]["default"], "present")
+        self.assertFalse(argument_spec["must_exist"]["default"])
+        self.assertEqual(argument_spec["path"]["default"], "/etc/sssd/sssd.conf")
+        self.assertTrue(argument_spec["options"]["required"])
+        self.assertTrue(sssd_config.SSSDConfigModule.module["supports_check_mode"])
+
+    def test_section_name_and_activation_arguments_are_not_exposed(self):
+        argument_spec = sssd_config.SSSDConfigModule.module["argument_spec"]
+
+        self.assertNotIn("section", argument_spec)
+        self.assertNotIn("name", argument_spec)
+        self.assertNotIn("active", argument_spec)
+
+
+class TestRequestParsing(unittest.TestCase):
+    def test_present_arguments_become_ensure_present_request(self):
+        request = sssd_config._parse_request(
+            state="present",
+            path="/tmp/sssd.conf",
+            options={"services": ["nss", "pam"]},
+            must_exist=True,
+        )
+
+        self.assertIsInstance(request, sssd_config_utils.EnsurePresent)
+        self.assertEqual(request.target.path, "/tmp/sssd.conf")
+        self.assertEqual(request.target.section, "sssd")
+        self.assertIsNone(request.target.name)
+        self.assertEqual(request.target.section_name, "sssd")
+        self.assertEqual(request.options, {"services": ["nss", "pam"]})
+        self.assertTrue(request.must_exist)
+        self.assertIsNone(request.active)
+
+    def test_present_options_are_copied(self):
+        raw_options = {"services": ["nss", "pam"]}
+        request = sssd_config._parse_request(
+            state="present",
+            path="/etc/sssd/sssd.conf",
+            options=raw_options,
+            must_exist=False,
+        )
+
+        raw_options["domains"] = ["example.com"]
+
+        self.assertEqual(request.options, {"services": ["nss", "pam"]})
+
+    def test_absent_arguments_become_remove_options_request(self):
+        request = sssd_config._parse_request(
+            state="absent",
+            path="/tmp/sssd.conf",
+            options={"debug_level": "ignored", "default_domain_suffix": None},
+            must_exist=True,
+        )
+
+        self.assertIsInstance(request, sssd_config_utils.RemoveOptions)
+        self.assertEqual(request.target.section_name, "sssd")
+        self.assertEqual(
+            request.option_names,
+            ("debug_level", "default_domain_suffix"),
+        )
+        self.assertFalse(hasattr(request, "must_exist"))
+
+    def test_absent_empty_mapping_is_remove_no_options(self):
+        request = sssd_config._parse_request(
+            state="absent",
+            path="/etc/sssd/sssd.conf",
+            options={},
+            must_exist=False,
+        )
+
+        self.assertIsInstance(request, sssd_config_utils.RemoveOptions)
+        self.assertEqual(request.option_names, ())
+
+
+class TestModuleInitialization(unittest.TestCase):
+    def test_missing_sssdconfig_library_fails(self):
+        helper = make_helper(options={})
+        helper.module.fail_json.side_effect = ModuleRaisedError
+
+        with patch.object(sssd_config, "HAS_SSSD_LIB", False):
+            with self.assertRaises(ModuleRaisedError):
+                helper.__init_module__()
+
+        kwargs = helper.module.fail_json.call_args.kwargs
+        self.assertIn("SSSDConfig", kwargs["msg"])
+        self.assertEqual(kwargs["exception"], sssd_config.SSSDCONFIG_IMPORT_ERROR)
+
+    def test_initialization_imports_existing_sssd_configuration(self):
+        helper = make_helper(
+            path="/tmp/sssd.conf",
+            options={"debug_level": 6},
+        )
+        config = MagicMock()
+        config.has_section.return_value = True
+
+        with patch.object(sssd_config, "HAS_SSSD_LIB", True):
+            with patch.object(
+                sssd_config,
+                "create_sssd_config",
+                return_value=config,
+            ) as constructor:
+                helper.__init_module__()
+
+        constructor.assert_called_once_with()
+        config.import_config.assert_called_once_with("/tmp/sssd.conf")
+        config.has_section.assert_called_once_with("sssd")
+        self.assertIs(helper.sssd_config, config)
+        self.assertEqual(helper.request.options, {"debug_level": 6})
+
+    def test_missing_sssd_section_fails(self):
+        helper = make_helper(path="/tmp/sssd.conf", options={})
+        helper.module.fail_json.side_effect = ModuleRaisedError
+        config = MagicMock()
+        config.has_section.return_value = False
+
+        with patch.object(sssd_config, "HAS_SSSD_LIB", True):
+            with patch.object(
+                sssd_config,
+                "create_sssd_config",
+                return_value=config,
+            ):
+                with self.assertRaises(ModuleRaisedError):
+                    helper.__init_module__()
+
+        helper.module.fail_json.assert_called_once_with(msg="The sssd section does not exist")
+
+    def test_initialization_captures_initial_diff_state_when_enabled(self):
+        helper = make_helper(options={}, diff_mode=True)
+        config = MagicMock()
+        config.has_section.return_value = True
+        before = {
+            "section_name": "sssd",
+            "exists": True,
+            "option_names": ["services"],
+        }
+        before_options = {"services": "nss"}
+        helper._get_diff_state = MagicMock(return_value=(before, before_options))
+
+        with patch.object(sssd_config, "HAS_SSSD_LIB", True):
+            with patch.object(
+                sssd_config,
+                "create_sssd_config",
+                return_value=config,
+            ):
+                helper.__init_module__()
+
+        helper._get_diff_state.assert_called_once_with()
+        self.assertEqual(helper._diff_before, before)
+        self.assertEqual(helper._diff_before_options, before_options)
+
+    def test_initialization_skips_initial_diff_state_when_disabled(self):
+        helper = make_helper(options={}, diff_mode=False)
+        config = MagicMock()
+        config.has_section.return_value = True
+        helper._get_diff_state = MagicMock()
+
+        with patch.object(sssd_config, "HAS_SSSD_LIB", True):
+            with patch.object(
+                sssd_config,
+                "create_sssd_config",
+                return_value=config,
+            ):
+                helper.__init_module__()
+
+        helper._get_diff_state.assert_not_called()
+
+
+class TestExplicitOptions(unittest.TestCase):
+    def test_get_explicit_options_uses_sssd_target(self):
+        helper = make_helper(options={})
+
+        with patch.object(
+            sssd_config,
+            "get_explicit_options",
+            return_value={"services": "nss, pam"},
+        ) as get_options:
+            result = helper._get_explicit_options()
+
+        self.assertEqual(result, {"services": "nss, pam"})
+        get_options.assert_called_once_with(helper.sssd_config, "sssd")
+
+
+class TestStatePresent(unittest.TestCase):
+    def test_must_exist_rejects_missing_options_in_sorted_order(self):
+        helper = make_helper(
+            options={
+                "z_option": 1,
+                "present_option": 2,
+                "a_option": 3,
+            },
+            must_exist=True,
+        )
+        helper._get_explicit_options = MagicMock(return_value={"present_option": "2"})
+        helper.do_raise = MagicMock(side_effect=ModuleRaisedError)
+
+        with patch.object(sssd_config, "set_sssd_options") as set_options:
+            with self.assertRaises(ModuleRaisedError):
+                helper.state_present()
+
+        helper.do_raise.assert_called_once_with("The following options must already exist: a_option, z_option")
+        set_options.assert_not_called()
+        self.assertFalse(helper.changed)
+
+    def test_must_exist_allows_updating_explicit_options(self):
+        requested_options = {"services": ["nss", "pam"]}
+        helper = make_helper(
+            options=requested_options,
+            must_exist=True,
+        )
+        helper._get_explicit_options = MagicMock(return_value={"services": "nss"})
+
+        with patch.object(
+            sssd_config,
+            "set_sssd_options",
+            return_value=True,
+        ) as set_options:
+            helper.state_present()
+
+        set_options.assert_called_once_with(
+            helper.sssd_config,
+            requested_options,
+        )
+        self.assertTrue(helper.changed)
+
+    def test_changed_options_mark_module_changed(self):
+        requested_options = {"debug_level": 6}
+        helper = make_helper(options=requested_options)
+        helper._get_explicit_options = MagicMock(return_value={})
+
+        with patch.object(
+            sssd_config,
+            "set_sssd_options",
+            return_value=True,
+        ) as set_options:
+            helper.state_present()
+
+        set_options.assert_called_once_with(
+            helper.sssd_config,
+            requested_options,
+        )
+        self.assertTrue(helper.changed)
+
+    def test_matching_options_are_idempotent(self):
+        helper = make_helper(options={"debug_level": 6})
+        helper._get_explicit_options = MagicMock(return_value={"debug_level": "6"})
+
+        with patch.object(
+            sssd_config,
+            "set_sssd_options",
+            return_value=False,
+        ):
+            helper.state_present()
+
+        self.assertFalse(helper.changed)
+
+    def test_state_handler_uses_parsed_request_instead_of_raw_arguments(self):
+        helper = make_helper(options={"debug_level": 6})
+        helper._get_explicit_options = MagicMock(return_value={})
+        helper.vars = None
+
+        with patch.object(
+            sssd_config,
+            "set_sssd_options",
+            return_value=True,
+        ) as set_options:
+            helper.state_present()
+
+        set_options.assert_called_once_with(
+            helper.sssd_config,
+            {"debug_level": 6},
+        )
+
+
+class TestStateAbsent(unittest.TestCase):
+    def test_only_requested_explicit_options_are_removed(self):
+        helper = make_helper(
+            state="absent",
+            options={
+                "debug_level": "ignored",
+                "default_domain_suffix": "ignored",
+            },
+        )
+        helper._get_explicit_options = MagicMock(
+            return_value={
+                "debug_level": "6",
+                "services": "nss, pam",
+            }
+        )
+
+        with patch.object(
+            sssd_config,
+            "remove_sssd_options",
+            return_value=True,
+        ) as remove_options:
+            helper.state_absent()
+
+        remove_options.assert_called_once_with(
+            helper.sssd_config,
+            ("debug_level",),
+        )
+        self.assertTrue(helper.changed)
+
+    def test_already_absent_options_are_idempotent(self):
+        helper = make_helper(
+            state="absent",
+            options={"debug_level": "ignored"},
+        )
+        helper._get_explicit_options = MagicMock(return_value={"services": "nss, pam"})
+
+        with patch.object(
+            sssd_config,
+            "remove_sssd_options",
+            return_value=False,
+        ) as remove_options:
+            helper.state_absent()
+
+        remove_options.assert_called_once_with(helper.sssd_config, ())
+        self.assertFalse(helper.changed)
+
+    def test_empty_options_mapping_is_idempotent(self):
+        helper = make_helper(state="absent", options={})
+        helper._get_explicit_options = MagicMock(return_value={"services": "nss, pam"})
+
+        with patch.object(
+            sssd_config,
+            "remove_sssd_options",
+            return_value=False,
+        ) as remove_options:
+            helper.state_absent()
+
+        remove_options.assert_called_once_with(helper.sssd_config, ())
+        self.assertFalse(helper.changed)
+
+    def test_must_exist_has_no_effect_when_removing_options(self):
+        helper = make_helper(
+            state="absent",
+            options={"missing_option": "ignored"},
+            must_exist=True,
+        )
+        helper._get_explicit_options = MagicMock(return_value={})
+
+        with patch.object(
+            sssd_config,
+            "remove_sssd_options",
+            return_value=False,
+        ) as remove_options:
+            helper.state_absent()
+
+        remove_options.assert_called_once_with(helper.sssd_config, ())
+        self.assertFalse(helper.changed)
+
+    def test_state_handler_uses_parsed_names_without_raw_arguments(self):
+        helper = make_helper(
+            state="absent",
+            options={"debug_level": "ignored"},
+        )
+        helper._get_explicit_options = MagicMock(return_value={"debug_level": "6"})
+        helper.vars = None
+
+        with patch.object(
+            sssd_config,
+            "remove_sssd_options",
+            return_value=True,
+        ) as remove_options:
+            helper.state_absent()
+
+        remove_options.assert_called_once_with(
+            helper.sssd_config,
+            ("debug_level",),
+        )
+
+
+class TestDiffMode(unittest.TestCase):
+    def test_get_diff_state_returns_explicit_option_names(self):
+        helper = make_helper(options={}, diff_mode=True)
+        explicit_options = {
+            "services": "nss, pam",
+            "config_file_version": "2",
+        }
+        helper._get_explicit_options = MagicMock(return_value=explicit_options)
+
+        state, options = helper._get_diff_state()
+
+        self.assertEqual(
+            state,
+            {
+                "section_name": "sssd",
+                "exists": True,
+                "option_names": ["config_file_version", "services"],
+            },
+        )
+        self.assertEqual(options, explicit_options)
+
+    def test_set_diff_reports_added_removed_and_changed_option_names(self):
+        helper = make_helper(options={}, diff_mode=True)
+        helper._diff_before = {
+            "section_name": "sssd",
+            "exists": True,
+            "option_names": ["domains", "old_option", "services"],
+        }
+        helper._diff_before_options = {
+            "domains": "old.example.com",
+            "old_option": "old-value",
+            "services": "nss",
+        }
+        helper._get_diff_state = MagicMock(
+            return_value=(
+                {
+                    "section_name": "sssd",
+                    "exists": True,
+                    "option_names": [
+                        "config_file_version",
+                        "domains",
+                        "services",
+                    ],
+                },
+                {
+                    "config_file_version": "2",
+                    "domains": "new.example.com",
+                    "services": "nss",
+                },
+            )
+        )
+        helper._set_diff()
+
+        self.assertEqual(
+            helper._result_diff,
+            {
+                "before": {
+                    "section_name": "sssd",
+                    "exists": True,
+                    "option_names": [
+                        "domains",
+                        "old_option",
+                        "services",
+                    ],
+                    "changed_option_names": [],
+                },
+                "after": {
+                    "section_name": "sssd",
+                    "exists": True,
+                    "option_names": [
+                        "config_file_version",
+                        "domains",
+                        "services",
+                    ],
+                    "changed_option_names": [
+                        "config_file_version",
+                        "domains",
+                        "old_option",
+                    ],
+                },
+            },
+        )
+
+    def test_diff_does_not_expose_option_values(self):
+        old_secret = "old-password"
+        new_secret = "new-password"
+        helper = make_helper(options={}, diff_mode=True)
+        helper._diff_before = {
+            "section_name": "sssd",
+            "exists": True,
+            "option_names": ["proxy_password"],
+        }
+        helper._diff_before_options = {"proxy_password": old_secret}
+        helper._get_diff_state = MagicMock(
+            return_value=(
+                {
+                    "section_name": "sssd",
+                    "exists": True,
+                    "option_names": ["proxy_password"],
+                },
+                {"proxy_password": new_secret},
+            )
+        )
+        helper._set_diff()
+
+        serialized_diff = json.dumps(helper._result_diff)
+        self.assertNotIn(old_secret, serialized_diff)
+        self.assertNotIn(new_secret, serialized_diff)
+
+    def test_set_diff_omits_unchanged_state(self):
+        helper = make_helper(options={}, diff_mode=True)
+        state = {
+            "section_name": "sssd",
+            "exists": True,
+            "option_names": ["services"],
+        }
+        options = {"services": "nss, pam"}
+        helper._diff_before = state
+        helper._diff_before_options = options
+        helper._get_diff_state = MagicMock(return_value=(dict(state), dict(options)))
+        helper._result_diff = {"stale": True}
+
+        helper._set_diff()
+
+        self.assertIsNone(helper._result_diff)
+
+    def test_set_diff_does_nothing_when_diff_mode_is_disabled(self):
+        helper = make_helper(options={}, diff_mode=False)
+        helper._get_diff_state = MagicMock()
+        helper._result_diff = {"stale": True}
+
+        helper._set_diff()
+
+        helper._get_diff_state.assert_not_called()
+        self.assertIsNone(helper._result_diff)
+
+    def test_output_merges_custom_diff_without_registering_reserved_name(self):
+        helper = make_helper(options={}, diff_mode=True)
+        helper.vars = MagicMock()
+        helper.vars.output.return_value = {
+            "path": "/etc/sssd/sssd.conf",
+        }
+        helper.vars.diff.return_value = None
+        helper._result_diff = {
+            "before": {"option_names": ["services"]},
+            "after": {"option_names": ["debug_level", "services"]},
+        }
+
+        result = helper.output
+
+        self.assertEqual(
+            result,
+            {
+                "path": "/etc/sssd/sssd.conf",
+                "diff": helper._result_diff,
+            },
+        )
+
+
+class TestQuitModule(unittest.TestCase):
+    def test_changed_configuration_is_written(self):
+        helper = make_helper(options={})
+        helper.changed = True
+        helper._set_diff = MagicMock()
+        helper._set_return_values = MagicMock()
+
+        helper.__quit_module__()
+
+        helper._set_diff.assert_called_once_with()
+        helper.sssd_config.write.assert_called_once_with()
+        helper._set_return_values.assert_called_once_with()
+
+    def test_unchanged_configuration_is_not_written(self):
+        helper = make_helper(options={})
+        helper.changed = False
+        helper._set_diff = MagicMock()
+        helper._set_return_values = MagicMock()
+
+        helper.__quit_module__()
+
+        helper._set_diff.assert_called_once_with()
+        helper.sssd_config.write.assert_not_called()
+        helper._set_return_values.assert_called_once_with()
+
+    def test_check_mode_does_not_write_changed_configuration(self):
+        helper = make_helper(options={})
+        helper.changed = True
+        helper.check_mode = True
+        helper._set_diff = MagicMock()
+        helper._set_return_values = MagicMock()
+
+        helper.__quit_module__()
+
+        helper._set_diff.assert_called_once_with()
+        helper.sssd_config.write.assert_not_called()
+        helper._set_return_values.assert_called_once_with()
+
+
+class TestReturnValues(unittest.TestCase):
+    def test_output_params_contains_only_path(self):
+        self.assertEqual(
+            sssd_config.SSSDConfigModule.output_params,
+            ("path",),
+        )
+
+    def test_return_values_describe_sssd_section(self):
+        helper = make_helper(options={})
+        helper._get_explicit_options = MagicMock(
+            return_value={
+                "services": "nss, pam",
+                "config_file_version": "2",
+            }
+        )
+        helper.update_output = MagicMock()
+
+        helper._set_return_values()
+
+        helper.update_output.assert_called_once_with(
+            section_name="sssd",
+            exists=True,
+            option_names=["config_file_version", "services"],
+        )
+
+
+class TestMain(unittest.TestCase):
+    def test_main_runs_module(self):
+        module = MagicMock()
+
+        with patch.object(
+            sssd_config,
+            "SSSDConfigModule",
+            return_value=module,
+        ):
+            sssd_config.main()
+
+        module.run.assert_called_once_with()


### PR DESCRIPTION
##### SUMMARY
Adds `community.general.sssd_config` for idempotently managing the `[sssd]` sections of SSSD configuration files. All configuration options and option values are validated and normalized using the SSSD schema located on the managed node. 

The module supports:
- Diff mode
- Check mode
- Selective addition to sssd options
- Updating sssd option values
- Removal of sssd options
- `must_exist`, which when true, enforces that the sssd options specified must already exist in the specified configuration file.

This is 1 of 3 modules proposed in Issue #12634. The `module_utils/_sssd_config.py` file contains code that will also be used by the separately planned `sssd_domain` and `sssd_service` modules. Due to this, some of the code in `module_utils/_sssd_config.py` is not utilized by this module, but will be utilized in other two modules in following PRs.

Part of #12634  

##### ISSUE TYPE
- New Module/Plugin Pull Request

##### COMPONENT NAME
sssd_config

##### ADDITIONAL INFORMATION
The module requires an existing configuration file with an `[sssd]` section.
Unit and integration tests included in this PR.

Assisted by: GPT-5.6 Sol
